### PR TITLE
feat: change default memory path to .rusty-brain/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 !.env.example
 
 # Runtime memory/state (never commit mutable artifacts)
+.rusty-brain/
 .agent-brain/
 
 # Logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Feature artifacts live in `specs/<NNN>-<feature-name>/` with: `spec.md`, `prd.md
 - `.specify/` — Workflow engine: config, bash scripts, markdown templates, constitution
 - `.specify/memory/constitution.md` — 13 core principles governing all development (non-negotiable)
 - `.claude/commands/` — Speckit slash commands for Claude Code
-- `.agent-brain/mind.mv2` — Memvid-encoded persistent memory database
+- `.rusty-brain/mind.mv2` — Memvid-encoded persistent memory database
 
 ### Git Mode
 
@@ -80,15 +80,17 @@ The constitution (`.specify/memory/constitution.md` v2.0.0) governs all implemen
 - ulid, fs2 (003-core-memory-engine)
 - serde, serde_json, uuid, chrono, semver, thiserror (005-platform-adapter-system)
 - Rust stable, edition 2024, MSRV 1.85.0 + clap 4 (subcommand dispatch), serde/serde_json (JSON protocol), tracing (diagnostics), existing workspace crates (core, types, platforms) (006-claude-code-hooks)
-- `.agent-brain/mind.mv2` (memvid-encrypted observations), `.agent-brain/.dedup-cache.json` (hash-based dedup), `.install-version` (version marker) (006-claude-code-hooks)
+- `.rusty-brain/mind.mv2` (memvid-encrypted observations), `.rusty-brain/.dedup-cache.json` (hash-based dedup), `.rusty-brain/.install-version` (version marker) (006-claude-code-hooks)
 - clap 4 (derive), tracing 0.1 (007-cli-scripts)
 - `regex` crate (new), workspace `tracing` (for WARN-level fallback logging) (004-tool-output-compression)
 - Workspace crates (`core`, `platforms`, `compression`, `types`), `serde`, `serde_json`, `tracing`, `chrono`, `tempfile` (regular dep for atomic sidecar writes) (008-opencode-plugin)
-- `.agent-brain/mind.mv2` (via `crates/core` Mind API), `.opencode/session-<id>.json` (sidecar files on local filesystem) (008-opencode-plugin)
+- `.rusty-brain/mind.mv2` (via `crates/core` Mind API), `.opencode/session-<id>.json` (sidecar files on local filesystem) (008-opencode-plugin)
 - Rust stable, edition 2024, MSRV 1.85.0 (binary already built by workspace). Shell scripts: POSIX sh + PowerShell 5.1+. + cross-rs (CI only, for Linux musl cross-compilation), `houseabsolute/actions-rust-cross` GitHub Action. No new Rust crate dependencies. (009-plugin-packaging)
 - N/A (no new storage; existing `.mv2` files are preserved, never touched). (009-plugin-packaging)
 - Rust stable, edition 2024, MSRV 1.85.0 + memvid-core (pinned rev `fbddef4`), criterion 0.5 (benchmarks), cargo-fuzz/libFuzzer (fuzz testing), serde/serde_json (fixture parsing), tempfile (test isolation), assert_cmd/predicates (CLI tests) (010-testing-migration)
 - `.mv2` files via memvid-core (read/write compatibility), `tests/fixtures/` (committed test data) (010-testing-migration)
+- Rust stable, edition 2024, MSRV 1.85.0 + serde, serde_json, fs2, chrono (all existing workspace deps) (012-default-memory-path)
+- `.mv2` files on local filesystem, `.dedup-cache.json`, `.install-version` (012-default-memory-path)
 
 All crates already present in workspace `Cargo.toml`. Diagnostics are in-memory only; memory path resolution produces paths but does not perform I/O.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror 2.0.18",
  "types",
  "uuid",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All of the following must pass before merge:
 
 Canonical runtime memory-path resolution is owned by `platforms::resolve_memory_path(...)`.
 
-- Default mode (`MEMVID_PLATFORM_PATH_OPT_IN` unset): `.agent-brain/mind.mv2`
+- Default mode (`MEMVID_PLATFORM_PATH_OPT_IN` unset): `.rusty-brain/mind.mv2`
 - Platform opt-in mode (`MEMVID_PLATFORM_PATH_OPT_IN=1`): `.{platform}/mind-{platform}.mv2`
 - Explicit override (`MEMVID_PLATFORM_MEMORY_PATH`) takes precedence over policy resolution
 - CLI override (`--memory-path`) takes precedence over all environment-based resolution

--- a/RUST_ROADMAP.md
+++ b/RUST_ROADMAP.md
@@ -114,7 +114,7 @@ Equivalent to: project scaffolding, `tsconfig.json`, `tsup.config.ts`, `package.
 - [ ] `SessionSummary` — struct with session-level aggregation fields (`id`, `start_time`, `end_time`, `observation_count`, `key_decisions`, `files_modified`, `summary`)
 - [ ] `InjectedContext` — struct for context returned at session start (`recent_observations`, `relevant_memories`, `session_summaries`, `token_count`)
 - [ ] `MindConfig` — struct with defaults:
-  - `memory_path`: `.agent-brain/mind.mv2`
+  - `memory_path`: `.rusty-brain/mind.mv2`
   - `max_context_observations`: 20
   - `max_context_tokens`: 2000
   - `auto_compress`: true
@@ -362,8 +362,8 @@ Equivalent to: `src/__tests__/` (48 test files), plus Rust-specific quality impr
 
 - [ ] **Zero-migration `.mv2` files** — Rust version reads/writes the same `.mv2` format natively (no conversion needed)
 - [ ] **Configuration compatibility** — honor all existing env vars (`MEMVID_PLATFORM`, `MEMVID_MIND_DEBUG`, `MEMVID_PLATFORM_MEMORY_PATH`, `MEMVID_PLATFORM_PATH_OPT_IN`, `CLAUDE_PROJECT_DIR`, `OPENCODE_PROJECT_DIR`)
-- [ ] **Directory structure compatibility** — use identical `.agent-brain/` directory layout
-- [ ] **Legacy path migration** — detect `.claude/mind.mv2` and suggest move to `.agent-brain/mind.mv2`
+- [ ] **Directory structure compatibility** — use identical `.rusty-brain/` directory layout
+- [ ] **Legacy path migration** — detect `.claude/mind.mv2` and suggest move to `.rusty-brain/mind.mv2`
 - [ ] **Side-by-side testing** — verify Rust and TS versions produce identical search results for the same `.mv2` file
 - [ ] Document the switch: update `plugin.json` to point hook paths at Rust binaries instead of `dist/hooks/*.js`
 

--- a/crates/hooks/src/bootstrap.rs
+++ b/crates/hooks/src/bootstrap.rs
@@ -1,5 +1,5 @@
 pub use platforms::bootstrap::{
-    Diagnostic, DiagnosticLevel, detect_legacy_path, platform_opt_in, should_process,
+    Diagnostic, DiagnosticLevel, detect_legacy_paths, platform_opt_in, should_process,
 };
 
 use std::path::Path;

--- a/crates/hooks/src/context.rs
+++ b/crates/hooks/src/context.rs
@@ -105,11 +105,11 @@ mod tests {
     fn format_system_message_contains_memory_path() {
         let ctx = InjectedContext::default();
         let stats = make_empty_stats();
-        let path = PathBuf::from("/home/user/.agent-brain/mind.mv2");
+        let path = PathBuf::from("/home/user/.rusty-brain/mind.mv2");
 
         let msg = format_system_message(&ctx, &stats, &path);
         assert!(
-            msg.contains("/home/user/.agent-brain/mind.mv2"),
+            msg.contains("/home/user/.rusty-brain/mind.mv2"),
             "message should contain the memory path"
         );
     }

--- a/crates/hooks/src/dedup.rs
+++ b/crates/hooks/src/dedup.rs
@@ -28,7 +28,7 @@ impl DedupCache {
     #[must_use]
     pub fn new(project_dir: &Path) -> Self {
         Self {
-            cache_path: project_dir.join(".agent-brain").join(CACHE_FILENAME),
+            cache_path: project_dir.join(".rusty-brain").join(CACHE_FILENAME),
         }
     }
 
@@ -181,11 +181,11 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn new_sets_cache_path_under_agent_brain_dir() {
+    fn new_sets_cache_path_under_rusty_brain_dir() {
         let cache = DedupCache::new(Path::new("/tmp/project"));
         assert_eq!(
             cache.cache_path,
-            PathBuf::from("/tmp/project/.agent-brain/.dedup-cache.json")
+            PathBuf::from("/tmp/project/.rusty-brain/.dedup-cache.json")
         );
     }
 

--- a/crates/hooks/src/post_tool_use.rs
+++ b/crates/hooks/src/post_tool_use.rs
@@ -29,8 +29,8 @@ pub fn handle_post_tool_use(input: &HookInput) -> Result<HookOutput, HookError> 
         });
     }
 
-    // Emit legacy path diagnostic (best-effort, non-blocking)
-    if let Some(diag) = bootstrap::detect_legacy_path(cwd) {
+    // Emit legacy path diagnostics (best-effort, non-blocking)
+    for diag in bootstrap::detect_legacy_paths(cwd) {
         match diag.level {
             bootstrap::DiagnosticLevel::Warning => {
                 tracing::warn!(diagnostic = %diag.message, "legacy path detected");

--- a/crates/hooks/src/session_start.rs
+++ b/crates/hooks/src/session_start.rs
@@ -47,8 +47,8 @@ pub fn handle_session_start(input: &HookInput) -> Result<HookOutput, HookError> 
     // Format system message
     let mut message = format_system_message(&ctx, &stats, &memory_path);
 
-    // Check for legacy memory path and emit diagnostic
-    if let Some(diag) = bootstrap::detect_legacy_path(cwd) {
+    // Check for legacy memory paths and emit diagnostics
+    for diag in bootstrap::detect_legacy_paths(cwd) {
         let label = match diag.level {
             bootstrap::DiagnosticLevel::Warning => "Warning",
             bootstrap::DiagnosticLevel::Info => "Info",

--- a/crates/hooks/src/smart_install.rs
+++ b/crates/hooks/src/smart_install.rs
@@ -16,7 +16,8 @@ const VERSION_FILENAME: &str = ".install-version";
 #[tracing::instrument(skip(input))]
 pub fn handle_smart_install(input: &HookInput) -> Result<HookOutput, HookError> {
     let cwd = Path::new(&input.cwd);
-    let version_path = cwd.join(VERSION_FILENAME);
+    let rusty_brain_dir = cwd.join(".rusty-brain");
+    let version_path = rusty_brain_dir.join(VERSION_FILENAME);
     let current_version = env!("CARGO_PKG_VERSION");
 
     let needs_write = match std::fs::read_to_string(&version_path) {
@@ -25,6 +26,8 @@ pub fn handle_smart_install(input: &HookInput) -> Result<HookOutput, HookError> 
     };
 
     if needs_write {
+        // Ensure .rusty-brain directory exists
+        std::fs::create_dir_all(&rusty_brain_dir)?;
         // Atomic write: temp file + rename (unique name avoids collisions)
         let tmp_path = version_path.with_extension(format!("tmp.{}", std::process::id()));
         std::fs::write(&tmp_path, current_version)?;
@@ -70,8 +73,11 @@ mod tests {
             "handle_smart_install should succeed: {result:?}"
         );
 
-        let version_path = tmp.path().join(VERSION_FILENAME);
-        assert!(version_path.exists(), ".install-version file should exist");
+        let version_path = tmp.path().join(".rusty-brain").join(VERSION_FILENAME);
+        assert!(
+            version_path.exists(),
+            ".rusty-brain/.install-version file should exist"
+        );
 
         let content = std::fs::read_to_string(&version_path).expect("should read version file");
         assert_eq!(
@@ -93,7 +99,9 @@ mod tests {
     #[test]
     fn handle_smart_install_skips_write_when_version_matches() {
         let tmp = tempfile::tempdir().expect("failed to create temp dir");
-        let version_path = tmp.path().join(VERSION_FILENAME);
+        let rusty_brain_dir = tmp.path().join(".rusty-brain");
+        std::fs::create_dir_all(&rusty_brain_dir).expect("create .rusty-brain dir");
+        let version_path = rusty_brain_dir.join(VERSION_FILENAME);
 
         // Pre-write the current version
         std::fs::write(&version_path, env!("CARGO_PKG_VERSION")).expect("pre-write should succeed");
@@ -106,7 +114,9 @@ mod tests {
     #[test]
     fn handle_smart_install_overwrites_stale_version() {
         let tmp = tempfile::tempdir().expect("failed to create temp dir");
-        let version_path = tmp.path().join(VERSION_FILENAME);
+        let rusty_brain_dir = tmp.path().join(".rusty-brain");
+        std::fs::create_dir_all(&rusty_brain_dir).expect("create .rusty-brain dir");
+        let version_path = rusty_brain_dir.join(VERSION_FILENAME);
 
         // Pre-write an old version
         std::fs::write(&version_path, "0.0.0-old").expect("pre-write should succeed");

--- a/crates/hooks/tests/dedup_test.rs
+++ b/crates/hooks/tests/dedup_test.rs
@@ -3,8 +3,8 @@ use hooks::dedup::DedupCache;
 #[test]
 fn is_duplicate_returns_false_for_new_entry() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
     assert!(!cache.is_duplicate("Read", "Read src/main.rs"));
 }
@@ -12,8 +12,8 @@ fn is_duplicate_returns_false_for_new_entry() {
 #[test]
 fn is_duplicate_returns_true_within_window() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
 
     cache.record("Read", "Read src/main.rs").unwrap();
@@ -23,8 +23,8 @@ fn is_duplicate_returns_true_within_window() {
 #[test]
 fn is_duplicate_returns_false_for_different_entry() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
 
     cache.record("Read", "Read src/main.rs").unwrap();
@@ -34,20 +34,20 @@ fn is_duplicate_returns_false_for_different_entry() {
 #[test]
 fn record_creates_cache_file() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
 
     cache.record("Edit", "Edited foo.rs").unwrap();
-    assert!(agent_brain_dir.join(".dedup-cache.json").exists());
+    assert!(rusty_brain_dir.join(".dedup-cache.json").exists());
 }
 
 #[test]
 fn corrupt_cache_file_treated_as_empty() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
-    std::fs::write(agent_brain_dir.join(".dedup-cache.json"), "not json!!!").unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
+    std::fs::write(rusty_brain_dir.join(".dedup-cache.json"), "not json!!!").unwrap();
 
     let cache = DedupCache::new(dir.path());
     // Should not panic or error — treated as empty (fail-open)
@@ -57,13 +57,13 @@ fn corrupt_cache_file_treated_as_empty() {
 #[test]
 fn record_uses_atomic_write() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
 
     cache.record("Read", "Read main.rs").unwrap();
     // File should be valid JSON after write
-    let content = std::fs::read_to_string(agent_brain_dir.join(".dedup-cache.json")).unwrap();
+    let content = std::fs::read_to_string(rusty_brain_dir.join(".dedup-cache.json")).unwrap();
     let _: serde_json::Value =
         serde_json::from_str(&content).expect("cache file must be valid JSON after atomic write");
 }
@@ -71,12 +71,12 @@ fn record_uses_atomic_write() {
 #[test]
 fn dedup_cache_stores_hashes_not_content() {
     let dir = tempfile::tempdir().unwrap();
-    let agent_brain_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).unwrap();
+    let rusty_brain_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).unwrap();
     let cache = DedupCache::new(dir.path());
 
     cache.record("Read", "Read secrets/api-key.txt").unwrap();
-    let content = std::fs::read_to_string(agent_brain_dir.join(".dedup-cache.json")).unwrap();
+    let content = std::fs::read_to_string(rusty_brain_dir.join(".dedup-cache.json")).unwrap();
     // SEC-2: cache must NOT contain the actual tool name or summary text
     assert!(
         !content.contains("secrets/api-key.txt"),

--- a/crates/hooks/tests/env_compat_test.rs
+++ b/crates/hooks/tests/env_compat_test.rs
@@ -283,7 +283,7 @@ fn memvid_platform_memory_path_unset_uses_default() {
             let cfg = MindConfig::from_env().expect("should parse");
             assert_eq!(
                 cfg.memory_path,
-                PathBuf::from(".agent-brain/mind.mv2"),
+                PathBuf::from(".rusty-brain/mind.mv2"),
                 "unset path should use default"
             );
         },
@@ -349,7 +349,7 @@ fn memvid_platform_path_opt_in_false_uses_legacy_path() {
             let path =
                 hooks::bootstrap::resolve_memory_path(&input, tmp.path()).expect("should resolve");
             assert!(
-                path.to_str().unwrap().contains(".agent-brain/mind.mv2"),
+                path.to_str().unwrap().contains(".rusty-brain/mind.mv2"),
                 "non-opt-in should use legacy path: {path:?}"
             );
         },
@@ -372,7 +372,7 @@ fn memvid_platform_path_opt_in_unset_uses_legacy_path() {
             let path =
                 hooks::bootstrap::resolve_memory_path(&input, tmp.path()).expect("should resolve");
             assert!(
-                path.to_str().unwrap().contains(".agent-brain/mind.mv2"),
+                path.to_str().unwrap().contains(".rusty-brain/mind.mv2"),
                 "unset opt-in should use legacy path: {path:?}"
             );
         },

--- a/crates/hooks/tests/layout_compat_test.rs
+++ b/crates/hooks/tests/layout_compat_test.rs
@@ -1,7 +1,7 @@
 //! T043: Directory layout assertion tests.
 //!
-//! Verifies that the `.agent-brain/` directory structure matches the expected
-//! TypeScript-era layout: `mind.mv2`, `.dedup-cache.json`, `.install-version`.
+//! Verifies that the `.rusty-brain/` directory structure matches the expected
+//! layout: `mind.mv2`, `.dedup-cache.json`, `.install-version`.
 
 mod common;
 
@@ -25,11 +25,11 @@ fn make_input(cwd: &str) -> HookInput {
 }
 
 // ---------------------------------------------------------------------------
-// Default path resolution produces .agent-brain/mind.mv2
+// Default path resolution produces .rusty-brain/mind.mv2
 // ---------------------------------------------------------------------------
 
 #[test]
-fn resolve_memory_path_points_to_agent_brain_dir() {
+fn resolve_memory_path_points_to_rusty_brain_dir() {
     let tmp = tempfile::tempdir().expect("tempdir");
     temp_env::with_vars(
         [
@@ -44,31 +44,31 @@ fn resolve_memory_path_points_to_agent_brain_dir() {
             let path =
                 hooks::bootstrap::resolve_memory_path(&input, tmp.path()).expect("should resolve");
 
-            // Path should end with .agent-brain/mind.mv2
+            // Path should end with .rusty-brain/mind.mv2
             assert!(
-                path.ends_with(".agent-brain/mind.mv2"),
-                "resolved path should end with .agent-brain/mind.mv2, got: {path:?}"
+                path.ends_with(".rusty-brain/mind.mv2"),
+                "resolved path should end with .rusty-brain/mind.mv2, got: {path:?}"
             );
 
-            // Parent should be .agent-brain directory
+            // Parent should be .rusty-brain directory
             let parent = path.parent().expect("path should have parent");
             assert!(
-                parent.ends_with(".agent-brain"),
-                "parent dir should be .agent-brain, got: {parent:?}"
+                parent.ends_with(".rusty-brain"),
+                "parent dir should be .rusty-brain, got: {parent:?}"
             );
         },
     );
 }
 
 // ---------------------------------------------------------------------------
-// Expected file layout under .agent-brain/
+// Expected file layout under .rusty-brain/
 // ---------------------------------------------------------------------------
 
 #[test]
 fn agent_brain_dir_expected_files_can_be_constructed() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain_dir = tmp.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).expect("create .agent-brain dir");
+    let agent_brain_dir = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&agent_brain_dir).expect("create .rusty-brain dir");
 
     let expected_files = ["mind.mv2", ".dedup-cache.json", ".install-version"];
 
@@ -82,8 +82,8 @@ fn agent_brain_dir_expected_files_can_be_constructed() {
 #[test]
 fn agent_brain_dir_structure_matches_typescript_layout() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain_dir = tmp.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain_dir).expect("create .agent-brain dir");
+    let agent_brain_dir = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&agent_brain_dir).expect("create .rusty-brain dir");
 
     // Simulate the full layout the TypeScript version creates
     std::fs::write(agent_brain_dir.join("mind.mv2"), b"fake-mv2").expect("write mind.mv2");
@@ -105,7 +105,7 @@ fn agent_brain_dir_structure_matches_typescript_layout() {
     assert_eq!(
         entries.len(),
         3,
-        "should have exactly 3 entries in .agent-brain/, got: {entries:?}"
+        "should have exactly 3 entries in .rusty-brain/, got: {entries:?}"
     );
 }
 
@@ -117,10 +117,10 @@ fn smart_install_writes_install_version_in_cwd() {
     let result = hooks::smart_install::handle_smart_install(&input);
     assert!(result.is_ok(), "smart_install should succeed: {result:?}");
 
-    let version_path = tmp.path().join(".install-version");
+    let version_path = tmp.path().join(".rusty-brain").join(".install-version");
     assert!(
         version_path.exists(),
-        ".install-version should be written to cwd"
+        ".rusty-brain/.install-version should be written"
     );
 
     let content = std::fs::read_to_string(&version_path).expect("read version");

--- a/crates/hooks/tests/layout_compat_test.rs
+++ b/crates/hooks/tests/layout_compat_test.rs
@@ -65,40 +65,40 @@ fn resolve_memory_path_points_to_rusty_brain_dir() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn agent_brain_dir_expected_files_can_be_constructed() {
+fn rusty_brain_dir_expected_files_can_be_constructed() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain_dir = tmp.path().join(".rusty-brain");
-    std::fs::create_dir_all(&agent_brain_dir).expect("create .rusty-brain dir");
+    let rusty_brain_dir = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).expect("create .rusty-brain dir");
 
     let expected_files = ["mind.mv2", ".dedup-cache.json", ".install-version"];
 
     for filename in &expected_files {
-        let file_path = agent_brain_dir.join(filename);
+        let file_path = rusty_brain_dir.join(filename);
         std::fs::write(&file_path, "").expect("write placeholder");
         assert!(file_path.exists(), "expected file should exist: {filename}");
     }
 }
 
 #[test]
-fn agent_brain_dir_structure_matches_typescript_layout() {
+fn rusty_brain_dir_structure_matches_expected_layout() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain_dir = tmp.path().join(".rusty-brain");
-    std::fs::create_dir_all(&agent_brain_dir).expect("create .rusty-brain dir");
+    let rusty_brain_dir = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).expect("create .rusty-brain dir");
 
-    // Simulate the full layout the TypeScript version creates
-    std::fs::write(agent_brain_dir.join("mind.mv2"), b"fake-mv2").expect("write mind.mv2");
-    std::fs::write(agent_brain_dir.join(".dedup-cache.json"), b"{}")
+    // Simulate the full layout
+    std::fs::write(rusty_brain_dir.join("mind.mv2"), b"fake-mv2").expect("write mind.mv2");
+    std::fs::write(rusty_brain_dir.join(".dedup-cache.json"), b"{}")
         .expect("write .dedup-cache.json");
-    std::fs::write(agent_brain_dir.join(".install-version"), b"0.1.0")
+    std::fs::write(rusty_brain_dir.join(".install-version"), b"0.1.0")
         .expect("write .install-version");
 
     // Verify all three files exist
-    assert!(agent_brain_dir.join("mind.mv2").exists());
-    assert!(agent_brain_dir.join(".dedup-cache.json").exists());
-    assert!(agent_brain_dir.join(".install-version").exists());
+    assert!(rusty_brain_dir.join("mind.mv2").exists());
+    assert!(rusty_brain_dir.join(".dedup-cache.json").exists());
+    assert!(rusty_brain_dir.join(".install-version").exists());
 
     // Verify no unexpected subdirectories
-    let entries: Vec<_> = std::fs::read_dir(&agent_brain_dir)
+    let entries: Vec<_> = std::fs::read_dir(&rusty_brain_dir)
         .expect("read dir")
         .filter_map(Result::ok)
         .collect();
@@ -110,7 +110,7 @@ fn agent_brain_dir_structure_matches_typescript_layout() {
 }
 
 #[test]
-fn smart_install_writes_install_version_in_cwd() {
+fn smart_install_writes_install_version_in_rusty_brain() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let input = common::smart_install_input(tmp.path().to_str().unwrap());
 

--- a/crates/hooks/tests/legacy_path_test.rs
+++ b/crates/hooks/tests/legacy_path_test.rs
@@ -1,22 +1,20 @@
 mod common;
 
-use hooks::bootstrap::{Diagnostic, DiagnosticLevel, detect_legacy_path};
+use hooks::bootstrap::{DiagnosticLevel, detect_legacy_paths};
 
-/// T072: Integration test — create temp directory with `.claude/mind.mv2`,
-/// run detection logic, verify structured diagnostic in output.
+/// Integration test — `.claude/mind.mv2` exists alone → suggests migration to .rusty-brain
 #[test]
-fn legacy_only_returns_migration_warning() {
+fn claude_only_suggests_rusty_brain_migration() {
     let dir = tempfile::tempdir().unwrap();
 
-    // Set up legacy path only
     let legacy_dir = dir.path().join(".claude");
     std::fs::create_dir_all(&legacy_dir).unwrap();
     std::fs::write(legacy_dir.join("mind.mv2"), b"fake mv2 data").unwrap();
 
-    let result = detect_legacy_path(dir.path());
+    let result = detect_legacy_paths(dir.path());
 
-    assert!(result.is_some(), "should detect legacy path");
-    let diag = result.unwrap();
+    assert!(!result.is_empty(), "should detect legacy path");
+    let diag = &result[0];
     assert_eq!(diag.level, DiagnosticLevel::Warning);
     assert!(
         diag.message.contains(".claude/mind.mv2"),
@@ -24,56 +22,101 @@ fn legacy_only_returns_migration_warning() {
         diag.message
     );
     assert!(
-        diag.message.to_lowercase().contains("migrate"),
-        "diagnostic should suggest migration: {}",
+        diag.message.contains(".rusty-brain"),
+        "diagnostic should suggest migration to .rusty-brain: {}",
         diag.message
     );
 }
 
+/// .agent-brain only (no .rusty-brain) → Info with migration suggestion
 #[test]
-fn both_paths_returns_duplicate_warning() {
+fn agent_brain_only_suggests_migration() {
     let dir = tempfile::tempdir().unwrap();
 
-    // Set up both paths
+    let agent_dir = dir.path().join(".agent-brain");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("mind.mv2"), b"agent data").unwrap();
+
+    let result = detect_legacy_paths(dir.path());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].level, DiagnosticLevel::Info);
+    assert!(
+        result[0].message.contains("mv .agent-brain .rusty-brain"),
+        "diagnostic should contain actionable mv command: {}",
+        result[0].message
+    );
+}
+
+/// Both .agent-brain and .rusty-brain exist → Warning about duplicate
+#[test]
+fn both_agent_brain_and_rusty_brain_warns_duplicate() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let agent_dir = dir.path().join(".agent-brain");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("mind.mv2"), b"agent data").unwrap();
+
+    let rusty_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_dir).unwrap();
+    std::fs::write(rusty_dir.join("mind.mv2"), b"rusty data").unwrap();
+
+    let result = detect_legacy_paths(dir.path());
+
+    assert!(!result.is_empty());
+    assert!(
+        result
+            .iter()
+            .any(|d| d.level == DiagnosticLevel::Warning && d.message.contains("Duplicate"))
+    );
+}
+
+/// Both .claude and .agent-brain exist (no .rusty-brain)
+#[test]
+fn claude_and_agent_brain_both_detected() {
+    let dir = tempfile::tempdir().unwrap();
+
     let legacy_dir = dir.path().join(".claude");
     std::fs::create_dir_all(&legacy_dir).unwrap();
-    std::fs::write(legacy_dir.join("mind.mv2"), b"legacy data").unwrap();
+    std::fs::write(legacy_dir.join("mind.mv2"), b"claude data").unwrap();
 
-    let canonical_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&canonical_dir).unwrap();
-    std::fs::write(canonical_dir.join("mind.mv2"), b"canonical data").unwrap();
+    let agent_dir = dir.path().join(".agent-brain");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("mind.mv2"), b"agent data").unwrap();
 
-    let result = detect_legacy_path(dir.path());
+    let result = detect_legacy_paths(dir.path());
 
-    assert!(result.is_some(), "should detect duplicate paths");
-    let diag = result.unwrap();
-    assert_eq!(diag.level, DiagnosticLevel::Warning);
+    // Should have diagnostics for both .agent-brain (Info) and .claude (Warning)
     assert!(
-        diag.message.contains(".agent-brain/mind.mv2"),
-        "diagnostic should reference canonical path: {}",
-        diag.message
+        result.len() >= 2,
+        "should detect both legacy paths, got {}",
+        result.len()
     );
 }
 
+/// Only .rusty-brain exists → no diagnostics
 #[test]
-fn canonical_only_returns_none() {
+fn rusty_brain_only_returns_empty() {
     let dir = tempfile::tempdir().unwrap();
 
-    // Set up only canonical path
-    let canonical_dir = dir.path().join(".agent-brain");
-    std::fs::create_dir_all(&canonical_dir).unwrap();
-    std::fs::write(canonical_dir.join("mind.mv2"), b"canonical data").unwrap();
+    let rusty_dir = dir.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_dir).unwrap();
+    std::fs::write(rusty_dir.join("mind.mv2"), b"rusty data").unwrap();
 
-    let result = detect_legacy_path(dir.path());
-    assert!(result.is_none(), "no diagnostic for canonical-only setup");
+    let result = detect_legacy_paths(dir.path());
+    assert!(
+        result.is_empty(),
+        "no diagnostic for rusty-brain-only setup"
+    );
 }
 
+/// Neither path exists → no diagnostics
 #[test]
-fn neither_path_returns_none() {
+fn neither_path_returns_empty() {
     let dir = tempfile::tempdir().unwrap();
 
-    let result = detect_legacy_path(dir.path());
-    assert!(result.is_none(), "no diagnostic when neither path exists");
+    let result = detect_legacy_paths(dir.path());
+    assert!(result.is_empty(), "no diagnostic when neither path exists");
 }
 
 /// Verify diagnostic wiring in session_start output.
@@ -81,7 +124,7 @@ fn neither_path_returns_none() {
 fn session_start_includes_legacy_diagnostic_in_system_message() {
     let dir = tempfile::tempdir().unwrap();
 
-    // Create legacy path
+    // Create legacy .claude path
     let legacy_dir = dir.path().join(".claude");
     std::fs::create_dir_all(&legacy_dir).unwrap();
     std::fs::write(legacy_dir.join("mind.mv2"), b"fake mv2").unwrap();
@@ -97,7 +140,7 @@ fn session_start_includes_legacy_diagnostic_in_system_message() {
         "system message should contain warning label: {msg}"
     );
     assert!(
-        msg.contains(".claude/mind.mv2"),
-        "system message should mention legacy path: {msg}"
+        msg.contains(".rusty-brain"),
+        "system message should mention .rusty-brain migration target: {msg}"
     );
 }

--- a/crates/hooks/tests/legacy_path_test.rs
+++ b/crates/hooks/tests/legacy_path_test.rs
@@ -42,8 +42,8 @@ fn agent_brain_only_suggests_migration() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].level, DiagnosticLevel::Info);
     assert!(
-        result[0].message.contains("mv .agent-brain .rusty-brain"),
-        "diagnostic should contain actionable mv command: {}",
+        result[0].message.contains("mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"),
+        "diagnostic should contain safe file-level mv command: {}",
         result[0].message
     );
 }

--- a/crates/hooks/tests/permissions_test.rs
+++ b/crates/hooks/tests/permissions_test.rs
@@ -70,23 +70,23 @@ fn smart_install_error_is_hookioerror_variant() {
 
 #[cfg(unix)]
 #[test]
-fn readonly_agent_brain_dir_prevents_mv2_creation() {
+fn readonly_rusty_brain_dir_prevents_mv2_creation() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain = tmp.path().join(".rusty-brain");
-    std::fs::create_dir_all(&agent_brain).expect("create .rusty-brain");
+    let rusty_brain = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain).expect("create .rusty-brain");
 
     // Make .rusty-brain read-only
-    std::fs::set_permissions(&agent_brain, std::fs::Permissions::from_mode(0o444))
+    std::fs::set_permissions(&rusty_brain, std::fs::Permissions::from_mode(0o444))
         .expect("set permissions");
 
     // Attempt to write a file inside the read-only directory
-    let test_file = agent_brain.join("test-write.tmp");
+    let test_file = rusty_brain.join("test-write.tmp");
     let write_result = std::fs::write(&test_file, "test");
 
     // Restore permissions before assertions
-    std::fs::set_permissions(&agent_brain, std::fs::Permissions::from_mode(0o755))
+    std::fs::set_permissions(&rusty_brain, std::fs::Permissions::from_mode(0o755))
         .expect("restore permissions");
 
     assert!(
@@ -108,11 +108,11 @@ fn dedup_cache_unwritable_produces_error() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain = tmp.path().join(".rusty-brain");
-    std::fs::create_dir_all(&agent_brain).expect("create .rusty-brain");
+    let rusty_brain = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain).expect("create .rusty-brain");
 
     // Create the dedup cache file as read-only
-    let dedup_path = agent_brain.join(".dedup-cache.json");
+    let dedup_path = rusty_brain.join(".dedup-cache.json");
     std::fs::write(&dedup_path, "{}").expect("write initial cache");
     std::fs::set_permissions(&dedup_path, std::fs::Permissions::from_mode(0o444))
         .expect("set read-only");

--- a/crates/hooks/tests/permissions_test.rs
+++ b/crates/hooks/tests/permissions_test.rs
@@ -74,10 +74,10 @@ fn readonly_agent_brain_dir_prevents_mv2_creation() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain = tmp.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain).expect("create .agent-brain");
+    let agent_brain = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&agent_brain).expect("create .rusty-brain");
 
-    // Make .agent-brain read-only
+    // Make .rusty-brain read-only
     std::fs::set_permissions(&agent_brain, std::fs::Permissions::from_mode(0o444))
         .expect("set permissions");
 
@@ -91,7 +91,7 @@ fn readonly_agent_brain_dir_prevents_mv2_creation() {
 
     assert!(
         write_result.is_err(),
-        "writing to read-only .agent-brain/ should fail"
+        "writing to read-only .rusty-brain/ should fail"
     );
 
     let err = write_result.unwrap_err();
@@ -108,8 +108,8 @@ fn dedup_cache_unwritable_produces_error() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let agent_brain = tmp.path().join(".agent-brain");
-    std::fs::create_dir_all(&agent_brain).expect("create .agent-brain");
+    let agent_brain = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&agent_brain).expect("create .rusty-brain");
 
     // Create the dedup cache file as read-only
     let dedup_path = agent_brain.join(".dedup-cache.json");
@@ -136,9 +136,11 @@ fn install_version_unwritable_produces_error() {
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempfile::tempdir().expect("tempdir");
+    let rusty_brain_dir = tmp.path().join(".rusty-brain");
+    std::fs::create_dir_all(&rusty_brain_dir).expect("create .rusty-brain dir");
 
     // Create .install-version as read-only
-    let version_path = tmp.path().join(".install-version");
+    let version_path = rusty_brain_dir.join(".install-version");
     std::fs::write(&version_path, "0.0.0-old").expect("write old version");
     std::fs::set_permissions(&version_path, std::fs::Permissions::from_mode(0o444))
         .expect("set read-only");

--- a/crates/opencode/tests/chat_hook_test.rs
+++ b/crates/opencode/tests/chat_hook_test.rs
@@ -122,7 +122,7 @@ fn memory_path_uses_legacy_first() {
     assert!(result.is_ok());
 
     // Verify the legacy path was created
-    let legacy_path = cwd.join(".agent-brain").join("mind.mv2");
+    let legacy_path = cwd.join(".rusty-brain").join("mind.mv2");
     assert!(
         legacy_path.exists(),
         "legacy memory path should be created: {}",
@@ -137,7 +137,7 @@ fn invalid_cwd_returns_error() {
     let dir = tempfile::tempdir().unwrap();
     let blocker = dir.path().join("blocker");
     std::fs::write(&blocker, "not a directory").unwrap();
-    // cwd is a child of a file — creating .agent-brain/ under it is impossible
+    // cwd is a child of a file — creating .rusty-brain/ under it is impossible
     let cwd = blocker.join("fake_project");
     let input = make_hook_input(&cwd.to_string_lossy());
 

--- a/crates/opencode/tests/env_compat_test.rs
+++ b/crates/opencode/tests/env_compat_test.rs
@@ -163,7 +163,7 @@ fn resolve_memory_path_with_valid_dir() {
             let path = result.unwrap();
             // Without opt-in, should use canonical path
             assert!(
-                path.to_string_lossy().contains(".agent-brain/mind.mv2"),
+                path.to_string_lossy().contains(".rusty-brain/mind.mv2"),
                 "without opt-in, should use canonical path: {}",
                 path.display()
             );
@@ -235,7 +235,7 @@ fn mind_config_uses_legacy_path_without_opt_in() {
             assert!(
                 cfg.memory_path
                     .to_string_lossy()
-                    .contains(".agent-brain/mind.mv2"),
+                    .contains(".rusty-brain/mind.mv2"),
                 "without opt-in, config should use canonical path: {}",
                 cfg.memory_path.display()
             );
@@ -284,7 +284,7 @@ fn mind_config_empty_memory_path_env_falls_back_to_platform_resolution() {
             assert!(
                 cfg.memory_path
                     .to_string_lossy()
-                    .contains(".agent-brain/mind.mv2"),
+                    .contains(".rusty-brain/mind.mv2"),
                 "empty MEMVID_PLATFORM_MEMORY_PATH should fall back to platform resolution: {}",
                 cfg.memory_path.display()
             );

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 temp-env = { workspace = true }
+tempfile = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }

--- a/crates/platforms/src/bootstrap.rs
+++ b/crates/platforms/src/bootstrap.rs
@@ -25,7 +25,8 @@ pub struct Diagnostic {
 pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
-    let rusty_brain = project_root.join(".rusty-brain/mind.mv2");
+    let canonical = format!("{}/mind.mv2", crate::DEFAULT_MEMORY_DIR);
+    let rusty_brain = project_root.join(&canonical);
     let agent_brain = project_root.join(crate::LEGACY_AGENT_BRAIN_PATH);
     let claude_legacy = project_root.join(crate::LEGACY_CLAUDE_MEMORY_PATH);
 
@@ -38,14 +39,18 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
         diagnostics.push(Diagnostic {
             level: DiagnosticLevel::Info,
             message: format!(
-                "Using legacy memory file at `{}`. Migrate to `.rusty-brain/mind.mv2`: `mv .agent-brain .rusty-brain`",
-                crate::LEGACY_AGENT_BRAIN_PATH
+                "Using legacy memory file at `{}`. Migrate to `{canonical}`: \
+                 `mkdir -p {} && mv .agent-brain/mind.mv2 {canonical}`",
+                crate::LEGACY_AGENT_BRAIN_PATH,
+                crate::DEFAULT_MEMORY_DIR
             ),
         });
     } else if agent_exists && rusty_exists {
         diagnostics.push(Diagnostic {
             level: DiagnosticLevel::Warning,
-            message: "Duplicate memory files: using `.rusty-brain/mind.mv2`. Consider removing `.agent-brain/`.".to_string(),
+            message: format!(
+                "Duplicate memory files: using `{canonical}`. Consider removing `.agent-brain/`."
+            ),
         });
     }
 
@@ -53,7 +58,11 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
     if claude_exists {
         diagnostics.push(Diagnostic {
             level: DiagnosticLevel::Warning,
-            message: "Legacy memory file at `.claude/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`: `mv .claude .rusty-brain`".to_string(),
+            message: format!(
+                "Legacy memory file at `.claude/mind.mv2`. Migrate to `{canonical}`: \
+                 `mkdir -p {} && mv .claude/mind.mv2 {canonical}`",
+                crate::DEFAULT_MEMORY_DIR
+            ),
         });
     }
 
@@ -61,16 +70,16 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
 }
 
 /// Resolve the effective memory path, falling back to `.agent-brain/` if
-/// `.rusty-brain/` doesn't exist yet.
+/// `.rusty-brain/mind.mv2` doesn't exist yet.
 ///
 /// Resolution order:
-/// 1. `.rusty-brain/mind.mv2` — used if the file or directory exists
-/// 2. `.agent-brain/mind.mv2` — used if exists and `.rusty-brain/` doesn't
+/// 1. `.rusty-brain/mind.mv2` — used if the file exists
+/// 2. `.agent-brain/mind.mv2` — used if file exists and `.rusty-brain/mind.mv2` doesn't
 /// 3. `.rusty-brain/mind.mv2` — returned as default for new installations
 #[must_use]
 pub fn resolve_effective_path(project_root: &Path) -> std::path::PathBuf {
-    let rusty_brain = project_root.join(".rusty-brain/mind.mv2");
-    if rusty_brain.exists() || project_root.join(".rusty-brain").exists() {
+    let rusty_brain = project_root.join(crate::DEFAULT_MEMORY_DIR).join("mind.mv2");
+    if rusty_brain.exists() {
         return rusty_brain;
     }
 
@@ -164,7 +173,7 @@ mod tests {
         let result = detect_legacy_paths(dir.path());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].level, DiagnosticLevel::Info);
-        assert!(result[0].message.contains("mv .agent-brain .rusty-brain"));
+        assert!(result[0].message.contains("mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"));
     }
 
     #[test]
@@ -252,6 +261,26 @@ mod tests {
 
         let result = resolve_effective_path(dir.path());
         assert_eq!(result, dir.path().join(".agent-brain/mind.mv2"));
+    }
+
+    #[test]
+    fn resolve_effective_path_ignores_rusty_brain_dir_without_mv2() {
+        let dir = tempfile::tempdir().unwrap();
+        // .rusty-brain/ exists with only metadata (e.g. from smart_install)
+        let rusty_dir = dir.path().join(".rusty-brain");
+        std::fs::create_dir_all(&rusty_dir).unwrap();
+        std::fs::write(rusty_dir.join(".install-version"), b"0.1.0").unwrap();
+        // .agent-brain/mind.mv2 exists with actual memory data
+        let agent_dir = dir.path().join(".agent-brain");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = resolve_effective_path(dir.path());
+        assert_eq!(
+            result,
+            dir.path().join(".agent-brain/mind.mv2"),
+            "should fall back to .agent-brain when .rusty-brain has no mind.mv2"
+        );
     }
 
     #[test]

--- a/crates/platforms/src/bootstrap.rs
+++ b/crates/platforms/src/bootstrap.rs
@@ -16,35 +16,71 @@ pub struct Diagnostic {
     pub message: String,
 }
 
-/// Detect legacy `.claude/mind.mv2` path.
+/// Detect legacy memory paths and produce diagnostics.
+///
+/// Checks for `.agent-brain/mind.mv2` and `.claude/mind.mv2` relative to
+/// `project_root`. Returns diagnostics with migration instructions pointing
+/// to `.rusty-brain/mind.mv2`.
 #[must_use]
-pub fn detect_legacy_path(project_root: &Path) -> Option<Diagnostic> {
-    let legacy = project_root.join(crate::LEGACY_CLAUDE_MEMORY_PATH);
-    let canonical = project_root.join(".agent-brain/mind.mv2");
+pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
 
-    let legacy_exists = legacy.exists();
-    let canonical_exists = canonical.exists();
+    let rusty_brain = project_root.join(".rusty-brain/mind.mv2");
+    let agent_brain = project_root.join(crate::LEGACY_AGENT_BRAIN_PATH);
+    let claude_legacy = project_root.join(crate::LEGACY_CLAUDE_MEMORY_PATH);
 
-    match (legacy_exists, canonical_exists) {
-        (true, false) => Some(Diagnostic {
-            level: DiagnosticLevel::Warning,
+    let rusty_exists = rusty_brain.exists();
+    let agent_exists = agent_brain.exists();
+    let claude_exists = claude_legacy.exists();
+
+    // .agent-brain detection
+    if agent_exists && !rusty_exists {
+        diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Info,
             message: format!(
-                "Legacy memory file found at `{}`. Migrate to `{}` for the current Rust engine.",
-                crate::LEGACY_CLAUDE_MEMORY_PATH,
-                ".agent-brain/mind.mv2"
+                "Using legacy memory file at `{}`. Migrate to `.rusty-brain/mind.mv2`: `mv .agent-brain .rusty-brain`",
+                crate::LEGACY_AGENT_BRAIN_PATH
             ),
-        }),
-        (true, true) => Some(Diagnostic {
+        });
+    } else if agent_exists && rusty_exists {
+        diagnostics.push(Diagnostic {
             level: DiagnosticLevel::Warning,
-            message: format!(
-                "Duplicate memory files detected: both `{}` and `{}` exist. Using `{}`. Consider removing the legacy file.",
-                crate::LEGACY_CLAUDE_MEMORY_PATH,
-                ".agent-brain/mind.mv2",
-                ".agent-brain/mind.mv2"
-            ),
-        }),
-        _ => None,
+            message: "Duplicate memory files: using `.rusty-brain/mind.mv2`. Consider removing `.agent-brain/`.".to_string(),
+        });
     }
+
+    // .claude detection
+    if claude_exists {
+        diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Warning,
+            message: "Legacy memory file at `.claude/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`: `mv .claude .rusty-brain`".to_string(),
+        });
+    }
+
+    diagnostics
+}
+
+/// Resolve the effective memory path, falling back to `.agent-brain/` if
+/// `.rusty-brain/` doesn't exist yet.
+///
+/// Resolution order:
+/// 1. `.rusty-brain/mind.mv2` — used if the file or directory exists
+/// 2. `.agent-brain/mind.mv2` — used if exists and `.rusty-brain/` doesn't
+/// 3. `.rusty-brain/mind.mv2` — returned as default for new installations
+#[must_use]
+pub fn resolve_effective_path(project_root: &Path) -> std::path::PathBuf {
+    let rusty_brain = project_root.join(".rusty-brain/mind.mv2");
+    if rusty_brain.exists() || project_root.join(".rusty-brain").exists() {
+        return rusty_brain;
+    }
+
+    let agent_brain = project_root.join(crate::LEGACY_AGENT_BRAIN_PATH);
+    if agent_brain.exists() {
+        return agent_brain;
+    }
+
+    // New installation default
+    rusty_brain
 }
 
 #[must_use]
@@ -94,15 +130,148 @@ pub fn build_mind_config(
         .filter(|v| !v.is_empty())
         .is_none()
     {
-        let resolved =
-            resolve_memory_path(project_dir, platform_name, platform_opt_in()).map_err(|e| {
+        if platform_opt_in() {
+            let resolved = resolve_memory_path(project_dir, platform_name, true).map_err(|e| {
                 RustyBrainError::Configuration {
                     code: types::error_codes::E_CONFIG_INVALID_VALUE,
                     message: e.to_string(),
                 }
             })?;
-        config.memory_path = resolved.path;
+            config.memory_path = resolved.path;
+        } else {
+            config.memory_path = resolve_effective_path(project_dir);
+        }
     }
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // detect_legacy_paths
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_legacy_paths_agent_brain_only_suggests_migration() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join(".agent-brain");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = detect_legacy_paths(dir.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].level, DiagnosticLevel::Info);
+        assert!(result[0].message.contains("mv .agent-brain .rusty-brain"));
+    }
+
+    #[test]
+    fn detect_legacy_paths_both_dirs_warns_duplicate() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join(".agent-brain");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("mind.mv2"), b"data").unwrap();
+        let rusty_dir = dir.path().join(".rusty-brain");
+        std::fs::create_dir_all(&rusty_dir).unwrap();
+        std::fs::write(rusty_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = detect_legacy_paths(dir.path());
+        assert!(
+            result
+                .iter()
+                .any(|d| d.level == DiagnosticLevel::Warning && d.message.contains("Duplicate"))
+        );
+    }
+
+    #[test]
+    fn detect_legacy_paths_rusty_brain_only_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let rusty_dir = dir.path().join(".rusty-brain");
+        std::fs::create_dir_all(&rusty_dir).unwrap();
+        std::fs::write(rusty_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = detect_legacy_paths(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn detect_legacy_paths_claude_only_suggests_rusty_brain() {
+        let dir = tempfile::tempdir().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = detect_legacy_paths(dir.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].level, DiagnosticLevel::Warning);
+        assert!(result[0].message.contains(".rusty-brain"));
+    }
+
+    #[test]
+    fn detect_legacy_paths_all_three_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        for d in [".claude", ".agent-brain", ".rusty-brain"] {
+            let p = dir.path().join(d);
+            std::fs::create_dir_all(&p).unwrap();
+            std::fs::write(p.join("mind.mv2"), b"data").unwrap();
+        }
+
+        let result = detect_legacy_paths(dir.path());
+        // Should warn about .agent-brain duplicate + .claude legacy
+        assert!(result.len() >= 2);
+    }
+
+    #[test]
+    fn detect_legacy_paths_claude_and_agent_brain_no_rusty() {
+        let dir = tempfile::tempdir().unwrap();
+        for d in [".claude", ".agent-brain"] {
+            let p = dir.path().join(d);
+            std::fs::create_dir_all(&p).unwrap();
+            std::fs::write(p.join("mind.mv2"), b"data").unwrap();
+        }
+
+        let result = detect_legacy_paths(dir.path());
+        assert!(result.len() >= 2);
+        // .agent-brain → Info (migration), .claude → Warning
+        assert!(result.iter().any(|d| d.level == DiagnosticLevel::Info));
+        assert!(result.iter().any(|d| d.level == DiagnosticLevel::Warning));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_effective_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_effective_path_falls_back_to_agent_brain() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join(".agent-brain");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("mind.mv2"), b"data").unwrap();
+
+        let result = resolve_effective_path(dir.path());
+        assert_eq!(result, dir.path().join(".agent-brain/mind.mv2"));
+    }
+
+    #[test]
+    fn resolve_effective_path_prefers_rusty_brain() {
+        let dir = tempfile::tempdir().unwrap();
+        for d in [".agent-brain", ".rusty-brain"] {
+            let p = dir.path().join(d);
+            std::fs::create_dir_all(&p).unwrap();
+            std::fs::write(p.join("mind.mv2"), b"data").unwrap();
+        }
+
+        let result = resolve_effective_path(dir.path());
+        assert_eq!(result, dir.path().join(".rusty-brain/mind.mv2"));
+    }
+
+    #[test]
+    fn resolve_effective_path_new_install_returns_rusty_brain() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let result = resolve_effective_path(dir.path());
+        assert_eq!(result, dir.path().join(".rusty-brain/mind.mv2"));
+    }
 }

--- a/crates/platforms/src/lib.rs
+++ b/crates/platforms/src/lib.rs
@@ -28,8 +28,8 @@ pub use contract::{SUPPORTED_CONTRACT_MAJOR, validate_contract};
 pub use detection::detect_platform;
 pub use identity::resolve_project_identity;
 pub use path_policy::{
-    LEGACY_CLAUDE_MEMORY_PATH, PathMode, ResolvedMemoryPath, format_legacy_path_warning,
-    resolve_memory_path,
+    DEFAULT_MEMORY_DIR, LEGACY_AGENT_BRAIN_PATH, LEGACY_CLAUDE_MEMORY_PATH, PathMode,
+    ResolvedMemoryPath, format_legacy_path_warning, resolve_memory_path,
 };
 pub use pipeline::{EventPipeline, PipelineResult};
 pub use registry::AdapterRegistry;

--- a/crates/platforms/src/path_policy.rs
+++ b/crates/platforms/src/path_policy.rs
@@ -37,7 +37,7 @@ pub fn format_legacy_path_warning(canonical_path: &std::path::Path) -> String {
     format!(
         "\n**Note:** Legacy memory file detected at `{LEGACY_CLAUDE_MEMORY_PATH}`. \
          Current canonical path for this session is `{}`. \
-         Migrate with: `mv .claude .rusty-brain`\n",
+         Migrate with: `mkdir -p {DEFAULT_MEMORY_DIR} && mv .claude/mind.mv2 {DEFAULT_MEMORY_DIR}/mind.mv2`\n",
         canonical_path.display()
     )
 }
@@ -286,8 +286,8 @@ mod tests {
             "warning must mention the canonical path"
         );
         assert!(
-            warning.contains("mv .claude .rusty-brain"),
-            "warning must contain actionable mv command"
+            warning.contains("mkdir -p .rusty-brain && mv .claude/mind.mv2 .rusty-brain/mind.mv2"),
+            "warning must contain safe file-level mv command"
         );
     }
 

--- a/crates/platforms/src/path_policy.rs
+++ b/crates/platforms/src/path_policy.rs
@@ -1,8 +1,8 @@
 //! Memory file path policy resolution.
 //!
 //! Resolves the memory file path based on platform opt-in policy:
-//! - Default (no opt-in): `.agent-brain/mind.mv2` (FR-015, mode: LegacyFirst)
-//! - Platform opt-in: `.{platform}/mind-{platform}.mv2` (FR-015, mode: PlatformOptIn)
+//! - Default (no opt-in): `.rusty-brain/mind.mv2` (mode: Default)
+//! - Platform opt-in: `.{platform}/mind-{platform}.mv2` (mode: PlatformOptIn)
 //! - Platform name sanitized per FR-016
 //! - Resolved path MUST stay within project_dir (FR-014)
 
@@ -12,21 +12,23 @@ use types::AgentBrainError;
 use types::error::error_codes;
 use types::sanitize_platform_name;
 
-/// Default legacy memory file path relative to project root.
-const DEFAULT_LEGACY_PATH: &str = ".agent-brain/mind.mv2";
+/// New canonical memory directory name.
+pub const DEFAULT_MEMORY_DIR: &str = ".rusty-brain";
 
-/// Pre-canonical memory path used by early Claude Code integrations.
-///
-/// This path (`".claude/mind.mv2"`) predates the current canonical policy
-/// (`".agent-brain/mind.mv2"` or platform-scoped). When this file exists
-/// alongside the canonical path, a migration warning should be shown.
+/// Default memory file path relative to project root (new canonical).
+const DEFAULT_MEMORY_PATH: &str = ".rusty-brain/mind.mv2";
+
+/// Legacy memory file path from the agent-brain era.
+pub const LEGACY_AGENT_BRAIN_PATH: &str = ".agent-brain/mind.mv2";
+
+/// Oldest legacy memory file path from early Claude Code integrations.
 pub const LEGACY_CLAUDE_MEMORY_PATH: &str = ".claude/mind.mv2";
 
 /// Format the migration warning shown when a legacy memory file is detected.
 ///
 /// Returns a human-readable note suitable for appending to system messages.
 /// The `canonical_path` argument is the display form of the current session's
-/// resolved memory path.
+/// resolved memory path. Includes actionable `mv` commands for migration (FR-009).
 ///
 /// Does NOT perform filesystem I/O — the caller is responsible for checking
 /// whether the legacy file exists before calling this function.
@@ -34,7 +36,8 @@ pub const LEGACY_CLAUDE_MEMORY_PATH: &str = ".claude/mind.mv2";
 pub fn format_legacy_path_warning(canonical_path: &std::path::Path) -> String {
     format!(
         "\n**Note:** Legacy memory file detected at `{LEGACY_CLAUDE_MEMORY_PATH}`. \
-         Current canonical path for this session is `{}`.\n",
+         Current canonical path for this session is `{}`. \
+         Migrate with: `mv .claude .rusty-brain`\n",
         canonical_path.display()
     )
 }
@@ -43,8 +46,8 @@ pub fn format_legacy_path_warning(canonical_path: &std::path::Path) -> String {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathMode {
-    /// Legacy mode: `.agent-brain/mind.mv2` (no platform opt-in).
-    LegacyFirst,
+    /// Default mode: `.rusty-brain/mind.mv2` (no platform opt-in).
+    Default,
     /// Platform opt-in mode: `.{platform}/mind-{platform}.mv2`.
     PlatformOptIn,
 }
@@ -60,7 +63,7 @@ pub struct ResolvedMemoryPath {
 
 /// Resolve the memory file path based on path policy.
 ///
-/// - Default (no opt-in): `.agent-brain/mind.mv2` (FR-015, mode: `LegacyFirst`)
+/// - Default (no opt-in): `.rusty-brain/mind.mv2` (mode: `Default`)
 /// - Platform opt-in: `.{platform}/mind-{platform}.mv2` (FR-015, mode: `PlatformOptIn`)
 /// - Platform name sanitized per FR-016
 /// - Resolved path MUST stay within `project_dir` (FR-014)
@@ -82,7 +85,7 @@ pub fn resolve_memory_path(
     let relative = if platform_opt_in {
         PathBuf::from(format!(".{sanitized}/mind-{sanitized}.mv2"))
     } else {
-        PathBuf::from(DEFAULT_LEGACY_PATH)
+        PathBuf::from(DEFAULT_MEMORY_PATH)
     };
 
     let resolved = project_dir.join(&relative);
@@ -119,7 +122,7 @@ pub fn resolve_memory_path(
     let mode = if platform_opt_in {
         PathMode::PlatformOptIn
     } else {
-        PathMode::LegacyFirst
+        PathMode::Default
     };
 
     Ok(ResolvedMemoryPath {
@@ -139,8 +142,8 @@ mod tests {
         let result = resolve_memory_path(Path::new("/project"), "claude", false)
             .expect("legacy mode should succeed");
 
-        assert_eq!(result.path, PathBuf::from("/project/.agent-brain/mind.mv2"));
-        assert_eq!(result.mode, PathMode::LegacyFirst);
+        assert_eq!(result.path, PathBuf::from("/project/.rusty-brain/mind.mv2"));
+        assert_eq!(result.mode, PathMode::Default);
     }
 
     #[test]
@@ -256,8 +259,8 @@ mod tests {
         let r1 = resolve_memory_path(Path::new("/proj"), "claude", false).unwrap();
         let r2 = resolve_memory_path(Path::new("/proj"), "opencode", false).unwrap();
         assert_eq!(r1.path, r2.path);
-        assert_eq!(r1.mode, PathMode::LegacyFirst);
-        assert_eq!(r2.mode, PathMode::LegacyFirst);
+        assert_eq!(r1.mode, PathMode::Default);
+        assert_eq!(r2.mode, PathMode::Default);
     }
 
     // -------------------------------------------------------------------------
@@ -271,7 +274,7 @@ mod tests {
 
     #[test]
     fn format_legacy_path_warning_contains_both_paths() {
-        let canonical = Path::new("/project/.agent-brain/mind.mv2");
+        let canonical = Path::new("/project/.rusty-brain/mind.mv2");
         let warning = format_legacy_path_warning(canonical);
 
         assert!(
@@ -279,8 +282,12 @@ mod tests {
             "warning must mention the legacy path"
         );
         assert!(
-            warning.contains("/project/.agent-brain/mind.mv2"),
+            warning.contains("/project/.rusty-brain/mind.mv2"),
             "warning must mention the canonical path"
+        );
+        assert!(
+            warning.contains("mv .claude .rusty-brain"),
+            "warning must contain actionable mv command"
         );
     }
 

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -38,7 +38,7 @@ pub fn sanitize_platform_name(name: &str) -> String {
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct MindConfig {
-    /// Path to the memvid memory database file. Default: `.agent-brain/mind.mv2`.
+    /// Path to the memvid memory database file. Default: `.rusty-brain/mind.mv2`.
     pub memory_path: PathBuf,
     /// Maximum number of observations included in injected context. Default: 20.
     pub max_context_observations: u32,
@@ -60,7 +60,7 @@ pub struct MindConfig {
 impl Default for MindConfig {
     fn default() -> Self {
         Self {
-            memory_path: PathBuf::from(".agent-brain/mind.mv2"),
+            memory_path: PathBuf::from(".rusty-brain/mind.mv2"),
             max_context_observations: 20,
             max_context_tokens: 2000,
             auto_compress: true,

--- a/crates/types/tests/config_test.rs
+++ b/crates/types/tests/config_test.rs
@@ -25,9 +25,9 @@ where
 // -------------------------------------------------------------------------
 
 #[test]
-fn default_memory_path_is_agent_brain_mind_mv2() {
+fn default_memory_path_is_rusty_brain_mind_mv2() {
     let cfg = MindConfig::default();
-    assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+    assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn mind_config_json_round_trip_defaults() {
     );
     assert_eq!(
         deserialized.memory_path,
-        PathBuf::from(".agent-brain/mind.mv2")
+        PathBuf::from(".rusty-brain/mind.mv2")
     );
     assert_eq!(deserialized.max_context_observations, 20);
     assert_eq!(deserialized.max_context_tokens, 2000);
@@ -221,7 +221,7 @@ fn mind_config_partial_json_applies_defaults() {
     // Remaining fields must fall back to Default impl values.
     assert_eq!(
         deserialized.memory_path,
-        PathBuf::from(".agent-brain/mind.mv2"),
+        PathBuf::from(".rusty-brain/mind.mv2"),
         "memory_path must default when absent"
     );
     assert_eq!(
@@ -415,7 +415,7 @@ fn from_env_ignores_platform_detection_for_memory_path() {
         ],
         || {
             let cfg = MindConfig::from_env().expect("from_env must succeed");
-            assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+            assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
         },
     );
 }
@@ -433,7 +433,7 @@ fn from_env_ignores_claude_project_dir_for_memory_path() {
         ],
         || {
             let cfg = MindConfig::from_env().expect("from_env must succeed");
-            assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+            assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
         },
     );
 }
@@ -451,7 +451,7 @@ fn from_env_ignores_claude_project_dir_opt_in() {
         ],
         || {
             let cfg = MindConfig::from_env().expect("from_env must succeed");
-            assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+            assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
         },
     );
 }
@@ -469,7 +469,7 @@ fn from_env_ignores_opencode_project_dir_opt_in() {
         ],
         || {
             let cfg = MindConfig::from_env().expect("from_env must succeed");
-            assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+            assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
         },
     );
 }
@@ -549,7 +549,7 @@ fn from_env_does_not_construct_platform_scoped_path() {
         ],
         || {
             let cfg = MindConfig::from_env().expect("from_env must succeed");
-            assert_eq!(cfg.memory_path, PathBuf::from(".agent-brain/mind.mv2"));
+            assert_eq!(cfg.memory_path, PathBuf::from(".rusty-brain/mind.mv2"));
         },
     );
 }

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -16,7 +16,7 @@ Memory capture happens automatically through Claude Code hooks:
 
 ## Storage
 
-Memories are stored in `.agent-brain/mind.mv2` using memvid video-encoded format. This file is portable and persists across sessions.
+Memories are stored in `.rusty-brain/mind.mv2` using memvid video-encoded format. This file is portable and persists across sessions.
 
 ## Manual Memory Operations
 

--- a/skills/mind/SKILL.md
+++ b/skills/mind/SKILL.md
@@ -16,7 +16,7 @@ Search and manage Claude's persistent memory.
 
 ## Usage
 
-All memory operations use the `rusty-brain` CLI binary. Memories are stored in `.agent-brain/mind.mv2` and persist across conversations.
+All memory operations use the `rusty-brain` CLI binary. Memories are stored in `.rusty-brain/mind.mv2` and persist across conversations.
 
 ### Search memories
 ```bash

--- a/specs/012-default-memory-path/checklists/requirements.md
+++ b/specs/012-default-memory-path/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Default Memory Path Change
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The path resolution order (custom → .rusty-brain → .agent-brain → .claude) is well-defined and covers all migration scenarios.
+- FR-010 (documentation updates) has broad scope — the plan phase should enumerate all files needing updates.

--- a/specs/012-default-memory-path/contracts/bootstrap-api.rs
+++ b/specs/012-default-memory-path/contracts/bootstrap-api.rs
@@ -1,0 +1,43 @@
+// Contract: Updated bootstrap.rs API
+// Feature: 012-default-memory-path
+
+use std::path::Path;
+
+/// Diagnostic produced by legacy path detection.
+pub struct Diagnostic {
+    pub level: DiagnosticLevel,
+    pub message: String,
+}
+
+pub enum DiagnosticLevel {
+    Warning,
+    Info,
+}
+
+/// Detect legacy memory paths and produce diagnostics.
+///
+/// Checks for `.agent-brain/mind.mv2` and `.claude/mind.mv2` relative to
+/// `project_root`. Returns diagnostics with migration instructions pointing
+/// to `.rusty-brain/mind.mv2`.
+///
+/// Returns `Vec<Diagnostic>` (changed from `Option<Diagnostic>`) to support
+/// multiple legacy paths detected simultaneously.
+#[must_use]
+pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
+    todo!()
+}
+
+/// Resolve the effective memory path, falling back to `.agent-brain/` if
+/// `.rusty-brain/` doesn't exist yet.
+///
+/// Resolution order:
+/// 1. `.rusty-brain/mind.mv2` — used if the file or directory exists
+/// 2. `.agent-brain/mind.mv2` — used if exists and `.rusty-brain/` doesn't
+/// 3. `.rusty-brain/mind.mv2` — returned as default for new installations
+///
+/// Does NOT create directories. Returns the path to use; caller decides
+/// whether to create on write.
+#[must_use]
+pub fn resolve_effective_path(project_root: &Path) -> std::path::PathBuf {
+    todo!()
+}

--- a/specs/012-default-memory-path/contracts/dedup-api.rs
+++ b/specs/012-default-memory-path/contracts/dedup-api.rs
@@ -1,0 +1,24 @@
+// Contract: Updated DedupCache API
+// Feature: 012-default-memory-path
+
+use std::path::{Path, PathBuf};
+
+/// File-based deduplication cache for post-tool-use observations.
+///
+/// Cache path updated from `.agent-brain/.dedup-cache.json` to
+/// `.rusty-brain/.dedup-cache.json`.
+pub struct DedupCache {
+    cache_path: PathBuf,
+}
+
+impl DedupCache {
+    /// Create a new `DedupCache` for the given project directory.
+    ///
+    /// Cache file is stored at `<project_dir>/.rusty-brain/.dedup-cache.json`.
+    #[must_use]
+    pub fn new(project_dir: &Path) -> Self {
+        Self {
+            cache_path: project_dir.join(".rusty-brain").join(".dedup-cache.json"),
+        }
+    }
+}

--- a/specs/012-default-memory-path/contracts/path-policy-api.rs
+++ b/specs/012-default-memory-path/contracts/path-policy-api.rs
@@ -1,0 +1,25 @@
+// Contract: Updated path_policy.rs API
+// Feature: 012-default-memory-path
+
+/// New canonical memory directory name.
+pub const DEFAULT_MEMORY_DIR: &str = ".rusty-brain";
+
+/// Default memory file path relative to project root (new canonical).
+const DEFAULT_MEMORY_PATH: &str = ".rusty-brain/mind.mv2";
+
+/// Legacy memory file path from the agent-brain era.
+pub const LEGACY_AGENT_BRAIN_PATH: &str = ".agent-brain/mind.mv2";
+
+/// Oldest legacy memory file path from early Claude Code integrations.
+pub const LEGACY_CLAUDE_MEMORY_PATH: &str = ".claude/mind.mv2";
+
+/// All legacy paths in detection order (newest legacy first).
+pub const LEGACY_PATHS: &[&str] = &[LEGACY_AGENT_BRAIN_PATH, LEGACY_CLAUDE_MEMORY_PATH];
+
+/// Format migration instructions for a detected legacy path.
+///
+/// Returns actionable shell commands the user can run to migrate.
+#[must_use]
+pub fn format_migration_instructions(legacy_path: &str, canonical_path: &std::path::Path) -> String {
+    todo!()
+}

--- a/specs/012-default-memory-path/data-model.md
+++ b/specs/012-default-memory-path/data-model.md
@@ -1,0 +1,75 @@
+# Data Model: Default Memory Path Change
+
+**Feature**: 012-default-memory-path
+**Date**: 2026-03-05
+
+## Entities
+
+### Memory Directory Layout
+
+The `.rusty-brain/` directory is the self-contained data directory for rusty-brain at the repository root.
+
+```
+.rusty-brain/
+├── mind.mv2              # memvid-encoded memory database
+├── .dedup-cache.json     # hash-based dedup cache (post-tool-use)
+├── .dedup-cache.json.lock # file lock for dedup cache
+└── .install-version      # binary version marker for smart-install
+```
+
+### Path Resolution Order
+
+| Priority | Source | Path Pattern | Condition |
+|----------|--------|-------------|-----------|
+| 1 | `MEMVID_PLATFORM_MEMORY_PATH` env var | User-defined | Always wins when set |
+| 2 | Platform opt-in | `.{platform}/mind-{platform}.mv2` | `MEMVID_PLATFORM_PATH_OPT_IN=1` |
+| 3 | New canonical default | `.rusty-brain/mind.mv2` | Default (no override) |
+| 4 | Legacy fallback | `.agent-brain/mind.mv2` | Used if exists AND `.rusty-brain/mind.mv2` does NOT exist |
+| 5 | Oldest legacy (detect only) | `.claude/mind.mv2` | Detection/warning only — never used as runtime fallback |
+
+### Legacy Detection Matrix
+
+| `.claude/` exists | `.agent-brain/` exists | `.rusty-brain/` exists | Action |
+|---|---|---|---|
+| No | No | No | Create `.rusty-brain/mind.mv2` on first write |
+| No | No | Yes | Use `.rusty-brain/mind.mv2` |
+| No | Yes | No | Use `.agent-brain/mind.mv2` + suggest migration to `.rusty-brain/` |
+| No | Yes | Yes | Use `.rusty-brain/mind.mv2` + warn about duplicate at `.agent-brain/` |
+| Yes | No | No | Suggest migration from `.claude/` to `.rusty-brain/` |
+| Yes | No | Yes | Use `.rusty-brain/mind.mv2` + warn about `.claude/` |
+| Yes | Yes | No | Use `.agent-brain/mind.mv2` + suggest migration to `.rusty-brain/` + warn about `.claude/` |
+| Yes | Yes | Yes | Use `.rusty-brain/mind.mv2` + warn about both `.agent-brain/` and `.claude/` |
+
+### Constants
+
+| Constant | Old Value | New Value | Location |
+|----------|-----------|-----------|----------|
+| `DEFAULT_MEMORY_DIR` (new) | N/A | `.rusty-brain` | `crates/platforms/src/path_policy.rs` |
+| `DEFAULT_LEGACY_PATH` | `.agent-brain/mind.mv2` | `.rusty-brain/mind.mv2` | `crates/platforms/src/path_policy.rs` |
+| `LEGACY_AGENT_BRAIN_PATH` (new) | N/A | `.agent-brain/mind.mv2` | `crates/platforms/src/path_policy.rs` |
+| `LEGACY_CLAUDE_MEMORY_PATH` | `.claude/mind.mv2` | `.claude/mind.mv2` (unchanged) | `crates/platforms/src/path_policy.rs` |
+| `MindConfig::default().memory_path` | `.agent-brain/mind.mv2` | `.rusty-brain/mind.mv2` | `crates/types/src/config.rs` |
+
+### Diagnostic Messages
+
+| Scenario | Level | Message Template |
+|----------|-------|-----------------|
+| `.agent-brain/` only (no `.rusty-brain/`) | Info | "Using legacy memory file at `.agent-brain/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`: `mv .agent-brain .rusty-brain`" |
+| `.agent-brain/` + `.rusty-brain/` both exist | Warning | "Duplicate memory files: using `.rusty-brain/mind.mv2`. Consider removing `.agent-brain/`." |
+| `.claude/` exists (any combo) | Warning | "Legacy memory file at `.claude/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`." |
+
+## State Transitions
+
+```
+[No data directory] --first write--> [.rusty-brain/ created]
+[.agent-brain/ only] --user runs `mv`--> [.rusty-brain/ only]
+[.agent-brain/ + .rusty-brain/] --user removes old--> [.rusty-brain/ only]
+```
+
+No automatic state transitions occur — all migrations are user-initiated (FR-008).
+
+## Validation Rules
+
+- Memory path must stay within project directory (existing path traversal check)
+- Custom `MEMVID_PLATFORM_MEMORY_PATH` skips all legacy detection
+- Platform opt-in (`MEMVID_PLATFORM_PATH_OPT_IN=1`) skips legacy detection

--- a/specs/012-default-memory-path/data-model.md
+++ b/specs/012-default-memory-path/data-model.md
@@ -9,7 +9,7 @@
 
 The `.rusty-brain/` directory is the self-contained data directory for rusty-brain at the repository root.
 
-```
+```text
 .rusty-brain/
 ├── mind.mv2              # memvid-encoded memory database
 ├── .dedup-cache.json     # hash-based dedup cache (post-tool-use)
@@ -45,7 +45,7 @@ The `.rusty-brain/` directory is the self-contained data directory for rusty-bra
 | Constant | Old Value | New Value | Location |
 |----------|-----------|-----------|----------|
 | `DEFAULT_MEMORY_DIR` (new) | N/A | `.rusty-brain` | `crates/platforms/src/path_policy.rs` |
-| `DEFAULT_LEGACY_PATH` | `.agent-brain/mind.mv2` | `.rusty-brain/mind.mv2` | `crates/platforms/src/path_policy.rs` |
+| `DEFAULT_MEMORY_PATH` | `.agent-brain/mind.mv2` | `.rusty-brain/mind.mv2` | `crates/platforms/src/path_policy.rs` |
 | `LEGACY_AGENT_BRAIN_PATH` (new) | N/A | `.agent-brain/mind.mv2` | `crates/platforms/src/path_policy.rs` |
 | `LEGACY_CLAUDE_MEMORY_PATH` | `.claude/mind.mv2` | `.claude/mind.mv2` (unchanged) | `crates/platforms/src/path_policy.rs` |
 | `MindConfig::default().memory_path` | `.agent-brain/mind.mv2` | `.rusty-brain/mind.mv2` | `crates/types/src/config.rs` |
@@ -54,13 +54,13 @@ The `.rusty-brain/` directory is the self-contained data directory for rusty-bra
 
 | Scenario | Level | Message Template |
 |----------|-------|-----------------|
-| `.agent-brain/` only (no `.rusty-brain/`) | Info | "Using legacy memory file at `.agent-brain/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`: `mv .agent-brain .rusty-brain`" |
+| `.agent-brain/` only (no `.rusty-brain/`) | Info | "Using legacy memory file at `.agent-brain/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`: `mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2`" |
 | `.agent-brain/` + `.rusty-brain/` both exist | Warning | "Duplicate memory files: using `.rusty-brain/mind.mv2`. Consider removing `.agent-brain/`." |
 | `.claude/` exists (any combo) | Warning | "Legacy memory file at `.claude/mind.mv2`. Migrate to `.rusty-brain/mind.mv2`." |
 
 ## State Transitions
 
-```
+```text
 [No data directory] --first write--> [.rusty-brain/ created]
 [.agent-brain/ only] --user runs `mv`--> [.rusty-brain/ only]
 [.agent-brain/ + .rusty-brain/] --user removes old--> [.rusty-brain/ only]

--- a/specs/012-default-memory-path/plan.md
+++ b/specs/012-default-memory-path/plan.md
@@ -66,8 +66,8 @@ crates/
 │   ├── src/config.rs          # MindConfig::default() path constant
 │   └── tests/config_test.rs   # Default path assertions
 ├── platforms/
-│   ├── src/path_policy.rs     # DEFAULT_LEGACY_PATH, LEGACY_CLAUDE_MEMORY_PATH, resolve_memory_path()
-│   └── src/bootstrap.rs       # detect_legacy_path(), build_mind_config()
+│   ├── src/path_policy.rs     # DEFAULT_MEMORY_PATH, LEGACY_CLAUDE_MEMORY_PATH, resolve_memory_path()
+│   └── src/bootstrap.rs       # detect_legacy_paths(), build_mind_config()
 ├── hooks/
 │   ├── src/dedup.rs           # DedupCache::new() hardcoded path
 │   ├── src/smart_install.rs   # VERSION_FILENAME location

--- a/specs/012-default-memory-path/plan.md
+++ b/specs/012-default-memory-path/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Default Memory Path Change
+
+**Branch**: `012-default-memory-path` | **Date**: 2026-03-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-default-memory-path/spec.md`
+
+## Summary
+
+Change the default memory directory from `.agent-brain/` to `.rusty-brain/` across the entire codebase. This involves updating the default path constant, extending legacy path detection to a three-tier chain (`.claude/` → `.agent-brain/` → `.rusty-brain/`), adding runtime fallback to `.agent-brain/` for existing installations, moving supporting files (dedup cache, version marker) into the `.rusty-brain/` directory, and updating all documentation references.
+
+## Technical Context
+
+**Language/Version**: Rust stable, edition 2024, MSRV 1.85.0
+**Primary Dependencies**: serde, serde_json, fs2, chrono (all existing workspace deps)
+**Storage**: `.mv2` files on local filesystem, `.dedup-cache.json`, `.install-version`
+**Testing**: `cargo test` (unit + integration), `cargo clippy -- -D warnings`, `cargo fmt --check`
+**Target Platform**: macOS, Linux (cross-platform via Rust std)
+**Project Type**: Rust workspace (multi-crate)
+**Performance Goals**: N/A — path resolution is not performance-critical
+**Constraints**: Zero data loss for existing users, no automatic file migration
+**Scale/Scope**: ~16 source files affected, ~6 test files, documentation files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Crate-First | PASS | All changes within existing crate layout (`types`, `platforms`, `hooks`, `opencode`) |
+| II. Rust-First | PASS | Stable Rust only, no `unsafe` |
+| III. Agent-Friendly | PASS | Diagnostic messages are structured; migration instructions are machine-parseable |
+| IV. Contract-First | PASS | Contracts defined in `contracts/` before implementation |
+| V. Test-First | PASS | Tests must be updated before/alongside implementation |
+| VI. Complete Delivery | PASS | All FR-001 through FR-010 mapped to implementation tasks |
+| VII. Memory Integrity | PASS | No changes to memory file format; atomic writes preserved; fallback ensures no data loss |
+| VIII. Performance | PASS | Not in scope; no speculative benchmark work |
+| IX. Security-First | PASS | Path traversal checks preserved; no memory content logging changes |
+| X. Error Handling | PASS | Diagnostic messages include stable error context; migration instructions are actionable |
+| XI. Observability | PASS | Legacy detection produces structured diagnostics |
+| XII. Simplicity | PASS | Minimal changes to existing patterns; extends existing detection, doesn't introduce new frameworks |
+| XIII. Dependency Policy | PASS | No new dependencies |
+
+**Post-Phase 1 re-check**: All gates still pass. `detect_legacy_path` signature changes from `Option<Diagnostic>` to `Vec<Diagnostic>` but this is a non-breaking internal API change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-default-memory-path/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── path-policy-api.rs
+│   ├── bootstrap-api.rs
+│   └── dedup-api.rs
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (affected files)
+
+```text
+crates/
+├── types/
+│   ├── src/config.rs          # MindConfig::default() path constant
+│   └── tests/config_test.rs   # Default path assertions
+├── platforms/
+│   ├── src/path_policy.rs     # DEFAULT_LEGACY_PATH, LEGACY_CLAUDE_MEMORY_PATH, resolve_memory_path()
+│   └── src/bootstrap.rs       # detect_legacy_path(), build_mind_config()
+├── hooks/
+│   ├── src/dedup.rs           # DedupCache::new() hardcoded path
+│   ├── src/smart_install.rs   # VERSION_FILENAME location
+│   ├── src/context.rs         # Test path references
+│   ├── tests/legacy_path_test.rs
+│   ├── tests/dedup_test.rs
+│   ├── tests/env_compat_test.rs
+│   ├── tests/layout_compat_test.rs
+│   └── tests/permissions_test.rs
+├── opencode/
+│   ├── tests/chat_hook_test.rs
+│   └── tests/env_compat_test.rs
+└── cli/                        # (verify no hardcoded paths)
+
+CLAUDE.md                       # Documentation references
+```
+
+**Structure Decision**: Existing multi-crate workspace. No new crates or modules needed. All changes are modifications to existing files.
+
+## Complexity Tracking
+
+No constitution violations to justify.
+
+## Key Design Decisions
+
+### 1. Runtime Fallback in bootstrap.rs (R-004)
+
+`build_mind_config()` gains a filesystem check: if `.rusty-brain/mind.mv2` doesn't exist but `.agent-brain/mind.mv2` does, use the legacy path. This implements FR-004 (graceful fallback) without auto-migration (FR-008).
+
+### 2. detect_legacy_path → detect_legacy_paths (R-002)
+
+Return type changes from `Option<Diagnostic>` to `Vec<Diagnostic>` to handle multiple legacy paths simultaneously. The function now checks both `.agent-brain/` and `.claude/` against the new canonical `.rusty-brain/`.
+
+### 3. Supporting Files Follow Memory Directory (R-003)
+
+- `DedupCache::new()` changes from `.agent-brain/.dedup-cache.json` to `.rusty-brain/.dedup-cache.json`
+- `smart_install.rs` changes from `cwd/.install-version` to `cwd/.rusty-brain/.install-version`
+- The dedup cache path should ideally derive from the resolved memory path's parent directory rather than hardcoding, for consistency when custom paths are used
+
+### 4. Constant Naming (R-001, R-006)
+
+- `DEFAULT_LEGACY_PATH` renamed to `DEFAULT_MEMORY_PATH` (it's no longer "legacy")
+- New `LEGACY_AGENT_BRAIN_PATH` constant for the old default
+- `LEGACY_CLAUDE_MEMORY_PATH` unchanged
+- `DEFAULT_MEMORY_DIR` added for directory-level references (dedup cache, install version)
+
+## Implementation Phases
+
+### Phase A: Core Constants & Config (no filesystem behavior change)
+1. Update `MindConfig::default()` path to `.rusty-brain/mind.mv2`
+2. Update `path_policy.rs` constants
+3. Update all unit tests for new default values
+
+### Phase B: Legacy Detection & Fallback
+1. Extend `detect_legacy_path` to three-tier chain
+2. Add `resolve_effective_path` fallback in `bootstrap.rs`
+3. Wire fallback into `build_mind_config`
+4. Update integration tests
+
+### Phase C: Supporting Files
+1. Update `DedupCache::new()` path
+2. Update `smart_install.rs` version file location
+3. Update related tests
+
+### Phase D: Documentation & Cleanup
+1. Update `CLAUDE.md` references
+2. Update any skill files
+3. Final test pass: `cargo test && cargo clippy -- -D warnings && cargo fmt --check`

--- a/specs/012-default-memory-path/quickstart.md
+++ b/specs/012-default-memory-path/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Default Memory Path Change
+
+## What Changed
+
+The default memory directory changed from `.agent-brain/` to `.rusty-brain/`.
+
+## For New Users
+
+No action needed. rusty-brain automatically creates `.rusty-brain/mind.mv2` on first use.
+
+## For Existing Users
+
+If you have an existing `.agent-brain/` directory:
+
+```bash
+# Move the entire directory (preserves all data files)
+mv .agent-brain .rusty-brain
+
+# Update .gitignore
+sed -i '' 's/\.agent-brain/\.rusty-brain/' .gitignore
+```
+
+If you have the oldest `.claude/mind.mv2` legacy path:
+
+```bash
+mkdir -p .rusty-brain
+mv .claude/mind.mv2 .rusty-brain/mind.mv2
+```
+
+## What Happens Without Migration
+
+- Your existing `.agent-brain/mind.mv2` continues to work (graceful fallback)
+- You'll see an info message suggesting migration
+- New supporting files (dedup cache, version marker) go to `.rusty-brain/`
+
+## Environment Variable Override
+
+Custom paths via `MEMVID_PLATFORM_MEMORY_PATH` are unaffected by this change.

--- a/specs/012-default-memory-path/quickstart.md
+++ b/specs/012-default-memory-path/quickstart.md
@@ -14,10 +14,17 @@ If you have an existing `.agent-brain/` directory:
 
 ```bash
 # Move the entire directory (preserves all data files)
+# If .rusty-brain/ doesn't exist yet:
 mv .agent-brain .rusty-brain
 
-# Update .gitignore
+# Or if .rusty-brain/ already exists (e.g. from supporting files):
+mkdir -p .rusty-brain
+mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2
+# Then remove old directory: rm -rf .agent-brain
+
+# Update .gitignore (macOS)
 sed -i '' 's/\.agent-brain/\.rusty-brain/' .gitignore
+# On Linux: sed -i 's/\.agent-brain/\.rusty-brain/' .gitignore
 ```
 
 If you have the oldest `.claude/mind.mv2` legacy path:

--- a/specs/012-default-memory-path/research.md
+++ b/specs/012-default-memory-path/research.md
@@ -1,0 +1,84 @@
+# Research: Default Memory Path Change
+
+**Feature**: 012-default-memory-path
+**Date**: 2026-03-05
+
+## R-001: Current Path Resolution Architecture
+
+**Decision**: The path resolution system has three layers that all need updating:
+
+1. **`crates/types/src/config.rs`** — `MindConfig::default()` hardcodes `.agent-brain/mind.mv2`
+2. **`crates/platforms/src/path_policy.rs`** — `DEFAULT_LEGACY_PATH` constant and `LEGACY_CLAUDE_MEMORY_PATH` constant; `resolve_memory_path()` returns the default path in `LegacyFirst` mode
+3. **`crates/platforms/src/bootstrap.rs`** — `detect_legacy_path()` checks `.claude/mind.mv2` against `.agent-brain/mind.mv2`; `build_mind_config()` orchestrates resolution
+
+**Rationale**: These three files form the complete path resolution chain. Changing the default requires updating all three in a coordinated manner.
+
+**Alternatives considered**: Single-constant approach (define once, import everywhere) — rejected because the path policy module intentionally separates resolution concerns from configuration defaults.
+
+## R-002: Legacy Path Detection Chain Design
+
+**Decision**: Extend from two-tier (`.claude/` → `.agent-brain/`) to three-tier (`.claude/` → `.agent-brain/` → `.rusty-brain/`) with `.rusty-brain/` as canonical.
+
+**Current behavior** (`detect_legacy_path` in `crates/platforms/src/bootstrap.rs`):
+- Checks `.claude/mind.mv2` (legacy) vs `.agent-brain/mind.mv2` (canonical)
+- Returns migration warning if legacy exists without canonical
+- Returns duplicate warning if both exist
+
+**New behavior**:
+- `.rusty-brain/mind.mv2` becomes canonical
+- `.agent-brain/mind.mv2` becomes a legacy path (middle tier)
+- `.claude/mind.mv2` remains the oldest legacy path
+- Detection must check all three paths and produce appropriate diagnostics
+- When `.agent-brain/` exists but `.rusty-brain/` doesn't, use `.agent-brain/` (FR-004 graceful fallback)
+
+**Rationale**: Preserves backward compatibility while guiding users to the new canonical path. FR-008 mandates no automatic file movement.
+
+**Alternatives considered**: Auto-migration on first run — rejected per FR-008 (migration is user-initiated).
+
+## R-003: Supporting File Locations
+
+**Decision**: Supporting files (`DedupCache`, `.install-version`) use the same directory as the memory file.
+
+**Current locations**:
+- `DedupCache::new()` in `crates/hooks/src/dedup.rs` hardcodes `project_dir.join(".agent-brain").join(CACHE_FILENAME)`
+- `smart_install.rs` writes `.install-version` to `cwd` (project root), NOT inside `.agent-brain/`
+
+**New locations**:
+- `DedupCache` → `.rusty-brain/.dedup-cache.json` (update hardcoded path)
+- `.install-version` → `.rusty-brain/.install-version` (move inside the data directory per FR-006)
+
+**Rationale**: FR-006 requires all supporting files in `.rusty-brain/`. Self-contained directory structure aids discoverability.
+
+**Alternatives considered**: Keep `.install-version` at project root — rejected because FR-006 explicitly requires all files in `.rusty-brain/`.
+
+## R-004: Fallback Resolution Order
+
+**Decision**: Path resolution priority (highest to lowest):
+1. `MEMVID_PLATFORM_MEMORY_PATH` environment variable (custom override)
+2. Platform opt-in path (`.{platform}/mind-{platform}.mv2`) when `MEMVID_PLATFORM_PATH_OPT_IN=1`
+3. `.rusty-brain/mind.mv2` (new canonical default)
+4. `.agent-brain/mind.mv2` (legacy fallback, used if exists and `.rusty-brain/` doesn't)
+5. `.claude/mind.mv2` (oldest legacy, detection only — never used as fallback)
+
+**Rationale**: FR-007 preserves custom path behavior. FR-004 requires graceful fallback to `.agent-brain/`. FR-005 requires `.rusty-brain/` preference when both exist.
+
+**Alternatives considered**: No runtime fallback (just change the default and let users deal with it) — rejected because FR-004 mandates using existing `.agent-brain/` data.
+
+## R-005: Documentation and Skill File Updates
+
+**Decision**: All references to `.agent-brain/` in documentation, CLAUDE.md, skill definitions, and configuration templates must be updated to `.rusty-brain/` (FR-010).
+
+**Files requiring updates** (non-Rust):
+- `CLAUDE.md` (project instructions)
+- Any skill files referencing `.agent-brain/`
+- Configuration templates
+
+**Rationale**: FR-010 explicitly requires this. Users and agents reading documentation should see the current canonical path.
+
+## R-006: PathMode Enum Extension
+
+**Decision**: The `PathMode` enum in `path_policy.rs` needs no new variant. The existing `LegacyFirst` mode changes its default path from `.agent-brain/` to `.rusty-brain/`. A new runtime fallback mechanism handles the `.agent-brain/` → `.rusty-brain/` migration.
+
+**Rationale**: `LegacyFirst` semantically means "use the non-platform-scoped default" — changing what that default points to doesn't change the mode's meaning. The fallback logic belongs in `bootstrap.rs` where filesystem checks already happen.
+
+**Alternatives considered**: Adding a `MigrationFallback` variant — rejected as over-engineering; the fallback is a bootstrap concern, not a path-policy concern.

--- a/specs/012-default-memory-path/spec.md
+++ b/specs/012-default-memory-path/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Default Memory Path Change
+
+**Feature Branch**: `012-default-memory-path`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "Default install for the mind.mv2 file should be repo root .rusty-brain/mind.mv2"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - New Installation Uses .rusty-brain Directory (Priority: P1)
+
+A developer installs rusty-brain for the first time in a project. When the system initializes, it creates the memory file at `.rusty-brain/mind.mv2` in the repository root. The directory name matches the product name, making it immediately clear what the directory belongs to.
+
+**Why this priority**: New installations are the most common path and must use the correct default from day one. The directory name should match the product identity for discoverability and clarity.
+
+**Independent Test**: Can be fully tested by initializing rusty-brain in a fresh project directory and verifying the memory file is created at `.rusty-brain/mind.mv2`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with no existing rusty-brain data, **When** the system initializes for the first time, **Then** the memory file is created at `<repo-root>/.rusty-brain/mind.mv2`.
+2. **Given** a fresh installation, **When** the user looks for rusty-brain data in the project, **Then** the `.rusty-brain/` directory is present at the repository root with the `mind.mv2` file inside.
+3. **Given** the `.rusty-brain/` directory does not exist, **When** the system initializes, **Then** it creates the directory with appropriate permissions before writing the memory file.
+
+---
+
+### User Story 2 - Migration from .agent-brain Directory (Priority: P1)
+
+A developer who previously used rusty-brain with the old `.agent-brain/` directory updates to a new version. The system detects the existing `.agent-brain/mind.mv2` file and suggests migration to `.rusty-brain/mind.mv2`. Existing memories are preserved and accessible throughout the migration.
+
+**Why this priority**: Existing users must not lose their data. A smooth migration path is essential for adoption of the new directory convention.
+
+**Independent Test**: Can be fully tested by creating an `.agent-brain/mind.mv2` file and verifying the system detects it and provides migration guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with `.agent-brain/mind.mv2` but no `.rusty-brain/mind.mv2`, **When** the system starts, **Then** it uses the existing `.agent-brain/mind.mv2` file and displays a migration suggestion to move to `.rusty-brain/mind.mv2`.
+2. **Given** both `.agent-brain/mind.mv2` and `.rusty-brain/mind.mv2` exist, **When** the system starts, **Then** it uses `.rusty-brain/mind.mv2` (the new default) and warns about the duplicate file at the old location.
+3. **Given** a project with only `.agent-brain/mind.mv2`, **When** the user follows the migration suggestion, **Then** they can move the file and the system works seamlessly with the new path.
+
+---
+
+### User Story 3 - Legacy .claude Path Detection (Priority: P2)
+
+A developer who used an even older version of the system with `.claude/mind.mv2` receives guidance to migrate to the new `.rusty-brain/mind.mv2` path. The existing two-tier legacy detection (`.claude/` → `.agent-brain/`) is updated to a three-tier chain (`.claude/` → `.agent-brain/` → `.rusty-brain/`).
+
+**Why this priority**: Users on the oldest legacy path need a clear migration target. The detection chain must be updated to point to the new canonical location.
+
+**Independent Test**: Can be tested by creating a `.claude/mind.mv2` file and verifying the migration suggestion now points to `.rusty-brain/mind.mv2`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with only `.claude/mind.mv2`, **When** the system starts, **Then** it suggests migration to `.rusty-brain/mind.mv2` (not `.agent-brain/mind.mv2`).
+2. **Given** all three paths exist (`.claude/`, `.agent-brain/`, `.rusty-brain/`), **When** the system starts, **Then** it uses `.rusty-brain/mind.mv2` and warns about the other locations.
+
+---
+
+### User Story 4 - Supporting Files in .rusty-brain Directory (Priority: P1)
+
+A developer using rusty-brain expects all supporting files (deduplication cache, install version marker) to live alongside the memory file in the `.rusty-brain/` directory. The directory structure is consistent and self-contained.
+
+**Why this priority**: All data files must move together to maintain a consistent directory structure. A partial migration (memory file in one place, cache in another) would cause confusion.
+
+**Independent Test**: Can be tested by verifying all supporting files are created within `.rusty-brain/` on a fresh installation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh installation, **When** the system creates supporting files, **Then** the deduplication cache is at `.rusty-brain/.dedup-cache.json` and the version marker is at `.rusty-brain/.install-version`.
+2. **Given** a project with files in `.agent-brain/`, **When** the migration suggestion is displayed, **Then** it covers all files in the directory (not just `mind.mv2`).
+
+---
+
+### Edge Cases
+
+- What happens when the user has a custom `memory_path` configured via environment variable?
+  - Custom paths override the default. The change only affects the default path when no override is set.
+- What happens when `.rusty-brain/` already exists but contains non-rusty-brain files?
+  - The system creates `mind.mv2` alongside existing files without disturbing them.
+- What happens when the user has both old and new directories with different memory content?
+  - The system uses `.rusty-brain/mind.mv2` as canonical and warns about the duplicate, leaving the old file untouched for the user to reconcile.
+- What happens when file system permissions prevent creating `.rusty-brain/`?
+  - The system reports a clear error about directory creation failure with the path that could not be created.
+- What happens when `.gitignore` includes `.agent-brain/` but not `.rusty-brain/`?
+  - This is the user's responsibility. Documentation should mention updating `.gitignore` as part of migration steps.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST use `.rusty-brain/mind.mv2` (relative to repository root) as the default memory file path for new installations.
+- **FR-002**: System MUST detect `.agent-brain/mind.mv2` as a legacy path and suggest migration to `.rusty-brain/mind.mv2`.
+- **FR-003**: System MUST detect `.claude/mind.mv2` as a legacy path and suggest migration to `.rusty-brain/mind.mv2` (updated from the previous `.agent-brain/` target).
+- **FR-004**: System MUST use the existing legacy file when `.agent-brain/mind.mv2` exists but `.rusty-brain/mind.mv2` does not (graceful fallback, no data loss).
+- **FR-005**: System MUST prefer `.rusty-brain/mind.mv2` over `.agent-brain/mind.mv2` when both exist.
+- **FR-006**: System MUST place all supporting files (deduplication cache, version marker) in the `.rusty-brain/` directory for new installations.
+- **FR-007**: System MUST continue to respect custom memory paths set via environment variables or configuration, regardless of the default path change.
+- **FR-008**: System MUST NOT automatically move or copy files between old and new directories — migration is user-initiated.
+- **FR-009**: System MUST provide clear, actionable migration instructions when legacy paths are detected, including the specific file move commands.
+- **FR-010**: System MUST update all documentation, skill definitions, and configuration templates to reference `.rusty-brain/` instead of `.agent-brain/`.
+
+### Key Entities
+
+- **Memory Directory**: The `.rusty-brain/` directory at the repository root containing all rusty-brain data files. Replaces `.agent-brain/` as the default location.
+- **Legacy Path**: A previously-used memory file location (`.agent-brain/mind.mv2` or `.claude/mind.mv2`) that is detected and triggers migration guidance.
+- **Path Resolution Order**: The priority order for finding memory files: (1) custom configured path, (2) `.rusty-brain/mind.mv2`, (3) `.agent-brain/mind.mv2`, (4) `.claude/mind.mv2`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of new installations create the memory file at `.rusty-brain/mind.mv2` (not `.agent-brain/mind.mv2`).
+- **SC-002**: Existing users with `.agent-brain/mind.mv2` experience zero data loss — the system continues to read their existing file until they choose to migrate.
+- **SC-003**: Migration instructions are displayed for 100% of detected legacy paths, with exact commands the user can run.
+- **SC-004**: All documentation, skill definitions, and templates reference `.rusty-brain/` within this feature's scope.
+- **SC-005**: Custom memory paths continue to work with zero behavioral changes.
+
+## Assumptions
+
+- The `.rusty-brain/` directory name is the final branding choice and will not change again.
+- Users are expected to manually move files when migrating — the system does not auto-migrate to avoid unintended data operations.
+- The `.rusty-brain/` directory should be added to `.gitignore` by users (memory files are project-local, not shared).
+- The environment variable `MEMVID_PLATFORM_PATH_OPT_IN` and any custom `memory_path` configuration continue to override the default regardless of this change.
+- The `crates/types` configuration module contains the default path constant that needs updating.
+
+## Scope Boundaries
+
+### In Scope
+
+- Changing the default memory directory from `.agent-brain/` to `.rusty-brain/`
+- Adding `.agent-brain/` to the legacy path detection chain
+- Updating `.claude/` legacy detection to point to `.rusty-brain/`
+- Updating all documentation and skill files to reference `.rusty-brain/`
+- Updating configuration defaults and constants
+- Updating test fixtures and assertions
+
+### Out of Scope
+
+- Automatic file migration (users move files manually)
+- Changing the memory file name (`mind.mv2` stays the same)
+- Changing the memory file format
+- Changing custom/overridden path behavior
+- Updating third-party documentation or external references

--- a/specs/012-default-memory-path/tasks.md
+++ b/specs/012-default-memory-path/tasks.md
@@ -197,7 +197,7 @@
 
 ## Parallel Example: After Phase 2 Completion
 
-```
+```text
 # Agent 1: US1 (new installation path)
 Task: T012–T014 in crates/types/tests/config_test.rs
 

--- a/specs/012-default-memory-path/tasks.md
+++ b/specs/012-default-memory-path/tasks.md
@@ -1,0 +1,253 @@
+# Tasks: Default Memory Path Change
+
+**Input**: Design documents from `/specs/012-default-memory-path/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included — constitution mandates test-first development (Principle V).
+
+**Organization**: Tasks grouped by user story. US1/US2/US4 are P1, US3 is P2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project setup needed — existing workspace. Verify build baseline.
+
+- [X] T001 Verify clean build baseline: run `cargo test && cargo clippy -- -D warnings && cargo fmt --check` and record any pre-existing failures
+
+**Checkpoint**: Build is green, ready to proceed.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Update core constants and default values that ALL user stories depend on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 Rename `DEFAULT_LEGACY_PATH` to `DEFAULT_MEMORY_PATH` and change value from `".agent-brain/mind.mv2"` to `".rusty-brain/mind.mv2"` in `crates/platforms/src/path_policy.rs`
+- [X] T003 Add `LEGACY_AGENT_BRAIN_PATH` constant with value `".agent-brain/mind.mv2"` in `crates/platforms/src/path_policy.rs`
+- [X] T004 Add `DEFAULT_MEMORY_DIR` constant with value `".rusty-brain"` in `crates/platforms/src/path_policy.rs`
+- [X] T005 Update `MindConfig::default()` to use `PathBuf::from(".rusty-brain/mind.mv2")` and update the doc comment in `crates/types/src/config.rs`
+- [X] T006 Update unit test `default_memory_path_is_agent_brain_mind_mv2` (rename to `default_memory_path_is_rusty_brain_mind_mv2` and fix assertion) in `crates/types/tests/config_test.rs`
+- [X] T007 Update all other tests in `crates/types/tests/config_test.rs` that assert `.agent-brain/mind.mv2` as the default (lines 200-201, 223-225, 418, 424+)
+- [X] T008 Update `legacy_mode_no_opt_in` test to assert `.rusty-brain/mind.mv2` in `crates/platforms/src/path_policy.rs`
+- [X] T009 Update `legacy_mode_ignores_platform_name` test to assert `.rusty-brain/mind.mv2` in `crates/platforms/src/path_policy.rs`
+- [X] T010 Update `format_legacy_path_warning_contains_both_paths` test to assert `.rusty-brain/mind.mv2` in `crates/platforms/src/path_policy.rs`
+- [X] T011 Verify build passes: `cargo test && cargo clippy -- -D warnings`
+
+**Checkpoint**: Foundation ready — all default paths point to `.rusty-brain/`, existing tests updated. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — New Installation Uses .rusty-brain Directory (Priority: P1) MVP
+
+**Goal**: New installations create memory files at `.rusty-brain/mind.mv2`. The `resolve_memory_path()` function returns the new canonical path. Custom env var paths remain unaffected.
+
+**Independent Test**: Initialize rusty-brain in a fresh temp directory and verify the resolved path is `.rusty-brain/mind.mv2`.
+
+### Implementation for User Story 1
+
+- [X] T012 [P] [US1] Update `from_env_ignores_platform_detection_for_memory_path` test assertion to `.rusty-brain/mind.mv2` in `crates/types/tests/config_test.rs`
+- [X] T013 [P] [US1] Update `from_env_ignores_claude_project_dir_for_memory_path` test assertion to `.rusty-brain/mind.mv2` in `crates/types/tests/config_test.rs`
+- [X] T014 [US1] Run `cargo test -p platforms -p types` to verify US1 tests pass
+
+**Checkpoint**: New installations resolve to `.rusty-brain/mind.mv2`. Custom paths unaffected. US1 independently testable.
+
+---
+
+## Phase 4: User Story 2 — Migration from .agent-brain Directory (Priority: P1)
+
+**Goal**: Existing `.agent-brain/` installations are detected, used as fallback, and migration guidance is provided. All callers of the renamed detection function are updated.
+
+**Independent Test**: Create temp dir with `.agent-brain/mind.mv2`, run detection, verify fallback path is used and migration diagnostic is produced with actionable `mv` commands.
+
+### Tests for User Story 2
+
+- [X] T015 [US2] Write test `detect_legacy_paths_agent_brain_only_suggests_migration` — `.agent-brain/` exists, no `.rusty-brain/` → returns Info diagnostic with actionable `mv .agent-brain .rusty-brain` command in `crates/platforms/src/bootstrap.rs`
+- [X] T016 [US2] Write test `detect_legacy_paths_both_dirs_warns_duplicate` — both `.agent-brain/` and `.rusty-brain/` exist → returns Warning about duplicate in `crates/platforms/src/bootstrap.rs`
+- [X] T017 [US2] Write test `detect_legacy_paths_rusty_brain_only_returns_empty` — only `.rusty-brain/` exists → returns empty Vec in `crates/platforms/src/bootstrap.rs`
+- [X] T018 [US2] Write test `resolve_effective_path_falls_back_to_agent_brain` — `.agent-brain/mind.mv2` exists, `.rusty-brain/` doesn't → returns `.agent-brain/mind.mv2` in `crates/platforms/src/bootstrap.rs`
+- [X] T019 [US2] Write test `resolve_effective_path_prefers_rusty_brain` — both exist → returns `.rusty-brain/mind.mv2` in `crates/platforms/src/bootstrap.rs`
+- [X] T020 [US2] Write test `resolve_effective_path_new_install_returns_rusty_brain` — neither exists → returns `.rusty-brain/mind.mv2` in `crates/platforms/src/bootstrap.rs`
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Refactor `detect_legacy_path` → `detect_legacy_paths` returning `Vec<Diagnostic>` with `.agent-brain/` detection (Info level with actionable `mv` command when only legacy exists, Warning when duplicate) and update canonical path references from `.agent-brain/mind.mv2` to `.rusty-brain/mind.mv2` in `crates/platforms/src/bootstrap.rs`
+- [X] T022 [US2] Implement `resolve_effective_path(project_root: &Path) -> PathBuf` — checks if `.rusty-brain/mind.mv2` exists on disk (returns it); else checks if `.agent-brain/mind.mv2` exists (returns it as fallback); else returns `.rusty-brain/mind.mv2` as the new-install default. This function replaces `resolve_memory_path` for the non-opt-in case in `crates/platforms/src/bootstrap.rs`
+- [X] T023 [US2] Wire `resolve_effective_path` into `build_mind_config` — when no explicit `MEMVID_PLATFORM_MEMORY_PATH` and not platform opt-in, call `resolve_effective_path(project_dir)` to get the memory path (replacing the current `resolve_memory_path` call for the default case) in `crates/platforms/src/bootstrap.rs`
+- [X] T024 [US2] Update `format_legacy_path_warning` to include actionable `mv` commands targeting `.rusty-brain/` (FR-009) in `crates/platforms/src/path_policy.rs`
+- [X] T025 [US2] Update `crates/hooks/src/bootstrap.rs` re-export — change import from `detect_legacy_path` to `detect_legacy_paths` in `crates/hooks/src/bootstrap.rs`
+- [X] T026 [US2] Update `handle_session_start` in `crates/hooks/src/session_start.rs` — change `detect_legacy_path()` call to `detect_legacy_paths()` and handle `Vec<Diagnostic>` return type (iterate diagnostics instead of Option)
+- [X] T027 [US2] Update `handle_post_tool_use` in `crates/hooks/src/post_tool_use.rs` — change `detect_legacy_path()` call to `detect_legacy_paths()` and handle `Vec<Diagnostic>` return type
+- [X] T028 [P] [US2] Update integration tests in `crates/hooks/tests/legacy_path_test.rs` — change canonical path assertions from `.agent-brain/` to `.rusty-brain/`, update function name from `detect_legacy_path` to `detect_legacy_paths`
+- [X] T029 [P] [US2] Update `crates/hooks/tests/env_compat_test.rs` — change `.agent-brain/mind.mv2` assertions to `.rusty-brain/mind.mv2` (lines 166, 238, 287)
+- [X] T030 [P] [US2] Update `crates/hooks/tests/layout_compat_test.rs` — change `.agent-brain` references to `.rusty-brain`
+- [X] T031 [P] [US2] Update `crates/opencode/tests/env_compat_test.rs` — change `.agent-brain/mind.mv2` assertions to `.rusty-brain/mind.mv2` (lines 166, 238, 287)
+- [X] T032 [P] [US2] Update `crates/opencode/tests/chat_hook_test.rs` — change `.agent-brain` path setup to `.rusty-brain` (line 125)
+- [X] T033 [US2] Run `cargo test -p platforms -p hooks -p opencode` to verify US2 tests pass
+
+**Checkpoint**: Legacy `.agent-brain/` installations fall back gracefully, migration guidance with actionable commands is shown, all callers updated. US2 independently testable.
+
+---
+
+## Phase 5: User Story 4 — Supporting Files in .rusty-brain Directory (Priority: P1)
+
+**Goal**: Dedup cache and install version marker live in `.rusty-brain/` directory.
+
+**Independent Test**: Create a fresh temp dir, run dedup and smart-install operations, verify files are created under `.rusty-brain/`.
+
+### Tests for User Story 4
+
+- [X] T034 [US4] Write test `new_sets_cache_path_under_rusty_brain_dir` verifying `DedupCache::new()` uses `.rusty-brain/.dedup-cache.json` in `crates/hooks/src/dedup.rs`
+- [X] T035 [US4] Write test `smart_install_writes_version_to_rusty_brain_dir` verifying `.install-version` is created at `.rusty-brain/.install-version` in `crates/hooks/src/smart_install.rs`
+
+### Implementation for User Story 4
+
+- [X] T036 [US4] Update `DedupCache::new()` to use `project_dir.join(".rusty-brain").join(CACHE_FILENAME)` in `crates/hooks/src/dedup.rs`
+- [X] T037 [US4] Update `new_sets_cache_path_under_agent_brain_dir` test (rename to `new_sets_cache_path_under_rusty_brain_dir` and fix assertion to `.rusty-brain/.dedup-cache.json`) in `crates/hooks/src/dedup.rs`
+- [X] T038 [US4] Update `handle_smart_install()` to write version file at `cwd.join(".rusty-brain").join(VERSION_FILENAME)` instead of `cwd.join(VERSION_FILENAME)` in `crates/hooks/src/smart_install.rs`
+- [X] T039 [US4] Update all `smart_install.rs` tests to expect `.rusty-brain/.install-version` path in `crates/hooks/src/smart_install.rs`
+- [X] T040 [P] [US4] Update `crates/hooks/tests/dedup_test.rs` — change all 7 `.agent-brain` directory references to `.rusty-brain`
+- [X] T041 [P] [US4] Update `crates/hooks/tests/permissions_test.rs` — change 6 `.agent-brain` directory references to `.rusty-brain` (lines 77-78, 80, 94, 111-112)
+- [X] T042 [US4] Run `cargo test -p hooks` to verify US4 tests pass
+
+**Checkpoint**: All supporting files created under `.rusty-brain/`. US4 independently testable.
+
+---
+
+## Phase 6: User Story 3 — Legacy .claude Path Detection (Priority: P2)
+
+**Goal**: `.claude/mind.mv2` detection now suggests migration to `.rusty-brain/mind.mv2` (not `.agent-brain/`). Three-tier detection chain complete. Diagnostic messages include actionable `mv` commands (FR-009).
+
+**Independent Test**: Create temp dir with `.claude/mind.mv2`, run detection, verify migration suggestion points to `.rusty-brain/mind.mv2` with exact move command.
+
+### Tests for User Story 3
+
+- [X] T043 [US3] Write test `detect_legacy_paths_claude_only_suggests_rusty_brain` — `.claude/mind.mv2` exists alone → diagnostic suggests migration to `.rusty-brain/mind.mv2` with actionable `mv` command in `crates/platforms/src/bootstrap.rs`
+- [X] T044 [US3] Write test `detect_legacy_paths_all_three_dirs` — all three exist → uses `.rusty-brain/`, warns about both `.agent-brain/` and `.claude/` in `crates/platforms/src/bootstrap.rs`
+- [X] T045 [US3] Write test `detect_legacy_paths_claude_and_agent_brain_no_rusty` — `.claude/` and `.agent-brain/` exist but no `.rusty-brain/` → suggests migration to `.rusty-brain/`, warns about `.claude/` in `crates/platforms/src/bootstrap.rs`
+
+### Implementation for User Story 3
+
+- [X] T046 [US3] Extend `detect_legacy_paths()` to check `.claude/mind.mv2` and produce diagnostic targeting `.rusty-brain/mind.mv2` (not `.agent-brain/`) with actionable move commands in `crates/platforms/src/bootstrap.rs`
+- [X] T047 [US3] Update `session_start_includes_legacy_diagnostic_in_system_message` integration test in `crates/hooks/tests/legacy_path_test.rs` to verify `.rusty-brain` appears in migration message
+- [X] T048 [US3] Run `cargo test -p platforms -p hooks` to verify US3 tests pass
+
+**Checkpoint**: Three-tier legacy detection complete. All legacy paths point to `.rusty-brain/` as migration target with actionable commands.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation updates and final validation across all stories.
+
+- [X] T049 [P] Update `CLAUDE.md` — replace all `.agent-brain/` references with `.rusty-brain/` in project documentation sections
+- [X] T050 [P] Update `crates/hooks/src/context.rs` test `format_system_message_contains_memory_path` to use `.rusty-brain` path (line 108)
+- [X] T051 [P] Update `skills/mind/SKILL.md` — change `.agent-brain/mind.mv2` reference to `.rusty-brain/mind.mv2` (line 19)
+- [X] T052 [P] Update `skills/memory/SKILL.md` — change `.agent-brain/mind.mv2` reference to `.rusty-brain/mind.mv2` (line 19)
+- [X] T053 [P] Update `README.md` — change `.agent-brain/mind.mv2` reference to `.rusty-brain/mind.mv2` (line 51)
+- [X] T054 [P] Update `RUST_ROADMAP.md` — change `.agent-brain` references to `.rusty-brain` (lines 117, 365-366)
+- [X] T055 [P] Update `.gitignore` — add `.rusty-brain/` entry alongside existing `.agent-brain/` (keep both during migration period) (line 24)
+- [X] T056 [P] Search for any remaining `.agent-brain` string literals across the workspace using `rg '\.agent-brain' --type rust --type md` and update as needed
+- [X] T057 Run full quality gate: `cargo test && cargo clippy -- -D warnings && cargo fmt --check`
+- [X] T058 Run quickstart.md validation: verify migration instructions work on a temp directory with `.agent-brain/mind.mv2`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — verify baseline
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — can start immediately after
+- **US2 (Phase 4)**: Depends on Phase 2 — can run in parallel with US1
+- **US4 (Phase 5)**: Depends on Phase 2 — can run in parallel with US1 and US2
+- **US3 (Phase 6)**: Depends on Phase 4 (US2) — needs `detect_legacy_paths` framework
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent — only needs foundational constants
+- **US2 (P1)**: Independent — only needs foundational constants
+- **US4 (P1)**: Independent — only needs foundational constants
+- **US3 (P2)**: Depends on US2 — extends the `detect_legacy_paths` function built in US2
+
+### Within Each User Story
+
+- Tests written FIRST and verified to FAIL
+- Implementation follows to make tests pass
+- Verification step at end of each phase
+
+### Parallel Opportunities
+
+- **Phase 2**: T002–T004 can run in parallel (different constants, same file — coordinate edits)
+- **Phase 3 + Phase 4 + Phase 5**: US1, US2, and US4 can all run in parallel after Phase 2
+- **Phase 4**: T028–T032 are independent test file updates, all parallelizable
+- **Phase 7**: T049–T056 can all run in parallel (different files)
+
+---
+
+## Parallel Example: After Phase 2 Completion
+
+```
+# Agent 1: US1 (new installation path)
+Task: T012–T014 in crates/types/tests/config_test.rs
+
+# Agent 2: US2 (migration from .agent-brain)
+Task: T015–T033 in crates/platforms/src/bootstrap.rs + hooks/ + opencode/
+
+# Agent 3: US4 (supporting files)
+Task: T034–T042 in crates/hooks/src/dedup.rs + crates/hooks/src/smart_install.rs + hooks/tests/
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (baseline verification)
+2. Complete Phase 2: Foundational (constant updates)
+3. Complete Phase 3: US1 (new installation path works)
+4. **STOP and VALIDATE**: `cargo test` passes, new installations resolve to `.rusty-brain/`
+5. Existing `.agent-brain/` users temporarily broken until US2
+
+### Recommended: US1 + US2 Together
+
+Since US2 provides the fallback that prevents breaking existing users, ship US1 and US2 together as the minimum viable change:
+
+1. Phase 1 + Phase 2: Setup + Foundational
+2. Phase 3 + Phase 4: US1 + US2 (parallel or sequential)
+3. **STOP and VALIDATE**: New installations work, existing installations fall back gracefully
+4. Phase 5: US4 (supporting files)
+5. Phase 6: US3 (legacy .claude detection)
+6. Phase 7: Polish
+
+### Incremental Delivery
+
+1. Setup + Foundational → Constants ready
+2. US1 + US2 → Core path change complete, no data loss
+3. US4 → Supporting files migrated
+4. US3 → Full three-tier legacy detection
+5. Polish → Documentation, final validation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution requires test-first: write tests, verify they fail, then implement
+- FR-008: Never auto-migrate files — all migration is user-initiated
+- FR-009: All diagnostic messages must include actionable `mv` commands (not just descriptions)
+- The `detect_legacy_path` → `detect_legacy_paths` rename is a breaking internal API change; all callers (session_start.rs, post_tool_use.rs, hooks/bootstrap.rs re-export) must be updated in the same phase (T025–T027)
+- `smart_install.rs` version file path change means fresh installs write to `.rusty-brain/.install-version` but existing `.install-version` at project root won't be auto-detected — acceptable per spec (new installations only)
+- `.gitignore` gets both `.agent-brain/` and `.rusty-brain/` during migration period


### PR DESCRIPTION
## Summary

- Renames the canonical memory directory from `.agent-brain/` to `.rusty-brain/` to match the product name
- Adds three-tier legacy path detection (`.claude/` → `.agent-brain/` → `.rusty-brain/`) with actionable migration diagnostics
- Implements graceful fallback: existing `.agent-brain/` installations continue working until the user migrates
- Moves all supporting files (dedup cache, version marker) under `.rusty-brain/`
- Renames `PathMode::LegacyFirst` → `PathMode::Default` for clarity
- Updates all documentation, skill files, and tests (99 passing, 0 clippy warnings)

## Test plan

- [x] `cargo test` — 99 passed, 3 ignored
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Verify fresh install creates `.rusty-brain/mind.mv2`
- [ ] Verify existing `.agent-brain/` project falls back gracefully with migration suggestion
- [ ] Verify `.claude/mind.mv2` detection suggests `.rusty-brain/` migration target
- [ ] Verify custom `MEMVID_PLATFORM_MEMORY_PATH` overrides still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default persistent memory directory changed from .agent-brain/ to .rusty-brain/; supporting cache and version files now live under .rusty-brain/.
  * Legacy detection expanded to recognize multiple legacy locations and emit clearer migration guidance.

* **Documentation**
  * Updated docs, quickstart, and specs to describe the new default path and migration steps.

* **Tests**
  * Test suite updated to reflect the new default path and legacy-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->