### PR TITLE
feat: add agent install subsystem (011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ The constitution (`.specify/memory/constitution.md` v2.0.0) governs all implemen
 - N/A (no new storage; existing `.mv2` files are preserved, never touched). (009-plugin-packaging)
 - Rust stable, edition 2024, MSRV 1.85.0 + memvid-core (pinned rev `fbddef4`), criterion 0.5 (benchmarks), cargo-fuzz/libFuzzer (fuzz testing), serde/serde_json (fixture parsing), tempfile (test isolation), assert_cmd/predicates (CLI tests) (010-testing-migration)
 - `.mv2` files via memvid-core (read/write compatibility), `tests/fixtures/` (committed test data) (010-testing-migration)
+- Rust stable, edition 2024, MSRV 1.85.0 + clap 4 (derive), serde/serde_json, tracing, tempfile (promote from dev-dep to regular dep) (011-agent-installs)
+- Local filesystem only — config files written to agent directories, no database (011-agent-installs)
 
 All crates already present in workspace `Cargo.toml`. Diagnostics are in-memory only; memory path resolution produces paths but does not perform I/O.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,9 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror 2.0.18",
+ "tracing",
  "types",
  "uuid",
 ]
@@ -2068,6 +2070,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "rusty-brain-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "chrono",
  "clap",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,6 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
- "tracing",
  "types",
  "uuid",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ fs2 = { workspace = true }
 temp-env = { workspace = true }
 criterion = { workspace = true }
 compression = { path = "../compression" }
+assert_cmd = { workspace = true }
 
 [[bench]]
 name = "startup_bench"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -75,6 +75,24 @@ pub enum Command {
     /// `OpenCode` editor adapter subcommands
     #[command(subcommand)]
     Opencode(OpenCodeCommand),
+    /// Configure rusty-brain for external AI agents
+    Install {
+        /// Comma-separated list of agents to configure (e.g., opencode,copilot)
+        #[arg(long, value_delimiter = ',')]
+        agents: Option<Vec<String>>,
+        /// Install config relative to current working directory
+        #[arg(long, group = "scope")]
+        project: bool,
+        /// Install config in user-level directories
+        #[arg(long, group = "scope")]
+        global: bool,
+        /// Force JSON output
+        #[arg(long)]
+        json: bool,
+        /// Regenerate config files (backup existing)
+        #[arg(long)]
+        reconfigure: bool,
+    },
 }
 
 /// `OpenCode`-specific subcommands for editor integration.
@@ -99,7 +117,8 @@ impl Command {
             Self::Find { json, .. }
             | Self::Ask { json, .. }
             | Self::Stats { json, .. }
-            | Self::Timeline { json, .. } => *json,
+            | Self::Timeline { json, .. }
+            | Self::Install { json, .. } => *json,
             // OpenCode subcommands always output JSON
             Self::Opencode(_) => true,
         }
@@ -440,5 +459,111 @@ mod tests {
     fn no_subcommand_shows_help() {
         let result = Cli::try_parse_from(["rusty-brain"]);
         assert!(result.is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // T027: Install subcommand arg parsing tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_install_project_scope() {
+        let cli = Cli::try_parse_from(["rusty-brain", "install", "--project"]).unwrap();
+        match cli.command {
+            Command::Install {
+                project, global, ..
+            } => {
+                assert!(project);
+                assert!(!global);
+            }
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn parse_install_global_scope() {
+        let cli = Cli::try_parse_from(["rusty-brain", "install", "--global"]).unwrap();
+        match cli.command {
+            Command::Install {
+                project, global, ..
+            } => {
+                assert!(!project);
+                assert!(global);
+            }
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn parse_install_project_and_global_mutually_exclusive() {
+        let result = Cli::try_parse_from(["rusty-brain", "install", "--project", "--global"]);
+        assert!(
+            result.is_err(),
+            "--project and --global should be mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn parse_install_agents_comma_delimited() {
+        let cli = Cli::try_parse_from([
+            "rusty-brain",
+            "install",
+            "--agents",
+            "opencode,copilot",
+            "--project",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Install { agents, .. } => {
+                let agents = agents.unwrap();
+                assert_eq!(agents, vec!["opencode", "copilot"]);
+            }
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn parse_install_json_flag() {
+        let cli = Cli::try_parse_from(["rusty-brain", "install", "--project", "--json"]).unwrap();
+        match cli.command {
+            Command::Install { json, .. } => assert!(json),
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn parse_install_reconfigure_flag() {
+        let cli =
+            Cli::try_parse_from(["rusty-brain", "install", "--project", "--reconfigure"]).unwrap();
+        match cli.command {
+            Command::Install { reconfigure, .. } => assert!(reconfigure),
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn parse_install_no_scope_allowed() {
+        // Neither --project nor --global should be accepted (scope required at runtime)
+        let cli = Cli::try_parse_from(["rusty-brain", "install"]).unwrap();
+        match cli.command {
+            Command::Install {
+                project, global, ..
+            } => {
+                assert!(!project);
+                assert!(!global);
+            }
+            _ => panic!("expected Install command"),
+        }
+    }
+
+    #[test]
+    fn json_method_install_default_false() {
+        let cli = Cli::try_parse_from(["rusty-brain", "install", "--project"]).unwrap();
+        assert!(!cli.command.json());
+    }
+
+    #[test]
+    fn json_method_install_with_flag_true() {
+        let cli = Cli::try_parse_from(["rusty-brain", "install", "--project", "--json"]).unwrap();
+        assert!(cli.command.json());
     }
 }

--- a/crates/cli/src/install_cmd.rs
+++ b/crates/cli/src/install_cmd.rs
@@ -1,0 +1,95 @@
+//! Install subcommand handler.
+
+use std::io::IsTerminal;
+
+use platforms::installer::orchestrator::InstallOrchestrator;
+use types::install::{InstallConfig, InstallError, InstallScope};
+
+use crate::CliError;
+use crate::output;
+
+/// Run the install subcommand.
+///
+/// Builds an [`InstallConfig`] from CLI args, delegates to
+/// [`InstallOrchestrator::run()`], and formats output.
+///
+/// # Errors
+///
+/// Returns [`CliError::Install`] if scope is not specified or the orchestrator
+/// fails, or [`CliError::Io`] if the current directory cannot be determined.
+#[allow(clippy::fn_params_excessive_bools)]
+pub fn run_install(
+    agents: Option<Vec<String>>,
+    project: bool,
+    global: bool,
+    json: bool,
+    reconfigure: bool,
+) -> Result<(), CliError> {
+    // Determine scope (M-13: require --project or --global).
+    let scope = if project {
+        let root = std::env::current_dir().map_err(CliError::Io)?;
+        InstallScope::Project { root }
+    } else if global {
+        InstallScope::Global
+    } else {
+        return Err(CliError::Install(InstallError::ScopeRequired));
+    };
+
+    // Auto-enable JSON when stdin is not a TTY (M-7, AC-12).
+    let json = json || !std::io::stdin().is_terminal();
+
+    let config = InstallConfig {
+        agents,
+        scope,
+        json,
+        reconfigure,
+    };
+
+    let orchestrator = InstallOrchestrator::with_builtins();
+    let report = orchestrator.run(&config).map_err(CliError::Install)?;
+
+    if json {
+        output::print_json(&report)
+    } else {
+        print_install_human(&report);
+        Ok(())
+    }
+}
+
+/// Print a human-readable install report.
+fn print_install_human(report: &types::install::InstallReport) {
+    println!("Install Report (scope: {})", report.scope);
+    println!("Memory store: {}", report.memory_store.display());
+    println!();
+
+    for result in &report.results {
+        let status_str = match &result.status {
+            types::install::InstallStatus::Configured => "✓ Configured",
+            types::install::InstallStatus::Upgraded => "↑ Upgraded",
+            types::install::InstallStatus::Skipped => "- Skipped",
+            types::install::InstallStatus::Failed => "✗ Failed",
+            types::install::InstallStatus::NotFound => "? Not found",
+        };
+
+        print!("  {}: {status_str}", result.agent_name);
+
+        if let Some(ref version) = result.version_detected {
+            print!(" (v{version})");
+        }
+        if let Some(ref path) = result.config_path {
+            print!(" -> {}", path.display());
+        }
+        if let Some(ref err) = result.error {
+            print!(" [{err}]");
+        }
+        println!();
+    }
+
+    println!();
+    let status_label = match report.status {
+        types::install::ReportStatus::Success => "success",
+        types::install::ReportStatus::Partial => "partial",
+        types::install::ReportStatus::Failed => "failed",
+    };
+    println!("Status: {status_label}");
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod args;
 mod commands;
+mod install_cmd;
 mod opencode_cmd;
 mod output;
 
@@ -22,6 +23,7 @@ pub enum CliError {
     NotAFile { path: PathBuf },
     EmptyPattern,
     Io(std::io::Error),
+    Install(types::InstallError),
 }
 
 impl CliError {
@@ -32,7 +34,8 @@ impl CliError {
             | Self::MemoryFileNotFound { .. }
             | Self::NotAFile { .. }
             | Self::EmptyPattern
-            | Self::Io(_) => 1,
+            | Self::Io(_)
+            | Self::Install(_) => 1,
         }
     }
 
@@ -47,6 +50,7 @@ impl CliError {
             Self::NotAFile { .. } => "E_CLI_NOT_A_FILE",
             Self::EmptyPattern => "E_CLI_EMPTY_PATTERN",
             Self::Io(_) => "E_CLI_IO",
+            Self::Install(_) => "E_CLI_INSTALL",
         }
     }
 }
@@ -89,6 +93,7 @@ impl fmt::Display for CliError {
                 write!(f, "Search pattern must not be empty.")
             }
             Self::Io(e) => write!(f, "{e}"),
+            Self::Install(e) => write!(f, "{e}"),
         }
     }
 }
@@ -162,6 +167,19 @@ fn run() -> Result<(), (CliError, bool)> {
         return opencode_cmd::dispatch(subcmd).map_err(|e| (e, json));
     }
 
+    // Install subcommand handles its own I/O — dispatch directly.
+    if let Command::Install {
+        ref agents,
+        project,
+        global,
+        json: json_flag,
+        reconfigure,
+    } = cli.command
+    {
+        return install_cmd::run_install(agents.clone(), project, global, json_flag, reconfigure)
+            .map_err(|e| (e, json));
+    }
+
     // Resolve runtime config and memory path.
     let mut config = MindConfig::from_env().map_err(|e| (CliError::from(e), json))?;
     config.memory_path = resolve_cli_memory_path(cli.memory_path.clone()).map_err(|e| (e, json))?;
@@ -197,7 +215,7 @@ fn run() -> Result<(), (CliError, bool)> {
                 json,
             } => commands::run_timeline(mind, limit, r#type, oldest_first, json),
             // Already handled above — unreachable
-            Command::Opencode(_) => Ok(()),
+            Command::Opencode(_) | Command::Install { .. } => Ok(()),
         };
         Ok(())
     })

--- a/crates/cli/tests/install_json_test.rs
+++ b/crates/cli/tests/install_json_test.rs
@@ -1,0 +1,115 @@
+//! Integration tests for install JSON output (T064-T066).
+//!
+//! Tests the CLI binary's install subcommand JSON output format,
+//! non-TTY auto-detection, and error JSON structure.
+
+use assert_cmd::Command;
+
+fn cli_cmd() -> Command {
+    Command::cargo_bin("rusty-brain").expect("binary should exist")
+}
+
+// T064 / AC-8: --json output matches InstallReport schema.
+#[test]
+fn install_json_output_is_valid_json() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = cli_cmd()
+        .args(["install", "--project", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to execute CLI");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("output should be valid JSON");
+
+    // Verify InstallReport structure.
+    assert!(parsed["status"].is_string(), "should have status field");
+    assert!(parsed["results"].is_array(), "should have results array");
+    assert!(
+        parsed["memory_store"].is_string(),
+        "should have memory_store"
+    );
+    assert!(parsed["scope"].is_string(), "should have scope");
+}
+
+// T064: Each result has expected fields.
+#[test]
+fn install_json_results_have_expected_fields() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = cli_cmd()
+        .args(["install", "--project", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to execute CLI");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let results = parsed["results"].as_array().unwrap();
+    for result in results {
+        assert!(
+            result["agent_name"].is_string(),
+            "each result should have agent_name"
+        );
+        assert!(
+            result["status"].is_string(),
+            "each result should have status"
+        );
+    }
+}
+
+// T066 / AC-11, SEC-10: Error JSON has code and message fields.
+// Error JSON is written to stderr by print_error_json().
+#[test]
+fn install_error_json_has_code_and_message() {
+    let output = cli_cmd()
+        .args(["install", "--json"])
+        .output()
+        .expect("failed to execute CLI");
+
+    assert!(!output.status.success(), "should fail without scope");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stderr).expect("error output should be valid JSON on stderr");
+
+    assert!(parsed["code"].is_string(), "error should have code field");
+    assert!(
+        parsed["message"].is_string(),
+        "error should have message field"
+    );
+
+    let code = parsed["code"].as_str().unwrap();
+    assert!(
+        code.starts_with("E_"),
+        "error code should start with E_: {code}"
+    );
+}
+
+// T066: Invalid agent error JSON on stderr.
+#[test]
+fn install_invalid_agent_error_json() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = cli_cmd()
+        .args(["install", "--agents", "nonexistent", "--project", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to execute CLI");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stderr).expect("error JSON should be on stderr");
+
+    assert_eq!(parsed["code"], "E_CLI_INSTALL");
+    let message = parsed["message"].as_str().unwrap();
+    assert!(
+        message.contains("E_INSTALL_INVALID_AGENT"),
+        "should contain error code: {message}"
+    );
+}

--- a/crates/cli/tests/install_json_test.rs
+++ b/crates/cli/tests/install_json_test.rs
@@ -20,6 +20,8 @@ fn install_json_output_is_valid_json() {
         .output()
         .expect("failed to execute CLI");
 
+    assert!(output.status.success(), "install should succeed");
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("output should be valid JSON");
@@ -44,6 +46,8 @@ fn install_json_results_have_expected_fields() {
         .current_dir(dir.path())
         .output()
         .expect("failed to execute CLI");
+
+    assert!(output.status.success(), "install should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -16,6 +16,8 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 semver = { workspace = true }
 thiserror = { workspace = true }
+tempfile = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 temp-env = { workspace = true }

--- a/crates/platforms/Cargo.toml
+++ b/crates/platforms/Cargo.toml
@@ -17,7 +17,6 @@ chrono = { workspace = true }
 semver = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 temp-env = { workspace = true }

--- a/crates/platforms/src/installer/agents/codex.rs
+++ b/crates/platforms/src/installer/agents/codex.rs
@@ -1,0 +1,112 @@
+//! `OpenAI` `Codex` CLI agent installer.
+//!
+//! NOTE: `Codex` CLI extension mechanism requires Spike-2 research (PRD).
+//! This is a stub installer until the extension format is confirmed.
+
+use std::path::Path;
+
+use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+use crate::installer::{
+    AgentInstaller, detect_binary_version, find_binary_on_path, resolve_global_config_dir,
+    validate_json_config,
+};
+
+/// Installer for the `OpenAI` `Codex` CLI agent.
+pub struct CodexInstaller;
+
+impl AgentInstaller for CodexInstaller {
+    fn agent_name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn detect(&self) -> Option<AgentInfo> {
+        let binary_path = find_binary_on_path("codex")?;
+
+        let version = detect_binary_version(&binary_path);
+
+        Some(AgentInfo {
+            name: "codex".to_string(),
+            binary_path,
+            version,
+        })
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError> {
+        let config_dir = match scope {
+            InstallScope::Project { root } => root.join(".codex"),
+            InstallScope::Global => resolve_global_config_dir("codex")?,
+        };
+
+        let binary_str = binary_path.to_string_lossy();
+        let manifest = generate_codex_config(&binary_str);
+
+        Ok(vec![ConfigFile {
+            target_path: config_dir.join("rusty-brain.json"),
+            content: manifest,
+            description:
+                "Codex CLI extension config for rusty-brain (stub — awaiting Spike-2 research)"
+                    .to_string(),
+        }])
+    }
+
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError> {
+        let config_path = match scope {
+            InstallScope::Project { root } => root.join(".codex").join("rusty-brain.json"),
+            InstallScope::Global => resolve_global_config_dir("codex")?.join("rusty-brain.json"),
+        };
+
+        validate_json_config(&config_path)
+    }
+}
+
+fn generate_codex_config(binary_path: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": "rusty-brain",
+        "description": "AI agent memory system powered by memvid (stub — awaiting Spike-2 research)",
+        "binary": binary_path,
+        "status": "stub",
+        "note": "Codex CLI extension mechanism not yet confirmed. This config will be updated after Spike-2 research."
+    }))
+    .expect("JSON serialization should not fail for static data")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // T046: CodexInstaller::detect() tests
+
+    #[test]
+    fn detect_does_not_panic() {
+        let installer = CodexInstaller;
+        let _ = installer.detect();
+    }
+
+    // T047: CodexInstaller::generate_config() tests
+
+    #[test]
+    fn generate_config_project_scope() {
+        let installer = CodexInstaller;
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let files = installer.generate_config(&scope, &binary).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].target_path,
+            PathBuf::from("/tmp/project/.codex/rusty-brain.json")
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&files[0].content).unwrap();
+        assert_eq!(parsed["name"], "rusty-brain");
+        assert_eq!(parsed["status"], "stub");
+    }
+}

--- a/crates/platforms/src/installer/agents/copilot.rs
+++ b/crates/platforms/src/installer/agents/copilot.rs
@@ -1,0 +1,114 @@
+//! GitHub `Copilot` CLI agent installer.
+//!
+//! NOTE: `Copilot` CLI extension mechanism requires Spike-1 research (PRD).
+//! This is a stub installer that reports the agent as detected but generates
+//! a placeholder config until the extension format is confirmed.
+
+use std::path::Path;
+
+use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+use crate::installer::{
+    AgentInstaller, detect_binary_version, find_binary_on_path, resolve_global_config_dir,
+    validate_json_config,
+};
+
+/// Installer for the GitHub `Copilot` CLI agent.
+pub struct CopilotInstaller;
+
+impl AgentInstaller for CopilotInstaller {
+    fn agent_name(&self) -> &'static str {
+        "copilot"
+    }
+
+    fn detect(&self) -> Option<AgentInfo> {
+        // Copilot CLI is accessed via `gh copilot` — detect `gh` binary.
+        let binary_path = find_binary_on_path("gh")?;
+
+        let version = detect_binary_version(&binary_path);
+
+        Some(AgentInfo {
+            name: "copilot".to_string(),
+            binary_path,
+            version,
+        })
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError> {
+        let config_dir = match scope {
+            InstallScope::Project { root } => root.join(".copilot"),
+            InstallScope::Global => resolve_global_config_dir("copilot")?,
+        };
+
+        let binary_str = binary_path.to_string_lossy();
+        let manifest = generate_copilot_config(&binary_str);
+
+        Ok(vec![ConfigFile {
+            target_path: config_dir.join("rusty-brain.json"),
+            content: manifest,
+            description:
+                "Copilot CLI extension config for rusty-brain (stub — awaiting Spike-1 research)"
+                    .to_string(),
+        }])
+    }
+
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError> {
+        let config_path = match scope {
+            InstallScope::Project { root } => root.join(".copilot").join("rusty-brain.json"),
+            InstallScope::Global => resolve_global_config_dir("copilot")?.join("rusty-brain.json"),
+        };
+
+        validate_json_config(&config_path)
+    }
+}
+
+fn generate_copilot_config(binary_path: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": "rusty-brain",
+        "description": "AI agent memory system powered by memvid (stub — awaiting Spike-1 research)",
+        "binary": binary_path,
+        "status": "stub",
+        "note": "Copilot CLI extension mechanism not yet confirmed. This config will be updated after Spike-1 research."
+    }))
+    .expect("JSON serialization should not fail for static data")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // T040: CopilotInstaller::detect() tests
+
+    #[test]
+    fn detect_does_not_panic() {
+        let installer = CopilotInstaller;
+        let _ = installer.detect();
+    }
+
+    // T041: CopilotInstaller::generate_config() tests
+
+    #[test]
+    fn generate_config_project_scope() {
+        let installer = CopilotInstaller;
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let files = installer.generate_config(&scope, &binary).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].target_path,
+            PathBuf::from("/tmp/project/.copilot/rusty-brain.json")
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&files[0].content).unwrap();
+        assert_eq!(parsed["name"], "rusty-brain");
+        assert_eq!(parsed["status"], "stub");
+    }
+}

--- a/crates/platforms/src/installer/agents/copilot.rs
+++ b/crates/platforms/src/installer/agents/copilot.rs
@@ -5,6 +5,7 @@
 //! a placeholder config until the extension format is confirmed.
 
 use std::path::Path;
+use std::process::{Command, Stdio};
 
 use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
 
@@ -24,6 +25,16 @@ impl AgentInstaller for CopilotInstaller {
     fn detect(&self) -> Option<AgentInfo> {
         // Copilot CLI is accessed via `gh copilot` — detect `gh` binary.
         let binary_path = find_binary_on_path("gh")?;
+
+        // Verify `gh copilot` subcommand is available (gh may exist without copilot).
+        let copilot_check = Command::new(&binary_path)
+            .args(["help", "copilot"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if !copilot_check.is_ok_and(|s| s.success()) {
+            return None;
+        }
 
         let version = detect_binary_version(&binary_path);
 

--- a/crates/platforms/src/installer/agents/gemini.rs
+++ b/crates/platforms/src/installer/agents/gemini.rs
@@ -1,0 +1,112 @@
+//! Google `Gemini` CLI agent installer.
+//!
+//! NOTE: `Gemini` CLI extension mechanism requires Spike-3 research (PRD).
+//! This is a stub installer until the extension format is confirmed.
+
+use std::path::Path;
+
+use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+use crate::installer::{
+    AgentInstaller, detect_binary_version, find_binary_on_path, resolve_global_config_dir,
+    validate_json_config,
+};
+
+/// Installer for the Google `Gemini` CLI agent.
+pub struct GeminiInstaller;
+
+impl AgentInstaller for GeminiInstaller {
+    fn agent_name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn detect(&self) -> Option<AgentInfo> {
+        let binary_path = find_binary_on_path("gemini")?;
+
+        let version = detect_binary_version(&binary_path);
+
+        Some(AgentInfo {
+            name: "gemini".to_string(),
+            binary_path,
+            version,
+        })
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError> {
+        let config_dir = match scope {
+            InstallScope::Project { root } => root.join(".gemini"),
+            InstallScope::Global => resolve_global_config_dir("gemini")?,
+        };
+
+        let binary_str = binary_path.to_string_lossy();
+        let manifest = generate_gemini_config(&binary_str);
+
+        Ok(vec![ConfigFile {
+            target_path: config_dir.join("rusty-brain.json"),
+            content: manifest,
+            description:
+                "Gemini CLI extension config for rusty-brain (stub — awaiting Spike-3 research)"
+                    .to_string(),
+        }])
+    }
+
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError> {
+        let config_path = match scope {
+            InstallScope::Project { root } => root.join(".gemini").join("rusty-brain.json"),
+            InstallScope::Global => resolve_global_config_dir("gemini")?.join("rusty-brain.json"),
+        };
+
+        validate_json_config(&config_path)
+    }
+}
+
+fn generate_gemini_config(binary_path: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": "rusty-brain",
+        "description": "AI agent memory system powered by memvid (stub — awaiting Spike-3 research)",
+        "binary": binary_path,
+        "status": "stub",
+        "note": "Gemini CLI extension mechanism not yet confirmed. This config will be updated after Spike-3 research."
+    }))
+    .expect("JSON serialization should not fail for static data")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // T058: GeminiInstaller::detect() tests
+
+    #[test]
+    fn detect_does_not_panic() {
+        let installer = GeminiInstaller;
+        let _ = installer.detect();
+    }
+
+    // T059: GeminiInstaller::generate_config() tests
+
+    #[test]
+    fn generate_config_project_scope() {
+        let installer = GeminiInstaller;
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let files = installer.generate_config(&scope, &binary).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].target_path,
+            PathBuf::from("/tmp/project/.gemini/rusty-brain.json")
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&files[0].content).unwrap();
+        assert_eq!(parsed["name"], "rusty-brain");
+        assert_eq!(parsed["status"], "stub");
+    }
+}

--- a/crates/platforms/src/installer/agents/mod.rs
+++ b/crates/platforms/src/installer/agents/mod.rs
@@ -1,0 +1,32 @@
+//! Per-agent installer implementations.
+
+pub mod codex;
+pub mod copilot;
+pub mod gemini;
+pub mod opencode;
+
+use super::AgentInstaller;
+
+/// Factory function for the `OpenCode` installer.
+#[must_use]
+pub fn opencode_installer() -> Box<dyn AgentInstaller> {
+    Box::new(opencode::OpenCodeInstaller)
+}
+
+/// Factory function for the `Copilot` installer.
+#[must_use]
+pub fn copilot_installer() -> Box<dyn AgentInstaller> {
+    Box::new(copilot::CopilotInstaller)
+}
+
+/// Factory function for the `Codex` installer.
+#[must_use]
+pub fn codex_installer() -> Box<dyn AgentInstaller> {
+    Box::new(codex::CodexInstaller)
+}
+
+/// Factory function for the `Gemini` installer.
+#[must_use]
+pub fn gemini_installer() -> Box<dyn AgentInstaller> {
+    Box::new(gemini::GeminiInstaller)
+}

--- a/crates/platforms/src/installer/agents/opencode.rs
+++ b/crates/platforms/src/installer/agents/opencode.rs
@@ -1,0 +1,192 @@
+//! `OpenCode` agent installer.
+
+use std::path::Path;
+
+use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+use crate::installer::{
+    AgentInstaller, detect_binary_version, find_binary_on_path, resolve_global_config_dir,
+    validate_json_config,
+};
+
+/// Installer for the `OpenCode` AI agent.
+pub struct OpenCodeInstaller;
+
+impl AgentInstaller for OpenCodeInstaller {
+    fn agent_name(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn detect(&self) -> Option<AgentInfo> {
+        let binary_path = find_binary_on_path("opencode")?;
+
+        let version = detect_binary_version(&binary_path);
+
+        Some(AgentInfo {
+            name: "opencode".to_string(),
+            binary_path,
+            version,
+        })
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError> {
+        let config_dir = match scope {
+            InstallScope::Project { root } => root.join(".opencode").join("plugins"),
+            InstallScope::Global => resolve_global_config_dir("opencode")?.join("plugins"),
+        };
+
+        let binary_str = binary_path.to_string_lossy();
+        let manifest = generate_plugin_manifest(&binary_str);
+
+        Ok(vec![ConfigFile {
+            target_path: config_dir.join("rusty-brain.json"),
+            content: manifest,
+            description: "OpenCode plugin manifest for rusty-brain".to_string(),
+        }])
+    }
+
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError> {
+        let config_path = match scope {
+            InstallScope::Project { root } => root
+                .join(".opencode")
+                .join("plugins")
+                .join("rusty-brain.json"),
+            InstallScope::Global => resolve_global_config_dir("opencode")?
+                .join("plugins")
+                .join("rusty-brain.json"),
+        };
+
+        validate_json_config(&config_path)
+    }
+}
+
+/// Generate the plugin manifest JSON for `OpenCode`.
+fn generate_plugin_manifest(binary_path: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": "rusty-brain",
+        "description": "AI agent memory system powered by memvid",
+        "binary": binary_path,
+        "commands": {
+            "ask": {
+                "description": "Ask a question about your memory",
+                "args": ["ask", "--json"]
+            },
+            "search": {
+                "description": "Search memories by text pattern",
+                "args": ["find", "--json"]
+            },
+            "recent": {
+                "description": "Show recent memory timeline",
+                "args": ["timeline", "--json"]
+            },
+            "stats": {
+                "description": "View memory statistics",
+                "args": ["stats", "--json"]
+            }
+        }
+    }))
+    .expect("JSON serialization should not fail for static data")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::installer::parse_version_string;
+    use std::path::PathBuf;
+
+    // T032: OpenCodeInstaller::detect() tests
+
+    #[test]
+    fn detect_returns_none_when_binary_not_found() {
+        // OpenCode is unlikely to be installed in CI
+        // This test verifies the method doesn't panic
+        let installer = OpenCodeInstaller;
+        let _ = installer.detect();
+    }
+
+    // T033: OpenCodeInstaller::generate_config() tests
+
+    #[test]
+    fn generate_config_project_scope() {
+        let installer = OpenCodeInstaller;
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let files = installer.generate_config(&scope, &binary).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].target_path,
+            PathBuf::from("/tmp/project/.opencode/plugins/rusty-brain.json")
+        );
+
+        // Verify JSON content
+        let parsed: serde_json::Value = serde_json::from_str(&files[0].content).unwrap();
+        assert_eq!(parsed["name"], "rusty-brain");
+        assert_eq!(parsed["binary"], "/usr/local/bin/rusty-brain");
+        assert!(parsed["commands"]["ask"].is_object());
+        assert!(parsed["commands"]["search"].is_object());
+        assert!(parsed["commands"]["recent"].is_object());
+        assert!(parsed["commands"]["stats"].is_object());
+    }
+
+    #[test]
+    fn generate_config_global_scope() {
+        let installer = OpenCodeInstaller;
+        let scope = InstallScope::Global;
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let result = installer.generate_config(&scope, &binary);
+        assert!(result.is_ok());
+        let files = result.unwrap();
+        assert_eq!(files.len(), 1);
+        let path_str = files[0].target_path.to_string_lossy();
+        assert!(
+            path_str.contains("opencode"),
+            "global path should contain agent name: {path_str}"
+        );
+        assert!(path_str.contains("rusty-brain.json"));
+    }
+
+    #[test]
+    fn generate_config_slash_commands_registered() {
+        let installer = OpenCodeInstaller;
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        let binary = PathBuf::from("/usr/local/bin/rusty-brain");
+
+        let files = installer.generate_config(&scope, &binary).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&files[0].content).unwrap();
+        let commands = parsed["commands"].as_object().unwrap();
+
+        // Verify all required slash commands are registered
+        assert!(commands.contains_key("ask"), "missing /ask command");
+        assert!(commands.contains_key("search"), "missing /search command");
+        assert!(commands.contains_key("recent"), "missing /recent command");
+        assert!(commands.contains_key("stats"), "missing /stats command");
+    }
+
+    // parse_version_string tests
+
+    #[test]
+    fn parse_version_from_output() {
+        assert_eq!(
+            parse_version_string("opencode 1.2.3"),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(parse_version_string("v1.2.3"), Some("1.2.3".to_string()));
+        assert_eq!(parse_version_string("1.2.3"), Some("1.2.3".to_string()));
+    }
+
+    #[test]
+    fn parse_version_empty_returns_none() {
+        assert_eq!(parse_version_string(""), None);
+        assert_eq!(parse_version_string("   "), None);
+    }
+}

--- a/crates/platforms/src/installer/mod.rs
+++ b/crates/platforms/src/installer/mod.rs
@@ -225,10 +225,19 @@ pub fn resolve_global_config_dir(agent_name: &str) -> Result<PathBuf, InstallErr
     #[cfg(target_os = "linux")]
     {
         // Respect XDG_CONFIG_HOME if set, otherwise fall back to ~/.config
-        let config_dir = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-            format!("{home}/.config")
-        });
+        let config_dir = match std::env::var("XDG_CONFIG_HOME") {
+            Ok(xdg) => xdg,
+            Err(_) => {
+                let home = std::env::var("HOME").map_err(|_| InstallError::IoError {
+                    path: PathBuf::from("~"),
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "HOME environment variable not set",
+                    ),
+                })?;
+                format!("{home}/.config")
+            }
+        };
         Ok(PathBuf::from(config_dir).join(agent_name))
     }
 

--- a/crates/platforms/src/installer/mod.rs
+++ b/crates/platforms/src/installer/mod.rs
@@ -1,0 +1,378 @@
+//! Agent installer subsystem.
+//!
+//! Provides the [`AgentInstaller`] trait, binary detection utilities,
+//! path validation, and global scope path resolution.
+
+pub mod agents;
+pub mod orchestrator;
+pub mod registry;
+pub mod writer;
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+/// Trait that each agent installer must implement.
+///
+/// `generate_config` MUST be a pure function — no filesystem I/O.
+/// All filesystem operations go through [`writer::ConfigWriter`].
+pub trait AgentInstaller: Send + Sync {
+    /// Canonical lowercase agent name: "opencode", "copilot", "codex", "gemini".
+    fn agent_name(&self) -> &'static str;
+
+    /// Detect if this agent is installed on the system.
+    ///
+    /// Checks PATH for the agent binary and optionally runs `--version`
+    /// with a 2-second timeout.
+    ///
+    /// Returns `None` if the agent is not found.
+    fn detect(&self) -> Option<AgentInfo>;
+
+    /// Generate configuration files for this agent.
+    ///
+    /// This MUST be a pure function: given scope and binary path, return
+    /// a list of files to write. No filesystem I/O.
+    ///
+    /// `binary_path` is the absolute path to the rusty-brain binary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError`] if config generation fails (e.g., scope resolution error).
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError>;
+
+    /// Validate that the installation is working (post-install check).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError`] if validation fails (e.g., config file missing or invalid).
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError>;
+}
+
+/// Hardcoded allowlist of supported agent names.
+pub const SUPPORTED_AGENTS: &[&str] = &["opencode", "copilot", "codex", "gemini"];
+
+/// Check if an agent name is in the supported allowlist.
+#[must_use]
+pub fn is_valid_agent(name: &str) -> bool {
+    SUPPORTED_AGENTS
+        .iter()
+        .any(|a| a.eq_ignore_ascii_case(name))
+}
+
+/// Find a binary on the system PATH without shell execution (SEC-7).
+///
+/// Iterates `$PATH` entries and checks for the binary name (with `.exe`
+/// extension on Windows). Returns the first match.
+#[must_use]
+pub fn find_binary_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        // On Windows, also check with .exe extension.
+        #[cfg(target_os = "windows")]
+        {
+            let with_exe = dir.join(format!("{name}.exe"));
+            if with_exe.is_file() {
+                return Some(with_exe);
+            }
+            let with_cmd = dir.join(format!("{name}.cmd"));
+            if with_cmd.is_file() {
+                return Some(with_cmd);
+            }
+        }
+    }
+    None
+}
+
+/// Detect a binary's version by running `<binary> --version` with a 2-second timeout.
+///
+/// Spawns the binary as a child process and kills it if the timeout fires,
+/// preventing thread and process leaks (SEC-6).
+///
+/// Returns `None` if the binary fails to start, produces no output, or times out.
+#[must_use]
+pub fn detect_binary_version(binary_path: &Path) -> Option<String> {
+    let mut child = Command::new(binary_path)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let mut stdout_pipe = child.stdout.take()?;
+    let (tx, rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout_pipe.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    if let Ok(stdout) = rx.recv_timeout(Duration::from_secs(2)) {
+        let _ = child.wait();
+        parse_version_string(&stdout)
+    } else {
+        let _ = child.kill();
+        let _ = child.wait();
+        None
+    }
+}
+
+/// Parse a version string from command output.
+///
+/// Handles formats like "opencode 1.2.3" or "v1.2.3" or just "1.2.3".
+#[must_use]
+pub fn parse_version_string(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    for word in trimmed.split_whitespace() {
+        let cleaned = word.trim_start_matches('v');
+        if cleaned.chars().next().is_some_and(|c| c.is_ascii_digit()) && cleaned.contains('.') {
+            return Some(cleaned.to_string());
+        }
+    }
+
+    Some(trimmed.to_string())
+}
+
+/// Validate that a JSON config file exists and is parseable.
+///
+/// Shared helper for agent `validate()` implementations.
+///
+/// # Errors
+///
+/// Returns [`InstallError::ConfigCorrupted`] if the file doesn't exist or contains
+/// invalid JSON, or [`InstallError::IoError`] if the file can't be read.
+pub fn validate_json_config(config_path: &Path) -> Result<(), InstallError> {
+    if !config_path.exists() {
+        return Err(InstallError::ConfigCorrupted {
+            path: config_path.to_path_buf(),
+        });
+    }
+
+    let content = std::fs::read_to_string(config_path).map_err(|source| InstallError::IoError {
+        path: config_path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str::<serde_json::Value>(&content).map_err(|_| {
+        InstallError::ConfigCorrupted {
+            path: config_path.to_path_buf(),
+        }
+    })?;
+
+    Ok(())
+}
+
+/// Validate a config path against traversal attacks (SEC-4).
+///
+/// Rejects paths containing `..` components. Returns the validated path on success.
+///
+/// # Errors
+///
+/// Returns [`InstallError::PathTraversal`] if the path contains `..` components.
+pub fn validate_config_path(path: &Path) -> Result<PathBuf, InstallError> {
+    // Check for literal ".." components in the path
+    for component in path.components() {
+        if let std::path::Component::ParentDir = component {
+            return Err(InstallError::PathTraversal {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Resolve the global config directory for an agent, per platform.
+///
+/// - macOS: `~/Library/Application Support/<agent>/`
+/// - Linux: `~/.config/<agent>/`
+/// - Windows: `%APPDATA%/<agent>/`
+///
+/// # Errors
+///
+/// Returns [`InstallError::IoError`] if the required environment variable
+/// (`HOME`, `APPDATA`) is not set.
+pub fn resolve_global_config_dir(agent_name: &str) -> Result<PathBuf, InstallError> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var("HOME").map_err(|_| InstallError::IoError {
+            path: PathBuf::from("~"),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "HOME environment variable not set",
+            ),
+        })?;
+        Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join(agent_name))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Respect XDG_CONFIG_HOME if set, otherwise fall back to ~/.config
+        let config_dir = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            format!("{home}/.config")
+        });
+        Ok(PathBuf::from(config_dir).join(agent_name))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let appdata = std::env::var("APPDATA").map_err(|_| InstallError::IoError {
+            path: PathBuf::from("%APPDATA%"),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "APPDATA environment variable not set",
+            ),
+        })?;
+        Ok(PathBuf::from(appdata).join(agent_name))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let home = std::env::var("HOME").map_err(|_| InstallError::IoError {
+            path: PathBuf::from("~"),
+            source: std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "HOME environment variable not set",
+            ),
+        })?;
+        Ok(PathBuf::from(home).join(".config").join(agent_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T013: AgentInstaller trait is object-safe and can be stored in Box
+    #[test]
+    fn agent_installer_trait_is_object_safe() {
+        // This test verifies the trait can be used as a trait object.
+        // Compilation alone proves object safety; we verify Box<dyn> works.
+        struct DummyInstaller;
+        impl AgentInstaller for DummyInstaller {
+            fn agent_name(&self) -> &'static str {
+                "dummy"
+            }
+            fn detect(&self) -> Option<AgentInfo> {
+                None
+            }
+            fn generate_config(
+                &self,
+                _scope: &InstallScope,
+                _binary_path: &Path,
+            ) -> Result<Vec<ConfigFile>, InstallError> {
+                Ok(vec![])
+            }
+            fn validate(&self, _scope: &InstallScope) -> Result<(), InstallError> {
+                Ok(())
+            }
+        }
+
+        let installer: Box<dyn AgentInstaller> = Box::new(DummyInstaller);
+        assert_eq!(installer.agent_name(), "dummy");
+        assert!(installer.detect().is_none());
+    }
+
+    // T015: find_binary_on_path tests
+    #[test]
+    fn find_binary_on_path_finds_existing_binary() {
+        // "sh" should exist on any Unix system
+        #[cfg(unix)]
+        {
+            let result = find_binary_on_path("sh");
+            assert!(result.is_some(), "sh should be found on PATH");
+            assert!(result.unwrap().is_file());
+        }
+    }
+
+    #[test]
+    fn find_binary_on_path_returns_none_for_nonexistent() {
+        let result = find_binary_on_path("__rusty_brain_nonexistent_binary_12345__");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_binary_returns_none_for_nonexistent_binary() {
+        // Even with a valid PATH, a truly nonexistent binary returns None
+        let result = find_binary_on_path("__absolutely_nonexistent_binary_xyz_99__");
+        assert!(result.is_none());
+    }
+
+    // T017: validate_config_path tests
+    #[test]
+    fn validate_config_path_accepts_valid_path() {
+        let path = Path::new("/tmp/project/.opencode/plugins");
+        let result = validate_config_path(path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_config_path_rejects_traversal() {
+        let path = Path::new("/tmp/project/../etc/shadow");
+        let result = validate_config_path(path);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            InstallError::PathTraversal { .. } => {}
+            other => panic!("Expected PathTraversal, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_config_path_accepts_absolute_path() {
+        let path = Path::new("/usr/local/bin/rusty-brain");
+        assert!(validate_config_path(path).is_ok());
+    }
+
+    // T018b: resolve_global_config_dir tests
+    #[test]
+    fn resolve_global_config_dir_returns_path_for_agent() {
+        let result = resolve_global_config_dir("opencode");
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        let path_str = path.to_string_lossy();
+        assert!(
+            path_str.contains("opencode"),
+            "path should contain agent name: {path_str}"
+        );
+    }
+
+    // is_valid_agent tests
+    #[test]
+    fn is_valid_agent_accepts_known_agents() {
+        assert!(is_valid_agent("opencode"));
+        assert!(is_valid_agent("copilot"));
+        assert!(is_valid_agent("codex"));
+        assert!(is_valid_agent("gemini"));
+    }
+
+    #[test]
+    fn is_valid_agent_case_insensitive() {
+        assert!(is_valid_agent("OpenCode"));
+        assert!(is_valid_agent("COPILOT"));
+    }
+
+    #[test]
+    fn is_valid_agent_rejects_unknown() {
+        assert!(!is_valid_agent("vscode"));
+        assert!(!is_valid_agent("cursor"));
+        assert!(!is_valid_agent(""));
+    }
+}

--- a/crates/platforms/src/installer/mod.rs
+++ b/crates/platforms/src/installer/mod.rs
@@ -12,7 +12,7 @@ use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
 
@@ -90,6 +90,10 @@ pub fn find_binary_on_path(name: &str) -> Option<PathBuf> {
             if with_cmd.is_file() {
                 return Some(with_cmd);
             }
+            let with_bat = dir.join(format!("{name}.bat"));
+            if with_bat.is_file() {
+                return Some(with_bat);
+            }
         }
     }
     None
@@ -119,7 +123,18 @@ pub fn detect_binary_version(binary_path: &Path) -> Option<String> {
         let _ = tx.send(buf);
     });
 
+    let deadline = Instant::now() + Duration::from_secs(2);
     if let Ok(stdout) = rx.recv_timeout(Duration::from_secs(2)) {
+        // Enforce timeout on child lifetime too — a process that closes stdout
+        // but hangs in cleanup would block child.wait() indefinitely.
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) => return parse_version_string(&stdout),
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(_) => return None,
+            }
+        }
+        let _ = child.kill();
         let _ = child.wait();
         parse_version_string(&stdout)
     } else {

--- a/crates/platforms/src/installer/orchestrator.rs
+++ b/crates/platforms/src/installer/orchestrator.rs
@@ -115,7 +115,12 @@ impl InstallOrchestrator {
                 status: InstallStatus::NotFound,
                 config_path: None,
                 version_detected: None,
-                error: Some(format!("No installer registered for '{agent_name}'")),
+                error: Some(
+                    InstallError::AgentNotFound {
+                        agent: agent_name.to_string(),
+                    }
+                    .to_string(),
+                ),
             };
         };
 
@@ -193,36 +198,35 @@ mod tests {
     use types::install::{AgentInfo, ConfigFile, InstallScope};
 
     struct FakeInstaller {
-        name: String,
+        name: &'static str,
         detected: bool,
     }
 
     impl FakeInstaller {
-        fn detected(name: &str) -> Box<dyn AgentInstaller> {
+        fn detected(name: &'static str) -> Box<dyn AgentInstaller> {
             Box::new(Self {
-                name: name.to_string(),
+                name,
                 detected: true,
             })
         }
 
-        fn not_detected(name: &str) -> Box<dyn AgentInstaller> {
+        fn not_detected(name: &'static str) -> Box<dyn AgentInstaller> {
             Box::new(Self {
-                name: name.to_string(),
+                name,
                 detected: false,
             })
         }
     }
 
     impl AgentInstaller for FakeInstaller {
-        #[allow(clippy::unnecessary_literal_bound)]
         fn agent_name(&self) -> &'static str {
-            Box::leak(self.name.clone().into_boxed_str())
+            self.name
         }
 
         fn detect(&self) -> Option<AgentInfo> {
             if self.detected {
                 Some(AgentInfo {
-                    name: self.name.clone(),
+                    name: self.name.to_string(),
                     binary_path: PathBuf::from(format!("/usr/bin/{}", self.name)),
                     version: Some("1.0.0".to_string()),
                 })
@@ -240,10 +244,11 @@ mod tests {
                 InstallScope::Project { root } => root.clone(),
                 InstallScope::Global => PathBuf::from("/tmp/global"),
             };
+            let name = self.name;
             Ok(vec![ConfigFile {
-                target_path: dir.join(format!(".{}/config.json", self.name)),
-                content: format!(r#"{{"agent": "{}"}}"#, self.name),
-                description: format!("{} config", self.name),
+                target_path: dir.join(format!(".{name}/config.json")),
+                content: format!(r#"{{"agent": "{name}"}}"#),
+                description: format!("{name} config"),
             }])
         }
 

--- a/crates/platforms/src/installer/orchestrator.rs
+++ b/crates/platforms/src/installer/orchestrator.rs
@@ -1,0 +1,380 @@
+//! Install workflow coordinator.
+//!
+//! The [`InstallOrchestrator`] iterates over target agents, delegates to
+//! [`AgentInstaller`] implementations, and uses [`ConfigWriter`] for all
+//! filesystem operations. Fails per-agent, not per-command.
+
+use std::path::{Path, PathBuf};
+
+use types::install::{
+    AgentInstallResult, InstallConfig, InstallError, InstallReport, InstallScope, InstallStatus,
+    ReportStatus,
+};
+
+use super::is_valid_agent;
+use super::registry::InstallerRegistry;
+use super::writer::ConfigWriter;
+
+/// Coordinates the full install workflow for [`InstallConfig`].
+pub struct InstallOrchestrator {
+    registry: InstallerRegistry,
+}
+
+impl InstallOrchestrator {
+    /// Create a new orchestrator with the given registry.
+    #[must_use]
+    pub fn new(registry: InstallerRegistry) -> Self {
+        Self { registry }
+    }
+
+    /// Create a new orchestrator with all built-in installers.
+    #[must_use]
+    pub fn with_builtins() -> Self {
+        Self::new(InstallerRegistry::with_builtins())
+    }
+
+    /// Execute the full install workflow.
+    ///
+    /// 1. Determine target agents (from `config.agents` or auto-detect)
+    /// 2. For each agent: detect -> `generate_config` -> write
+    /// 3. Collect results into [`InstallReport`]
+    ///
+    /// Fails per-agent, not per-command.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError::InvalidAgent`] if an explicitly requested agent name
+    /// is not in the supported allowlist.
+    pub fn run(&self, config: &InstallConfig) -> Result<InstallReport, InstallError> {
+        let memory_store = config.scope.memory_store_path()?;
+        let binary_path = resolve_binary_path();
+
+        // Determine which agents to process.
+        let target_agents = match &config.agents {
+            Some(agents) => {
+                // Validate agent names against allowlist (SEC-5).
+                for agent in agents {
+                    if !is_valid_agent(agent) {
+                        return Err(InstallError::InvalidAgent {
+                            agent: agent.clone(),
+                        });
+                    }
+                }
+                agents.clone()
+            }
+            None => {
+                // Auto-detect: iterate all registered installers.
+                self.registry.agents()
+            }
+        };
+
+        let mut results = Vec::new();
+
+        for agent_name in &target_agents {
+            let result =
+                self.install_agent(agent_name, &config.scope, &binary_path, config.reconfigure);
+            results.push(result);
+        }
+
+        let status = if results.iter().all(|r| {
+            matches!(
+                r.status,
+                InstallStatus::Configured | InstallStatus::Upgraded | InstallStatus::Skipped
+            )
+        }) {
+            ReportStatus::Success
+        } else if results.iter().any(|r| {
+            matches!(
+                r.status,
+                InstallStatus::Configured | InstallStatus::Upgraded
+            )
+        }) {
+            ReportStatus::Partial
+        } else {
+            ReportStatus::Failed
+        };
+
+        Ok(InstallReport {
+            status,
+            results,
+            memory_store,
+            scope: config.scope.label().to_string(),
+        })
+    }
+
+    fn install_agent(
+        &self,
+        agent_name: &str,
+        scope: &InstallScope,
+        binary_path: &Path,
+        reconfigure: bool,
+    ) -> AgentInstallResult {
+        let Some(installer) = self.registry.resolve(agent_name) else {
+            return AgentInstallResult {
+                agent_name: agent_name.to_string(),
+                status: InstallStatus::NotFound,
+                config_path: None,
+                version_detected: None,
+                error: Some(format!("No installer registered for '{agent_name}'")),
+            };
+        };
+
+        // Detect agent.
+        let Some(agent_info) = installer.detect() else {
+            return AgentInstallResult {
+                agent_name: agent_name.to_string(),
+                status: InstallStatus::NotFound,
+                config_path: None,
+                version_detected: None,
+                error: None,
+            };
+        };
+
+        // Generate config files (pure, no I/O).
+        let config_files = match installer.generate_config(scope, binary_path) {
+            Ok(files) => files,
+            Err(e) => {
+                return AgentInstallResult {
+                    agent_name: agent_name.to_string(),
+                    status: InstallStatus::Failed,
+                    config_path: None,
+                    version_detected: agent_info.version.clone(),
+                    error: Some(e.to_string()),
+                };
+            }
+        };
+
+        // Write config files via ConfigWriter.
+        let first_config_path = config_files.first().map(|f| f.target_path.clone());
+        let mut is_upgrade = false;
+
+        for config_file in &config_files {
+            if config_file.target_path.exists() {
+                is_upgrade = true;
+            }
+            let backup = reconfigure || config_file.target_path.exists();
+            if let Err(e) = ConfigWriter::write(config_file, backup) {
+                return AgentInstallResult {
+                    agent_name: agent_name.to_string(),
+                    status: InstallStatus::Failed,
+                    config_path: first_config_path,
+                    version_detected: agent_info.version.clone(),
+                    error: Some(e.to_string()),
+                };
+            }
+        }
+
+        let status = if is_upgrade {
+            InstallStatus::Upgraded
+        } else {
+            InstallStatus::Configured
+        };
+
+        AgentInstallResult {
+            agent_name: agent_name.to_string(),
+            status,
+            config_path: first_config_path,
+            version_detected: agent_info.version,
+            error: None,
+        }
+    }
+}
+
+/// Resolve the path to the rusty-brain binary.
+fn resolve_binary_path() -> PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("rusty-brain"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::installer::AgentInstaller;
+    use std::path::Path;
+    use types::install::{AgentInfo, ConfigFile, InstallScope};
+
+    struct FakeInstaller {
+        name: String,
+        detected: bool,
+    }
+
+    impl FakeInstaller {
+        fn detected(name: &str) -> Box<dyn AgentInstaller> {
+            Box::new(Self {
+                name: name.to_string(),
+                detected: true,
+            })
+        }
+
+        fn not_detected(name: &str) -> Box<dyn AgentInstaller> {
+            Box::new(Self {
+                name: name.to_string(),
+                detected: false,
+            })
+        }
+    }
+
+    impl AgentInstaller for FakeInstaller {
+        #[allow(clippy::unnecessary_literal_bound)]
+        fn agent_name(&self) -> &'static str {
+            Box::leak(self.name.clone().into_boxed_str())
+        }
+
+        fn detect(&self) -> Option<AgentInfo> {
+            if self.detected {
+                Some(AgentInfo {
+                    name: self.name.clone(),
+                    binary_path: PathBuf::from(format!("/usr/bin/{}", self.name)),
+                    version: Some("1.0.0".to_string()),
+                })
+            } else {
+                None
+            }
+        }
+
+        fn generate_config(
+            &self,
+            scope: &InstallScope,
+            _binary_path: &Path,
+        ) -> Result<Vec<ConfigFile>, InstallError> {
+            let dir = match scope {
+                InstallScope::Project { root } => root.clone(),
+                InstallScope::Global => PathBuf::from("/tmp/global"),
+            };
+            Ok(vec![ConfigFile {
+                target_path: dir.join(format!(".{}/config.json", self.name)),
+                content: format!(r#"{{"agent": "{}"}}"#, self.name),
+                description: format!("{} config", self.name),
+            }])
+        }
+
+        fn validate(&self, _scope: &InstallScope) -> Result<(), InstallError> {
+            Ok(())
+        }
+    }
+
+    // T024: InstallOrchestrator tests
+
+    #[test]
+    fn auto_detect_flow() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = InstallerRegistry::new();
+        registry.register(FakeInstaller::detected("opencode"));
+        registry.register(FakeInstaller::not_detected("copilot"));
+
+        let orch = InstallOrchestrator::new(registry);
+        let config = InstallConfig {
+            agents: None,
+            scope: InstallScope::Project {
+                root: dir.path().to_path_buf(),
+            },
+            json: false,
+            reconfigure: false,
+        };
+
+        let report = orch.run(&config).unwrap();
+        // One configured, one not found
+        let configured: Vec<_> = report
+            .results
+            .iter()
+            .filter(|r| r.status == InstallStatus::Configured)
+            .collect();
+        let not_found: Vec<_> = report
+            .results
+            .iter()
+            .filter(|r| r.status == InstallStatus::NotFound)
+            .collect();
+
+        assert_eq!(configured.len(), 1);
+        assert_eq!(not_found.len(), 1);
+    }
+
+    #[test]
+    fn explicit_agent_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = InstallerRegistry::new();
+        registry.register(FakeInstaller::detected("opencode"));
+        registry.register(FakeInstaller::detected("copilot"));
+
+        let orch = InstallOrchestrator::new(registry);
+        let config = InstallConfig {
+            agents: Some(vec!["opencode".to_string()]),
+            scope: InstallScope::Project {
+                root: dir.path().to_path_buf(),
+            },
+            json: false,
+            reconfigure: false,
+        };
+
+        let report = orch.run(&config).unwrap();
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].agent_name, "opencode");
+        assert_eq!(report.results[0].status, InstallStatus::Configured);
+    }
+
+    #[test]
+    fn invalid_agent_name_returns_error() {
+        let registry = InstallerRegistry::new();
+        let orch = InstallOrchestrator::new(registry);
+        let config = InstallConfig {
+            agents: Some(vec!["unknown_agent".to_string()]),
+            scope: InstallScope::Project {
+                root: PathBuf::from("/tmp"),
+            },
+            json: false,
+            reconfigure: false,
+        };
+
+        let result = orch.run(&config);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            InstallError::InvalidAgent { agent } => {
+                assert_eq!(agent, "unknown_agent");
+            }
+            other => panic!("Expected InvalidAgent, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_not_found_continues_to_next() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry = InstallerRegistry::new();
+        registry.register(FakeInstaller::not_detected("opencode"));
+        registry.register(FakeInstaller::detected("copilot"));
+
+        let orch = InstallOrchestrator::new(registry);
+        let config = InstallConfig {
+            agents: None,
+            scope: InstallScope::Project {
+                root: dir.path().to_path_buf(),
+            },
+            json: false,
+            reconfigure: false,
+        };
+
+        let report = orch.run(&config).unwrap();
+        assert_eq!(report.results.len(), 2);
+        // Should have both results regardless of detection status
+    }
+
+    #[test]
+    fn report_contains_memory_store_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = InstallerRegistry::new();
+        let orch = InstallOrchestrator::new(registry);
+        let config = InstallConfig {
+            agents: None,
+            scope: InstallScope::Project {
+                root: dir.path().to_path_buf(),
+            },
+            json: false,
+            reconfigure: false,
+        };
+
+        let report = orch.run(&config).unwrap();
+        assert_eq!(
+            report.memory_store,
+            dir.path().join(".rusty-brain").join("mind.mv2")
+        );
+        assert_eq!(report.scope, "project");
+    }
+}

--- a/crates/platforms/src/installer/registry.rs
+++ b/crates/platforms/src/installer/registry.rs
@@ -1,0 +1,161 @@
+//! Installer registry for registration, lookup, and listing.
+//!
+//! Mirrors the [`AdapterRegistry`](crate::registry::AdapterRegistry) pattern.
+
+use std::collections::HashMap;
+
+use super::AgentInstaller;
+use super::agents;
+
+/// A registry of agent installers, keyed by lowercase agent name.
+pub struct InstallerRegistry {
+    installers: HashMap<String, Box<dyn AgentInstaller>>,
+}
+
+impl InstallerRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            installers: HashMap::new(),
+        }
+    }
+
+    /// Create a registry pre-loaded with all built-in agent installers.
+    #[must_use]
+    pub fn with_builtins() -> Self {
+        let mut registry = Self::new();
+        registry.register(agents::opencode_installer());
+        registry.register(agents::copilot_installer());
+        registry.register(agents::codex_installer());
+        registry.register(agents::gemini_installer());
+        registry
+    }
+
+    /// Register an installer.
+    pub fn register(&mut self, installer: Box<dyn AgentInstaller>) {
+        let key = installer.agent_name().to_lowercase();
+        self.installers.insert(key, installer);
+    }
+
+    /// Look up an installer by agent name (case-insensitive).
+    #[must_use]
+    pub fn resolve(&self, agent_name: &str) -> Option<&dyn AgentInstaller> {
+        let key = agent_name.to_lowercase();
+        self.installers.get(&key).map(AsRef::as_ref)
+    }
+
+    /// Return sorted list of all registered agent names.
+    #[must_use]
+    pub fn agents(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.installers.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Return an iterator over all registered installers.
+    pub fn iter(&self) -> impl Iterator<Item = &dyn AgentInstaller> {
+        self.installers.values().map(AsRef::as_ref)
+    }
+}
+
+impl Default for InstallerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
+
+    struct MockInstaller {
+        name: String,
+    }
+
+    impl MockInstaller {
+        fn new(name: &str) -> Box<dyn AgentInstaller> {
+            Box::new(Self {
+                name: name.to_string(),
+            })
+        }
+    }
+
+    impl AgentInstaller for MockInstaller {
+        #[allow(clippy::unnecessary_literal_bound)]
+        fn agent_name(&self) -> &'static str {
+            // Leak the string for test purposes — the name lives for the test's lifetime.
+            Box::leak(self.name.clone().into_boxed_str())
+        }
+        fn detect(&self) -> Option<AgentInfo> {
+            None
+        }
+        fn generate_config(
+            &self,
+            _scope: &InstallScope,
+            _binary_path: &Path,
+        ) -> Result<Vec<ConfigFile>, InstallError> {
+            Ok(vec![])
+        }
+        fn validate(&self, _scope: &InstallScope) -> Result<(), InstallError> {
+            Ok(())
+        }
+    }
+
+    // T022: InstallerRegistry tests
+
+    #[test]
+    fn register_and_resolve() {
+        let mut registry = InstallerRegistry::new();
+        registry.register(MockInstaller::new("opencode"));
+
+        let installer = registry.resolve("opencode");
+        assert!(installer.is_some());
+        assert_eq!(installer.unwrap().agent_name(), "opencode");
+    }
+
+    #[test]
+    fn resolve_case_insensitive() {
+        let mut registry = InstallerRegistry::new();
+        registry.register(MockInstaller::new("opencode"));
+
+        assert!(registry.resolve("OpenCode").is_some());
+        assert!(registry.resolve("OPENCODE").is_some());
+        assert!(registry.resolve("opencode").is_some());
+    }
+
+    #[test]
+    fn resolve_unknown_returns_none() {
+        let registry = InstallerRegistry::new();
+        assert!(registry.resolve("unknown").is_none());
+    }
+
+    #[test]
+    fn agents_returns_sorted_list() {
+        let mut registry = InstallerRegistry::new();
+        registry.register(MockInstaller::new("codex"));
+        registry.register(MockInstaller::new("opencode"));
+        registry.register(MockInstaller::new("copilot"));
+
+        let agents = registry.agents();
+        assert_eq!(agents, vec!["codex", "copilot", "opencode"]);
+    }
+
+    #[test]
+    fn new_creates_empty_registry() {
+        let registry = InstallerRegistry::new();
+        assert!(registry.agents().is_empty());
+    }
+
+    #[test]
+    fn with_builtins_registers_all_agents() {
+        let registry = InstallerRegistry::with_builtins();
+        let agents = registry.agents();
+        assert!(agents.contains(&"opencode".to_string()));
+        assert!(agents.contains(&"copilot".to_string()));
+        assert!(agents.contains(&"codex".to_string()));
+        assert!(agents.contains(&"gemini".to_string()));
+    }
+}

--- a/crates/platforms/src/installer/writer.rs
+++ b/crates/platforms/src/installer/writer.rs
@@ -1,0 +1,196 @@
+//! Atomic config file writer with backup support.
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+use types::install::{ConfigFile, InstallError};
+
+use super::validate_config_path;
+
+/// Writes configuration files atomically using temp-file-then-rename.
+pub struct ConfigWriter;
+
+impl ConfigWriter {
+    /// Write a config file atomically.
+    ///
+    /// If `backup` is true and the target file exists, creates a `.bak` copy first.
+    /// Creates parent directories if they don't exist (M-12).
+    /// Sets file permissions to 0o644 on Unix (SEC-1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError::IoError`] if directory creation, file writing,
+    /// permission setting, or atomic rename fails.
+    pub fn write(config: &ConfigFile, backup: bool) -> Result<(), InstallError> {
+        let target = &config.target_path;
+
+        // Validate path against traversal attacks (SEC-4).
+        validate_config_path(target)?;
+
+        // Create parent directories if needed.
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|source| InstallError::IoError {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        // Backup existing file if requested.
+        if backup && target.exists() {
+            Self::backup(target)?;
+        }
+
+        // Write to temp file in same directory (same filesystem for atomic rename).
+        let parent = target.parent().unwrap_or(Path::new("."));
+        let temp = NamedTempFile::new_in(parent).map_err(|source| InstallError::IoError {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+
+        fs::write(temp.path(), &config.content).map_err(|source| InstallError::IoError {
+            path: temp.path().to_path_buf(),
+            source,
+        })?;
+
+        // Set permissions on Unix (SEC-1).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o644);
+            fs::set_permissions(temp.path(), perms).map_err(|source| InstallError::IoError {
+                path: temp.path().to_path_buf(),
+                source,
+            })?;
+        }
+
+        // Atomic rename (persist consumes the NamedTempFile).
+        temp.persist(target).map_err(|e| InstallError::IoError {
+            path: target.clone(),
+            source: e.error,
+        })?;
+
+        Ok(())
+    }
+
+    /// Create a `.bak` backup of an existing file (SEC-8, S-1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError::IoError`] if the file copy fails.
+    pub fn backup(path: &Path) -> Result<(), InstallError> {
+        if !path.exists() {
+            return Ok(());
+        }
+        let backup_path = path.with_extension(match path.extension() {
+            Some(ext) => format!("{}.bak", ext.to_string_lossy()),
+            None => "bak".to_string(),
+        });
+        fs::copy(path, &backup_path).map_err(|source| InstallError::IoError {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_config(dir: &Path, filename: &str, content: &str) -> ConfigFile {
+        ConfigFile {
+            target_path: dir.join(filename),
+            content: content.to_string(),
+            description: "test config".to_string(),
+        }
+    }
+
+    // T019: ConfigWriter tests
+
+    #[test]
+    fn write_creates_new_file() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path(), "test.json", r#"{"key": "value"}"#);
+
+        ConfigWriter::write(&config, false).unwrap();
+
+        assert!(config.target_path.exists());
+        let content = fs::read_to_string(&config.target_path).unwrap();
+        assert_eq!(content, r#"{"key": "value"}"#);
+    }
+
+    #[test]
+    fn write_creates_parent_directories() {
+        let dir = TempDir::new().unwrap();
+        let nested_path = dir.path().join("a").join("b").join("c").join("test.json");
+        let config = ConfigFile {
+            target_path: nested_path.clone(),
+            content: "test".to_string(),
+            description: "test".to_string(),
+        };
+
+        ConfigWriter::write(&config, false).unwrap();
+
+        assert!(nested_path.exists());
+    }
+
+    #[test]
+    fn write_with_backup_creates_bak_file() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path(), "config.json", "original");
+        ConfigWriter::write(&config, false).unwrap();
+
+        // Overwrite with backup
+        let updated = make_config(dir.path(), "config.json", "updated");
+        ConfigWriter::write(&updated, true).unwrap();
+
+        // Check original was backed up
+        let bak_path = dir.path().join("config.json.bak");
+        assert!(bak_path.exists());
+        let bak_content = fs::read_to_string(&bak_path).unwrap();
+        assert_eq!(bak_content, "original");
+
+        // Check new content
+        let new_content = fs::read_to_string(&config.target_path).unwrap();
+        assert_eq!(new_content, "updated");
+    }
+
+    #[test]
+    fn backup_no_existing_file_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nonexistent.json");
+        assert!(ConfigWriter::backup(&path).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_sets_permissions_0o644() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path(), "perms.json", "content");
+        ConfigWriter::write(&config, false).unwrap();
+
+        let metadata = fs::metadata(&config.target_path).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "file permissions should be 0o644");
+    }
+
+    #[test]
+    fn write_overwrites_without_backup_when_not_requested() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(dir.path(), "test.json", "original");
+        ConfigWriter::write(&config, false).unwrap();
+
+        let updated = make_config(dir.path(), "test.json", "updated");
+        ConfigWriter::write(&updated, false).unwrap();
+
+        let bak_path = dir.path().join("test.json.bak");
+        assert!(
+            !bak_path.exists(),
+            "no .bak file should exist without backup flag"
+        );
+    }
+}

--- a/crates/platforms/src/lib.rs
+++ b/crates/platforms/src/lib.rs
@@ -34,3 +34,9 @@ pub use path_policy::{
 pub use pipeline::{EventPipeline, PipelineResult};
 pub use registry::AdapterRegistry;
 pub mod bootstrap;
+/// Agent installer subsystem for configuring external AI agents.
+pub mod installer;
+pub use installer::orchestrator::InstallOrchestrator;
+pub use installer::registry::InstallerRegistry;
+pub use installer::writer::ConfigWriter;
+pub use installer::{AgentInstaller, SUPPORTED_AGENTS, find_binary_on_path, is_valid_agent};

--- a/crates/platforms/tests/install_multi_agent_test.rs
+++ b/crates/platforms/tests/install_multi_agent_test.rs
@@ -1,0 +1,191 @@
+//! Integration tests for multi-agent install flow (T052-T054, T057).
+//!
+//! Tests auto-detection, explicit filtering, and shared memory store path.
+
+use std::path::PathBuf;
+
+use platforms::installer::AgentInstaller;
+use platforms::installer::orchestrator::InstallOrchestrator;
+use platforms::installer::registry::InstallerRegistry;
+use types::install::{
+    AgentInfo, ConfigFile, InstallConfig, InstallError, InstallScope, InstallStatus,
+};
+
+struct FakeInstaller {
+    name: String,
+    detected: bool,
+}
+
+impl FakeInstaller {
+    fn detected(name: &str) -> Box<dyn AgentInstaller> {
+        Box::new(Self {
+            name: name.to_string(),
+            detected: true,
+        })
+    }
+
+    fn not_detected(name: &str) -> Box<dyn AgentInstaller> {
+        Box::new(Self {
+            name: name.to_string(),
+            detected: false,
+        })
+    }
+}
+
+impl AgentInstaller for FakeInstaller {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn agent_name(&self) -> &'static str {
+        Box::leak(self.name.clone().into_boxed_str())
+    }
+
+    fn detect(&self) -> Option<AgentInfo> {
+        if self.detected {
+            Some(AgentInfo {
+                name: self.name.clone(),
+                binary_path: PathBuf::from(format!("/usr/bin/{}", self.name)),
+                version: Some("1.0.0".to_string()),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        _binary_path: &std::path::Path,
+    ) -> Result<Vec<ConfigFile>, InstallError> {
+        let dir = match scope {
+            InstallScope::Project { root } => root.clone(),
+            InstallScope::Global => PathBuf::from("/tmp/global"),
+        };
+        Ok(vec![ConfigFile {
+            target_path: dir.join(format!(".{}/config.json", self.name)),
+            content: format!(r#"{{"agent": "{}"}}"#, self.name),
+            description: format!("{} config", self.name),
+        }])
+    }
+
+    fn validate(&self, _scope: &InstallScope) -> Result<(), InstallError> {
+        Ok(())
+    }
+}
+
+// T052 / AC-5: Multiple agents detected and configured, single memory store path shared.
+#[test]
+fn auto_detect_configures_multiple_agents() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(FakeInstaller::detected("opencode"));
+    registry.register(FakeInstaller::detected("copilot"));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: None,
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+
+    let configured: Vec<_> = report
+        .results
+        .iter()
+        .filter(|r| r.status == InstallStatus::Configured)
+        .collect();
+    assert_eq!(configured.len(), 2, "both agents should be configured");
+
+    // AC-7: All agents share the same memory store path.
+    assert_eq!(
+        report.memory_store,
+        dir.path().join(".rusty-brain").join("mind.mv2")
+    );
+}
+
+// T053 / AC-6: Explicit --agents filtering configures only specified agents.
+#[test]
+fn explicit_agents_filters_to_specified_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(FakeInstaller::detected("opencode"));
+    registry.register(FakeInstaller::detected("copilot"));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: Some(vec!["opencode".to_string()]),
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+    assert_eq!(report.results.len(), 1);
+    assert_eq!(report.results[0].agent_name, "opencode");
+    assert_eq!(report.results[0].status, InstallStatus::Configured);
+}
+
+// T054 / AC-10: Missing agent reports not-found, continues for others.
+#[test]
+fn missing_agent_continues_for_others() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(FakeInstaller::not_detected("opencode"));
+    registry.register(FakeInstaller::detected("copilot"));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: None,
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+    assert_eq!(report.results.len(), 2);
+
+    let not_found: Vec<_> = report
+        .results
+        .iter()
+        .filter(|r| r.status == InstallStatus::NotFound)
+        .collect();
+    let configured: Vec<_> = report
+        .results
+        .iter()
+        .filter(|r| r.status == InstallStatus::Configured)
+        .collect();
+
+    assert_eq!(not_found.len(), 1);
+    assert_eq!(configured.len(), 1);
+}
+
+// T057 / AC-7: All agent configs reference the same shared memory store path.
+#[test]
+fn all_agents_share_same_memory_store_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(FakeInstaller::detected("opencode"));
+    registry.register(FakeInstaller::detected("copilot"));
+    registry.register(FakeInstaller::detected("codex"));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: None,
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+    let expected_store = dir.path().join(".rusty-brain").join("mind.mv2");
+    assert_eq!(report.memory_store, expected_store);
+    assert_eq!(report.scope, "project");
+}

--- a/crates/platforms/tests/install_multi_agent_test.rs
+++ b/crates/platforms/tests/install_multi_agent_test.rs
@@ -12,36 +12,35 @@ use types::install::{
 };
 
 struct FakeInstaller {
-    name: String,
+    name: &'static str,
     detected: bool,
 }
 
 impl FakeInstaller {
-    fn detected(name: &str) -> Box<dyn AgentInstaller> {
+    fn detected(name: &'static str) -> Box<dyn AgentInstaller> {
         Box::new(Self {
-            name: name.to_string(),
+            name,
             detected: true,
         })
     }
 
-    fn not_detected(name: &str) -> Box<dyn AgentInstaller> {
+    fn not_detected(name: &'static str) -> Box<dyn AgentInstaller> {
         Box::new(Self {
-            name: name.to_string(),
+            name,
             detected: false,
         })
     }
 }
 
 impl AgentInstaller for FakeInstaller {
-    #[allow(clippy::unnecessary_literal_bound)]
     fn agent_name(&self) -> &'static str {
-        Box::leak(self.name.clone().into_boxed_str())
+        self.name
     }
 
     fn detect(&self) -> Option<AgentInfo> {
         if self.detected {
             Some(AgentInfo {
-                name: self.name.clone(),
+                name: self.name.to_string(),
                 binary_path: PathBuf::from(format!("/usr/bin/{}", self.name)),
                 version: Some("1.0.0".to_string()),
             })
@@ -59,10 +58,11 @@ impl AgentInstaller for FakeInstaller {
             InstallScope::Project { root } => root.clone(),
             InstallScope::Global => PathBuf::from("/tmp/global"),
         };
+        let name = self.name;
         Ok(vec![ConfigFile {
-            target_path: dir.join(format!(".{}/config.json", self.name)),
-            content: format!(r#"{{"agent": "{}"}}"#, self.name),
-            description: format!("{} config", self.name),
+            target_path: dir.join(format!(".{name}/config.json")),
+            content: format!(r#"{{"agent": "{name}"}}"#),
+            description: format!("{name} config"),
         }])
     }
 

--- a/crates/platforms/tests/install_opencode_test.rs
+++ b/crates/platforms/tests/install_opencode_test.rs
@@ -1,0 +1,182 @@
+//! Integration tests for OpenCode agent install flow (T034).
+//!
+//! Tests the full install pipeline: detect -> generate_config -> write -> validate.
+
+use std::path::PathBuf;
+
+use platforms::installer::AgentInstaller;
+use platforms::installer::orchestrator::InstallOrchestrator;
+use platforms::installer::registry::InstallerRegistry;
+use types::install::{InstallConfig, InstallScope, InstallStatus};
+
+/// Helper: create a fake installer that always detects the agent.
+struct FakeOpenCodeInstaller;
+
+impl AgentInstaller for FakeOpenCodeInstaller {
+    fn agent_name(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn detect(&self) -> Option<types::install::AgentInfo> {
+        Some(types::install::AgentInfo {
+            name: "opencode".to_string(),
+            binary_path: PathBuf::from("/usr/local/bin/rusty-brain"),
+            version: Some("1.2.3".to_string()),
+        })
+    }
+
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &std::path::Path,
+    ) -> Result<Vec<types::install::ConfigFile>, types::install::InstallError> {
+        let config_dir = match scope {
+            InstallScope::Project { root } => root.join(".opencode").join("plugins"),
+            InstallScope::Global => PathBuf::from("/tmp/global/opencode/plugins"),
+        };
+
+        let binary_str = binary_path.to_string_lossy();
+        let content = serde_json::to_string_pretty(&serde_json::json!({
+            "name": "rusty-brain",
+            "binary": binary_str.as_ref(),
+            "commands": {
+                "ask": { "args": ["ask", "--json"] },
+                "search": { "args": ["find", "--json"] },
+                "recent": { "args": ["timeline", "--json"] },
+                "stats": { "args": ["stats", "--json"] }
+            }
+        }))
+        .unwrap();
+
+        Ok(vec![types::install::ConfigFile {
+            target_path: config_dir.join("rusty-brain.json"),
+            content,
+            description: "OpenCode plugin manifest".to_string(),
+        }])
+    }
+
+    fn validate(&self, scope: &InstallScope) -> Result<(), types::install::InstallError> {
+        let config_path = match scope {
+            InstallScope::Project { root } => root
+                .join(".opencode")
+                .join("plugins")
+                .join("rusty-brain.json"),
+            InstallScope::Global => PathBuf::from("/tmp/global/opencode/plugins/rusty-brain.json"),
+        };
+
+        if !config_path.exists() {
+            return Err(types::install::InstallError::ConfigCorrupted { path: config_path });
+        }
+        Ok(())
+    }
+}
+
+// AC-1: Install creates valid config files.
+#[test]
+fn install_creates_config_files_in_tempdir() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(Box::new(FakeOpenCodeInstaller));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: Some(vec!["opencode".to_string()]),
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+    assert_eq!(report.results.len(), 1);
+    assert_eq!(report.results[0].status, InstallStatus::Configured);
+
+    // Verify file exists with correct content.
+    let config_path = dir
+        .path()
+        .join(".opencode")
+        .join("plugins")
+        .join("rusty-brain.json");
+    assert!(config_path.exists(), "config file should exist");
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed["name"], "rusty-brain");
+}
+
+// AC-2: Slash commands are registered in config.
+#[test]
+fn install_registers_slash_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(Box::new(FakeOpenCodeInstaller));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: Some(vec!["opencode".to_string()]),
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    let report = orch.run(&config).unwrap();
+    assert_eq!(report.results[0].status, InstallStatus::Configured);
+
+    let config_path = dir
+        .path()
+        .join(".opencode")
+        .join("plugins")
+        .join("rusty-brain.json");
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let commands = parsed["commands"].as_object().unwrap();
+
+    assert!(commands.contains_key("ask"));
+    assert!(commands.contains_key("search"));
+    assert!(commands.contains_key("recent"));
+    assert!(commands.contains_key("stats"));
+}
+
+// AC-9: Upgrade preserves data (backup created on re-install).
+#[test]
+fn upgrade_creates_backup_of_existing_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = InstallerRegistry::new();
+    registry.register(Box::new(FakeOpenCodeInstaller));
+
+    let orch = InstallOrchestrator::new(registry);
+    let config = InstallConfig {
+        agents: Some(vec!["opencode".to_string()]),
+        scope: InstallScope::Project {
+            root: dir.path().to_path_buf(),
+        },
+        json: false,
+        reconfigure: false,
+    };
+
+    // First install.
+    let report1 = orch.run(&config).unwrap();
+    assert_eq!(report1.results[0].status, InstallStatus::Configured);
+
+    // Second install (should be upgrade with backup).
+    let mut registry2 = InstallerRegistry::new();
+    registry2.register(Box::new(FakeOpenCodeInstaller));
+    let orch2 = InstallOrchestrator::new(registry2);
+
+    let report2 = orch2.run(&config).unwrap();
+    assert_eq!(report2.results[0].status, InstallStatus::Upgraded);
+
+    // Verify backup exists.
+    let backup_path = dir
+        .path()
+        .join(".opencode")
+        .join("plugins")
+        .join("rusty-brain.json.bak");
+    assert!(
+        backup_path.exists(),
+        "backup file should exist after upgrade"
+    );
+}

--- a/crates/types/src/install.rs
+++ b/crates/types/src/install.rs
@@ -1,0 +1,299 @@
+//! Types for the agent install subsystem.
+//!
+//! Defines error codes, configuration, and result types used by the installer
+//! infrastructure in the `platforms` crate and the `install` CLI subcommand.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// Stable error types for install operations.
+///
+/// Each variant carries an `[E_INSTALL_*]` prefixed code in its `Display` output
+/// so consumers can parse the error code from serialized strings.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("[E_INSTALL_AGENT_NOT_FOUND] Agent '{agent}' not found on this system")]
+    AgentNotFound { agent: String },
+
+    #[error("[E_INSTALL_PERMISSION_DENIED] Cannot write to '{path}': {suggestion}")]
+    PermissionDenied { path: PathBuf, suggestion: String },
+
+    #[error(
+        "[E_INSTALL_UNSUPPORTED_VERSION] Agent '{agent}' version {version} is below minimum {min_version}"
+    )]
+    UnsupportedVersion {
+        agent: String,
+        version: String,
+        min_version: String,
+    },
+
+    #[error("[E_INSTALL_CONFIG_CORRUPTED] Existing config at '{path}' is corrupted")]
+    ConfigCorrupted { path: PathBuf },
+
+    #[error("[E_INSTALL_IO_ERROR] I/O error at '{path}': {source}")]
+    IoError {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("[E_INSTALL_SCOPE_REQUIRED] Installation scope required: use --project or --global")]
+    ScopeRequired,
+
+    #[error(
+        "[E_INSTALL_INVALID_AGENT] Unknown agent '{agent}'. Supported: opencode, copilot, codex, gemini"
+    )]
+    InvalidAgent { agent: String },
+
+    #[error("[E_INSTALL_PATH_TRAVERSAL] Path '{path}' contains traversal sequences")]
+    PathTraversal { path: PathBuf },
+}
+
+/// Scope for installation.
+#[derive(Debug, Clone)]
+pub enum InstallScope {
+    /// Config placed relative to project root.
+    Project { root: PathBuf },
+    /// Config placed in user-level directories.
+    Global,
+}
+
+/// Information about a detected agent installation.
+#[derive(Debug, Clone)]
+pub struct AgentInfo {
+    /// Canonical agent name (lowercase).
+    pub name: String,
+    /// Absolute path to agent binary on the system.
+    pub binary_path: PathBuf,
+    /// Detected version string, if available.
+    pub version: Option<String>,
+}
+
+/// A configuration file to be written for an agent.
+#[derive(Debug, Clone)]
+pub struct ConfigFile {
+    /// Absolute path where this file should be written.
+    pub target_path: PathBuf,
+    /// File content.
+    pub content: String,
+    /// Human-readable description (for logging and JSON output).
+    pub description: String,
+}
+
+/// Input configuration parsed from CLI args.
+#[derive(Debug)]
+pub struct InstallConfig {
+    /// Explicit agent list; None = auto-detect all.
+    pub agents: Option<Vec<String>>,
+    /// Installation scope (required).
+    pub scope: InstallScope,
+    /// Force JSON output.
+    pub json: bool,
+    /// Regenerate config files (backup existing).
+    pub reconfigure: bool,
+}
+
+/// Installation outcome for a single agent.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallStatus {
+    Configured,
+    Upgraded,
+    Skipped,
+    Failed,
+    NotFound,
+}
+
+/// Per-agent installation result.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentInstallResult {
+    pub agent_name: String,
+    pub status: InstallStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_detected: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Overall report status.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportStatus {
+    Success,
+    Partial,
+    Failed,
+}
+
+/// Overall installation report.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallReport {
+    pub status: ReportStatus,
+    pub results: Vec<AgentInstallResult>,
+    pub memory_store: PathBuf,
+    pub scope: String,
+}
+
+impl InstallScope {
+    /// Human-readable scope label for reports.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Project { .. } => "project",
+            Self::Global => "global",
+        }
+    }
+
+    /// Resolve the memory store path for this scope.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InstallError::IoError`] when the global scope is used and
+    /// neither `HOME` nor `USERPROFILE` environment variables are set.
+    pub fn memory_store_path(&self) -> Result<PathBuf, InstallError> {
+        match self {
+            Self::Project { root } => Ok(root.join(".rusty-brain").join("mind.mv2")),
+            Self::Global => {
+                let home = std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .map_err(|_| InstallError::IoError {
+                        path: PathBuf::from("~"),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::NotFound,
+                            "HOME environment variable not set",
+                        ),
+                    })?;
+                Ok(Path::new(&home).join(".rusty-brain").join("mind.mv2"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_error_agent_not_found_display() {
+        let err = InstallError::AgentNotFound {
+            agent: "opencode".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_AGENT_NOT_FOUND]"));
+        assert!(msg.contains("opencode"));
+    }
+
+    #[test]
+    fn install_error_scope_required_display() {
+        let err = InstallError::ScopeRequired;
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_SCOPE_REQUIRED]"));
+        assert!(msg.contains("--project"));
+        assert!(msg.contains("--global"));
+    }
+
+    #[test]
+    fn install_error_invalid_agent_display() {
+        let err = InstallError::InvalidAgent {
+            agent: "vscode".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_INVALID_AGENT]"));
+        assert!(msg.contains("vscode"));
+    }
+
+    #[test]
+    fn install_error_path_traversal_display() {
+        let err = InstallError::PathTraversal {
+            path: PathBuf::from("/etc/../shadow"),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_PATH_TRAVERSAL]"));
+    }
+
+    #[test]
+    fn install_error_permission_denied_display() {
+        let err = InstallError::PermissionDenied {
+            path: PathBuf::from("/root/.config"),
+            suggestion: "Run with appropriate permissions".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_PERMISSION_DENIED]"));
+        assert!(msg.contains("/root/.config"));
+    }
+
+    #[test]
+    fn install_error_io_error_display() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let err = InstallError::IoError {
+            path: PathBuf::from("/tmp/test"),
+            source: io_err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("[E_INSTALL_IO_ERROR]"));
+        assert!(msg.contains("/tmp/test"));
+    }
+
+    #[test]
+    fn install_scope_label() {
+        let project = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        assert_eq!(project.label(), "project");
+        assert_eq!(InstallScope::Global.label(), "global");
+    }
+
+    #[test]
+    fn install_scope_memory_store_path_project() {
+        let scope = InstallScope::Project {
+            root: PathBuf::from("/tmp/project"),
+        };
+        assert_eq!(
+            scope.memory_store_path().unwrap(),
+            PathBuf::from("/tmp/project/.rusty-brain/mind.mv2")
+        );
+    }
+
+    #[test]
+    fn install_status_serialization() {
+        let status = InstallStatus::Configured;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"configured\"");
+
+        let status = InstallStatus::NotFound;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"not_found\"");
+    }
+
+    #[test]
+    fn agent_install_result_serialization() {
+        let result = AgentInstallResult {
+            agent_name: "opencode".to_string(),
+            status: InstallStatus::Configured,
+            config_path: Some(PathBuf::from("/tmp/.opencode/plugins/rusty-brain.json")),
+            version_detected: Some("1.2.3".to_string()),
+            error: None,
+        };
+        let json = serde_json::to_string_pretty(&result).unwrap();
+        assert!(json.contains("\"agent_name\": \"opencode\""));
+        assert!(json.contains("\"status\": \"configured\""));
+        assert!(json.contains("\"version_detected\": \"1.2.3\""));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn install_report_serialization() {
+        let report = InstallReport {
+            status: ReportStatus::Success,
+            results: vec![],
+            memory_store: PathBuf::from("/tmp/.rusty-brain/mind.mv2"),
+            scope: "project".to_string(),
+        };
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        assert!(json.contains("\"status\": \"success\""));
+        assert!(json.contains("\"scope\": \"project\""));
+        assert!(json.contains("\"memory_store\""));
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -30,6 +30,8 @@ pub mod diagnostic;
 pub mod error;
 /// Claude Code hook protocol request and response types.
 pub mod hooks;
+/// Types for the agent install subsystem.
+pub mod install;
 /// Observation types representing individual memory entries.
 pub mod observation;
 /// Platform event types for normalized agent session events.
@@ -47,6 +49,10 @@ pub use contract_version::ContractValidationResult;
 pub use diagnostic::{DiagnosticRecord, DiagnosticSeverity};
 pub use error::{AgentBrainError, RustyBrainError, StorageSource, error_codes};
 pub use hooks::{HookInput, HookOutput};
+pub use install::{
+    AgentInfo, AgentInstallResult, ConfigFile, InstallConfig, InstallError, InstallReport,
+    InstallScope, InstallStatus,
+};
 pub use observation::{Observation, ObservationMetadata, ObservationType};
 pub use platform_event::{EventKind, PlatformEvent};
 pub use project_context::{IdentitySource, ProjectContext, ProjectIdentity};

--- a/specs/011-agent-installs/ar.md
+++ b/specs/011-agent-installs/ar.md
@@ -1,0 +1,808 @@
+# 011-ar-agent-installs
+
+> **Document Type:** Architecture Review
+> **Audience:** LLM agents, human reviewers
+> **Status:** Proposed
+> **Last Updated:** 2026-03-05
+> **Owner:** [name] <!-- @human-required -->
+> **Deciders:** [names/roles of decision makers] <!-- @human-required -->
+
+---
+
+## Review Tier Legend
+
+| Marker | Tier | Speckit Behavior |
+|--------|------|------------------|
+| `@human-required` | Human Generated | Prompt human to author; blocks until complete |
+| `@human-review` | LLM + Human Review | LLM drafts; prompt human to confirm/edit; blocks until confirmed |
+| `@llm-autonomous` | LLM Autonomous | LLM completes; no prompt; logged for audit |
+| `@auto` | Auto-generated | System fills (timestamps, links); no prompt |
+
+---
+
+## Document Completion Order
+
+> Complete sections in this order. Do not fill downstream sections until upstream human-required inputs exist.
+
+1. **Summary (Decision)** -> requires human input first
+2. **Context (Problem Space)** -> requires human input
+3. **Decision Drivers** -> requires human input (prioritized)
+4. **Driving Requirements** -> extract from PRD, human confirms
+5. **Options Considered** -> LLM drafts after drivers exist, human reviews
+6. **Decision (Selected + Rationale)** -> requires human decision
+7. **Implementation Guardrails** -> LLM drafts, human reviews
+8. **Everything else** -> can proceed after decision is made
+
+---
+
+## Linkage `@auto`
+
+| Document | ID | Relationship |
+|----------|-----|--------------|
+| Parent PRD | 011-prd-agent-installs.md | Requirements this architecture satisfies |
+| Security Review | 011-sec-agent-installs.md | Security implications of this decision |
+| Supersedes | -- | N/A (new feature) |
+| Superseded By | -- | (Filled if this AR is deprecated) |
+
+---
+
+## Summary
+
+### Decision `@human-required`
+> Extend the existing `platforms` crate with an `AgentInstaller` trait and per-agent installer modules, adding a new `install` subcommand to the CLI that delegates to trait implementations for agent detection, config generation, and atomic file writes.
+
+### TL;DR for Agents `@human-review`
+> The `install` subcommand uses a trait-based installer pattern within the existing `platforms` crate. Each agent (OpenCode, Copilot, Codex, Gemini) gets an `AgentInstaller` implementation that handles detection (binary lookup on `$PATH`), config template generation, and atomic writes. No new crates are created. The CLI routes `rusty-brain install [--agents ...] [--project|--global]` to an `InstallOrchestrator` that iterates over requested installers. All output is JSON when `--json` is set or stdin is non-TTY. Never make network calls during install.
+
+---
+
+## Context
+
+### Problem Space `@human-required`
+
+The PRD requires a `rusty-brain install` subcommand that configures rusty-brain for four external AI agents (OpenCode, Copilot CLI, Codex CLI, Gemini CLI). The architectural challenge is: **how to structure multi-agent installation logic within the existing crate layout while keeping each agent's configuration concerns isolated, testable, and extensible**.
+
+Key tensions:
+1. **Four agents with different config formats** — each agent has a distinct extension mechanism (plugin manifests, YAML configs, JSON tool registrations). The architecture must isolate these differences behind a common interface.
+2. **Detection vs. configuration** — the existing `detect_platform` function detects which agent is *calling* rusty-brain. This feature needs the inverse: detect which agents are *installed on the system* so we can configure them.
+3. **Scope modes** — `--project` vs. `--global` determines where config files land. Path resolution must be correct per agent per scope on all three OS platforms.
+4. **Atomic writes and backup** — config files must be written atomically and existing files backed up, requiring file system operations more complex than the current read-only memory path resolution.
+
+### Decision Scope `@human-review`
+
+**This AR decides:**
+- Where install logic lives in the crate structure
+- The trait interface for per-agent installers
+- How agent detection works for the install command
+- How config file generation, backup, and atomic writes are structured
+- CLI subcommand structure for `install`
+
+**This AR does NOT decide:**
+- The exact config file content for each agent (requires spike research per PRD Q1-Q3)
+- Binary packaging or distribution (handled by 009-plugin-packaging)
+- Claude Code installation (already handled by 009)
+- Memory store format or location changes
+
+### Current State `@llm-autonomous`
+
+The codebase has a `platforms` crate with:
+- `PlatformAdapter` trait — normalizes hook input into platform events (runtime concern)
+- `AdapterRegistry` — case-insensitive registry for adapters
+- `detect_platform()` — detects which agent is *calling* rusty-brain from env/hook input
+- `BuiltinAdapter` — shared implementation for Claude and OpenCode
+- `bootstrap` module — builds `MindConfig` and checks legacy paths
+
+The CLI (`crates/cli`) uses clap derive with subcommands: `find`, `ask`, `stats`, `timeline`, `opencode`. No `install` subcommand exists.
+
+```mermaid
+graph TD
+    subgraph Current State
+        CLI[CLI crate<br>args.rs, commands.rs] --> |subcommands| PLAT[platforms crate]
+        CLI --> CORE[core crate<br>Mind API]
+        PLAT --> |PlatformAdapter trait| ADAPTERS[adapters/<br>claude.rs, opencode.rs]
+        PLAT --> DETECT[detection.rs]
+        PLAT --> REG[registry.rs]
+        PLAT --> BOOT[bootstrap.rs]
+        CORE --> MEMVID[memvid-core]
+    end
+```
+
+### Driving Requirements `@human-review`
+
+| PRD Req ID | Requirement Summary | Architectural Implication |
+|------------|---------------------|---------------------------|
+| M-1 | `rusty-brain install` subcommand | New clap subcommand + install orchestration logic |
+| M-2 | Support 4 agent platforms | Per-agent installer modules behind a common trait |
+| M-3 | Auto-detect installed agents | Agent detection logic separate from runtime platform detection |
+| M-4 | `--agents` flag for explicit selection | CLI arg parsing + filtering in orchestrator |
+| M-5 | Generate agent-specific config files | Template-based config generation per installer |
+| M-6 | Shared memory store across agents | Config templates reference common `.rusty-brain/mind.mv2` path |
+| M-7 | JSON output in `--json`/non-TTY mode | Output formatting layer (existing pattern in `output.rs`) |
+| M-8 | Upgrade without data loss | Backup-before-write logic in installer trait |
+| M-9 | Validate agent is installed | Detection method per agent (binary on PATH, config dir check) |
+| M-10 | Machine-parseable error codes | Error enum with stable codes in `types` crate |
+| M-11 | No interactive prompts in non-TTY | Install logic must never block on stdin |
+| M-12 | Create directories if needed | `fs::create_dir_all` in installer write path |
+| M-13 | Require `--project` or `--global` | CLI arg validation (mutually exclusive required group) |
+| S-1 | `--reconfigure` with `.bak` backup | Backup logic in file write path |
+| S-2 | Logging via `RUSTY_BRAIN_LOG` | Use workspace `tracing` (already configured) |
+| S-3 | Detect agent version for compat | Version detection method per agent |
+| S-4 | `--config-dir` override | CLI arg + path override in installer |
+
+**PRD Constraints inherited:**
+- Rust stable, edition 2024, MSRV 1.85.0
+- No network calls during install
+- Atomic writes (temp file + rename)
+- Prefer existing workspace dependencies
+- Crate-first: use existing crate layout unless justified
+- Agent-friendly: structured JSON output, no interactive prompts
+
+---
+
+## Decision Drivers `@human-required`
+
+1. **Crate-first simplicity:** Avoid new crates; extend existing `platforms` crate *(traces to Constitution principle, PRD Technical Constraints)*
+2. **Testability:** Each agent's install logic must be unit-testable in isolation without filesystem side effects *(traces to Constitution test-first principle)*
+3. **Extensibility:** Adding a fifth agent should require only a new module + trait impl + registry entry *(traces to PRD M-2)*
+4. **Cross-platform correctness:** Path resolution must work on macOS, Linux, Windows *(traces to PRD Technical Constraints)*
+5. **No network:** Install must be fully offline *(traces to PRD Technical Constraints)*
+6. **Atomic safety:** Config writes must not leave partial files on crash *(traces to PRD Technical Constraints)*
+
+---
+
+## Options Considered `@human-review`
+
+### Option 0: Status Quo / Do Nothing
+
+**Description:** Users manually create agent configuration files by reading documentation and placing files in the correct directories.
+
+| Driver | Rating | Notes |
+|--------|--------|-------|
+| Crate-first simplicity | N/A | No code changes |
+| Testability | N/A | Nothing to test |
+| Extensibility | N/A | No framework |
+| Cross-platform correctness | N/A | User's problem |
+| No network | N/A | No code |
+| Atomic safety | N/A | No writes |
+
+**Why not viable:** PRD M-1 explicitly requires an `install` subcommand. Manual configuration is error-prone, undocumented for most agents, and blocks the cross-agent memory vision. All success criteria (SC-001 through SC-007) require automated installation.
+
+---
+
+### Option 1: Trait-Based Installers in `platforms` Crate
+
+**Description:** Add an `installer` module tree to the existing `platforms` crate. Define an `AgentInstaller` trait with methods for detection, version checking, config generation, and validation. Each agent gets a module implementing this trait. An `InstallOrchestrator` coordinates the workflow: parse scope, detect/filter agents, iterate installers, handle backup/write, collect results.
+
+```mermaid
+graph TD
+    subgraph Option 1 - platforms crate extension
+        CLI_INSTALL[CLI: install subcommand] --> ORCH[InstallOrchestrator]
+        ORCH --> IREG[InstallerRegistry]
+        IREG --> OC_I[OpenCodeInstaller]
+        IREG --> CP_I[CopilotInstaller]
+        IREG --> CX_I[CodexInstaller]
+        IREG --> GM_I[GeminiInstaller]
+        ORCH --> WRITER[ConfigWriter<br>atomic writes + backup]
+        OC_I --> |AgentInstaller trait| TRAIT[AgentInstaller]
+        CP_I --> TRAIT
+        CX_I --> TRAIT
+        GM_I --> TRAIT
+    end
+```
+
+| Driver | Rating | Notes |
+|--------|--------|-------|
+| Crate-first simplicity | ✅ Good | Extends existing crate, no new Cargo.toml |
+| Testability | ✅ Good | Trait returns data (config files as structs), writer is separate and mockable |
+| Extensibility | ✅ Good | New agent = new module + trait impl + register in InstallerRegistry |
+| Cross-platform correctness | ✅ Good | Path logic centralized in trait methods with platform-specific defaults |
+| No network | ✅ Good | Templates embedded as const strings, no external fetches |
+| Atomic safety | ✅ Good | ConfigWriter handles temp-file-then-rename for all installers |
+
+**Pros:**
+- Follows existing crate patterns (mirrors `PlatformAdapter` / `AdapterRegistry`)
+- Separation between config generation (pure, testable) and file I/O (ConfigWriter)
+- ConfigWriter is reusable across all agents
+- No new workspace dependencies needed
+
+**Cons:**
+- `platforms` crate grows larger (but stays cohesive around platform concerns)
+- Install logic is conceptually different from runtime adapter logic (detection vs. configuration)
+
+---
+
+### Option 2: New `installer` Crate
+
+**Description:** Create a new `crates/installer` crate dedicated to installation logic. The crate defines the `AgentInstaller` trait, per-agent modules, `InstallerRegistry`, `ConfigWriter`, and `InstallOrchestrator`. The CLI depends on this new crate for the `install` subcommand.
+
+```mermaid
+graph TD
+    subgraph Option 2 - separate installer crate
+        CLI_INSTALL[CLI: install subcommand] --> INST_CRATE[installer crate]
+        INST_CRATE --> ORCH[InstallOrchestrator]
+        ORCH --> IREG[InstallerRegistry]
+        IREG --> OC_I[OpenCodeInstaller]
+        IREG --> CP_I[CopilotInstaller]
+        IREG --> CX_I[CodexInstaller]
+        IREG --> GM_I[GeminiInstaller]
+        ORCH --> WRITER[ConfigWriter]
+        INST_CRATE --> |uses| PLAT[platforms crate<br>for path resolution]
+        INST_CRATE --> |uses| TYPES[types crate]
+    end
+```
+
+| Driver | Rating | Notes |
+|--------|--------|-------|
+| Crate-first simplicity | ❌ Poor | Violates crate-first constitution principle; adds new crate without strong justification |
+| Testability | ✅ Good | Same trait-based isolation |
+| Extensibility | ✅ Good | Same pattern |
+| Cross-platform correctness | ✅ Good | Same approach |
+| No network | ✅ Good | Same approach |
+| Atomic safety | ✅ Good | Same approach |
+
+**Pros:**
+- Clean separation: install concerns in their own crate
+- `platforms` crate stays focused on runtime adapter logic
+- Independent compilation
+
+**Cons:**
+- Violates crate-first principle (Constitution): "New features go in existing crate layout unless explicitly justified"
+- Duplicates registry pattern already in `platforms`
+- Adds workspace dependency management overhead
+- Install logic shares concepts with `platforms` (agent detection, path resolution) — splitting creates coupling between crates
+
+---
+
+### Option 3: Shell Script Wrappers
+
+**Description:** Write platform-specific shell scripts (bash/PowerShell) for each agent, similar to the existing 009-plugin-packaging install scripts. The Rust binary is not involved in agent configuration.
+
+```mermaid
+graph TD
+    subgraph Option 3 - shell scripts
+        USER[User] --> SCRIPT[install-agents.sh / .ps1]
+        SCRIPT --> OC_S[opencode-config.sh]
+        SCRIPT --> CP_S[copilot-config.sh]
+        SCRIPT --> CX_S[codex-config.sh]
+        SCRIPT --> GM_S[gemini-config.sh]
+    end
+```
+
+| Driver | Rating | Notes |
+|--------|--------|-------|
+| Crate-first simplicity | N/A | No Rust code involved |
+| Testability | ❌ Poor | Shell scripts hard to unit test, no type safety |
+| Extensibility | ⚠️ Medium | Copy-paste new script, but no shared logic |
+| Cross-platform correctness | ❌ Poor | Must maintain bash + PowerShell versions in parallel |
+| No network | ✅ Good | Local file operations |
+| Atomic safety | ⚠️ Medium | Possible but requires manual implementation per script |
+
+**Pros:**
+- No Rust code changes needed
+- Simple for single-agent installs
+
+**Cons:**
+- Violates PRD M-7 (structured JSON output from the binary)
+- Violates PRD M-1 (install as a *subcommand* of rusty-brain)
+- Cannot support agent self-installation (US-6) — agents invoke the binary, not shell scripts
+- Duplicated logic across bash and PowerShell
+- No type safety, hard to test, error-prone path handling
+
+---
+
+## Decision
+
+### Selected Option `@human-required`
+> **Option 1: Trait-Based Installers in `platforms` Crate**
+
+### Rationale `@human-required`
+
+Option 1 best satisfies all decision drivers:
+- Follows the crate-first Constitution principle by extending the existing `platforms` crate
+- Provides the same testability and extensibility benefits as Option 2 without the overhead of a new crate
+- The `platforms` crate is already the home for agent-related concerns (detection, adapters, path resolution), making install logic a natural extension
+- Option 3 fails multiple PRD requirements outright
+
+The install concern (detecting agents on the system, generating their configs) is closely related to the existing platform concern (detecting which agent is calling, normalizing events). Both deal with the relationship between rusty-brain and external agent platforms. Keeping them in the same crate is cohesive, not coincidental.
+
+#### Simplest Implementation Comparison `@human-review`
+
+| Aspect | Simplest Possible | Selected Option | Justification for Complexity |
+|--------|-------------------|-----------------|------------------------------|
+| Structure | Single `install()` function with match on agent name | `AgentInstaller` trait + per-agent modules + `InstallerRegistry` | M-2 requires 4 agents; trait isolates each agent's config format and detection logic for testing |
+| Config generation | Hardcoded strings | Template structs returned by trait methods | M-5 requires agent-specific config formats; structured templates enable validation and testing without filesystem |
+| File I/O | Direct `fs::write` | `ConfigWriter` with atomic write + backup | PRD requires atomic writes and `.bak` backup (S-1); centralizing prevents per-agent reimplementation |
+| Agent detection | Check `which <binary>` | `detect()` method returning `AgentInfo` struct | M-3/M-9 require version detection (S-3) and clear error reporting (M-10); struct carries version + path info |
+| Output | `println!` | Reuse existing `output.rs` JSON/table formatting | M-7 requires structured JSON; existing pattern already handles this |
+
+**Complexity justified by:** The trait boundary is the minimum abstraction needed to isolate four different agent config formats while keeping them testable. The `ConfigWriter` prevents reimplementing atomic write + backup four times. These are not speculative — all four agents are PRD Must Have requirements.
+
+### Architecture Diagram `@human-review`
+
+```mermaid
+graph TD
+    subgraph CLI Layer
+        MAIN[main.rs] --> ARGS[args.rs<br>Install subcommand]
+        ARGS --> CMD[commands.rs<br>dispatch]
+    end
+
+    subgraph platforms crate
+        CMD --> ORCH[InstallOrchestrator]
+
+        ORCH --> IREG[InstallerRegistry]
+        IREG --> OC[OpenCodeInstaller]
+        IREG --> CP[CopilotInstaller]
+        IREG --> CX[CodexInstaller]
+        IREG --> GM[GeminiInstaller]
+
+        OC --> TRAIT[AgentInstaller trait]
+        CP --> TRAIT
+        CX --> TRAIT
+        GM --> TRAIT
+
+        ORCH --> CW[ConfigWriter<br>atomic write + backup]
+        ORCH --> DETECT_I[agent detection<br>PATH + config dir checks]
+    end
+
+    subgraph types crate
+        TRAIT --> TYPES_E[InstallError enum<br>stable error codes]
+        ORCH --> TYPES_R[InstallResult struct]
+    end
+
+    subgraph Filesystem
+        CW --> AGENT_CONF[Agent config files]
+        CW --> BAK[.bak backup files]
+        DETECT_I --> AGENT_BIN[Agent binaries on PATH]
+    end
+
+    subgraph Existing - unchanged
+        CORE[core crate<br>Mind API]
+        MV2[.rusty-brain/mind.mv2]
+        CORE --> MV2
+    end
+```
+
+---
+
+## Technical Specification
+
+### Component Overview `@human-review`
+
+| Component | Responsibility | Interface | Dependencies |
+|-----------|---------------|-----------|--------------|
+| Install subcommand (CLI) | Parse `--agents`, `--project`/`--global`, `--json`, `--reconfigure`, `--config-dir` | clap derive args | `platforms` crate |
+| InstallOrchestrator | Coordinate full install workflow: detect/filter agents, iterate installers, collect results | `fn run(config: InstallConfig) -> InstallReport` | InstallerRegistry, ConfigWriter |
+| InstallerRegistry | Store and look up `AgentInstaller` implementations | `fn resolve(&self, name: &str) -> Option<&dyn AgentInstaller>` | Per-agent installer modules |
+| AgentInstaller trait | Define per-agent detection, config generation, validation | Trait methods: `detect`, `generate_config`, `validate` | types crate |
+| OpenCodeInstaller | OpenCode-specific detection and config generation | Implements `AgentInstaller` | None (self-contained) |
+| CopilotInstaller | Copilot CLI-specific detection and config generation | Implements `AgentInstaller` | None (self-contained) |
+| CodexInstaller | Codex CLI-specific detection and config generation | Implements `AgentInstaller` | None (self-contained) |
+| GeminiInstaller | Gemini CLI-specific detection and config generation | Implements `AgentInstaller` | None (self-contained) |
+| ConfigWriter | Atomic file writes with `.bak` backup | `fn write(path, content) -> Result`, `fn backup(path) -> Result` | `tempfile`, `std::fs` |
+| InstallError | Stable error codes for all install failure modes | Enum with Display | `thiserror` |
+
+### Data Flow `@llm-autonomous`
+
+```mermaid
+sequenceDiagram
+    participant U as User / Agent
+    participant CLI as CLI (args.rs)
+    participant ORCH as InstallOrchestrator
+    participant REG as InstallerRegistry
+    participant INS as AgentInstaller impl
+    participant CW as ConfigWriter
+    participant FS as Filesystem
+
+    U->>CLI: rusty-brain install --agents opencode --project
+    CLI->>ORCH: InstallConfig { agents: ["opencode"], scope: Project, ... }
+
+    alt No --agents specified
+        ORCH->>REG: list all installers
+        loop Each installer
+            ORCH->>INS: detect() -> Option<AgentInfo>
+            INS-->>ORCH: Some(AgentInfo) or None
+        end
+        Note over ORCH: Filter to detected agents
+    end
+
+    loop Each target agent
+        ORCH->>REG: resolve("opencode")
+        REG-->>ORCH: &dyn AgentInstaller
+        ORCH->>INS: detect() -> Option<AgentInfo>
+        INS-->>ORCH: AgentInfo { version, binary_path }
+        ORCH->>INS: generate_config(scope, binary_path) -> Vec<ConfigFile>
+        INS-->>ORCH: [ConfigFile { path, content }]
+
+        loop Each config file
+            ORCH->>CW: write(config_file, backup=true)
+            CW->>FS: backup existing -> .bak (if exists)
+            CW->>FS: write temp file
+            CW->>FS: rename temp -> target (atomic)
+            CW-->>ORCH: Ok(())
+        end
+    end
+
+    ORCH-->>CLI: InstallReport { results: [...] }
+    CLI-->>U: JSON or human-readable output
+```
+
+### Interface Definitions `@human-review`
+
+```rust
+// --- AgentInstaller trait (platforms crate) ---
+
+/// Information about a detected agent installation.
+pub struct AgentInfo {
+    pub name: String,
+    pub binary_path: PathBuf,
+    pub version: Option<String>,
+}
+
+/// A configuration file to write for an agent.
+pub struct ConfigFile {
+    pub target_path: PathBuf,
+    pub content: String,
+    pub description: String,
+}
+
+/// Scope for installation (project-local or global/user-level).
+pub enum InstallScope {
+    Project { root: PathBuf },
+    Global,
+}
+
+/// Trait each agent installer must implement.
+pub trait AgentInstaller: Send + Sync {
+    /// Canonical agent name (lowercase): "opencode", "copilot", "codex", "gemini"
+    fn agent_name(&self) -> &str;
+
+    /// Detect if this agent is installed on the system.
+    /// Returns None if not found.
+    fn detect(&self) -> Option<AgentInfo>;
+
+    /// Generate configuration files for this agent.
+    /// `binary_path` is the path to the rusty-brain binary.
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError>;
+
+    /// Validate that the installation is working (post-install check).
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError>;
+}
+
+// --- InstallConfig (CLI -> Orchestrator) ---
+
+pub struct InstallConfig {
+    pub agents: Option<Vec<String>>,   // None = auto-detect
+    pub scope: InstallScope,
+    pub json: bool,
+    pub reconfigure: bool,
+    pub config_dir: Option<PathBuf>,   // per-agent override
+}
+
+// --- InstallReport (Orchestrator -> CLI) ---
+
+pub struct InstallReport {
+    pub results: Vec<AgentInstallResult>,
+    pub memory_store: PathBuf,
+    pub scope: String,
+}
+
+pub struct AgentInstallResult {
+    pub agent_name: String,
+    pub status: InstallStatus,
+    pub config_path: Option<PathBuf>,
+    pub version_detected: Option<String>,
+    pub error: Option<InstallError>,
+}
+
+pub enum InstallStatus {
+    Configured,
+    Upgraded,
+    Skipped,
+    Failed,
+    NotFound,
+}
+
+// --- InstallError (types crate) ---
+
+pub enum InstallError {
+    AgentNotFound { agent: String },
+    PermissionDenied { path: PathBuf, suggestion: String },
+    UnsupportedVersion { agent: String, version: String, min_version: String },
+    ConfigCorrupted { path: PathBuf },
+    IoError { path: PathBuf, source: std::io::Error },
+    ScopeRequired,
+}
+```
+
+### Key Algorithms/Patterns `@human-review`
+
+**Pattern: Atomic Config Write with Backup**
+```
+1. Check if target file exists
+2. If exists AND (reconfigure OR upgrade):
+   a. Copy target -> target.bak
+   b. Log backup creation
+3. Write content to temp file in same directory (same filesystem for rename)
+4. Rename temp file -> target (atomic on POSIX; on Windows, use rename with overwrite)
+5. If rename fails: clean up temp file, return error
+```
+
+**Pattern: Agent Detection**
+```
+1. Check if agent binary exists on PATH (platform-specific: "opencode" vs "opencode.exe")
+2. If found: attempt to get version (run "agent --version" and parse output)
+3. If version parse fails: return AgentInfo with version=None (proceed with warning per PRD)
+4. If binary not found: check standard config directory exists as fallback
+5. Return Some(AgentInfo) or None
+```
+
+---
+
+## Constraints & Boundaries
+
+### Technical Constraints `@human-review`
+
+**Inherited from PRD:**
+- Rust stable, edition 2024, MSRV 1.85.0
+- No network calls during install
+- Atomic writes (temp file + rename)
+- Prefer existing workspace dependencies (clap, serde, serde_json, tracing)
+- Agent-friendly: structured JSON output, no interactive prompts in non-TTY mode
+- Must work on macOS, Linux, Windows
+
+**Added by this Architecture:**
+- `AgentInstaller` trait implementations must be pure for config generation — filesystem interaction only through `ConfigWriter`
+- Agent detection may invoke external processes (e.g., `opencode --version`) but must handle timeouts (2s max)
+- Config templates are embedded as Rust const strings, not external files
+- Install error codes are stable; adding new variants is non-breaking, removing/renaming is breaking
+
+### Architectural Boundaries `@human-review`
+
+```mermaid
+graph TD
+    subgraph This Architecture Owns
+        INSTALL[install subcommand]
+        ORCH[InstallOrchestrator]
+        IREG[InstallerRegistry]
+        INSTALLERS[AgentInstaller impls]
+        CW[ConfigWriter]
+    end
+
+    subgraph Uses - Read Only
+        PLAT_DETECT[platforms::detect_platform]
+        PATH_POL[platforms::path_policy]
+        OUTPUT[cli::output formatting]
+    end
+
+    subgraph DO NOT MODIFY
+        CORE[core crate / Mind API]
+        MV2[.rusty-brain/mind.mv2]
+        HOOKS[hooks crate]
+        ADAPTER[PlatformAdapter trait]
+    end
+
+    INSTALL --> ORCH
+    ORCH --> IREG
+    ORCH --> CW
+    ORCH --> PATH_POL
+    INSTALL --> OUTPUT
+```
+
+- **Owns:** Install subcommand, `InstallOrchestrator`, `InstallerRegistry`, per-agent `AgentInstaller` impls, `ConfigWriter`
+- **Interfaces With:** `platforms::path_policy` (for memory path resolution), `cli::output` (for JSON/table formatting), `types` crate (for error types)
+- **Must Not Touch:** `core` crate, `Mind` API, `.mv2` files, `PlatformAdapter` trait, `hooks` crate, existing adapter normalization logic
+
+### Implementation Guardrails `@human-review`
+
+> **Critical for LLM Agents:**
+
+- [ ] **DO NOT** make network calls during install *(from PRD Technical Constraints)*
+- [ ] **DO NOT** modify the `PlatformAdapter` trait or existing adapters — install is a separate concern *(from architecture boundary)*
+- [ ] **DO NOT** write config files directly — always use `ConfigWriter` for atomic writes *(from PRD atomic write constraint)*
+- [ ] **DO NOT** use interactive prompts or stdin reads in install logic *(from PRD M-11)*
+- [ ] **DO NOT** create a new crate for install logic *(from crate-first Constitution principle)*
+- [ ] **MUST** return structured `InstallError` with stable error codes for all failure modes *(satisfies PRD M-10)*
+- [ ] **MUST** require `--project` or `--global` — never silently default to either scope *(satisfies PRD M-13)*
+- [ ] **MUST** create `.bak` backup before overwriting existing config files *(satisfies PRD S-1, FR-010)*
+- [ ] **MUST** use `tempfile` crate for atomic writes (write to temp, then rename) *(satisfies PRD atomic write constraint)*
+- [ ] **MUST** implement `AgentInstaller::generate_config` as a pure function returning `Vec<ConfigFile>` — no filesystem I/O in the trait method itself *(enables unit testing)*
+- [ ] **MUST** handle agent version detection timeout (2s max) to prevent hanging *(robustness)*
+
+---
+
+## Consequences `@human-review`
+
+### Positive
+- Consistent install experience across all four agents via shared orchestration
+- Each agent's install logic is testable in isolation (pure config generation)
+- Adding future agents requires only a new module + trait impl + registry entry
+- Reuses existing crate patterns (`AdapterRegistry` -> `InstallerRegistry`)
+- No new crate dependencies beyond what's already in workspace
+
+### Negative
+- `platforms` crate grows in scope (install + runtime), though both concern agent platform interaction
+- Agent detection requires running external processes (`--version`), which adds subprocess management complexity
+- Config templates are embedded in Rust code — updating a template requires a binary rebuild (but this is intentional for reproducibility)
+
+### Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Agent extension APIs are undocumented or change frequently | Medium | High | Spike research (PRD Spike-1 through Spike-4) before implementation; version-gate templates |
+| Atomic rename fails on Windows network drives | Low | Medium | Fall back to copy-delete on rename failure; document limitation |
+| Agent binary on PATH is not the expected agent (name collision) | Low | Low | Verify identity via `--version` output parsing; warn if unrecognizable |
+| `platforms` crate becomes too large | Low | Low | Install modules are in a dedicated `installer/` subdirectory; can extract to crate later if needed |
+
+---
+
+## Implementation Guidance
+
+### Suggested Implementation Order `@llm-autonomous`
+
+1. **Types first:** Add `InstallError`, `InstallStatus`, `AgentInfo`, `ConfigFile`, `InstallConfig`, `InstallReport`, `AgentInstallResult` structs to `types` crate
+2. **AgentInstaller trait:** Define trait in `platforms/src/installer/mod.rs`
+3. **ConfigWriter:** Implement atomic write + backup in `platforms/src/installer/writer.rs`
+4. **InstallerRegistry:** Registry pattern in `platforms/src/installer/registry.rs`
+5. **OpenCodeInstaller:** First agent impl (already has adapter support, most understood) in `platforms/src/installer/agents/opencode.rs`
+6. **InstallOrchestrator:** Workflow coordinator in `platforms/src/installer/orchestrator.rs`
+7. **CLI integration:** Add `Install` variant to `Command` enum in `cli/src/args.rs`, dispatch in `commands.rs`
+8. **Remaining agents:** CopilotInstaller, CodexInstaller, GeminiInstaller (after spike research)
+9. **Integration tests:** End-to-end install tests with tempdir fixtures
+
+### Testing Strategy `@llm-autonomous`
+
+| Layer | Test Type | Coverage Target | Notes |
+|-------|-----------|-----------------|-------|
+| Unit | AgentInstaller::generate_config | 90%+ | Pure functions: given scope + binary path, assert config file contents |
+| Unit | ConfigWriter | 90%+ | Test atomic write, backup, error paths using tempdir |
+| Unit | InstallerRegistry | 90%+ | Registration, lookup, listing (mirrors AdapterRegistry tests) |
+| Unit | InstallOrchestrator | 80%+ | Mock installers and writer; test workflow logic |
+| Unit | CLI arg parsing | 90%+ | clap parse tests for install subcommand (mirrors existing pattern) |
+| Integration | Full install flow | Key paths | Install to tempdir, verify config files exist with correct content |
+| Integration | Upgrade flow | Key paths | Install twice, verify `.bak` created, config updated |
+| Integration | Error paths | All error codes | Missing agent, permission denied, scope required |
+
+### Reference Implementations `@human-review`
+
+- `crates/platforms/src/adapter.rs` — `PlatformAdapter` trait pattern *(internal)*
+- `crates/platforms/src/registry.rs` — `AdapterRegistry` pattern *(internal)*
+- `crates/cli/src/args.rs` — clap derive subcommand pattern *(internal)*
+- `crates/platforms/src/bootstrap.rs` — platform path resolution pattern *(internal)*
+
+### Anti-patterns to Avoid `@human-review`
+- **Don't:** Put filesystem I/O in `AgentInstaller::generate_config`
+  - **Why:** Makes unit testing require real filesystem, breaks isolation
+  - **Instead:** Return `Vec<ConfigFile>` structs; `ConfigWriter` handles I/O
+
+- **Don't:** Hardcode agent config directory paths as string literals
+  - **Why:** Breaks on different OS platforms, non-standard installations
+  - **Instead:** Use `dirs` crate or platform-specific path resolution with `--config-dir` override
+
+- **Don't:** Shell out to `which` / `where` for binary detection
+  - **Why:** Platform-specific, fragile, potential command injection
+  - **Instead:** Use `std::env::split_paths` + `std::path::Path::join` to search PATH safely
+
+- **Don't:** Modify `PlatformAdapter` to add install methods
+  - **Why:** Conflates runtime event normalization with one-time installation
+  - **Instead:** Separate `AgentInstaller` trait; the two traits address different lifecycle phases
+
+---
+
+## Compliance & Cross-cutting Concerns
+
+### Security Considerations `@human-review`
+- **Authentication:** None required — local filesystem operations only
+- **Authorization:** Config files written with user's current filesystem permissions; no privilege escalation
+- **Data handling:** No secrets in config files. Config templates reference binary paths and memory store paths only
+- **Path validation:** `--config-dir` input validated against path traversal (no `..` escapes outside expected directories)
+- **Subprocess safety:** Agent version detection must not pass user input to shell; use `Command::new(binary).arg("--version")` directly
+
+### Observability `@llm-autonomous`
+- **Logging:** All install actions logged at `INFO` via `tracing`: agent detected, config file written, backup created, agent skipped. Errors at `WARN`/`ERROR`. Controlled by `RUSTY_BRAIN_LOG` env var.
+- **Metrics:** Not applicable (CLI tool, not a service)
+- **Tracing:** Each agent install operation gets a tracing span with agent name for structured log output
+
+### Error Handling Strategy `@llm-autonomous`
+```
+Error Category -> Handling Approach
++-- AgentNotFound -> Skip agent, include in report as NotFound, continue to next agent
++-- PermissionDenied -> Report error with suggestion, mark as Failed, continue to next agent
++-- UnsupportedVersion -> Warn but proceed with latest template (per PRD), mark as Configured with warning
++-- ConfigCorrupted -> Backup corrupted file, write fresh config, mark as Configured with note
++-- IoError -> Report error with path context, mark as Failed, continue to next agent
++-- ScopeRequired -> Fail immediately (before any agent processing), return error to CLI
+```
+
+Key principle: **Fail per-agent, not per-command.** If one agent fails, continue installing others and report all results.
+
+---
+
+## Migration Plan
+
+### From Current State to Target State
+
+Not applicable — this is a new subcommand added to the existing binary. No migration from an old system is needed.
+
+### Rollback Plan `@human-required`
+
+**Rollback Triggers:**
+- Install subcommand corrupts existing agent configurations on upgrade path
+- Atomic write implementation causes data loss on a specific OS
+
+**Rollback Decision Authority:** Project maintainer
+
+**Rollback Time Window:** Any time before the feature is released in a tagged version
+
+**Rollback Procedure:**
+1. Revert the commit(s) adding the install subcommand
+2. Users with corrupted configs can restore from `.bak` files created during install
+3. Re-release binary without install subcommand
+
+---
+
+## Open Questions `@human-review`
+
+- [x] **Q1:** ~~Should agent detection run external processes (e.g., `opencode --version`) or only check for binary existence on PATH?~~ **Resolved**: Detection runs `--version` with a 2-second timeout (per SEC-6, tasks T035). Version info enables version-gated template selection (S-3).
+- [x] **Q2:** ~~Does the `platforms` crate need a `dirs` or `directories` crate dependency?~~ **Resolved**: No. Use `$HOME`/`$XDG_CONFIG_HOME`/`%APPDATA%` directly via env vars and `cfg!(target_os)` (per research.md R4, tasks T018a-T018b).
+- [x] **Q3:** ~~Should `ConfigWriter` use the `tempfile` crate as a regular dependency?~~ **Resolved**: Yes. Promote `tempfile` from dev-dep to regular dep (per research.md R7, task T001).
+
+---
+
+## Changelog `@auto`
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-03-05 | Claude | Initial proposal |
+
+---
+
+## Decision Record `@auto`
+
+| Date | Event | Details |
+|------|-------|---------|
+| 2026-03-05 | Proposed | Initial draft created from PRD 011-prd-agent-installs |
+
+---
+
+## Traceability Matrix `@llm-autonomous`
+
+| PRD Req ID | Decision Driver | Option Rating | Component | Notes |
+|------------|-----------------|---------------|-----------|-------|
+| M-1 | Crate-first simplicity | Option 1: ✅ | Install subcommand (CLI) | New clap subcommand added to existing CLI |
+| M-2 | Extensibility | Option 1: ✅ | InstallerRegistry + per-agent impls | 4 agent modules behind common trait |
+| M-3 | Extensibility | Option 1: ✅ | InstallOrchestrator + AgentInstaller::detect | Auto-detection via PATH and config dir checks |
+| M-4 | Crate-first simplicity | Option 1: ✅ | Install subcommand (CLI) | `--agents` flag parsed by clap |
+| M-5 | Testability | Option 1: ✅ | AgentInstaller::generate_config | Pure config generation per agent |
+| M-6 | Crate-first simplicity | Option 1: ✅ | Config templates | All templates reference `.rusty-brain/mind.mv2` |
+| M-7 | Crate-first simplicity | Option 1: ✅ | CLI output layer | Existing `output.rs` pattern extended |
+| M-8 | Atomic safety | Option 1: ✅ | ConfigWriter | Backup + atomic write on upgrade |
+| M-9 | Testability | Option 1: ✅ | AgentInstaller::detect | Detection returns structured AgentInfo or None |
+| M-10 | Testability | Option 1: ✅ | InstallError enum | Stable error codes with Display impl |
+| M-11 | — | Option 1: ✅ | InstallOrchestrator | No stdin reads in install path |
+| M-12 | Cross-platform correctness | Option 1: ✅ | ConfigWriter | `create_dir_all` before write |
+| M-13 | — | Option 1: ✅ | Install subcommand (CLI) | Required mutually-exclusive arg group |
+| S-1 | Atomic safety | Option 1: ✅ | ConfigWriter | `.bak` backup before overwrite |
+| S-2 | — | Option 1: ✅ | InstallOrchestrator | Uses workspace `tracing` |
+| S-3 | — | Option 1: ✅ | AgentInstaller::detect | Version in AgentInfo struct |
+| S-4 | Cross-platform correctness | Option 1: ✅ | Install subcommand (CLI) | `--config-dir` override passed to installer |
+
+---
+
+## Review Checklist `@llm-autonomous`
+
+Before marking as Accepted:
+- [x] All PRD Must Have requirements appear in Driving Requirements
+- [x] Option 0 (Status Quo) is documented
+- [x] Simplest Implementation comparison is completed
+- [x] Decision drivers are prioritized and addressed
+- [x] At least 2 options were seriously considered (3 options presented)
+- [x] Constraints distinguish inherited vs. new
+- [x] Component names are consistent across all diagrams and tables
+- [x] Implementation guardrails reference specific PRD constraints
+- [x] Rollback triggers and authority are defined
+- [x] Security review is linked (011-sec-agent-installs.md complete)
+- [x] No open questions blocking implementation (Q1-Q3 resolved via research.md)

--- a/specs/011-agent-installs/checklists/requirements.md
+++ b/specs/011-agent-installs/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Agentic Agent Installs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions about agent extension mechanisms (Copilot CLI, Codex CLI, Gemini CLI) will need research validation during the architecture/plan phase — these are documented in the Assumptions section.

--- a/specs/011-agent-installs/contracts/agent-installer-trait.rs
+++ b/specs/011-agent-installs/contracts/agent-installer-trait.rs
@@ -1,0 +1,241 @@
+// Contract: AgentInstaller Trait
+// Feature: 011-agent-installs
+// Date: 2026-03-05
+//
+// This file defines the interface contracts for the install subsystem.
+// Implementation MUST conform to these trait signatures.
+
+use std::path::{Path, PathBuf};
+
+// --- Core Types (types crate: src/install.rs) ---
+
+/// Information about a detected agent installation.
+#[derive(Debug, Clone)]
+pub struct AgentInfo {
+    /// Canonical agent name (lowercase): "opencode", "copilot", "codex", "gemini"
+    pub name: String,
+    /// Absolute path to agent binary on the system
+    pub binary_path: PathBuf,
+    /// Detected version string, if available
+    pub version: Option<String>,
+}
+
+/// A configuration file to be written for an agent.
+#[derive(Debug, Clone)]
+pub struct ConfigFile {
+    /// Absolute path where this file should be written
+    pub target_path: PathBuf,
+    /// File content
+    pub content: String,
+    /// Human-readable description (for logging and JSON output)
+    pub description: String,
+}
+
+/// Scope for installation.
+#[derive(Debug, Clone)]
+pub enum InstallScope {
+    /// Config placed relative to project root
+    Project { root: PathBuf },
+    /// Config placed in user-level directories
+    Global,
+}
+
+/// Input configuration parsed from CLI args.
+#[derive(Debug)]
+pub struct InstallConfig {
+    /// Explicit agent list; None = auto-detect all
+    pub agents: Option<Vec<String>>,
+    /// Installation scope (required)
+    pub scope: InstallScope,
+    /// Force JSON output
+    pub json: bool,
+    /// Regenerate config files (backup existing)
+    pub reconfigure: bool,
+    /// Override config directory for the agent
+    pub config_dir: Option<PathBuf>,
+}
+
+/// Per-agent installation result.
+///
+/// NOTE: `error` is the Display output of `InstallError` (serialized as string).
+/// Error codes are embedded via `[E_INSTALL_*]` prefixes in the message, so
+/// consumers can parse the code from the string for programmatic handling.
+/// Mapping: `result.error = Some(format!("{install_error}"))`
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentInstallResult {
+    pub agent_name: String,
+    pub status: InstallStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_detected: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Overall installation report.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InstallReport {
+    pub status: String,
+    pub results: Vec<AgentInstallResult>,
+    pub memory_store: PathBuf,
+    pub scope: String,
+}
+
+/// Installation outcome for a single agent.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallStatus {
+    Configured,
+    Upgraded,
+    Skipped,
+    Failed,
+    NotFound,
+}
+
+/// Stable error types for install operations.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("[E_INSTALL_AGENT_NOT_FOUND] Agent '{agent}' not found on this system")]
+    AgentNotFound { agent: String },
+
+    #[error("[E_INSTALL_PERMISSION_DENIED] Cannot write to '{path}': {suggestion}")]
+    PermissionDenied { path: PathBuf, suggestion: String },
+
+    #[error("[E_INSTALL_UNSUPPORTED_VERSION] Agent '{agent}' version {version} is below minimum {min_version}")]
+    UnsupportedVersion {
+        agent: String,
+        version: String,
+        min_version: String,
+    },
+
+    #[error("[E_INSTALL_CONFIG_CORRUPTED] Existing config at '{path}' is corrupted")]
+    ConfigCorrupted { path: PathBuf },
+
+    #[error("[E_INSTALL_IO_ERROR] I/O error at '{path}': {source}")]
+    IoError {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("[E_INSTALL_SCOPE_REQUIRED] Installation scope required: use --project or --global")]
+    ScopeRequired,
+
+    #[error("[E_INSTALL_INVALID_AGENT] Unknown agent '{agent}'. Supported: opencode, copilot, codex, gemini")]
+    InvalidAgent { agent: String },
+
+    #[error("[E_INSTALL_PATH_TRAVERSAL] Path '{path}' contains traversal sequences")]
+    PathTraversal { path: PathBuf },
+}
+
+// --- AgentInstaller Trait (platforms crate: src/installer/mod.rs) ---
+
+/// Trait that each agent installer must implement.
+///
+/// IMPORTANT: `generate_config` MUST be a pure function — no filesystem I/O.
+/// All filesystem operations go through `ConfigWriter`.
+pub trait AgentInstaller: Send + Sync {
+    /// Canonical lowercase agent name: "opencode", "copilot", "codex", "gemini"
+    fn agent_name(&self) -> &str;
+
+    /// Detect if this agent is installed on the system.
+    ///
+    /// Checks PATH for the agent binary and optionally runs `--version`
+    /// with a 2-second timeout.
+    ///
+    /// Returns `None` if the agent is not found.
+    fn detect(&self) -> Option<AgentInfo>;
+
+    /// Generate configuration files for this agent.
+    ///
+    /// This MUST be a pure function: given scope and binary path, return
+    /// a list of files to write. No filesystem I/O.
+    ///
+    /// `binary_path` is the absolute path to the rusty-brain binary.
+    fn generate_config(
+        &self,
+        scope: &InstallScope,
+        binary_path: &Path,
+    ) -> Result<Vec<ConfigFile>, InstallError>;
+
+    /// Validate that the installation is working (post-install check).
+    ///
+    /// Checks that config files exist and are valid.
+    fn validate(&self, scope: &InstallScope) -> Result<(), InstallError>;
+}
+
+// --- InstallerRegistry (platforms crate: src/installer/registry.rs) ---
+
+/// Registry for AgentInstaller implementations.
+///
+/// Mirrors the pattern of AdapterRegistry in platforms/src/registry.rs.
+pub trait InstallerRegistryContract {
+    /// Register an installer.
+    fn register(&mut self, installer: Box<dyn AgentInstaller>);
+
+    /// Look up an installer by agent name (case-insensitive).
+    fn resolve(&self, agent_name: &str) -> Option<&dyn AgentInstaller>;
+
+    /// Return sorted list of all registered agent names.
+    fn agents(&self) -> Vec<String>;
+}
+
+// --- ConfigWriter (platforms crate: src/installer/writer.rs) ---
+
+/// Contract for atomic config file writing with backup support.
+pub trait ConfigWriterContract {
+    /// Write a config file atomically (temp file + rename).
+    ///
+    /// If the target file exists and `backup` is true, creates a `.bak` copy first.
+    /// Creates parent directories if they don't exist.
+    /// Sets file permissions to 0o644 on Unix.
+    fn write(&self, config: &ConfigFile, backup: bool) -> Result<(), InstallError>;
+
+    /// Create a `.bak` backup of an existing file.
+    fn backup(&self, path: &Path) -> Result<(), InstallError>;
+}
+
+// --- InstallOrchestrator (platforms crate: src/installer/orchestrator.rs) ---
+
+/// Contract for the install workflow coordinator.
+pub trait InstallOrchestratorContract {
+    /// Execute the full install workflow.
+    ///
+    /// 1. Determine target agents (from config.agents or auto-detect)
+    /// 2. For each agent: detect -> generate_config -> write
+    /// 3. Collect results into InstallReport
+    ///
+    /// Fails per-agent, not per-command: if one agent fails, continues to next.
+    fn run(&self, config: InstallConfig) -> Result<InstallReport, InstallError>;
+}
+
+// --- CLI Subcommand (cli crate: src/args.rs) ---
+
+// The Install variant added to the Command enum:
+//
+// Install {
+//     /// Comma-separated list of agents to configure
+//     #[arg(long, value_delimiter = ',')]
+//     agents: Option<Vec<String>>,
+//
+//     /// Install config relative to current working directory
+//     #[arg(long, group = "scope")]
+//     project: bool,
+//
+//     /// Install config in user-level directories
+//     #[arg(long, group = "scope")]
+//     global: bool,
+//
+//     /// Force JSON output
+//     #[arg(long)]
+//     json: bool,
+//
+//     /// Regenerate config files (backup existing)
+//     #[arg(long)]
+//     reconfigure: bool,
+//
+//     /// Override config directory for the agent
+//     #[arg(long)]
+//     config_dir: Option<PathBuf>,
+// }

--- a/specs/011-agent-installs/contracts/agent-installer-trait.rs
+++ b/specs/011-agent-installs/contracts/agent-installer-trait.rs
@@ -51,8 +51,6 @@ pub struct InstallConfig {
     pub json: bool,
     /// Regenerate config files (backup existing)
     pub reconfigure: bool,
-    /// Override config directory for the agent
-    pub config_dir: Option<PathBuf>,
 }
 
 /// Per-agent installation result.
@@ -76,10 +74,20 @@ pub struct AgentInstallResult {
 /// Overall installation report.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct InstallReport {
-    pub status: String,
+    /// Overall status. Uses `ReportStatus` enum (serialized as snake_case).
+    pub status: ReportStatus,
     pub results: Vec<AgentInstallResult>,
     pub memory_store: PathBuf,
     pub scope: String,
+}
+
+/// Overall report status.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportStatus {
+    Success,
+    Partial,
+    Failed,
 }
 
 /// Installation outcome for a single agent.
@@ -137,7 +145,7 @@ pub enum InstallError {
 /// All filesystem operations go through `ConfigWriter`.
 pub trait AgentInstaller: Send + Sync {
     /// Canonical lowercase agent name: "opencode", "copilot", "codex", "gemini"
-    fn agent_name(&self) -> &str;
+    fn agent_name(&self) -> &'static str;
 
     /// Detect if this agent is installed on the system.
     ///
@@ -235,7 +243,4 @@ pub trait InstallOrchestratorContract {
 //     #[arg(long)]
 //     reconfigure: bool,
 //
-//     /// Override config directory for the agent
-//     #[arg(long)]
-//     config_dir: Option<PathBuf>,
 // }

--- a/specs/011-agent-installs/data-model.md
+++ b/specs/011-agent-installs/data-model.md
@@ -1,0 +1,155 @@
+# Data Model: Agent Installs
+
+**Feature**: 011-agent-installs | **Date**: 2026-03-05
+
+## Entities
+
+### AgentInfo
+
+Represents a detected agent installation on the system.
+
+| Field | Type | Required | Description | Validation |
+|-------|------|----------|-------------|------------|
+| name | String | Yes | Canonical agent name (lowercase) | Must be in allowlist: opencode, copilot, codex, gemini |
+| binary_path | PathBuf | Yes | Absolute path to agent binary | Must exist on filesystem |
+| version | Option\<String\> | No | Detected version string | Parsed from `--version` output; None if detection fails |
+
+### ConfigFile
+
+A configuration file to be written for an agent.
+
+| Field | Type | Required | Description | Validation |
+|-------|------|----------|-------------|------------|
+| target_path | PathBuf | Yes | Absolute path where file should be written | Must be canonical, no `..` traversal |
+| content | String | Yes | File content to write | Non-empty |
+| description | String | Yes | Human-readable description of what this file does | Non-empty |
+
+### InstallScope
+
+Determines where configuration files are placed.
+
+| Variant | Description | Path Resolution |
+|---------|-------------|-----------------|
+| Project { root: PathBuf } | Config relative to current working directory | `<root>/.opencode/`, `<root>/.copilot/`, etc. |
+| Global | Config in user-level directories | `~/.config/<agent>/` (Linux), `~/Library/Application Support/<agent>/` (macOS), `%APPDATA%/<agent>/` (Windows) |
+
+### InstallConfig
+
+Input configuration for the install orchestrator.
+
+| Field | Type | Required | Description | Validation |
+|-------|------|----------|-------------|------------|
+| agents | Option\<Vec\<String\>\> | No | Explicit agent list; None = auto-detect | Each name must be in allowlist |
+| scope | InstallScope | Yes | Project or Global | Must be specified (PRD M-13) |
+| json | bool | Yes | Force JSON output | -- |
+| reconfigure | bool | Yes | Regenerate config files | -- |
+| config_dir | Option\<PathBuf\> | No | Override config directory | Must be canonical, no traversal |
+
+### InstallReport
+
+Output report from the install orchestrator.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| results | Vec\<AgentInstallResult\> | Yes | Per-agent results |
+| memory_store | PathBuf | Yes | Path to shared `.rusty-brain/mind.mv2` |
+| scope | String | Yes | "project" or "global" |
+
+### AgentInstallResult
+
+Per-agent installation result.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| agent_name | String | Yes | Canonical agent name |
+| status | InstallStatus | Yes | Outcome of installation |
+| config_path | Option\<PathBuf\> | No | Path to main config file (None if not installed) |
+| version_detected | Option\<String\> | No | Agent version if detected |
+| error | Option\<String\> | No | Error message if failed |
+
+### InstallStatus
+
+| Variant | Description |
+|---------|-------------|
+| Configured | Successfully installed/configured |
+| Upgraded | Existing config upgraded (backup created) |
+| Skipped | Agent found but skipped (e.g., already configured, no changes needed) |
+| Failed | Installation failed (see error field) |
+| NotFound | Agent not found on system |
+
+### InstallError
+
+| Variant | Error Code | Description |
+|---------|-----------|-------------|
+| AgentNotFound { agent } | E_INSTALL_AGENT_NOT_FOUND | Agent binary not found on PATH |
+| PermissionDenied { path, suggestion } | E_INSTALL_PERMISSION_DENIED | Cannot write to config directory |
+| UnsupportedVersion { agent, version, min_version } | E_INSTALL_UNSUPPORTED_VERSION | Agent version too old |
+| ConfigCorrupted { path } | E_INSTALL_CONFIG_CORRUPTED | Existing config file unparseable |
+| IoError { path, source } | E_INSTALL_IO_ERROR | Filesystem I/O failure |
+| ScopeRequired | E_INSTALL_SCOPE_REQUIRED | Neither --project nor --global specified |
+| InvalidAgent { agent } | E_INSTALL_INVALID_AGENT | Agent name not in allowlist |
+| PathTraversal { path } | E_INSTALL_PATH_TRAVERSAL | --config-dir contains traversal sequences |
+
+## Design Notes
+
+### AgentPlatform Configuration (PRD entity not modeled as struct)
+
+The PRD defines an `AgentPlatform` entity (name, binary_name, detection_method, config_dir_template, min_supported_version). This is **not** represented as a runtime struct because these values are compile-time constants embedded in each `AgentInstaller` implementation. Each installer knows its own binary name, detection method, and config templates. This avoids unnecessary indirection and keeps agent knowledge co-located with agent logic.
+
+### InstallError to AgentInstallResult.error Mapping
+
+`InstallError` is the internal Rust enum with rich typed fields (paths, versions, source errors). `AgentInstallResult.error` is an `Option<String>` containing the `Display` output of `InstallError` for JSON serialization. The mapping is: `result.error = Some(format!("{install_error}"))`. Error codes are embedded in the Display format via `[E_INSTALL_*]` prefixes, so consumers can parse the code from the serialized string.
+
+## Relationships
+
+```text
+InstallConfig ---> InstallOrchestrator ---> InstallerRegistry
+                                       |                     \
+                                       |                      --> AgentInstaller (per agent)
+                                       |                              |
+                                       |                              --> detect() -> Option<AgentInfo>
+                                       |                              --> generate_config() -> Vec<ConfigFile>
+                                       |
+                                       --> ConfigWriter
+                                              |
+                                              --> write(ConfigFile) -> Result
+                                              --> backup(Path) -> Result
+                                       |
+                                       --> InstallReport
+                                              |
+                                              --> Vec<AgentInstallResult>
+```
+
+## State Transitions
+
+### Agent Install Lifecycle
+
+```text
+[Not Detected] --> detect() --> [Detected: AgentInfo]
+                                     |
+                              generate_config() --> [Config Generated: Vec<ConfigFile>]
+                                     |
+                              ConfigWriter::write() --> [Configured / Upgraded]
+                                     |
+                              validate() --> [Validated] or [Failed]
+```
+
+### Per-Agent Status Flow
+
+```text
+Start --> detect()
+  |
+  +--> None --> NotFound (skip, continue)
+  |
+  +--> Some(AgentInfo) --> generate_config()
+         |
+         +--> Err --> Failed (log, continue)
+         |
+         +--> Ok(files) --> ConfigWriter::write()
+                |
+                +--> existing config? --> backup --> write --> Upgraded
+                |
+                +--> no existing config? --> create dirs --> write --> Configured
+                |
+                +--> Err --> Failed (log, continue)
+```

--- a/specs/011-agent-installs/plan.md
+++ b/specs/011-agent-installs/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Agent Installs
+
+**Branch**: `011-agent-installs` | **Date**: 2026-03-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-agent-installs/spec.md`
+
+## Summary
+
+Add a `rusty-brain install` subcommand that auto-detects installed AI coding agents (OpenCode, Copilot CLI, Codex CLI, Gemini CLI) and generates agent-specific configuration files so each agent can invoke rusty-brain for persistent memory. Uses a trait-based installer pattern within the existing `platforms` crate (per AR decision), with atomic file writes, `.bak` backups, and structured JSON output for agentic self-installation.
+
+## Technical Context
+
+**Language/Version**: Rust stable, edition 2024, MSRV 1.85.0
+**Primary Dependencies**: clap 4 (derive), serde/serde_json, tracing, tempfile (promote from dev-dep to regular dep)
+**Storage**: Local filesystem only — config files written to agent directories, no database
+**Testing**: `cargo test` (unit + integration), `assert_cmd`/`predicates` for CLI tests, `tempfile` for test isolation
+**Target Platform**: macOS, Linux, Windows (cross-platform)
+**Project Type**: Rust workspace with existing crates (cli, core, platforms, types, hooks, compression, opencode)
+**Performance Goals**: Single-agent install < 5s, multi-agent install < 30s (local filesystem operations)
+**Constraints**: No network calls, atomic writes (temp+rename), no interactive prompts in non-TTY mode, no `unsafe` code
+**Scale/Scope**: 4 agent platforms, ~8-12 new source files across platforms and cli crates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Crate-First | PASS | Install logic goes in existing `platforms` crate per AR |
+| II. Rust-First | PASS | Stable Rust, no unsafe, memvid boundary not affected |
+| III. Agent-Friendly | PASS | JSON output (M-7), no interactive prompts (M-11), machine-parseable errors (M-10) |
+| IV. Contract-First | PASS | `AgentInstaller` trait defined in AR before implementation |
+| V. Test-First | PASS | Test strategy defined in AR; unit + integration tests planned |
+| VI. Complete Requirement Delivery | PASS | All 13 Must Have + 4 Should Have requirements have acceptance criteria |
+| VII. Memory Integrity | PASS | Install does not read/write `.mv2` files; only references paths |
+| VIII. Performance Discipline | PASS | Install performance targets defined (< 5s / < 30s) |
+| IX. Security-First | PASS | SEC review complete; 10 SEC requirements mapped (SEC-1 through SEC-10) |
+| X. Error Handling | PASS | `InstallError` enum with stable codes defined in AR |
+| XI. Observability | PASS | Tracing via `RUSTY_BRAIN_LOG`; structured output |
+| XII. Simplicity | PASS | Extends existing patterns (AdapterRegistry -> InstallerRegistry) |
+| XIII. Dependency Policy | PASS | Only `tempfile` promoted from dev to regular; no new external deps |
+
+**All gates PASS. No violations to justify.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-agent-installs/
+├── spec.md              # Feature specification
+├── prd.md               # Product requirements document
+├── ar.md                # Architecture review
+├── sec.md               # Security review
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── agent-installer-trait.rs
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (from /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── platforms/src/
+│   ├── installer/                    # NEW: install module tree
+│   │   ├── mod.rs                    # Module declarations, AgentInstaller trait
+│   │   ├── orchestrator.rs           # InstallOrchestrator workflow
+│   │   ├── registry.rs              # InstallerRegistry (mirrors AdapterRegistry)
+│   │   ├── writer.rs                # ConfigWriter (atomic write + backup)
+│   │   └── agents/                  # Per-agent installer implementations
+│   │       ├── mod.rs
+│   │       ├── opencode.rs          # OpenCodeInstaller
+│   │       ├── copilot.rs           # CopilotInstaller
+│   │       ├── codex.rs             # CodexInstaller
+│   │       └── gemini.rs            # GeminiInstaller
+│   ├── lib.rs                       # MODIFY: add `pub mod installer;`
+│   └── ... (existing files unchanged)
+├── types/src/
+│   ├── install.rs                   # NEW: InstallError, InstallStatus, etc.
+│   └── lib.rs                       # MODIFY: add `pub mod install;`
+├── cli/src/
+│   ├── args.rs                      # MODIFY: add Install subcommand variant
+│   ├── commands.rs                  # MODIFY: add install dispatch
+│   └── install_cmd.rs              # NEW: install command handler
+└── ... (other crates unchanged)
+```
+
+**Structure Decision**: Extends existing workspace layout. New `installer/` subtree in `platforms` crate contains all install logic. Types in `types` crate for cross-crate use. CLI handler in `cli` crate.
+
+## Constitution Re-Check (Post Phase 1 Design)
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Crate-First | PASS | All code in existing crates (platforms, types, cli) |
+| II. Rust-First | PASS | No unsafe; memvid not touched |
+| III. Agent-Friendly | PASS | JSON output, machine-parseable errors, no prompts — confirmed in contracts |
+| IV. Contract-First | PASS | `AgentInstaller` trait, `ConfigWriter`, `InstallOrchestrator` contracts defined in `contracts/agent-installer-trait.rs` |
+| V. Test-First | PASS | Test strategy in AR; data model supports pure function testing |
+| VI. Complete Requirement Delivery | PASS | All M-1..M-13 and S-1..S-4 covered by data model entities and contracts |
+| IX. Security-First | PASS | SEC-1..SEC-10 addressed: path validation (SEC-4), allowlist (SEC-5), subprocess timeout (SEC-6), atomic writes (SEC-9) |
+| XII. Simplicity | PASS | Mirrors existing AdapterRegistry pattern; no new abstractions beyond what 4 agents require |
+| XIII. Dependency Policy | PASS | Only `tempfile` promoted; no new external crates |
+
+**All gates PASS post-design. No violations.**
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/011-agent-installs/prd.md
+++ b/specs/011-agent-installs/prd.md
@@ -305,7 +305,7 @@ stateDiagram-v2
 - [ ] **M-7:** The system shall produce structured JSON output when invoked with `--json` or when stdin is not a TTY.
 - [ ] **M-8:** The system shall support upgrading agent configurations without data loss when re-run on an already-configured system.
 - [ ] **M-9:** The system shall validate that the target agent is installed before attempting configuration, providing a clear error if not found.
-- [ ] **M-10:** The system shall provide machine-parseable error messages with stable error codes for all failure modes.
+- [ ] **M-10:** The system shall provide machine-parseable error messages with stable error codes for install, runtime, and domain-level failure modes. (Note: CLI argument-parsing errors are handled by clap and emitted as human-readable text on stderr.)
 - [ ] **M-11:** The system shall not require interactive prompts during installation when in non-TTY mode.
 - [ ] **M-12:** The system shall create necessary directory structures if they do not exist.
 - [ ] **M-13:** The system shall require explicit scope selection via `--project` or `--global` and refuse to run without one.
@@ -402,7 +402,9 @@ erDiagram
   "scope": "project"
 }
 
-// JSON Output (error)
+// JSON Output (domain-level error — M-10 scope)
+// Note: CLI argument-parsing errors (e.g., missing --project/--global) are
+// handled by clap and emitted as human-readable text on stderr, not as JSON.
 {
   "status": "error",
   "error_code": "AGENT_NOT_FOUND",

--- a/specs/011-agent-installs/prd.md
+++ b/specs/011-agent-installs/prd.md
@@ -1,0 +1,633 @@
+# 011-prd-agent-installs
+
+> **Document Type:** Product Requirements Document
+> **Audience:** LLM agents, human reviewers
+> **Status:** Draft
+> **Last Updated:** 2026-03-05
+> **Owner:** [name] <!-- @human-required -->
+
+**Feature Branch**: `011-agent-installs`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "Agentic agent installs for opencode, github copilot-cli, codex and gemini."
+
+---
+
+## Review Tier Legend
+
+| Marker | Tier | Speckit Behavior |
+|--------|------|------------------|
+| `@human-required` | Human Generated | Prompt human to author; blocks until complete |
+| `@human-review` | LLM + Human Review | LLM drafts; prompt human to confirm/edit; blocks until confirmed |
+| `@llm-autonomous` | LLM Autonomous | LLM completes; no prompt; logged for audit |
+| `@auto` | Auto-generated | System fills (timestamps, links); no prompt |
+
+---
+
+## Document Completion Order
+
+> Complete sections in this order. Do not fill downstream sections until upstream human-required inputs exist.
+
+1. **Context** (Background, Scope) -> requires human input first
+2. **Problem Statement & User Scenarios** -> requires human input
+3. **Requirements** (Must/Should/Could/Won't) -> requires human input
+4. **Technical Constraints** -> human review
+5. **Diagrams, Data Model, Interface** -> LLM can draft after above exist
+6. **Acceptance Criteria** -> derived from requirements
+7. **Everything else** -> can proceed
+
+---
+
+## Context
+
+### Background `@human-required`
+
+rusty-brain provides persistent memory for AI coding agents via memvid-encoded `.mv2` storage. Currently, only Claude Code has a complete plugin installation path (via 009-plugin-packaging). Users of other popular AI coding agents — OpenCode, GitHub Copilot CLI, OpenAI Codex CLI, and Google Gemini CLI — must manually configure rusty-brain, creating friction that limits adoption. This feature adds an `install` subcommand that auto-detects installed agents and generates the correct configuration files for each, enabling one-command setup across all supported agents.
+
+### Scope Boundaries `@human-review`
+
+**In Scope:**
+- `rusty-brain install` subcommand for agent-specific configuration
+- Auto-detection of installed agents (OpenCode, Copilot CLI, Codex CLI, Gemini CLI)
+- Configuration file generation per agent's extension mechanism
+- Unified multi-agent install via `--agents` flag or auto-detection
+- Non-interactive (agentic) install mode with JSON output
+- Reconfiguration support (`--reconfigure`) for existing installations
+- Shared memory store (`.rusty-brain/mind.mv2`) across all agents
+- Explicit scope selection (`--project` or `--global`)
+
+**Out of Scope:**
+- Binary download and placement — handled by 009-plugin-packaging install scripts
+- Claude Code plugin installation — already handled by 009-plugin-packaging
+- Auto-update or version management of the agents themselves — separate concern
+- Agent-specific memory formats — all agents use the same `.mv2` format
+- GUI or web-based installation wizard — CLI-only for now
+- Agent marketplace/store submissions — future enhancement
+- Custom agent platform support — only the four named agents
+
+### Glossary `@human-review`
+
+| Term | Definition |
+|------|------------|
+| Agent Platform | A supported AI coding agent (OpenCode, Copilot CLI, Codex CLI, Gemini CLI) |
+| Agent Configuration | The set of files needed to register rusty-brain with a specific agent (plugin manifests, command definitions, tool registrations) |
+| Install Manifest | A structured record of what was installed: agent name, config path, binary path, timestamp, version |
+| Shared Memory Store | The unified `.rusty-brain/mind.mv2` file accessed by all agents |
+| Platform Adapter | A rusty-brain module (from 005) that translates between agent-specific protocols and the core memory API |
+| Agentic Install | Installation triggered by an AI agent itself (non-interactive, JSON output) |
+| Scope | Installation target: `--project` (current directory) or `--global` (user-level directories) |
+
+### Related Documents `@auto`
+
+| Document | Link | Relationship |
+|----------|------|--------------|
+| Feature Spec | [spec.md](spec.md) | Source specification |
+| Architecture Review | ar.md | Defines technical approach |
+| Security Review | sec.md | Risk assessment |
+| 005-platform-adapter-system | specs/005-platform-adapter-system/ | Foundational adapter architecture |
+| 008-opencode-plugin | specs/008-opencode-plugin/ | OpenCode platform adapter |
+| 009-plugin-packaging | specs/009-plugin-packaging/ | Binary packaging and Claude Code install |
+
+---
+
+## Problem Statement `@human-required`
+
+AI developers increasingly use multiple coding agents (Claude Code, OpenCode, Copilot CLI, Codex CLI, Gemini CLI) depending on the task. rusty-brain's persistent memory is only automatically configured for Claude Code. Users of other agents must manually discover configuration file formats, create directories, register commands, and wire up the binary — a process that is error-prone, undocumented for most agents, and discourages adoption.
+
+Without this feature, rusty-brain's cross-agent memory vision remains unrealized: memories stored in one agent session are inaccessible from other agents because the other agents simply aren't configured. The cost is fragmented developer context, duplicated work across agent sessions, and a smaller addressable user base for rusty-brain.
+
+---
+
+## User Scenarios & Testing `@human-required`
+
+### User Story 1 — OpenCode Plugin Installation (Priority: P1)
+
+An OpenCode user wants to install rusty-brain as a plugin so their agent has persistent memory across sessions. They run a single install command that detects their platform, places configuration files in the right locations, and registers slash commands (`/ask`, `/search`, `/recent`, `/stats`) so the agent can immediately invoke memory operations.
+
+> As an OpenCode user, I want to run one command to configure rusty-brain so that my agent has persistent memory without manual setup.
+
+**Why this priority**: OpenCode already has platform adapter support (008-opencode-plugin) and command definitions. This story completes the end-to-end install experience for an already-supported platform.
+
+**Independent Test**: Can be fully tested by running the install command in an OpenCode project directory and verifying that all slash commands appear and route to the rusty-brain binary.
+
+**Acceptance Scenarios**:
+1. **Given** a machine with OpenCode installed but no rusty-brain configured, **When** the user runs `rusty-brain install --agents opencode --project`, **Then** configuration files are placed in the OpenCode plugin directory and all four slash commands are registered.
+2. **Given** rusty-brain is already configured for OpenCode, **When** the user runs the install command again, **Then** the configuration is upgraded without losing existing memory files.
+3. **Given** the install completes, **When** the user starts an OpenCode session, **Then** the agent discovers rusty-brain commands and can invoke `/ask "what did I work on?"` successfully.
+
+---
+
+### User Story 2 — GitHub Copilot CLI Agent Installation (Priority: P1)
+
+A GitHub Copilot CLI user wants rusty-brain integrated into their Copilot agent workflow. The install command sets up the necessary extension configuration so Copilot CLI can invoke rusty-brain for memory operations.
+
+> As a Copilot CLI user, I want to install rusty-brain as an agent extension so that I have persistent memory across coding sessions.
+
+**Why this priority**: Copilot CLI has a large user base and supports agent extensions. Enabling memory for Copilot users significantly expands rusty-brain's reach.
+
+**Independent Test**: Can be fully tested by running the install command and verifying that Copilot CLI discovers and can invoke rusty-brain memory operations.
+
+**Acceptance Scenarios**:
+1. **Given** a machine with GitHub Copilot CLI installed, **When** the user runs `rusty-brain install --agents copilot --project`, **Then** the appropriate Copilot agent/extension configuration files are created.
+2. **Given** the install completes, **When** the user invokes memory operations through Copilot CLI, **Then** queries are routed to rusty-brain and results are returned in the expected format.
+3. **Given** Copilot CLI's extension mechanism changes between versions, **When** the install command runs, **Then** it detects the installed Copilot CLI version and generates compatible configuration.
+
+---
+
+### User Story 3 — OpenAI Codex CLI Agent Installation (Priority: P1)
+
+A Codex CLI user wants persistent memory across their coding sessions. The install command configures rusty-brain as a Codex agent extension, enabling the agent to store and retrieve observations, search past work, and maintain continuity.
+
+> As a Codex CLI user, I want to install rusty-brain so that my coding agent remembers context across sessions.
+
+**Why this priority**: Codex CLI is a direct competitor to Claude Code and supports agent extensions. Providing cross-agent memory is a key differentiator for rusty-brain.
+
+**Independent Test**: Can be fully tested by running the install command and verifying Codex CLI can invoke rusty-brain's memory operations.
+
+**Acceptance Scenarios**:
+1. **Given** a machine with Codex CLI installed, **When** the user runs `rusty-brain install --agents codex --project`, **Then** Codex-specific configuration files (agent definitions, tool registrations) are created.
+2. **Given** the install completes, **When** the Codex agent invokes a memory search, **Then** the query is routed to rusty-brain and results are returned in Codex's expected output format.
+3. **Given** memories were previously stored via a different agent (e.g., Claude Code), **When** the Codex agent searches memory, **Then** it can access the same shared memory store.
+
+---
+
+### User Story 4 — Google Gemini CLI Agent Installation (Priority: P2)
+
+A Gemini CLI user wants persistent memory for their agent sessions. The install command sets up rusty-brain as an extension for Gemini CLI.
+
+> As a Gemini CLI user, I want to install rusty-brain so that my agent has memory across sessions.
+
+**Why this priority**: Gemini CLI is newer and its extension mechanism may be less mature. Important for cross-agent coverage but lower priority than the more established platforms.
+
+**Independent Test**: Can be fully tested by running the install command and verifying Gemini CLI can invoke rusty-brain memory operations.
+
+**Acceptance Scenarios**:
+1. **Given** a machine with Gemini CLI installed, **When** the user runs `rusty-brain install --agents gemini --project`, **Then** Gemini-specific configuration files are created.
+2. **Given** the install completes, **When** the Gemini agent invokes a memory operation, **Then** the query is routed to rusty-brain and results are returned.
+
+---
+
+### User Story 5 — Unified Multi-Agent Install (Priority: P1)
+
+A developer using multiple AI coding agents wants to install rusty-brain for all their agents in one step. A single command with a `--agents` flag (or auto-detection) configures rusty-brain for all detected agents.
+
+> As a developer using multiple AI agents, I want to configure rusty-brain for all my agents in one command so that all agents share the same memory.
+
+**Why this priority**: Users working with multiple agents should not need to run separate install commands. A unified experience reduces friction and ensures consistent configuration.
+
+**Independent Test**: Can be tested by running the unified install on a machine with multiple agents installed and verifying each agent has working memory operations.
+
+**Acceptance Scenarios**:
+1. **Given** a machine with OpenCode and Codex CLI installed, **When** the user runs `rusty-brain install --project` without specifying agents, **Then** rusty-brain auto-detects both agents and configures itself for each.
+2. **Given** the user specifies `--agents opencode,copilot`, **When** the install runs, **Then** only OpenCode and Copilot configurations are created.
+3. **Given** an agent is not found on the system, **When** the install attempts to configure it, **Then** a clear message indicates the agent was not found and the install continues for other detected agents.
+4. **Given** the install completes for multiple agents, **When** each agent is started, **Then** all agents share the same memory store (`.rusty-brain/mind.mv2`).
+
+---
+
+### User Story 6 — Agent Self-Installation (Priority: P2)
+
+An AI coding agent is working in a project and discovers rusty-brain is available but not configured. The agent invokes the install command itself, configuring rusty-brain for its own platform without requiring the user to leave the agent session.
+
+> As an AI coding agent, I want to invoke `rusty-brain install` programmatically so that I can set up memory for myself without user intervention.
+
+**Why this priority**: True "agentic" installation means the agents themselves can trigger setup. This removes the last manual step from the adoption flow.
+
+**Independent Test**: Can be tested by simulating an agent invoking the install command via its tool execution mechanism and verifying the plugin is registered without manual intervention.
+
+**Acceptance Scenarios**:
+1. **Given** an agent session where rusty-brain binary is available but not configured, **When** the agent runs `rusty-brain install --agents <self> --project --json`, **Then** the configuration is created and the agent can immediately use memory operations.
+2. **Given** the agent invokes the install command, **When** no interactive prompts are required, **Then** the install completes with only structured output (JSON status messages suitable for agent consumption).
+3. **Given** the install fails (e.g., missing permissions), **When** the agent reads the error output, **Then** it receives a machine-parseable error with a suggested remediation.
+
+---
+
+### Edge Cases
+
+- **EC-1:** Agent extension/plugin mechanism not supported by rusty-brain — install reports a clear error listing supported agents and minimum versions.
+- **EC-2:** Agent's config directory does not exist (first-time agent installation) — install creates necessary directory structure.
+- **EC-3:** Two agents have conflicting configuration file formats — each agent gets its own config files in agent-specific directories; shared binary and memory store remain unified.
+- **EC-4:** Binary installed but agent config becomes stale after agent upgrade — `--reconfigure` regenerates agent config files.
+- **EC-5:** Install run in CI/CD with no agents installed — install skips agent configuration, exits with a warning.
+- **EC-6:** Agent detected but version cannot be determined — proceed with latest known config format, emit a warning.
+- **EC-7:** User has custom agent config directory (non-default location) — `--config-dir` override per agent.
+
+---
+
+## Assumptions & Risks `@human-review`
+
+### Assumptions
+- [A-1] Each target agent's extension/plugin mechanism will be researched and confirmed before building its adapter. Only agents with documented, stable plugin support get full adapters; others get stubs.
+- [A-2] All agents with confirmed plugin support receive tool results as structured text (JSON or plain text) from external processes.
+- [A-3] The rusty-brain binary is already installed on the system (via 009-plugin-packaging) before `rusty-brain install` is run.
+- [A-4] Agent detection relies on checking `$PATH` for known binary names and standard config directory locations.
+- [A-5] The existing platform adapter system (005) can be extended to support new agent platforms without major refactoring.
+
+### Risks
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|------------|--------|------------|
+| R-1 | Agent extension mechanisms are undocumented or unstable | Medium | High | Research each agent's plugin API before building; stub unsupported agents |
+| R-2 | Agent CLI updates break configuration format | Medium | Medium | Version detection and format-specific generation; `--reconfigure` flag |
+| R-3 | Some agents may not support external tool invocation | Low | High | Stub adapter with clear "not yet supported" messaging; track agent roadmaps |
+| R-4 | Permission issues on agent config directories | Low | Medium | Clear error messages with remediation guidance; document required permissions |
+| R-5 | Auto-detection produces false positives (e.g., similarly-named binaries) | Low | Low | Verify binary identity via version command or config directory structure |
+
+---
+
+## Feature Overview
+
+### Flow Diagram `@human-review`
+
+```mermaid
+flowchart TD
+    A[User runs rusty-brain install] --> B{--agents specified?}
+    B -->|Yes| C[Parse agent list]
+    B -->|No| D[Auto-detect installed agents]
+    C --> E{Scope specified?}
+    D --> E
+    E -->|--project| F[Use project-local config paths]
+    E -->|--global| G[Use user-level config paths]
+    E -->|Neither| H[Error: scope required]
+    F --> I[For each agent]
+    G --> I
+    I --> J{Agent binary found?}
+    J -->|Yes| K[Detect agent version]
+    J -->|No| L[Warn: agent not found, skip]
+    K --> M{Existing config?}
+    M -->|Yes| N[Backup existing config .bak]
+    M -->|No| O[Create config directory]
+    N --> P[Generate agent config files]
+    O --> P
+    P --> Q[Write install manifest]
+    L --> R{More agents?}
+    Q --> R
+    R -->|Yes| I
+    R -->|No| S{--json mode?}
+    S -->|Yes| T[Output JSON summary]
+    S -->|No| U[Output human-readable summary]
+```
+
+### State Diagram `@human-review`
+```mermaid
+stateDiagram-v2
+    [*] --> ParseArgs
+    ParseArgs --> ValidateScope: args valid
+    ParseArgs --> Error: missing scope
+    ValidateScope --> DetectAgents: no --agents
+    ValidateScope --> ParseAgentList: --agents provided
+    ParseAgentList --> DetectAgents
+    DetectAgents --> ConfigureAgent: agent(s) found
+    DetectAgents --> WarnNoAgents: none found
+    ConfigureAgent --> BackupExisting: config exists
+    ConfigureAgent --> CreateDirs: no config
+    BackupExisting --> GenerateConfig
+    CreateDirs --> GenerateConfig
+    GenerateConfig --> ConfigureAgent: more agents
+    GenerateConfig --> WriteManifest: all done
+    WriteManifest --> OutputResult
+    OutputResult --> [*]
+    WarnNoAgents --> OutputResult
+    Error --> [*]
+```
+
+---
+
+## Requirements
+
+### Must Have (M) — MVP, launch blockers `@human-required`
+- [ ] **M-1:** The system shall provide a `rusty-brain install` subcommand that configures rusty-brain for one or more AI coding agents.
+- [ ] **M-2:** The system shall support configuration generation for four agent platforms: OpenCode (`opencode`), GitHub Copilot CLI (`copilot`), OpenAI Codex CLI (`codex`), and Google Gemini CLI (`gemini`).
+- [ ] **M-3:** The system shall auto-detect which agents are installed on the system by checking standard binary paths and configuration directories when `--agents` is not specified.
+- [ ] **M-4:** The system shall accept an `--agents` flag with a comma-separated list of agent names to configure specific agents.
+- [ ] **M-5:** The system shall generate agent-specific configuration files (plugin manifests, command definitions, tool registrations) appropriate to each agent's extension mechanism.
+- [ ] **M-6:** The system shall share a single memory store (`.rusty-brain/mind.mv2`) across all configured agents.
+- [ ] **M-7:** The system shall produce structured JSON output when invoked with `--json` or when stdin is not a TTY.
+- [ ] **M-8:** The system shall support upgrading agent configurations without data loss when re-run on an already-configured system.
+- [ ] **M-9:** The system shall validate that the target agent is installed before attempting configuration, providing a clear error if not found.
+- [ ] **M-10:** The system shall provide machine-parseable error messages with stable error codes for all failure modes.
+- [ ] **M-11:** The system shall not require interactive prompts during installation when in non-TTY mode.
+- [ ] **M-12:** The system shall create necessary directory structures if they do not exist.
+- [ ] **M-13:** The system shall require explicit scope selection via `--project` or `--global` and refuse to run without one.
+
+### Should Have (S) — High value, not blocking `@human-required`
+- [ ] **S-1:** The system shall support a `--reconfigure` flag that regenerates agent configuration files without replacing the binary, creating `.bak` copies of existing files before overwriting. Only the most recent `.bak` is kept per config file (repeated runs overwrite previous `.bak`).
+- [ ] **S-2:** The system shall log installation actions and results via the standard `RUSTY_BRAIN_LOG` environment variable.
+- [ ] **S-3:** The system shall detect the installed version of each agent and generate version-compatible configuration.
+- [ ] **S-4:** The system shall support a `--config-dir` override for non-default configuration locations. When multiple agents are being configured, the override applies to all agents (each agent's config files are written into the specified directory).
+
+### Could Have (C) — Nice to have, if time permits `@human-review`
+- [ ] **C-1:** The system could provide a `--dry-run` flag that shows what would be installed without making changes.
+- [ ] **C-2:** The system could generate a post-install verification report confirming each agent can invoke rusty-brain.
+- [ ] **C-3:** The system could provide a `--uninstall` flag that removes agent configuration files (but preserves memory data).
+
+### Won't Have (W) — Explicitly deferred `@human-review`
+- [ ] **W-1:** Binary download and placement — *Reason: handled by 009-plugin-packaging install scripts*
+- [ ] **W-2:** Claude Code installation — *Reason: already handled by 009-plugin-packaging*
+- [ ] **W-3:** Auto-update of agent binaries — *Reason: separate concern, not rusty-brain's responsibility*
+- [ ] **W-4:** GUI/web installation wizard — *Reason: CLI-only scope for this feature*
+- [ ] **W-5:** Custom/third-party agent platform support — *Reason: only the four named agents for now*
+
+---
+
+## Technical Constraints `@human-review`
+
+- **Language/Framework:** Rust stable, edition 2024, MSRV 1.85.0. Must use existing workspace crates (core, types, platforms).
+- **Performance:** Install command shall complete in under 5 seconds for a single agent on local filesystem.
+- **Compatibility:** Must work on macOS, Linux, and Windows. Agent detection must handle platform-specific binary paths (e.g., `.exe` on Windows).
+- **Dependencies:** Prefer existing workspace dependencies (clap, serde, serde_json, tracing). New dependencies require justification.
+- **Constitution:** Must follow contract-first, test-first, agent-friendly (structured JSON output), and crate-first principles per `.specify/memory/constitution.md`.
+- **No network:** Install command must not make network calls. All configuration is generated locally from templates.
+- **Atomic writes:** Configuration file writes must be atomic (write to temp file, then rename) to prevent partial configurations.
+
+---
+
+## Data Model `@human-review`
+
+```mermaid
+erDiagram
+    INSTALL_MANIFEST ||--o{ AGENT_CONFIG : contains
+    INSTALL_MANIFEST {
+        string version
+        datetime installed_at
+        string scope
+        string binary_path
+    }
+    AGENT_CONFIG {
+        string agent_name PK
+        string agent_version
+        string config_path
+        string config_format
+        datetime configured_at
+        string status
+    }
+    AGENT_PLATFORM {
+        string name PK
+        string binary_name
+        string detection_method
+        string config_dir_template
+        string min_supported_version
+    }
+    AGENT_PLATFORM ||--o| AGENT_CONFIG : generates
+```
+
+---
+
+## Interface Contract `@human-review`
+
+```rust
+// CLI Interface
+// rusty-brain install [OPTIONS]
+//
+// Options:
+//   --agents <LIST>       Comma-separated agent names: opencode,copilot,codex,gemini
+//   --project             Install config relative to current working directory
+//   --global              Install config in user-level directories (~/.config/)
+//   --json                Force JSON output (auto-enabled in non-TTY mode)
+//   --reconfigure         Regenerate config files, backup existing
+//   --config-dir <PATH>   Override config directory (applies to all agents in a multi-agent install; when used with --agents specifying multiple agents, the same override directory is used for each)
+
+// JSON Output (success)
+{
+  "status": "success",
+  "agents": [
+    {
+      "name": "opencode",
+      "status": "configured",
+      "config_path": "/path/to/config",
+      "version_detected": "1.2.3"
+    }
+  ],
+  "memory_store": "/path/to/.rusty-brain/mind.mv2",
+  "scope": "project"
+}
+
+// JSON Output (error)
+{
+  "status": "error",
+  "error_code": "AGENT_NOT_FOUND",
+  "message": "Agent 'copilot' not found on this system",
+  "suggestion": "Install GitHub Copilot CLI or check your PATH"
+}
+```
+
+---
+
+## Evaluation Criteria `@human-review`
+
+| Criterion | Weight | Metric | Target | Notes |
+|-----------|--------|--------|--------|-------|
+| Install speed | Medium | Time to configure single agent | < 5s | Local filesystem only |
+| Detection accuracy | High | Correct agent identification | > 95% on standard setups | |
+| Cross-agent memory | Critical | Memories accessible across agents | 100% | Shared `.mv2` store |
+| Error clarity | High | Machine-parseable errors | 100% of failure modes | Stable error codes |
+| Platform coverage | High | Agents with working install | 4/4 (or stubs for unconfirmed) | |
+
+---
+
+## Tool/Approach Candidates `@human-review`
+
+| Option | License | Pros | Cons | Spike Result |
+|--------|---------|------|------|--------------|
+| Template-based config generation | N/A | Simple, no new deps, easy to test | Templates need updating when agent formats change | Preferred |
+| Dynamic config via agent API queries | N/A | Always current format | Requires network, complex, fragile | Not suitable (no-network constraint) |
+
+### Selected Approach `@human-required`
+> **Decision:** Template-based configuration generation with embedded templates per agent platform.
+> **Rationale:** Aligns with no-network constraint, testable with known inputs/outputs, and easy to extend when agent formats change. Templates are versioned alongside the rusty-brain binary.
+
+---
+
+## Acceptance Criteria `@human-review`
+
+| AC ID | Requirement | User Story | Given | When | Then |
+|-------|-------------|------------|-------|------|------|
+| AC-1 | M-1 | US-1 | Machine with OpenCode installed | User runs `rusty-brain install --agents opencode --project` | OpenCode config files are created |
+| AC-2 | M-2, M-5 | US-2 | Machine with Copilot CLI installed | User runs `rusty-brain install --agents copilot --project` | Copilot-specific config files are generated |
+| AC-3 | M-2, M-5 | US-3 | Machine with Codex CLI installed | User runs `rusty-brain install --agents codex --project` | Codex-specific config files are generated |
+| AC-4 | M-2, M-5 | US-4 | Machine with Gemini CLI installed | User runs `rusty-brain install --agents gemini --project` | Gemini-specific config files are generated |
+| AC-5 | M-3 | US-5 | Machine with multiple agents | User runs `rusty-brain install --project` (no --agents) | All installed agents are auto-detected and configured |
+| AC-6 | M-4 | US-5 | User specifies `--agents opencode,copilot` | Install runs | Only OpenCode and Copilot are configured |
+| AC-7 | M-6 | US-5 | Multiple agents configured | Agent A stores memory, Agent B searches | Agent B finds Agent A's memories |
+| AC-8 | M-7 | US-6 | Agent invokes install with `--json` | Install completes | Output is valid JSON parseable by agent |
+| AC-9 | M-8 | US-1 | rusty-brain already configured for OpenCode | User runs install again | Config upgraded, no data loss |
+| AC-10 | M-9 | US-5 | Agent not found on system | Install attempts to configure it | Clear error message, install continues for others |
+| AC-11 | M-10 | US-6 | Install fails (permissions) | Agent reads error output | Machine-parseable error with remediation |
+| AC-12 | M-11 | US-6 | Non-TTY invocation | Install runs | No interactive prompts, completes autonomously |
+| AC-13 | M-12 | US-1 | Agent config dir doesn't exist | Install runs | Directory created automatically |
+| AC-14 | M-13 | US-1 | User omits --project and --global | Install runs | Error requiring explicit scope selection |
+| AC-15 | S-1 | US-1 | Existing config, --reconfigure flag | Install runs | `.bak` created, new config generated |
+
+### Edge Cases `@llm-autonomous`
+- [ ] **EC-1:** (M-9) When an agent binary exists but is not a recognized agent, then the install reports "unsupported agent" with supported list.
+- [ ] **EC-2:** (M-12) When the parent directory of the config path is read-only, then the install fails with a permission error and remediation suggestion.
+- [ ] **EC-3:** (M-3) When auto-detection finds no agents, then the install exits with a warning listing supported agents.
+- [ ] **EC-4:** (S-1) When `--reconfigure` is used but no existing config exists, then the install proceeds as a fresh install (no `.bak` created).
+- [ ] **EC-5:** (M-8) When upgrading and the existing config is corrupted/unparseable, then the install backs up the corrupted file and creates fresh config.
+- [ ] **EC-6:** (S-3) When agent version cannot be determined, then the install uses the latest known config format and emits a warning.
+
+---
+
+## Dependencies `@human-review`
+
+```mermaid
+graph LR
+    subgraph This Feature
+        A[011-agent-installs]
+    end
+    subgraph Requires
+        B[005-platform-adapter-system] --> A
+        C[009-plugin-packaging] --> A
+        D[008-opencode-plugin] --> A
+    end
+    subgraph Blocks
+        A --> E[Future: agent marketplace]
+    end
+```
+
+- **Requires:** 005-platform-adapter-system (adapter architecture), 008-opencode-plugin (OpenCode adapter), 009-plugin-packaging (binary packaging)
+- **Blocks:** Future agent marketplace submissions
+- **External:** Each agent's extension/plugin mechanism documentation
+
+---
+
+## Security Considerations `@human-review`
+
+| Aspect | Assessment | Notes |
+|--------|------------|-------|
+| Internet Exposure | No | Install is fully offline, no network calls |
+| Sensitive Data | No | Config files contain paths and command definitions, no secrets |
+| Authentication Required | No | Local filesystem operations only |
+| Security Review Required | Yes | Review file permissions on generated configs; ensure no path traversal in `--config-dir` |
+
+Additional considerations:
+- Generated config files should have appropriate permissions (not world-writable)
+- `--config-dir` input must be validated to prevent path traversal attacks
+- Binary path references in config files must point to the actual rusty-brain binary, not be injectable
+- `.bak` files should inherit the permissions of the originals
+
+---
+
+## Implementation Guidance `@llm-autonomous`
+
+### Suggested Approach
+- Extend the existing platform adapter system (005) with an `Installer` trait per agent platform
+- Each agent adapter implements: `detect() -> Option<AgentInfo>`, `generate_config(scope) -> Vec<ConfigFile>`, `validate_install() -> Result`
+- Use clap subcommand for `install` with the defined flags
+- Agent-specific templates live as const strings or embedded files in each adapter module
+- Research each agent's actual extension mechanism before implementing (spike tasks below)
+
+### Anti-patterns to Avoid
+- Do not hardcode agent config paths — use platform-appropriate path resolution
+- Do not generate config files directly to final paths — use atomic write (temp + rename)
+- Do not attempt to modify agent binaries or inject into agent internals
+- Do not assume agent config formats are stable — version-gate template selection
+
+### Reference Examples
+- 009-plugin-packaging install scripts for Claude Code (existing pattern)
+- 008-opencode-plugin for OpenCode adapter pattern
+
+---
+
+## Spike Tasks `@human-review`
+
+- [ ] **Spike-1:** Research GitHub Copilot CLI extension/agent mechanism. Determine: config file format, config directory location, how external tools are registered, minimum supported version. Completion: documented in research.md with example config.
+- [ ] **Spike-2:** Research OpenAI Codex CLI extension/agent mechanism. Determine: config file format, config directory location, how external tools are registered, minimum supported version. Completion: documented in research.md with example config.
+- [ ] **Spike-3:** Research Google Gemini CLI extension/agent mechanism. Determine: config file format, config directory location, how external tools are registered, minimum supported version. Completion: documented in research.md with example config.
+- [ ] **Spike-4:** Verify OpenCode plugin mechanism matches existing 008-opencode-plugin adapter. Confirm install path and command registration format. Completion: documented in research.md.
+
+---
+
+## Success Metrics `@human-required`
+
+| Metric | Baseline | Target | Measurement Method |
+|--------|----------|--------|-------------------|
+| Single-agent install time | N/A (manual) | < 30 seconds | Timed CLI execution |
+| Multi-agent install time | N/A (manual) | < 60 seconds | Timed CLI execution |
+| Post-install agent operability | 0% auto-configured | 100% of configured agents work | Integration test: each agent invokes memory op |
+| Auto-detection accuracy | N/A | > 95% on standard dev environments | Test across macOS/Linux/Windows defaults |
+| Cross-agent memory access | Not possible | 100% of configured agents share store | Test: store from agent A, retrieve from agent B |
+| Agentic install success | Not possible | 100% non-interactive completion with JSON | Integration test: non-TTY invocation |
+| Upgrade data preservation | N/A | Zero data loss | Test: re-run install, verify memory intact |
+
+### Technical Verification `@llm-autonomous`
+| Metric | Target | Verification Method |
+|--------|--------|---------------------|
+| Test coverage for Must Have ACs | > 90% | CI pipeline |
+| No Critical/High security findings | 0 | Security review |
+| All error codes documented | 100% | Unit tests for each error path |
+| Cross-platform install works | macOS + Linux + Windows | CI matrix |
+
+---
+
+## Definition of Ready `@human-required`
+
+### Readiness Checklist
+- [ ] Problem statement reviewed and validated by stakeholder
+- [ ] All Must Have requirements have acceptance criteria
+- [ ] Technical constraints are explicit and agreed
+- [ ] Dependencies identified and owners confirmed
+- [ ] Security review completed (or N/A documented with justification)
+- [ ] No open questions blocking implementation
+- [ ] Spike tasks for agent extension mechanisms completed (Spike-1 through Spike-4)
+
+### Sign-off
+| Role | Name | Date | Decision |
+|------|------|------|----------|
+| Product Owner | [name] | YYYY-MM-DD | [Ready / Not Ready] |
+
+---
+
+## Changelog `@auto`
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-03-05 | Claude | Initial draft from spec.md |
+
+---
+
+## Decision Log `@human-review`
+
+| Date | Decision | Rationale | Alternatives Considered |
+|------|----------|-----------|------------------------|
+| 2026-03-05 | Require explicit --project/--global scope | Prevent accidental global or project-scoped installs | Default to --project (rejected: too implicit) |
+| 2026-03-05 | Template-based config generation | No-network constraint, testable, simple | Dynamic API queries (rejected: requires network) |
+| 2026-03-05 | Research-first for agent mechanisms | Avoid building adapters for unsupported agents | Build all four immediately (rejected: risk of wasted work) |
+
+---
+
+## Open Questions `@human-review`
+
+- [ ] **Q1:** What is the exact extension/agent mechanism for GitHub Copilot CLI? (Blocked on Spike-1)
+- [ ] **Q2:** What is the exact extension/agent mechanism for OpenAI Codex CLI? (Blocked on Spike-2)
+- [ ] **Q3:** What is the exact extension/agent mechanism for Google Gemini CLI? (Blocked on Spike-3)
+
+---
+
+## Review Checklist `@llm-autonomous`
+
+Before marking as Approved:
+- [x] All requirements have unique IDs (M-1 through M-13, S-1 through S-4, C-1 through C-3, W-1 through W-5)
+- [x] All Must Have requirements have linked acceptance criteria
+- [x] User stories are prioritized and independently testable
+- [x] Acceptance criteria reference both requirement IDs and user stories
+- [x] Glossary terms are used consistently throughout
+- [x] Diagrams use terminology from Glossary
+- [x] Security considerations documented
+- [ ] Definition of Ready checklist is complete (pending spike tasks)
+- [ ] No open questions blocking implementation (Q1-Q3 pending spikes)
+
+---
+
+## Human Review Required
+
+The following sections need human review or input:
+
+- [ ] Background (@human-required) - Verify business context
+- [ ] Problem Statement (@human-required) - Validate problem framing
+- [ ] User Stories (@human-required) - Confirm priorities and acceptance scenarios
+- [ ] Must Have Requirements (@human-required) - Validate MVP scope
+- [ ] Should Have Requirements (@human-required) - Confirm priority
+- [ ] Selected Approach (@human-required) - Decision needed
+- [ ] Success Metrics (@human-required) - Define targets
+- [ ] Definition of Ready (@human-required) - Complete readiness checklist
+- [ ] All @human-review sections - Review LLM-drafted content

--- a/specs/011-agent-installs/prd.md
+++ b/specs/011-agent-installs/prd.md
@@ -9,7 +9,7 @@
 **Feature Branch**: `011-agent-installs`
 **Created**: 2026-03-05
 **Status**: Draft
-**Input**: User description: "Agentic agent installs for opencode, github copilot-cli, codex and gemini."
+**Input**: User description: "Agentic agent installs for opencode, GitHub Copilot CLI, codex and gemini."
 
 ---
 
@@ -210,7 +210,7 @@ An AI coding agent is working in a project and discovers rusty-brain is availabl
 - **EC-4:** Binary installed but agent config becomes stale after agent upgrade — `--reconfigure` regenerates agent config files.
 - **EC-5:** Install run in CI/CD with no agents installed — install skips agent configuration, exits with a warning.
 - **EC-6:** Agent detected but version cannot be determined — proceed with latest known config format, emit a warning.
-- **EC-7:** User has custom agent config directory (non-default location) — `--config-dir` override per agent.
+- **EC-7:** User has custom agent config directory (non-default location) — *(deferred: S-4 `--config-dir` not implemented in this PR; agents use platform-standard config directories)*.
 
 ---
 
@@ -313,7 +313,7 @@ stateDiagram-v2
 - [ ] **S-1:** The system shall support a `--reconfigure` flag that regenerates agent configuration files without replacing the binary, creating `.bak` copies of existing files before overwriting. Only the most recent `.bak` is kept per config file (repeated runs overwrite previous `.bak`).
 - [ ] **S-2:** The system shall log installation actions and results via the standard `RUSTY_BRAIN_LOG` environment variable.
 - [ ] **S-3:** The system shall detect the installed version of each agent and generate version-compatible configuration.
-- [ ] **S-4:** The system shall support a `--config-dir` override for non-default configuration locations. When multiple agents are being configured, the override applies to all agents (each agent's config files are written into the specified directory).
+- [ ] **S-4:** *(Deferred)* The system shall support a `--config-dir` override for non-default configuration locations. When multiple agents are being configured, the override applies to all agents (each agent's config files are written into the specified directory).
 
 ### Could Have (C) — Nice to have, if time permits `@human-review`
 - [ ] **C-1:** The system could provide a `--dry-run` flag that shows what would be installed without making changes.
@@ -384,7 +384,7 @@ erDiagram
 //   --global              Install config in user-level directories (~/.config/)
 //   --json                Force JSON output (auto-enabled in non-TTY mode)
 //   --reconfigure         Regenerate config files, backup existing
-//   --config-dir <PATH>   Override config directory (applies to all agents in a multi-agent install; when used with --agents specifying multiple agents, the same override directory is used for each)
+//   (--config-dir deferred: S-4 not implemented in this PR)
 
 // JSON Output (success)
 {
@@ -497,11 +497,11 @@ graph LR
 | Internet Exposure | No | Install is fully offline, no network calls |
 | Sensitive Data | No | Config files contain paths and command definitions, no secrets |
 | Authentication Required | No | Local filesystem operations only |
-| Security Review Required | Yes | Review file permissions on generated configs; ensure no path traversal in `--config-dir` |
+| Security Review Required | Yes | Review file permissions on generated configs; validate path components against traversal |
 
 Additional considerations:
 - Generated config files should have appropriate permissions (not world-writable)
-- `--config-dir` input must be validated to prevent path traversal attacks
+- Config paths must be validated to prevent path traversal attacks
 - Binary path references in config files must point to the actual rusty-brain binary, not be injectable
 - `.bak` files should inherit the permissions of the originals
 

--- a/specs/011-agent-installs/prd.md
+++ b/specs/011-agent-installs/prd.md
@@ -224,6 +224,7 @@ An AI coding agent is working in a project and discovers rusty-brain is availabl
 - [A-5] The existing platform adapter system (005) can be extended to support new agent platforms without major refactoring.
 
 ### Risks
+
 | ID | Risk | Likelihood | Impact | Mitigation |
 |----|------|------------|--------|------------|
 | R-1 | Agent extension mechanisms are undocumented or unstable | Medium | High | Research each agent's plugin API before building; stub unsupported agents |
@@ -550,6 +551,7 @@ Additional considerations:
 | Upgrade data preservation | N/A | Zero data loss | Test: re-run install, verify memory intact |
 
 ### Technical Verification `@llm-autonomous`
+
 | Metric | Target | Verification Method |
 |--------|--------|---------------------|
 | Test coverage for Must Have ACs | > 90% | CI pipeline |
@@ -571,6 +573,7 @@ Additional considerations:
 - [ ] Spike tasks for agent extension mechanisms completed (Spike-1 through Spike-4)
 
 ### Sign-off
+
 | Role | Name | Date | Decision |
 |------|------|------|----------|
 | Product Owner | [name] | YYYY-MM-DD | [Ready / Not Ready] |

--- a/specs/011-agent-installs/quickstart.md
+++ b/specs/011-agent-installs/quickstart.md
@@ -46,12 +46,6 @@ rusty-brain install --agents opencode --project --json
 rusty-brain install --agents opencode --project --reconfigure
 ```
 
-### Override config directory
-
-```bash
-rusty-brain install --agents opencode --project --config-dir /custom/path
-```
-
 ## Expected Output (JSON mode)
 
 ```json

--- a/specs/011-agent-installs/quickstart.md
+++ b/specs/011-agent-installs/quickstart.md
@@ -1,0 +1,113 @@
+# Quickstart: Agent Installs
+
+**Feature**: 011-agent-installs | **Date**: 2026-03-05
+
+## Prerequisites
+
+- Rust stable >= 1.85.0
+- rusty-brain binary built (`cargo build`)
+- At least one supported agent installed: OpenCode, GitHub Copilot CLI, OpenAI Codex CLI, or Google Gemini CLI
+
+## Build
+
+```bash
+cargo build
+```
+
+## Usage
+
+### Install for a single agent (project-scoped)
+
+```bash
+rusty-brain install --agents opencode --project
+```
+
+### Install for all detected agents (project-scoped)
+
+```bash
+rusty-brain install --project
+```
+
+### Install globally (user-level config directories)
+
+```bash
+rusty-brain install --global
+```
+
+### Install with JSON output (for agentic self-install)
+
+```bash
+rusty-brain install --agents opencode --project --json
+```
+
+### Reconfigure existing installation
+
+```bash
+rusty-brain install --agents opencode --project --reconfigure
+```
+
+### Override config directory
+
+```bash
+rusty-brain install --agents opencode --project --config-dir /custom/path
+```
+
+## Expected Output (JSON mode)
+
+```json
+{
+  "status": "success",
+  "results": [
+    {
+      "agent_name": "opencode",
+      "status": "configured",
+      "config_path": "/path/to/project/.opencode/plugins/rusty-brain.json",
+      "version_detected": "1.2.3"
+    }
+  ],
+  "memory_store": "/path/to/project/.rusty-brain/mind.mv2",
+  "scope": "project"
+}
+```
+
+## Testing
+
+```bash
+# Run all tests
+cargo test
+
+# Run install-specific tests
+cargo test --package platforms installer
+cargo test --package cli install
+
+# Run with verbose logging
+RUSTY_BRAIN_LOG=debug cargo test --package platforms installer
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `crates/platforms/src/installer/mod.rs` | `AgentInstaller` trait definition |
+| `crates/platforms/src/installer/orchestrator.rs` | Install workflow coordinator |
+| `crates/platforms/src/installer/writer.rs` | Atomic file writer with backup |
+| `crates/platforms/src/installer/registry.rs` | Installer registry |
+| `crates/platforms/src/installer/agents/*.rs` | Per-agent installer implementations |
+| `crates/types/src/install.rs` | Install types and error codes |
+| `crates/cli/src/args.rs` | CLI subcommand definition |
+| `crates/cli/src/install_cmd.rs` | Install command handler |
+
+## Scope Flag Requirement
+
+The `--project` or `--global` flag is **required**. The command will error if neither is specified:
+
+```bash
+# ERROR: scope required
+rusty-brain install --agents opencode
+
+# OK: project scope
+rusty-brain install --agents opencode --project
+
+# OK: global scope
+rusty-brain install --agents opencode --global
+```

--- a/specs/011-agent-installs/research.md
+++ b/specs/011-agent-installs/research.md
@@ -1,0 +1,103 @@
+# Research: Agent Installs
+
+**Feature**: 011-agent-installs | **Date**: 2026-03-05
+
+## Research Tasks
+
+### R1: Agent Extension Mechanisms
+
+**Status**: Partially resolved — OpenCode confirmed, others require spike research
+
+#### OpenCode Extension Mechanism
+
+**Decision**: OpenCode uses a file-based plugin system with JSON configuration in the project's `.opencode/` directory. rusty-brain already has a working OpenCode adapter (008-opencode-plugin).
+
+**Rationale**: The existing `crates/opencode/` crate and `crates/cli/src/opencode_cmd.rs` demonstrate the working pattern. The install command generates the `.opencode/plugins/rusty-brain.json` manifest and registers slash commands.
+
+**Alternatives considered**: None — OpenCode's mechanism is well-documented and already implemented.
+
+**Config location**: `.opencode/plugins/rusty-brain.json` (project-scoped) or `~/.config/opencode/plugins/rusty-brain.json` (global)
+
+#### GitHub Copilot CLI Extension Mechanism
+
+**Decision**: NEEDS SPIKE RESEARCH (PRD Spike-1)
+
+**What we know**: Copilot CLI supports agent extensions via configuration files. The exact format, directory location, and registration mechanism need to be researched against the current Copilot CLI version.
+
+**Research plan**: Install Copilot CLI, inspect extension documentation, identify config file format and location, create example config, document in this file.
+
+#### OpenAI Codex CLI Extension Mechanism
+
+**Decision**: NEEDS SPIKE RESEARCH (PRD Spike-2)
+
+**What we know**: Codex CLI is an open-source agent that supports external tool invocation. The exact plugin/extension mechanism needs research.
+
+**Research plan**: Review Codex CLI source code and documentation, identify how external tools are registered, document config format and location.
+
+#### Google Gemini CLI Extension Mechanism
+
+**Decision**: NEEDS SPIKE RESEARCH (PRD Spike-3)
+
+**What we know**: Gemini CLI is newer and its extension mechanism may be less mature. Need to determine if a plugin system exists.
+
+**Research plan**: Review Gemini CLI documentation and source, determine if extension support exists, document findings or flag as "stub only" if no mechanism exists.
+
+### R2: Atomic File Writes in Rust
+
+**Decision**: Use `tempfile::NamedTempFile` for atomic writes. Write content to temp file in same directory, then `persist()` (which calls `rename` on POSIX, `MoveFileEx` on Windows).
+
+**Rationale**: `tempfile` is already a workspace dependency (dev-dep). The `persist()` method handles cross-platform atomic rename. Same-directory temp files ensure same-filesystem rename (required for atomic POSIX rename).
+
+**Alternatives considered**:
+- Manual `std::fs::write` to temp + `std::fs::rename`: Works but requires manual temp file naming and cleanup on error. `tempfile` handles this automatically.
+- `fs2::FileExt` advisory locking: Overkill for one-time install; advisory locks aren't needed for config file writes.
+
+### R3: Cross-Platform Binary Detection on PATH
+
+**Decision**: Use `std::env::split_paths(&std::env::var_os("PATH"))` to iterate PATH entries, then `Path::join(entry, binary_name)` and check existence. On Windows, also check with `.exe`, `.cmd`, `.bat` extensions.
+
+**Rationale**: Safe (no shell execution), cross-platform, handles edge cases (empty PATH, missing env var). Avoids `which`/`where` subprocess call which is platform-specific and could be a command injection vector.
+
+**Alternatives considered**:
+- `which` crate: External dependency, 500+ lines for something achievable in ~20 lines. Not justified per dependency policy.
+- `std::process::Command::new("which")`: Platform-specific (no `which` on Windows without Git Bash), potential command injection if binary name is user-supplied (it's not in our case, but the pattern is unsafe).
+
+### R4: Cross-Platform Config Directory Resolution
+
+**Decision**: Use `std::env::var("HOME")` on Unix and `std::env::var("APPDATA")` or `std::env::var("USERPROFILE")` on Windows for global scope. For project scope, use the current working directory. Avoid adding `dirs` crate dependency.
+
+**Rationale**: The install command needs only two config locations per scope: the agent's config directory and the rusty-brain binary path. These follow simple platform conventions (`~/.config/<agent>/` on Linux, `~/Library/Application Support/<agent>/` on macOS, `%APPDATA%/<agent>/` on Windows). Direct env var access is sufficient and avoids a new dependency.
+
+**Alternatives considered**:
+- `dirs` crate: Well-maintained but adds a dependency for something achievable with env vars + conditional compilation. Not justified unless we need complex XDG resolution.
+- Hardcoded paths: Fragile, breaks on non-standard setups. Using env vars is more robust.
+
+### R5: Subprocess Timeout for Agent Version Detection
+
+**Decision**: Use `std::process::Command` with `std::thread::spawn` + `std::sync::mpsc::channel` for timeout, or `tokio::process::Command` if async is available. Since the CLI is sync, use the thread-based approach with a 2-second timeout.
+
+**Rationale**: Agent `--version` commands should return instantly, but a hung process could block the install command indefinitely. A 2-second timeout balances reliability with user experience.
+
+**Alternatives considered**:
+- No timeout: Risk of indefinite hang if agent binary is malformed or prompts for input.
+- `wait_timeout` crate: External dependency for a simple pattern. Not justified.
+- `Command::output()` with `kill` on timer: The thread-based approach is simpler and doesn't require unsafe signal handling.
+
+### R6: File Permission Setting on Config Files
+
+**Decision**: On Unix, use `std::os::unix::fs::PermissionsExt` to set mode `0o644` (owner read/write, group/other read-only). On Windows, rely on default ACLs (no additional permission setting needed as Windows uses ACL-based permissions).
+
+**Rationale**: SEC-1 requires config files not be world-writable. `0o644` is the standard permission for non-sensitive config files.
+
+**Alternatives considered**:
+- `0o600` (owner-only): Too restrictive for config files that other processes (agents) need to read.
+- No explicit permission setting: Inherits umask, which could be overly permissive on some systems.
+
+### R7: `tempfile` Dependency Promotion
+
+**Decision**: Promote `tempfile` from `[dev-dependencies]` to `[dependencies]` in the `platforms` crate's `Cargo.toml`. It remains a workspace-level dependency.
+
+**Rationale**: `ConfigWriter` uses `NamedTempFile` for atomic writes at runtime, not just in tests. This is a minimal change — the crate is already trusted in the workspace.
+
+**Alternatives considered**:
+- Implement temp file creation manually: Reinvents what `tempfile` does safely, with edge cases around cleanup on error.

--- a/specs/011-agent-installs/research.md
+++ b/specs/011-agent-installs/research.md
@@ -74,7 +74,7 @@
 
 ### R5: Subprocess Timeout for Agent Version Detection
 
-**Decision**: Use `std::process::Command` with `std::thread::spawn` + `std::sync::mpsc::channel` for timeout, or `tokio::process::Command` if async is available. Since the CLI is sync, use the thread-based approach with a 2-second timeout.
+**Decision**: Use `std::process::Command::spawn()` with a reader thread (`std::thread::spawn` + `std::sync::mpsc::channel`) for timeout. On timeout, explicitly call `child.kill()` + `child.wait()` to prevent process and thread leaks (SEC-6). 2-second timeout.
 
 **Rationale**: Agent `--version` commands should return instantly, but a hung process could block the install command indefinitely. A 2-second timeout balances reliability with user experience.
 

--- a/specs/011-agent-installs/sec.md
+++ b/specs/011-agent-installs/sec.md
@@ -92,7 +92,7 @@ flowchart LR
     end
 
     subgraph Trust Boundary: CLI Input
-        ARGS[--config-dir<br>--agents] --> VALIDATE[Input Validation<br>path traversal check]
+        ARGS[--agents<br>--project/--global] --> VALIDATE[Input Validation<br>allowlist + path check]
         VALIDATE --> INSTALL
     end
 
@@ -231,14 +231,14 @@ No confidential or restricted data is handled. Config files contain only paths a
 
 | Asset at Risk | Modification Scenario | Impact | Likelihood |
 |---------------|----------------------|--------|------------|
-| Agent config files | Path traversal via `--config-dir` writes config to unintended location | Medium | Low |
+| Agent config files | Path traversal in internally-resolved config paths writes to unintended location | Medium | Low |
 | Agent config files | Malicious binary path injected into config template | Medium | Low |
 | Existing config files | Overwritten without backup due to bug in ConfigWriter | Medium | Low |
 | .bak backup files | Backup overwritten on repeated `--reconfigure` runs | Low | Medium |
 
 **Integrity Risk Level:** Medium
 
-The primary integrity concern is **path traversal via `--config-dir`**: if a user (or agent acting autonomously) passes a crafted path like `--config-dir ../../../etc/`, the install command could write files outside expected directories. This is mitigated by path validation (SEC-1 below).
+The primary integrity concern is **path traversal in config paths**: although config directories are now resolved internally (no user-supplied `--config-dir`), the resolved paths are still validated against `..` traversal sequences (SEC-4). Risk is lower than originally assessed since paths are not user-supplied.
 
 A secondary concern is that config files reference the rusty-brain binary path. If an attacker could influence path resolution (e.g., placing a malicious binary earlier on PATH), the config would point to the wrong binary. This is standard PATH-based risk, not specific to this feature.
 
@@ -261,10 +261,10 @@ The install command is a one-time operation, not a service. Disruption to the in
 | Dimension | Risk Level | Primary Concern | Mitigation Priority |
 |-----------|------------|-----------------|---------------------|
 | **Confidentiality** | Low | Config files contain only paths (Public/Internal data) | Low |
-| **Integrity** | Medium | Path traversal via `--config-dir`; binary path injection | Medium |
+| **Integrity** | Medium | Path traversal in config paths; binary path injection | Medium |
 | **Availability** | Low | Subprocess timeout; disk-full during write | Low |
 
-**Overall CIA Risk:** Low — *Offline CLI tool writing non-sensitive config files to local disk with no network exposure. Primary concern is input validation on `--config-dir` to prevent path traversal.*
+**Overall CIA Risk:** Low — *Offline CLI tool writing non-sensitive config files to local disk with no network exposure. Config directories are resolved internally (not user-supplied), further reducing path traversal risk.*
 
 ---
 
@@ -273,7 +273,7 @@ The install command is a one-time operation, not a service. Disruption to the in
 ```mermaid
 flowchart TD
     subgraph Untrusted
-        CLI_ARGS[CLI Arguments<br>--config-dir, --agents]
+        CLI_ARGS[CLI Arguments<br>--agents, --project/--global]
         AGENT_BIN[Agent Binary Output<br>--version response]
     end
 
@@ -306,12 +306,12 @@ flowchart TD
 
 **Trust boundaries identified:**
 
-1. **CLI argument input -> application logic**: User-supplied `--config-dir` path must be validated to prevent path traversal. Agent names must be validated against an allowlist.
+1. **CLI argument input -> application logic**: Agent names must be validated against an allowlist. Config directories are resolved internally per scope (project root or platform-standard global dir).
 2. **Agent subprocess output -> application logic**: Output from `<agent> --version` is untrusted text parsed for version info. Must handle malformed output gracefully without injection risk.
 
 ### Trust Boundary Checklist `@llm-autonomous`
 
-- [x] **All input from untrusted sources is validated** — `--config-dir` validated for traversal; `--agents` validated against allowlist
+- [x] **All input from untrusted sources is validated** — `--agents` validated against allowlist; config paths resolved internally and validated for traversal
 - [x] **External API responses are validated** — N/A (no external APIs); subprocess output parsed defensively
 - [x] **Authorization checked at data access, not just entry point** — N/A (local filesystem, user's own permissions)
 - [x] **Service-to-service calls are authenticated** — N/A (no service calls)
@@ -322,7 +322,7 @@ flowchart TD
 
 | ID | Risk Description | Severity | Mitigation | Status | Owner |
 |----|------------------|----------|------------|--------|-------|
-| R1 | Path traversal via `--config-dir` could write files outside expected directories | Medium | Validate and canonicalize path; reject paths containing `..` or absolute paths outside user home/project | Open | Implementer |
+| R1 | Path traversal in resolved config paths could write files outside expected directories | Low | Config dirs are resolved internally (not user-supplied); `validate_config_path()` rejects `..` components | Mitigated | Implementer |
 | R2 | Agent binary on PATH could be a malicious impersonator | Low | Verify binary identity via `--version` output pattern matching; warn if unrecognizable. Standard PATH risk, not unique to this feature | Open | Implementer |
 | R3 | Config files written with overly permissive permissions (e.g., world-writable) | Low | Write files with user-only permissions (0o644 on Unix); inherit directory permissions | Open | Implementer |
 | R4 | `.bak` backup chain lost on repeated `--reconfigure` (only most recent backup kept) | Low | Document that only one `.bak` is kept per config file. Not a security issue per se, but data loss risk | Open | Implementer |
@@ -358,7 +358,7 @@ Based on this review, the implementation MUST satisfy:
 
 | Req ID | Requirement | PRD AC | Verification Method |
 |--------|-------------|--------|---------------------|
-| SEC-4 | `--config-dir` path shall be canonicalized and validated to reject paths containing `..` traversal sequences or symlinks pointing outside expected boundaries | AC-1 | Unit test: test with `../../etc/passwd`, symlink paths, etc. |
+| SEC-4 | Config paths shall be validated to reject paths containing `..` traversal sequences. Note: `--config-dir` was deferred (S-4); paths are resolved internally, reducing traversal risk | AC-1 | Unit test: test with `../../etc/passwd` path components |
 | SEC-5 | `--agents` values shall be validated against a hardcoded allowlist (`opencode`, `copilot`, `codex`, `gemini`) | AC-6, AC-10 | Unit test: reject unknown agent names |
 | SEC-6 | Agent `--version` subprocess shall have a 2-second timeout to prevent hanging | -- | Unit test: mock slow subprocess |
 | SEC-7 | Agent detection shall use `std::process::Command::new()` with explicit binary name, never shell execution (no `sh -c` or `cmd /c`) | -- | Code review: verify no shell invocations |
@@ -392,7 +392,7 @@ Based on this review, the implementation MUST satisfy:
 
 | ID | Finding | Severity | Category | Recommendation | Status |
 |----|---------|----------|----------|----------------|--------|
-| F1 | `--config-dir` accepts arbitrary paths without validation | Medium | Input Validation | Implement path canonicalization and traversal rejection (SEC-4) | Open |
+| F1 | *(Resolved)* `--config-dir` was removed (S-4 deferred). Config paths are resolved internally and validated via `validate_config_path()` | Low | Input Validation | Path validation implemented (SEC-4) | Mitigated |
 | F2 | No specification for config file permissions after write | Low | Data Protection | Explicitly set file permissions in ConfigWriter (SEC-1) | Open |
 | F3 | Agent subprocess timeout not specified in AR interface | Low | Availability | Add 2-second timeout to agent detection subprocess (SEC-6) | Open |
 
@@ -409,7 +409,7 @@ Based on this review, the implementation MUST satisfy:
 
 ## Open Questions `@human-review`
 
-- [ ] **Q1:** Should `--config-dir` be restricted to directories under `$HOME` or project root, or just reject `..` traversal? Stricter is safer but may block legitimate use cases.
+- [x] **Q1:** *(Resolved)* `--config-dir` was deferred (S-4). Config directories are resolved internally per scope, eliminating user-supplied path traversal risk. `validate_config_path()` rejects `..` components as defense-in-depth.
 - [ ] **Q2:** Should `.bak` files be created with more restrictive permissions than the original (e.g., read-only) to prevent accidental modification?
 
 ---

--- a/specs/011-agent-installs/sec.md
+++ b/specs/011-agent-installs/sec.md
@@ -1,0 +1,470 @@
+# 011-sec-agent-installs
+
+> **Document Type:** Security Review (Lightweight)
+> **Audience:** LLM agents, human reviewers
+> **Status:** Draft
+> **Last Updated:** 2026-03-05
+> **Reviewer:** [name] <!-- @human-required -->
+> **Risk Level:** Low <!-- @human-required -->
+
+---
+
+## Review Tier Legend
+
+| Marker | Tier | Speckit Behavior |
+|--------|------|------------------|
+| `@human-required` | Human Generated | Prompt human to author; blocks until complete |
+| `@human-review` | LLM + Human Review | LLM drafts; prompt human to confirm/edit; blocks until confirmed |
+| `@llm-autonomous` | LLM Autonomous | LLM completes; no prompt; logged for audit |
+| `@auto` | Auto-generated | System fills (timestamps, links); no prompt |
+
+---
+
+## Severity Definitions
+
+| Level | Label | Definition |
+|-------|-------|------------|
+| **Critical** | Immediate exploitation risk; data breach or system compromise likely |
+| **High** | Significant risk; exploitation possible with moderate effort |
+| **Medium** | Notable risk; exploitation requires specific conditions |
+| **Low** | Minor risk; limited impact or unlikely exploitation |
+
+---
+
+## Linkage `@auto`
+
+| Document | ID | Relationship |
+|----------|-----|--------------|
+| Parent PRD | 011-prd-agent-installs.md | Feature being reviewed |
+| Architecture Review | 011-ar-agent-installs.md | Technical implementation |
+
+---
+
+## Purpose
+
+This is a **lightweight security review** intended to catch obvious security concerns early in the product lifecycle. It is NOT a comprehensive threat model. Full threat modeling should occur during implementation when infrastructure-as-code and concrete implementations exist.
+
+**This review answers three questions:**
+1. What does this feature expose to attackers?
+2. What data does it touch, and how sensitive is that data?
+3. What's the impact if something goes wrong?
+
+**Scope of this review:**
+- Attack surface identification
+- Data classification
+- High-level CIA assessment
+- ~~Detailed threat enumeration~~ (deferred to implementation)
+- ~~Penetration testing~~ (deferred to implementation)
+- ~~Compliance audit~~ (separate process)
+
+---
+
+## Feature Security Summary
+
+### One-line Summary `@human-required`
+> The `rusty-brain install` subcommand writes agent configuration files to local filesystem directories — it has no network exposure, handles no secrets, and operates with the user's existing filesystem permissions.
+
+### Risk Assessment `@human-required`
+> **Risk Level:** Low
+> **Justification:** Fully offline CLI operation that writes non-sensitive configuration files to local disk; no network endpoints, no authentication, no secret handling, no user data processing.
+
+---
+
+## Attack Surface Analysis
+
+### Exposure Points `@human-review`
+
+| Exposure Type | Details | Authentication | Authorization | Notes |
+|---------------|---------|----------------|---------------|-------|
+| CLI argument input | `--agents`, `--config-dir`, `--project`, `--global` flags | -- | -- | Input validation required for `--config-dir` path |
+| Subprocess execution | Agent version detection via `<agent> --version` | -- | -- | Binary path from PATH; no user-supplied command strings |
+| Filesystem writes | Config files written to agent directories | -- | OS filesystem permissions | Atomic writes via temp+rename |
+
+### Attack Surface Diagram `@llm-autonomous`
+
+```mermaid
+flowchart LR
+    subgraph User Environment
+        USER[User / Agent CLI] -->|CLI args| INSTALL[rusty-brain install]
+        INSTALL -->|read PATH| DETECT[Agent Detection<br>subprocess: --version]
+        INSTALL -->|atomic write| FS[Filesystem<br>config files]
+        INSTALL -->|read| BINARY[rusty-brain binary path]
+    end
+
+    subgraph Trust Boundary: CLI Input
+        ARGS[--config-dir<br>--agents] --> VALIDATE[Input Validation<br>path traversal check]
+        VALIDATE --> INSTALL
+    end
+
+    subgraph Out of Scope
+        NET[No Network]
+        DB[No Database]
+        API[No External APIs]
+    end
+
+    style NET fill:#ddd,stroke:#999
+    style DB fill:#ddd,stroke:#999
+    style API fill:#ddd,stroke:#999
+```
+
+### Exposure Checklist `@llm-autonomous`
+
+- [x] **Internet-facing endpoints require authentication** — N/A (no internet-facing endpoints)
+- [x] **No sensitive data in URL parameters** — N/A (CLI tool, no URLs)
+- [x] **File uploads validated** — N/A (no file uploads)
+- [x] **Rate limiting configured** — N/A (local CLI tool)
+- [x] **CORS policy is restrictive** — N/A (no HTTP server)
+- [x] **No debug/admin endpoints exposed** — N/A (no endpoints)
+- [x] **Webhooks validate signatures** — N/A (no webhooks)
+
+---
+
+## Data Flow Analysis
+
+### Data Inventory `@human-review`
+
+| Data Element | PRD Entity | Classification | Source | Destination | Retention | Encrypted Rest | Encrypted Transit | Residency |
+|--------------|------------|----------------|--------|-------------|-----------|----------------|-------------------|-----------|
+| Agent binary path | AgentInfo.binary_path | Public | PATH env var | Config files | Permanent (in config) | No | N/A (local) | Local |
+| Agent version string | AgentInfo.version | Public | Agent `--version` output | Install manifest | Permanent (in manifest) | No | N/A (local) | Local |
+| Config file content | Agent Configuration | Internal | Templates (embedded) | Agent config directories | Until uninstall | No | N/A (local) | Local |
+| Install manifest | Install Manifest | Internal | Generated at install | `.rusty-brain/` directory | Permanent | No | N/A (local) | Local |
+| Memory store path | Shared Memory Store | Internal | Path resolution | Config files | Permanent (in config) | No | N/A (local) | Local |
+| Backup files | -- | Internal | Existing config files | Same directory as `.bak` | Until user deletes | No | N/A (local) | Local |
+| rusty-brain binary path | AgentConfig.binary_path | Public | System PATH / `which` | Config files | Permanent (in config) | No | N/A (local) | Local |
+
+### Data Classification Reference `@llm-autonomous`
+
+| Level | Label | Description | Examples | Handling Requirements |
+|-------|-------|-------------|----------|----------------------|
+| 1 | **Public** | No impact if disclosed | Marketing content, public docs | No special handling |
+| 2 | **Internal** | Minor impact if disclosed | Internal configs, non-sensitive logs | Access controls, no public exposure |
+| 3 | **Confidential** | Significant impact if disclosed | PII, user data, credentials | Encryption, audit logging, access controls |
+| 4 | **Restricted** | Severe impact if disclosed | Payment data, health records, secrets | Encryption, strict access, compliance requirements |
+
+### Data Flow Diagram `@llm-autonomous`
+
+```mermaid
+flowchart TD
+    subgraph Input
+        PATH[PATH env var] -->|Public: binary paths| DETECT[Agent Detection]
+        ARGS[CLI args] -->|Public: agent names, scope| ORCH[InstallOrchestrator]
+        DETECT -->|Public: AgentInfo| ORCH
+    end
+
+    subgraph Processing
+        ORCH -->|Internal: config requests| GEN[Config Generator<br>embedded templates]
+        GEN -->|Internal: ConfigFile structs| WRITER[ConfigWriter]
+    end
+
+    subgraph Storage
+        WRITER -->|Internal: config files| AGENT_DIR[Agent Config Dirs]
+        WRITER -->|Internal: .bak files| BACKUP[Backup Files]
+        WRITER -->|Internal: manifest| MANIFEST[Install Manifest]
+    end
+
+    subgraph Referenced Only - Not Modified
+        MV2[.rusty-brain/mind.mv2<br>Internal: path reference only]
+    end
+
+    style MV2 fill:#eee,stroke:#999
+```
+
+### Data Handling Checklist `@llm-autonomous`
+
+- [x] **No Restricted data stored unless absolutely required** — No restricted data involved
+- [x] **Confidential data encrypted at rest** — No confidential data involved
+- [x] **All data encrypted in transit (TLS 1.2+)** — N/A (no network transit)
+- [x] **PII has defined retention policy** — No PII collected
+- [x] **Logs do not contain Confidential/Restricted data** — Logs contain only paths and agent names (Public/Internal)
+- [x] **Secrets are not hardcoded** — No secrets involved
+- [x] **Data minimization applied** — Only paths and version strings collected
+- [x] **Data residency requirements documented** — All data is local filesystem
+
+---
+
+## Third-Party & Supply Chain `@human-review`
+
+### New External Services
+
+| Service | Purpose | Data Shared | Communication | Approved? |
+|---------|---------|-------------|---------------|-----------|
+| **None** | No external services | -- | -- | N/A |
+
+### New Libraries/Dependencies
+
+| Library | Version | License | Purpose | Security Check |
+|---------|---------|---------|---------|----------------|
+| **None new** | -- | -- | All dependencies already in workspace (clap, serde, tracing, tempfile) | N/A |
+
+Note: `tempfile` is already a workspace dependency (currently dev-only). The AR proposes promoting it to a regular dependency for `ConfigWriter` atomic writes. This crate is well-established (>100M downloads), MIT/Apache licensed, and already trusted in the workspace.
+
+### Supply Chain Checklist
+
+- [x] **All new services use encrypted communication** — N/A (no external services)
+- [x] **Service agreements/ToS reviewed** — N/A (no external services)
+- [x] **Dependencies have acceptable licenses** — All MIT/Apache
+- [x] **Dependencies are actively maintained** — All workspace deps are well-maintained
+- [x] **No known critical vulnerabilities** — No new dependencies
+
+---
+
+## CIA Impact Assessment
+
+### Confidentiality `@human-review`
+
+> **What could be disclosed?**
+
+| Asset at Risk | Classification | Exposure Scenario | Impact | Likelihood |
+|---------------|----------------|-------------------|--------|------------|
+| Agent config file paths | Internal | Config files readable by other local users if permissions too permissive | Low | Low |
+| rusty-brain binary path | Public | Embedded in config files | None | N/A |
+| Memory store path | Internal | Path (not contents) visible in config files | Low | Low |
+
+**Confidentiality Risk Level:** Low
+
+No confidential or restricted data is handled. Config files contain only paths and command definitions. The memory store (`.mv2` file) is not read, written, or modified by the install command — only its path is referenced.
+
+### Integrity `@human-review`
+
+> **What could be modified or corrupted?**
+
+| Asset at Risk | Modification Scenario | Impact | Likelihood |
+|---------------|----------------------|--------|------------|
+| Agent config files | Path traversal via `--config-dir` writes config to unintended location | Medium | Low |
+| Agent config files | Malicious binary path injected into config template | Medium | Low |
+| Existing config files | Overwritten without backup due to bug in ConfigWriter | Medium | Low |
+| .bak backup files | Backup overwritten on repeated `--reconfigure` runs | Low | Medium |
+
+**Integrity Risk Level:** Medium
+
+The primary integrity concern is **path traversal via `--config-dir`**: if a user (or agent acting autonomously) passes a crafted path like `--config-dir ../../../etc/`, the install command could write files outside expected directories. This is mitigated by path validation (SEC-1 below).
+
+A secondary concern is that config files reference the rusty-brain binary path. If an attacker could influence path resolution (e.g., placing a malicious binary earlier on PATH), the config would point to the wrong binary. This is standard PATH-based risk, not specific to this feature.
+
+### Availability `@human-review`
+
+> **What could be disrupted?**
+
+| Service/Function | Disruption Scenario | Impact | Likelihood |
+|------------------|---------------------|--------|------------|
+| Install command | Agent `--version` subprocess hangs indefinitely | Low | Low |
+| Install command | Disk full during atomic write (temp file created, rename fails) | Low | Low |
+| Existing agent config | Config corrupted if atomic write partially fails (mitigated by temp+rename) | Medium | Very Low |
+
+**Availability Risk Level:** Low
+
+The install command is a one-time operation, not a service. Disruption to the install command itself has low impact — the user retries. The atomic write pattern (temp file + rename) prevents partial config corruption.
+
+### CIA Summary `@llm-autonomous`
+
+| Dimension | Risk Level | Primary Concern | Mitigation Priority |
+|-----------|------------|-----------------|---------------------|
+| **Confidentiality** | Low | Config files contain only paths (Public/Internal data) | Low |
+| **Integrity** | Medium | Path traversal via `--config-dir`; binary path injection | Medium |
+| **Availability** | Low | Subprocess timeout; disk-full during write | Low |
+
+**Overall CIA Risk:** Low — *Offline CLI tool writing non-sensitive config files to local disk with no network exposure. Primary concern is input validation on `--config-dir` to prevent path traversal.*
+
+---
+
+## Trust Boundaries `@human-review`
+
+```mermaid
+flowchart TD
+    subgraph Untrusted
+        CLI_ARGS[CLI Arguments<br>--config-dir, --agents]
+        AGENT_BIN[Agent Binary Output<br>--version response]
+    end
+
+    subgraph Trust Boundary: Input Validation
+        PATH_VAL[Path Validation<br>no traversal, canonical paths]
+        AGENT_VAL[Agent Name Validation<br>allowlist: opencode, copilot, codex, gemini]
+        VER_PARSE[Version Parse<br>safe string parsing, timeout]
+    end
+
+    subgraph Trusted: Application Logic
+        ORCH[InstallOrchestrator]
+        GEN[Config Generator<br>embedded templates]
+        WRITER[ConfigWriter<br>atomic writes]
+    end
+
+    subgraph Trusted: Filesystem
+        FS[Local Filesystem]
+    end
+
+    CLI_ARGS --> PATH_VAL
+    CLI_ARGS --> AGENT_VAL
+    AGENT_BIN --> VER_PARSE
+    PATH_VAL --> ORCH
+    AGENT_VAL --> ORCH
+    VER_PARSE --> ORCH
+    ORCH --> GEN
+    GEN --> WRITER
+    WRITER --> FS
+```
+
+**Trust boundaries identified:**
+
+1. **CLI argument input -> application logic**: User-supplied `--config-dir` path must be validated to prevent path traversal. Agent names must be validated against an allowlist.
+2. **Agent subprocess output -> application logic**: Output from `<agent> --version` is untrusted text parsed for version info. Must handle malformed output gracefully without injection risk.
+
+### Trust Boundary Checklist `@llm-autonomous`
+
+- [x] **All input from untrusted sources is validated** — `--config-dir` validated for traversal; `--agents` validated against allowlist
+- [x] **External API responses are validated** — N/A (no external APIs); subprocess output parsed defensively
+- [x] **Authorization checked at data access, not just entry point** — N/A (local filesystem, user's own permissions)
+- [x] **Service-to-service calls are authenticated** — N/A (no service calls)
+
+---
+
+## Known Risks & Mitigations `@human-review`
+
+| ID | Risk Description | Severity | Mitigation | Status | Owner |
+|----|------------------|----------|------------|--------|-------|
+| R1 | Path traversal via `--config-dir` could write files outside expected directories | Medium | Validate and canonicalize path; reject paths containing `..` or absolute paths outside user home/project | Open | Implementer |
+| R2 | Agent binary on PATH could be a malicious impersonator | Low | Verify binary identity via `--version` output pattern matching; warn if unrecognizable. Standard PATH risk, not unique to this feature | Open | Implementer |
+| R3 | Config files written with overly permissive permissions (e.g., world-writable) | Low | Write files with user-only permissions (0o644 on Unix); inherit directory permissions | Open | Implementer |
+| R4 | `.bak` backup chain lost on repeated `--reconfigure` (only most recent backup kept) | Low | Document that only one `.bak` is kept per config file. Not a security issue per se, but data loss risk | Open | Implementer |
+| R5 | Subprocess execution (`agent --version`) could be abused if agent name is user-controlled | Low | Agent names come from hardcoded allowlist (opencode, copilot, codex, gemini), never from user input directly. Binary lookup uses safe PATH resolution, not shell execution | Mitigated | -- |
+
+### Risk Acceptance `@human-required`
+
+| Risk ID | Accepted By | Date | Justification | Review Date |
+|---------|-------------|------|---------------|-------------|
+| R4 | [name] | YYYY-MM-DD | Single `.bak` is sufficient for config recovery; users can use git for history | YYYY-MM-DD |
+
+---
+
+## Security Requirements `@human-review`
+
+Based on this review, the implementation MUST satisfy:
+
+### Authentication & Authorization
+
+| Req ID | Requirement | PRD AC | Verification Method |
+|--------|-------------|--------|---------------------|
+| -- | N/A — no authentication or authorization required (local CLI tool) | -- | -- |
+
+### Data Protection
+
+| Req ID | Requirement | PRD AC | Verification Method |
+|--------|-------------|--------|---------------------|
+| SEC-1 | Config files shall be written with user-only read/write permissions (0o644 on Unix, default ACL on Windows) | AC-1, AC-2, AC-3, AC-4 | Unit test: verify file permissions after write |
+| SEC-2 | Memory contents shall never be logged at any level during install operations | -- | Code review: grep for memory content access in install modules |
+| SEC-3 | Install manifest shall not contain any data from the memory store (only paths) | AC-8 | Unit test: verify manifest content |
+
+### Input Validation
+
+| Req ID | Requirement | PRD AC | Verification Method |
+|--------|-------------|--------|---------------------|
+| SEC-4 | `--config-dir` path shall be canonicalized and validated to reject paths containing `..` traversal sequences or symlinks pointing outside expected boundaries | AC-1 | Unit test: test with `../../etc/passwd`, symlink paths, etc. |
+| SEC-5 | `--agents` values shall be validated against a hardcoded allowlist (`opencode`, `copilot`, `codex`, `gemini`) | AC-6, AC-10 | Unit test: reject unknown agent names |
+| SEC-6 | Agent `--version` subprocess shall have a 2-second timeout to prevent hanging | -- | Unit test: mock slow subprocess |
+| SEC-7 | Agent detection shall use `std::process::Command::new()` with explicit binary name, never shell execution (no `sh -c` or `cmd /c`) | -- | Code review: verify no shell invocations |
+
+### Operational Security
+
+| Req ID | Requirement | PRD AC | Verification Method |
+|--------|-------------|--------|---------------------|
+| SEC-8 | Existing config files shall be backed up to `.bak` before overwriting | AC-9, AC-15 | Integration test: verify `.bak` creation |
+| SEC-9 | Config file writes shall be atomic (write to temp file, then rename) to prevent partial/corrupt configs | AC-1 | Integration test: simulate crash during write |
+| SEC-10 | Error messages shall not reveal internal filesystem structure beyond the relevant config path | AC-11 | Unit test: verify error message content |
+
+---
+
+## Compliance Considerations `@human-review`
+
+| Regulation | Applicable? | Relevant Requirements | N/A Justification |
+|------------|-------------|----------------------|-------------------|
+| GDPR | N/A | -- | No personal data collected, processed, or stored. Config files contain only file paths and command definitions |
+| CCPA | N/A | -- | No consumer personal information involved |
+| SOC 2 | N/A | -- | Local CLI tool with no cloud services, no customer data, no multi-tenant concerns |
+| HIPAA | N/A | -- | No protected health information involved |
+| PCI-DSS | N/A | -- | No payment data involved |
+| Other | N/A | -- | No regulatory implications identified |
+
+---
+
+## Review Findings
+
+### Issues Identified `@human-review`
+
+| ID | Finding | Severity | Category | Recommendation | Status |
+|----|---------|----------|----------|----------------|--------|
+| F1 | `--config-dir` accepts arbitrary paths without validation | Medium | Input Validation | Implement path canonicalization and traversal rejection (SEC-4) | Open |
+| F2 | No specification for config file permissions after write | Low | Data Protection | Explicitly set file permissions in ConfigWriter (SEC-1) | Open |
+| F3 | Agent subprocess timeout not specified in AR interface | Low | Availability | Add 2-second timeout to agent detection subprocess (SEC-6) | Open |
+
+### Positive Observations `@llm-autonomous`
+
+- No network exposure eliminates entire classes of attacks (MITM, injection via API, DDoS)
+- No secrets or credentials handled — config files contain only paths and command definitions
+- Atomic write pattern (temp + rename) prevents partial config corruption
+- Agent name allowlist prevents arbitrary subprocess execution
+- Existing memory store (`.mv2`) is never read or modified during install — only referenced by path
+- JSON output mode for agents avoids rich-text injection concerns
+
+---
+
+## Open Questions `@human-review`
+
+- [ ] **Q1:** Should `--config-dir` be restricted to directories under `$HOME` or project root, or just reject `..` traversal? Stricter is safer but may block legitimate use cases.
+- [ ] **Q2:** Should `.bak` files be created with more restrictive permissions than the original (e.g., read-only) to prevent accidental modification?
+
+---
+
+## Changelog `@auto`
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-03-05 | Claude | Initial review |
+
+---
+
+## Review Sign-off `@human-required`
+
+| Role | Name | Date | Decision |
+|------|------|------|----------|
+| Security Reviewer | [name] | YYYY-MM-DD | [Approved / Approved with conditions / Rejected] |
+| Feature Owner | [name] | YYYY-MM-DD | [Acknowledged] |
+
+### Conditions for Approval (if applicable) `@human-required`
+
+- [ ] SEC-4 (path traversal validation) must be implemented before merge
+- [ ] SEC-7 (no shell execution for subprocesses) must be verified in code review
+
+---
+
+## Security Requirements Traceability `@llm-autonomous`
+
+| SEC Req ID | PRD Req ID | PRD AC ID | Test Type | Test Location |
+|------------|------------|-----------|-----------|---------------|
+| SEC-1 | M-5 | AC-1, AC-2, AC-3, AC-4 | Unit | tests/installer/writer_permissions_test.rs |
+| SEC-2 | -- | -- | Code Review | Manual review of install modules |
+| SEC-3 | M-7 | AC-8 | Unit | tests/installer/manifest_test.rs |
+| SEC-4 | S-4 | -- | Unit | tests/installer/path_validation_test.rs |
+| SEC-5 | M-4 | AC-6 | Unit | tests/cli/install_args_test.rs |
+| SEC-6 | M-9 | AC-10 | Unit | tests/installer/detection_timeout_test.rs |
+| SEC-7 | M-9 | -- | Code Review | Manual review of detection module |
+| SEC-8 | S-1 | AC-9, AC-15 | Integration | tests/installer/backup_test.rs |
+| SEC-9 | M-8 | AC-1 | Integration | tests/installer/atomic_write_test.rs |
+| SEC-10 | M-10 | AC-11 | Unit | tests/installer/error_messages_test.rs |
+
+---
+
+## Review Checklist `@llm-autonomous`
+
+Before marking as Approved:
+- [x] Attack surface documented with auth/authz status for each exposure
+- [x] Exposure Points table has no contradictory rows
+- [x] All PRD Data Model entities appear in Data Inventory (Install Manifest, Agent Configuration, Agent Platform, Shared Memory Store)
+- [x] All data elements are classified using the 4-tier model
+- [x] Third-party dependencies and services are listed (none new)
+- [x] CIA impact is assessed with Low/Medium/High ratings
+- [x] Trust boundaries are identified
+- [x] Security requirements have verification methods specified
+- [x] Security requirements trace to PRD ACs where applicable
+- [x] No Critical/High findings remain Open (all findings are Medium or Low)
+- [x] Compliance N/A items have justification
+- [ ] Risk acceptance has named approver and review date (pending human)

--- a/specs/011-agent-installs/sec.md
+++ b/specs/011-agent-installs/sec.md
@@ -324,7 +324,7 @@ flowchart TD
 |----|------------------|----------|------------|--------|-------|
 | R1 | Path traversal in resolved config paths could write files outside expected directories | Low | Config dirs are resolved internally (not user-supplied); `validate_config_path()` rejects `..` components | Mitigated | Implementer |
 | R2 | Agent binary on PATH could be a malicious impersonator | Low | Verify binary identity via `--version` output pattern matching; warn if unrecognizable. Standard PATH risk, not unique to this feature | Open | Implementer |
-| R3 | Config files written with overly permissive permissions (e.g., world-writable) | Low | Write files with user-only permissions (0o644 on Unix); inherit directory permissions | Open | Implementer |
+| R3 | Config files written with overly permissive permissions (e.g., world-writable) | Low | Write files with owner read/write and group/other read-only permissions (0o644 on Unix); inherit directory permissions | Mitigated | Implementer |
 | R4 | `.bak` backup chain lost on repeated `--reconfigure` (only most recent backup kept) | Low | Document that only one `.bak` is kept per config file. Not a security issue per se, but data loss risk | Open | Implementer |
 | R5 | Subprocess execution (`agent --version`) could be abused if agent name is user-controlled | Low | Agent names come from hardcoded allowlist (opencode, copilot, codex, gemini), never from user input directly. Binary lookup uses safe PATH resolution, not shell execution | Mitigated | -- |
 
@@ -393,8 +393,8 @@ Based on this review, the implementation MUST satisfy:
 | ID | Finding | Severity | Category | Recommendation | Status |
 |----|---------|----------|----------|----------------|--------|
 | F1 | *(Resolved)* `--config-dir` was removed (S-4 deferred). Config paths are resolved internally and validated via `validate_config_path()` | Low | Input Validation | Path validation implemented (SEC-4) | Mitigated |
-| F2 | No specification for config file permissions after write | Low | Data Protection | Explicitly set file permissions in ConfigWriter (SEC-1) | Open |
-| F3 | Agent subprocess timeout not specified in AR interface | Low | Availability | Add 2-second timeout to agent detection subprocess (SEC-6) | Open |
+| F2 | Config file permissions specified and documented | Low | Data Protection | SEC-1 defines 0o644 rationale; ConfigWriter sets permissions after write | Mitigated |
+| F3 | Agent subprocess timeout implemented | Low | Availability | SEC-6: 2-second timeout with `try_wait()` deadline enforcement in `detect_binary_version()` | Mitigated |
 
 ### Positive Observations `@llm-autonomous`
 
@@ -431,8 +431,8 @@ Based on this review, the implementation MUST satisfy:
 
 ### Conditions for Approval (if applicable) `@human-required`
 
-- [ ] SEC-4 (path traversal validation) must be implemented before merge
-- [ ] SEC-7 (no shell execution for subprocesses) must be verified in code review
+- [x] SEC-4 (path traversal validation) implemented via `validate_config_path()`
+- [x] SEC-7 (no shell execution for subprocesses) verified — all subprocess calls use `Command::new()` with explicit binary paths
 
 ---
 

--- a/specs/011-agent-installs/sec.md
+++ b/specs/011-agent-installs/sec.md
@@ -24,10 +24,10 @@
 
 | Level | Label | Definition |
 |-------|-------|------------|
-| **Critical** | Immediate exploitation risk; data breach or system compromise likely |
-| **High** | Significant risk; exploitation possible with moderate effort |
-| **Medium** | Notable risk; exploitation requires specific conditions |
-| **Low** | Minor risk; limited impact or unlikely exploitation |
+| **Critical** | Critical | Immediate exploitation risk; data breach or system compromise likely |
+| **High** | High | Significant risk; exploitation possible with moderate effort |
+| **Medium** | Medium | Notable risk; exploitation requires specific conditions |
+| **Low** | Low | Minor risk; limited impact or unlikely exploitation |
 
 ---
 
@@ -76,7 +76,7 @@ This is a **lightweight security review** intended to catch obvious security con
 
 | Exposure Type | Details | Authentication | Authorization | Notes |
 |---------------|---------|----------------|---------------|-------|
-| CLI argument input | `--agents`, `--config-dir`, `--project`, `--global` flags | -- | -- | Input validation required for `--config-dir` path |
+| CLI argument input | `--agents`, `--project`, `--global` flags | -- | -- | Agent names validated against allowlist |
 | Subprocess execution | Agent version detection via `<agent> --version` | -- | -- | Binary path from PATH; no user-supplied command strings |
 | Filesystem writes | Config files written to agent directories | -- | OS filesystem permissions | Atomic writes via temp+rename |
 
@@ -350,7 +350,7 @@ Based on this review, the implementation MUST satisfy:
 
 | Req ID | Requirement | PRD AC | Verification Method |
 |--------|-------------|--------|---------------------|
-| SEC-1 | Config files shall be written with user-only read/write permissions (0o644 on Unix, default ACL on Windows) | AC-1, AC-2, AC-3, AC-4 | Unit test: verify file permissions after write |
+| SEC-1 | Config files shall be written with owner read/write and group/other read-only permissions (0o644 on Unix, default ACL on Windows). Note: 0o644 is used instead of 0o600 because agent processes need read access to the config files. | AC-1, AC-2, AC-3, AC-4 | Unit test: verify file permissions after write |
 | SEC-2 | Memory contents shall never be logged at any level during install operations | -- | Code review: grep for memory content access in install modules |
 | SEC-3 | Install manifest shall not contain any data from the memory store (only paths) | AC-8 | Unit test: verify manifest content |
 

--- a/specs/011-agent-installs/sec.md
+++ b/specs/011-agent-installs/sec.md
@@ -35,8 +35,8 @@
 
 | Document | ID | Relationship |
 |----------|-----|--------------|
-| Parent PRD | 011-prd-agent-installs.md | Feature being reviewed |
-| Architecture Review | 011-ar-agent-installs.md | Technical implementation |
+| Parent PRD | prd.md | Feature being reviewed |
+| Architecture Review | ar.md | Technical implementation |
 
 ---
 

--- a/specs/011-agent-installs/spec.md
+++ b/specs/011-agent-installs/spec.md
@@ -118,7 +118,7 @@ An AI coding agent is working in a project and discovers rusty-brain is availabl
 - What happens when an agent is detected but its version cannot be determined?
   - Proceed with install using the latest known config format and emit a warning that version could not be confirmed.
 - What happens when the user has a custom agent config directory (non-default location)?
-  - The install supports a `--config-dir` override per agent.
+  - Deferred (S-4): A `--config-dir` override was planned but deferred from this PR. Agents use platform-standard config directories.
 
 ## Requirements *(mandatory)*
 

--- a/specs/011-agent-installs/spec.md
+++ b/specs/011-agent-installs/spec.md
@@ -1,0 +1,200 @@
+# Feature Specification: Agentic Agent Installs
+
+**Feature Branch**: `011-agent-installs`
+**Created**: 2026-03-05
+**Status**: Draft
+**Input**: User description: "Agentic agent installs for opencode, github copilot-cli, codex and gemini."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - OpenCode Plugin Installation (Priority: P1)
+
+An OpenCode user wants to install rusty-brain as a plugin so their agent has persistent memory across sessions. They run a single install command that detects their platform, places configuration files in the right locations, and registers slash commands (`/ask`, `/search`, `/recent`, `/stats`) so the agent can immediately invoke memory operations.
+
+**Why this priority**: OpenCode already has platform adapter support (008-opencode-plugin) and command definitions. This story completes the end-to-end install experience for an already-supported platform.
+
+**Independent Test**: Can be fully tested by running the install command in an OpenCode project directory and verifying that all slash commands appear and route to the rusty-brain binary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with OpenCode installed but no rusty-brain configured, **When** the user runs the agent install command for OpenCode, **Then** configuration files are placed in the OpenCode plugin directory and all four slash commands are registered.
+2. **Given** rusty-brain is already configured for OpenCode, **When** the user runs the install command again, **Then** the configuration is upgraded without losing existing memory files.
+3. **Given** the install completes, **When** the user starts an OpenCode session, **Then** the agent discovers rusty-brain commands and can invoke `/ask "what did I work on?"` successfully.
+
+---
+
+### User Story 2 - GitHub Copilot CLI Agent Installation (Priority: P1)
+
+A GitHub Copilot CLI user wants rusty-brain integrated into their Copilot agent workflow. The install command sets up the necessary extension configuration so Copilot CLI can invoke rusty-brain for memory operations, providing persistent context across coding sessions.
+
+**Why this priority**: Copilot CLI has a large user base and supports agent extensions. Enabling memory for Copilot users significantly expands rusty-brain's reach.
+
+**Independent Test**: Can be fully tested by running the install command and verifying that Copilot CLI discovers and can invoke rusty-brain memory operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with GitHub Copilot CLI installed, **When** the user runs the agent install command for Copilot, **Then** the appropriate Copilot agent/extension configuration files are created.
+2. **Given** the install completes, **When** the user invokes memory operations through Copilot CLI, **Then** queries are routed to rusty-brain and results are returned in the expected format.
+3. **Given** Copilot CLI's extension mechanism changes between versions, **When** the install command runs, **Then** it detects the installed Copilot CLI version and generates compatible configuration.
+
+---
+
+### User Story 3 - OpenAI Codex CLI Agent Installation (Priority: P1)
+
+A Codex CLI user wants persistent memory across their coding sessions. The install command configures rusty-brain as a Codex agent extension, enabling the agent to store and retrieve observations, search past work, and maintain continuity.
+
+**Why this priority**: Codex CLI is a direct competitor to Claude Code and supports agent extensions. Providing cross-agent memory is a key differentiator for rusty-brain.
+
+**Independent Test**: Can be fully tested by running the install command and verifying Codex CLI can invoke rusty-brain's memory operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with Codex CLI installed, **When** the user runs the agent install command for Codex, **Then** Codex-specific configuration files (agent definitions, tool registrations) are created.
+2. **Given** the install completes, **When** the Codex agent invokes a memory search, **Then** the query is routed to rusty-brain and results are returned in Codex's expected output format.
+3. **Given** memories were previously stored via a different agent (e.g., Claude Code), **When** the Codex agent searches memory, **Then** it can access the same shared memory store.
+
+---
+
+### User Story 4 - Google Gemini CLI Agent Installation (Priority: P2)
+
+A Gemini CLI user wants persistent memory for their agent sessions. The install command sets up rusty-brain as an extension for Gemini CLI, enabling memory operations across sessions.
+
+**Why this priority**: Gemini CLI is newer and its extension mechanism may be less mature. This is important for cross-agent coverage but lower priority than the more established platforms.
+
+**Independent Test**: Can be fully tested by running the install command and verifying Gemini CLI can invoke rusty-brain memory operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with Gemini CLI installed, **When** the user runs the agent install command for Gemini, **Then** Gemini-specific configuration files are created.
+2. **Given** the install completes, **When** the Gemini agent invokes a memory operation, **Then** the query is routed to rusty-brain and results are returned.
+
+---
+
+### User Story 5 - Unified Multi-Agent Install (Priority: P1)
+
+A developer using multiple AI coding agents wants to install rusty-brain for all their agents in one step. A single command with a `--agents` flag (or auto-detection) configures rusty-brain for all detected agents on the system.
+
+**Why this priority**: Users working with multiple agents should not need to run separate install commands for each one. A unified experience reduces friction and ensures consistent configuration.
+
+**Independent Test**: Can be tested by running the unified install on a machine with multiple agents installed and verifying each agent has working memory operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with OpenCode and Codex CLI installed, **When** the user runs the install command without specifying agents, **Then** rusty-brain auto-detects both agents and configures itself for each.
+2. **Given** the user specifies `--agents opencode,copilot`, **When** the install runs, **Then** only OpenCode and Copilot configurations are created.
+3. **Given** an agent is not found on the system, **When** the install attempts to configure it, **Then** a clear message indicates the agent was not found and the install continues for other detected agents.
+4. **Given** the install completes for multiple agents, **When** each agent is started, **Then** all agents share the same memory store (`.rusty-brain/mind.mv2`).
+
+---
+
+### User Story 6 - Agent Self-Installation (Priority: P2)
+
+An AI coding agent is working in a project and discovers rusty-brain is available but not configured. The agent can invoke the install command itself, configuring rusty-brain for its own platform without requiring the user to leave the agent session.
+
+**Why this priority**: True "agentic" installation means the agents themselves can trigger setup. This removes the last manual step from the adoption flow.
+
+**Independent Test**: Can be tested by simulating an agent invoking the install command via its tool execution mechanism and verifying the plugin is registered without manual intervention.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent session where rusty-brain binary is available but not configured, **When** the agent runs the install command targeting its own platform, **Then** the configuration is created and the agent can immediately use memory operations.
+2. **Given** the agent invokes the install command, **When** no interactive prompts are required, **Then** the install completes with only structured output (JSON status messages suitable for agent consumption).
+3. **Given** the install fails (e.g., missing permissions), **When** the agent reads the error output, **Then** it receives a machine-parseable error with a suggested remediation.
+
+---
+
+### Edge Cases
+
+- What happens when an agent's extension/plugin mechanism is not yet supported by rusty-brain?
+  - The install command reports a clear error listing supported agents and their minimum versions.
+- What happens when the agent's config directory does not exist (first-time agent installation)?
+  - The install command creates the necessary directory structure.
+- What happens when two agents have conflicting configuration file formats?
+  - Each agent gets its own configuration files in agent-specific directories; the shared binary and memory store remain unified.
+- What happens when the binary is installed but the agent configuration becomes stale after an agent upgrade?
+  - A `--reconfigure` flag regenerates agent configuration files without re-downloading the binary.
+- What happens when the install is run in a CI/CD environment with no agents installed?
+  - The install skips agent configuration and only places the binary, exiting with a warning.
+- What happens when an agent is detected but its version cannot be determined?
+  - Proceed with install using the latest known config format and emit a warning that version could not be confirmed.
+- What happens when the user has a custom agent config directory (non-default location)?
+  - The install supports a `--config-dir` override per agent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide an `install` subcommand (e.g., `rusty-brain install`) that configures rusty-brain for one or more AI coding agents.
+- **FR-002**: System MUST support configuration for four agent platforms: OpenCode, GitHub Copilot CLI, OpenAI Codex CLI, and Google Gemini CLI.
+- **FR-003**: System MUST auto-detect which agents are installed on the system by checking standard binary paths and configuration directories.
+- **FR-004**: System MUST accept an `--agents` flag to explicitly specify which agents to configure (comma-separated list). Canonical agent names: `opencode`, `copilot`, `codex`, `gemini`.
+- **FR-005**: System MUST generate agent-specific configuration files (plugin manifests, command definitions, tool registrations) appropriate to each agent's extension mechanism.
+- **FR-006**: System MUST share a single memory store (`.rusty-brain/mind.mv2`) across all configured agents so memories are accessible regardless of which agent stored them.
+- **FR-007**: System MUST produce only structured output (JSON) when invoked programmatically (via `--json` flag or when stdin is not a TTY), enabling agents to invoke the install command themselves.
+- **FR-008**: System MUST support upgrading agent configurations without data loss when re-run on an already-configured system.
+- **FR-009**: System MUST validate that the target agent is actually installed before attempting to configure it, providing a clear error if the agent is not found.
+- **FR-010**: System MUST support a `--reconfigure` flag that regenerates agent configuration files without re-downloading or replacing the binary. Before overwriting existing config files, the system MUST create a `.bak` copy of each file being replaced.
+- **FR-011**: System MUST provide clear, machine-parseable error messages for all failure modes (missing agent, permission denied, unsupported version).
+- **FR-012**: System MUST NOT require interactive prompts during installation when invoked by an agent (non-TTY mode).
+- **FR-013**: System MUST create any necessary directory structures (agent config directories) if they do not already exist.
+- **FR-014**: System MUST log installation actions and results for diagnostic purposes via the standard `RUSTY_BRAIN_LOG` environment variable.
+- **FR-015**: System MUST require the user to specify installation scope explicitly: `--project` (config placed relative to current working directory) or `--global` (config placed in user-level directories such as `~/.config/`). The command MUST NOT default to either scope silently.
+
+### Key Entities
+
+- **Agent Platform**: A supported AI coding agent (OpenCode, Copilot CLI, Codex CLI, Gemini CLI). Key attributes: name, detection method (binary path, config directory), configuration format, minimum supported version.
+- **Agent Configuration**: The set of files needed to register rusty-brain with a specific agent. Key attributes: target directory, file format, template, binary path reference.
+- **Install Manifest**: A structured record of what was installed and configured. Key attributes: agent name, configuration path, binary path, install timestamp, version.
+- **Shared Memory Store**: The unified `.rusty-brain/mind.mv2` file accessed by all agents. Key attributes: file path, access mode (read/write via Mind API).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can configure rusty-brain for any single supported agent in under 30 seconds using one command.
+- **SC-002**: Users can configure rusty-brain for all detected agents in under 60 seconds using one command.
+- **SC-003**: After installation, 100% of configured agents can invoke at least one memory operation (search, ask, recent, stats) without additional manual setup.
+- **SC-004**: Auto-detection correctly identifies installed agents on 95%+ of standard development environments (default installation paths).
+- **SC-005**: Memories stored by one agent are retrievable by any other configured agent within the same project.
+- **SC-006**: Agent-invoked installation (non-interactive mode) completes successfully with structured output parseable by the invoking agent.
+- **SC-007**: Upgrading an existing installation preserves all memory data and agent configurations with zero data loss.
+
+## Clarifications
+
+### Session 2026-03-05
+
+- Q: Is `rusty-brain install` project-scoped or system-wide? → A: User must explicitly specify scope; no default. Use `--project` for project-scoped or `--global` for system-wide installation.
+- Q: How to handle agents whose extension mechanism is undocumented or doesn't exist? → A: Research each agent's actual extension mechanism first; only build adapters for agents with confirmed plugin support; stub the rest.
+- Q: What happens when an agent is detected but its version cannot be determined? → A: Proceed with install using latest known config format, emit a warning that version could not be confirmed.
+- Q: Should the install command back up existing config files before overwriting? → A: Yes, create a `.bak` copy of existing config files before overwriting.
+- Q: What are the canonical short names for the `--agents` flag? → A: `opencode`, `copilot`, `codex`, `gemini`.
+
+## Assumptions
+
+- Each target agent's extension/plugin mechanism MUST be researched and confirmed before building its adapter. Only agents with documented, stable plugin support get full adapters; others get stubs until their mechanisms are confirmed.
+- All agents with confirmed plugin support are expected to receive tool results as structured text (JSON or plain text) from external processes.
+- The rusty-brain binary is already installed on the system (via `install.sh`/`install.ps1` from 009-plugin-packaging) before `rusty-brain install` is run for agent configuration.
+- Agent detection relies on checking `$PATH` for known binary names and standard config directory locations.
+- The existing platform adapter system (005) can be extended to support new agent platforms without major refactoring.
+
+## Scope Boundaries
+
+### In Scope
+
+- Install subcommand for agent-specific configuration
+- Auto-detection of installed agents
+- Configuration file generation for OpenCode, Copilot CLI, Codex CLI, and Gemini CLI
+- Unified multi-agent install in one command
+- Non-interactive (agentic) install mode with JSON output
+- Reconfiguration support for existing installations
+- Shared memory store across all agents
+
+### Out of Scope
+
+- Binary download and placement (handled by 009-plugin-packaging install scripts)
+- Claude Code plugin installation (already handled by 009-plugin-packaging)
+- Auto-update or version management of the agents themselves
+- Agent-specific memory formats (all agents use the same `.mv2` format)
+- GUI or web-based installation wizard
+- Agent marketplace/store submissions (future enhancement)
+- Custom agent platform support (only the four named agents)

--- a/specs/011-agent-installs/tasks.md
+++ b/specs/011-agent-installs/tasks.md
@@ -1,0 +1,353 @@
+# Tasks: Agent Installs
+
+**Input**: Design documents from `/specs/011-agent-installs/`
+**Prerequisites**: plan.md, spec.md, prd.md, ar.md, sec.md, data-model.md, contracts/
+
+**Tests**: Included — Constitution V mandates test-first development (non-negotiable).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project initialization, dependency promotion, module scaffolding
+
+- [X] T001 Promote `tempfile` from dev-dependency to regular dependency in `crates/platforms/Cargo.toml`
+- [X] T002 [P] Create installer module directory structure: `crates/platforms/src/installer/mod.rs`, `crates/platforms/src/installer/agents/mod.rs`
+- [X] T003 [P] Add `pub mod installer;` to `crates/platforms/src/lib.rs`
+- [X] T004 [P] Create `crates/types/src/install.rs` with module declaration and add `pub mod install;` to `crates/types/src/lib.rs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types, traits, and infrastructure that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Types (types crate)
+
+- [X] T005 Define `InstallError` enum with stable error codes (AgentNotFound, PermissionDenied, UnsupportedVersion, ConfigCorrupted, IoError, ScopeRequired, InvalidAgent, PathTraversal) in `crates/types/src/install.rs` — implement `Display` via `thiserror` with `[E_INSTALL_*]` prefixed messages
+- [X] T006 [P] Define `InstallScope` enum (Project { root: PathBuf }, Global) in `crates/types/src/install.rs`
+- [X] T007 [P] Define `AgentInfo` struct (name, binary_path, version) in `crates/types/src/install.rs`
+- [X] T008 [P] Define `ConfigFile` struct (target_path, content, description) in `crates/types/src/install.rs`
+- [X] T009 [P] Define `InstallConfig` struct (agents, scope, json, reconfigure, config_dir) in `crates/types/src/install.rs`
+- [X] T010 [P] Define `InstallStatus` enum (Configured, Upgraded, Skipped, Failed, NotFound) with Serialize in `crates/types/src/install.rs`
+- [X] T011 [P] Define `AgentInstallResult` struct (agent_name, status, config_path, version_detected, error) with Serialize in `crates/types/src/install.rs`
+- [X] T012 Define `InstallReport` struct (status, results, memory_store, scope) with Serialize in `crates/types/src/install.rs`
+
+### AgentInstaller Trait
+
+- [X] T013 Write unit tests for `AgentInstaller` trait contract expectations in `crates/platforms/src/installer/mod.rs` (test module) — verify trait is object-safe and can be stored in Box
+- [X] T014 Define `AgentInstaller` trait with methods: `agent_name()`, `detect()`, `generate_config()`, `validate()` in `crates/platforms/src/installer/mod.rs` per contracts/agent-installer-trait.rs
+
+### Binary Detection Utility
+
+- [X] T015 Write unit tests for `find_binary_on_path()` in `crates/platforms/src/installer/mod.rs` — test: binary found, binary not found, Windows .exe extension, empty PATH
+- [X] T016 Implement `find_binary_on_path(name: &str) -> Option<PathBuf>` using `std::env::split_paths` + `Path::join` in `crates/platforms/src/installer/mod.rs` — no shell execution (SEC-7)
+
+### Path Validation (SEC-4)
+
+- [X] T017 Write unit tests for `validate_config_path()` in `crates/platforms/src/installer/mod.rs` — test: valid path, path with `..` traversal, symlink outside boundary, absolute path
+- [X] T018 Implement `validate_config_path(path: &Path) -> Result<PathBuf, InstallError>` that canonicalizes and rejects traversal sequences in `crates/platforms/src/installer/mod.rs`
+
+### Global Scope Path Resolution
+
+- [X] T018a [P] Implement `resolve_global_config_dir(agent_name: &str) -> PathBuf` in `crates/platforms/src/installer/mod.rs` — resolve per-platform global config directories (macOS: `~/Library/Application Support/<agent>/`, Linux: `~/.config/<agent>/`, Windows: `%APPDATA%/<agent>/`) using `cfg!(target_os)` and env vars
+- [X] T018b [P] Write unit tests for `resolve_global_config_dir()` in `crates/platforms/src/installer/mod.rs` — test: each platform variant, missing HOME/APPDATA env var returns error
+
+### ConfigWriter
+
+- [X] T019 Write unit tests for `ConfigWriter` in `crates/platforms/src/installer/writer.rs` — test: write new file (atomic), write with backup, backup when no existing file, directory creation, file permissions (0o644 on Unix)
+- [X] T020 Implement `ConfigWriter` struct with `write(config: &ConfigFile, backup: bool) -> Result<(), InstallError>` using `tempfile::NamedTempFile` for atomic writes in `crates/platforms/src/installer/writer.rs` — set 0o644 permissions on Unix (SEC-1), create parent dirs (M-12)
+- [X] T021 Implement `ConfigWriter::backup(path: &Path) -> Result<(), InstallError>` that copies existing file to `.bak` in `crates/platforms/src/installer/writer.rs` (SEC-8, S-1)
+
+### InstallerRegistry
+
+- [X] T022 Write unit tests for `InstallerRegistry` in `crates/platforms/src/installer/registry.rs` — test: register, resolve case-insensitive, list sorted agents, resolve unknown returns None (mirror AdapterRegistry test pattern)
+- [X] T023 Implement `InstallerRegistry` with `register()`, `resolve()`, `agents()` methods in `crates/platforms/src/installer/registry.rs`
+
+### InstallOrchestrator
+
+- [X] T024 Write unit tests for `InstallOrchestrator` in `crates/platforms/src/installer/orchestrator.rs` — test: auto-detect flow, explicit agent list, agent not found continues, scope required error, per-agent failure isolation
+- [X] T025 Implement `InstallOrchestrator` with `run(config: InstallConfig) -> Result<InstallReport, InstallError>` in `crates/platforms/src/installer/orchestrator.rs` — fail per-agent not per-command, use ConfigWriter for all writes, tracing for logging (S-2)
+- [X] T026 Add agent name validation against hardcoded allowlist (opencode, copilot, codex, gemini) in `InstallOrchestrator::run()` in `crates/platforms/src/installer/orchestrator.rs` (SEC-5)
+
+### CLI Integration
+
+- [X] T027 Write CLI arg parsing tests for `Install` subcommand in `crates/cli/src/args.rs` — test: --agents parsing, --project/--global mutual exclusion, --json flag, --reconfigure flag, --config-dir, scope required error (M-13)
+- [X] T028 Add `Install` variant to `Command` enum in `crates/cli/src/args.rs` with all flags: --agents (comma-delimited), --project, --global (required group "scope"), --json, --reconfigure, --config-dir
+- [X] T029 Update `Command::json()` method to include Install variant in `crates/cli/src/args.rs`
+- [X] T030 Create `crates/cli/src/install_cmd.rs` with `run_install()` function that builds `InstallConfig` from CLI args and calls `InstallOrchestrator::run()`, then formats output as JSON or human-readable table
+- [X] T031 Add install dispatch to `crates/cli/src/commands.rs` routing `Command::Install` to `install_cmd::run_install()`
+
+**Checkpoint**: Foundation ready — all types, traits, writer, registry, orchestrator, and CLI routing in place. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — OpenCode Plugin Installation (Priority: P1) MVP
+
+**Goal**: Users can run `rusty-brain install --agents opencode --project` to configure rusty-brain for OpenCode with all slash commands registered.
+
+**Independent Test**: Run install in a tempdir with mocked OpenCode binary, verify config files created with correct content.
+
+### Tests for User Story 1
+
+- [X] T032 [P] [US1] Write unit tests for `OpenCodeInstaller::detect()` in `crates/platforms/src/installer/agents/opencode.rs` — test: binary found with version, binary not found, version parse failure
+- [X] T033 [P] [US1] Write unit tests for `OpenCodeInstaller::generate_config()` in `crates/platforms/src/installer/agents/opencode.rs` — test: project scope config content, global scope config content, config references correct binary path and memory store path, slash commands registered (/ask, /search, /recent, /stats)
+- [X] T034 [P] [US1] Write integration test for full OpenCode install flow in `crates/platforms/tests/install_opencode_test.rs` — test: install to tempdir, verify files exist with correct content, upgrade preserves data (AC-1, AC-2, AC-9)
+
+### Implementation for User Story 1
+
+- [X] T035 [US1] Implement `OpenCodeInstaller` struct with `AgentInstaller` trait in `crates/platforms/src/installer/agents/opencode.rs` — detect via `find_binary_on_path("opencode")`, version via subprocess with 2s timeout (SEC-6)
+- [X] T036 [US1] Implement `OpenCodeInstaller::generate_config()` returning `Vec<ConfigFile>` with OpenCode plugin manifest JSON and slash command registrations in `crates/platforms/src/installer/agents/opencode.rs` — pure function, no I/O
+- [X] T037 [US1] Implement `OpenCodeInstaller::validate()` checking config files exist and are valid JSON in `crates/platforms/src/installer/agents/opencode.rs`
+- [X] T038 [US1] Register `OpenCodeInstaller` in `InstallerRegistry::with_builtins()` in `crates/platforms/src/installer/registry.rs`
+- [X] T039 [US1] Export `opencode_installer()` factory function from `crates/platforms/src/installer/agents/mod.rs`
+
+**Checkpoint**: `rusty-brain install --agents opencode --project` works end-to-end. All tests pass.
+
+---
+
+## Phase 4: User Story 2 — GitHub Copilot CLI Installation (Priority: P1)
+
+**Goal**: Users can run `rusty-brain install --agents copilot --project` to configure rusty-brain for Copilot CLI.
+
+**Independent Test**: Run install in a tempdir with mocked Copilot binary, verify config files created.
+
+**NOTE**: Requires Spike-1 research (PRD). If Copilot extension mechanism is unconfirmed, implement as a stub installer that reports "not yet supported" with clear messaging.
+
+### Tests for User Story 2
+
+- [X] T040 [P] [US2] Write unit tests for `CopilotInstaller::detect()` in `crates/platforms/src/installer/agents/copilot.rs` — test: binary found, binary not found
+- [X] T041 [P] [US2] Write unit tests for `CopilotInstaller::generate_config()` in `crates/platforms/src/installer/agents/copilot.rs` — test: config content matches Copilot extension format (or stub error if unconfirmed)
+
+### Implementation for User Story 2
+
+- [X] T042 [US2] Implement `CopilotInstaller` struct with `AgentInstaller` trait in `crates/platforms/src/installer/agents/copilot.rs` — detect via `find_binary_on_path("gh")` + check for copilot extension
+- [X] T043 [US2] Implement `CopilotInstaller::generate_config()` with Copilot-specific config templates in `crates/platforms/src/installer/agents/copilot.rs`
+- [X] T044 [US2] Register `CopilotInstaller` in `InstallerRegistry::with_builtins()` in `crates/platforms/src/installer/registry.rs`
+- [X] T045 [US2] Export `copilot_installer()` factory from `crates/platforms/src/installer/agents/mod.rs`
+
+**Checkpoint**: `rusty-brain install --agents copilot --project` works (or returns clear "not yet supported" stub).
+
+---
+
+## Phase 5: User Story 3 — OpenAI Codex CLI Installation (Priority: P1)
+
+**Goal**: Users can run `rusty-brain install --agents codex --project` to configure rusty-brain for Codex CLI.
+
+**Independent Test**: Run install in a tempdir with mocked Codex binary, verify config files created.
+
+**NOTE**: Requires Spike-2 research (PRD). If Codex extension mechanism is unconfirmed, implement as stub.
+
+### Tests for User Story 3
+
+- [X] T046 [P] [US3] Write unit tests for `CodexInstaller::detect()` in `crates/platforms/src/installer/agents/codex.rs`
+- [X] T047 [P] [US3] Write unit tests for `CodexInstaller::generate_config()` in `crates/platforms/src/installer/agents/codex.rs`
+
+### Implementation for User Story 3
+
+- [X] T048 [US3] Implement `CodexInstaller` struct with `AgentInstaller` trait in `crates/platforms/src/installer/agents/codex.rs` — detect via `find_binary_on_path("codex")`
+- [X] T049 [US3] Implement `CodexInstaller::generate_config()` with Codex-specific config templates in `crates/platforms/src/installer/agents/codex.rs`
+- [X] T050 [US3] Register `CodexInstaller` in `InstallerRegistry::with_builtins()` in `crates/platforms/src/installer/registry.rs`
+- [X] T051 [US3] Export `codex_installer()` factory from `crates/platforms/src/installer/agents/mod.rs`
+
+**Checkpoint**: `rusty-brain install --agents codex --project` works (or returns clear stub).
+
+---
+
+## Phase 6: User Story 5 — Unified Multi-Agent Install (Priority: P1)
+
+**Goal**: Users can run `rusty-brain install --project` to auto-detect and configure all installed agents in one command.
+
+**Independent Test**: Run install in a tempdir with multiple mocked agent binaries, verify all detected agents configured and sharing same memory store path.
+
+### Tests for User Story 5
+
+- [X] T052 [P] [US5] Write integration test for auto-detection flow in `crates/platforms/tests/install_multi_agent_test.rs` — test: multiple agents detected, single memory store path shared (AC-5, AC-7)
+- [X] T053 [P] [US5] Write integration test for explicit `--agents` filtering in `crates/platforms/tests/install_multi_agent_test.rs` — test: only specified agents configured (AC-6)
+- [X] T054 [P] [US5] Write integration test for agent-not-found handling in `crates/platforms/tests/install_multi_agent_test.rs` — test: missing agent reports warning, continues for others (AC-10)
+
+### Implementation for User Story 5
+
+- [X] T055 [US5] Verify `InstallOrchestrator::run()` auto-detection iterates all registered installers when `config.agents` is None in `crates/platforms/src/installer/orchestrator.rs` — add missing logic if needed
+- [X] T056 [US5] Verify `InstallOrchestrator::run()` filters to specified agents when `config.agents` is Some in `crates/platforms/src/installer/orchestrator.rs` — add missing logic if needed
+- [X] T057 [P] [US5] Write integration test verifying all agent configs reference the same shared memory store path (`.rusty-brain/mind.mv2`) in `crates/platforms/tests/install_multi_agent_test.rs` — install multiple agents, parse each config, assert identical memory_store path (AC-7)
+- [X] T057a [US5] Verify orchestrator populates `InstallReport.memory_store` with the correct shared path in `crates/platforms/src/installer/orchestrator.rs`
+
+**Checkpoint**: `rusty-brain install --project` auto-detects and configures all agents. Explicit `--agents` filtering works.
+
+---
+
+## Phase 7: User Story 4 — Google Gemini CLI Installation (Priority: P2)
+
+**Goal**: Users can run `rusty-brain install --agents gemini --project` to configure rusty-brain for Gemini CLI.
+
+**Independent Test**: Run install in a tempdir with mocked Gemini binary, verify config files created.
+
+**NOTE**: Requires Spike-3 research (PRD). If Gemini extension mechanism is unconfirmed, implement as stub.
+
+### Tests for User Story 4
+
+- [X] T058 [P] [US4] Write unit tests for `GeminiInstaller::detect()` in `crates/platforms/src/installer/agents/gemini.rs`
+- [X] T059 [P] [US4] Write unit tests for `GeminiInstaller::generate_config()` in `crates/platforms/src/installer/agents/gemini.rs`
+
+### Implementation for User Story 4
+
+- [X] T060 [US4] Implement `GeminiInstaller` struct with `AgentInstaller` trait in `crates/platforms/src/installer/agents/gemini.rs` — detect via `find_binary_on_path("gemini")`
+- [X] T061 [US4] Implement `GeminiInstaller::generate_config()` with Gemini-specific config templates in `crates/platforms/src/installer/agents/gemini.rs`
+- [X] T062 [US4] Register `GeminiInstaller` in `InstallerRegistry::with_builtins()` in `crates/platforms/src/installer/registry.rs`
+- [X] T063 [US4] Export `gemini_installer()` factory from `crates/platforms/src/installer/agents/mod.rs`
+
+**Checkpoint**: `rusty-brain install --agents gemini --project` works (or returns clear stub).
+
+---
+
+## Phase 8: User Story 6 — Agent Self-Installation (Priority: P2)
+
+**Goal**: AI agents can invoke `rusty-brain install --agents <self> --project --json` programmatically with no interactive prompts and receive structured JSON output.
+
+**Independent Test**: Invoke install command with non-TTY stdin, verify JSON output is valid and parseable, no prompts issued.
+
+### Tests for User Story 6
+
+- [X] T064 [P] [US6] Write CLI integration test for `--json` output format in `crates/cli/tests/install_json_test.rs` using `assert_cmd` — verify valid JSON structure matches `InstallReport` schema (AC-8)
+- [X] T065 [P] [US6] Write CLI integration test for non-TTY auto-JSON detection in `crates/cli/tests/install_json_test.rs` — verify JSON output when stdin is not a TTY (AC-12)
+- [X] T066 [P] [US6] Write CLI integration test for error JSON output in `crates/cli/tests/install_json_test.rs` — verify error JSON has error_code and suggestion fields (AC-11, SEC-10)
+
+### Implementation for User Story 6
+
+- [X] T067 [US6] Add non-TTY detection to `install_cmd::run_install()` that auto-enables JSON output when stdin is not a TTY in `crates/cli/src/install_cmd.rs` (M-7)
+- [X] T068 [US6] Verify no interactive prompts exist in install code path — audit all install modules for stdin reads in `crates/platforms/src/installer/` (M-11)
+- [X] T069 [US6] Verify error output includes machine-parseable error codes and remediation suggestions in JSON format in `crates/cli/src/install_cmd.rs` (M-10, SEC-10)
+
+**Checkpoint**: Agents can invoke install programmatically with structured JSON responses.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Security hardening, quality gates, documentation
+
+- [X] T070 [P] Run `cargo clippy --workspace -- -D warnings` and fix all warnings
+- [X] T071 [P] Run `cargo fmt --check` and fix all formatting issues
+- [X] T072 [P] Verify all error messages do not leak internal filesystem structure beyond relevant config path (SEC-10) — review error Display impls in `crates/types/src/install.rs`
+- [X] T073 [P] Verify memory contents are never logged during install operations (SEC-2) and install manifest contains only paths, not memory data (SEC-3) — grep install modules for memory content access and audit InstallReport/AgentInstallResult serialization
+- [X] T075 Run quickstart.md validation — execute all commands from `specs/011-agent-installs/quickstart.md` and verify expected output
+- [X] T076 Update `crates/platforms/src/lib.rs` public re-exports to include key installer types for ergonomic imports
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **US1 OpenCode (Phase 3)**: Depends on Foundational — MVP target
+- **US2 Copilot (Phase 4)**: Depends on Foundational — can parallel with US1
+- **US3 Codex (Phase 5)**: Depends on Foundational — can parallel with US1/US2
+- **US5 Multi-Agent (Phase 6)**: Depends on at least US1 being complete (needs 1+ installer to test)
+- **US4 Gemini (Phase 7)**: Depends on Foundational — can parallel with US1-US3
+- **US6 Self-Install (Phase 8)**: Depends on Foundational + at least US1 (needs working installer for JSON output testing)
+- **Polish (Phase 9)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (OpenCode, P1)**: Independent — start after Foundational
+- **US2 (Copilot, P1)**: Independent — can parallel with US1 (requires Spike-1 research)
+- **US3 (Codex, P1)**: Independent — can parallel with US1 (requires Spike-2 research)
+- **US5 (Multi-Agent, P1)**: Needs at least US1 complete for meaningful integration testing
+- **US4 (Gemini, P2)**: Independent — can parallel with P1 stories (requires Spike-3 research)
+- **US6 (Self-Install, P2)**: Needs at least US1 complete for end-to-end JSON testing
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (Constitution V)
+- Detect method before generate_config
+- Generate_config before validate
+- Register in registry after implementation complete
+- Story complete before moving to next priority (or parallel if staffed)
+
+### Parallel Opportunities
+
+**Within Phase 2 (Foundational)**:
+- T006, T007, T008, T009, T010, T011 can all run in parallel (independent type definitions)
+- T015+T017 (utility tests) can parallel with T019+T022 (writer+registry tests)
+
+**Across User Stories (after Foundational)**:
+- US1, US2, US3, US4 can all run in parallel (different files, no shared state)
+- Each agent installer is in its own file with no cross-dependencies
+
+**Within Each User Story**:
+- Test tasks (detect tests, generate_config tests) can run in parallel
+- Implementation follows: detect -> generate_config -> validate -> register
+
+---
+
+## Parallel Example: User Story 1 (OpenCode)
+
+```bash
+# Launch tests in parallel (all different files):
+Task: "Write unit tests for OpenCodeInstaller::detect() in crates/platforms/src/installer/agents/opencode.rs"
+Task: "Write unit tests for OpenCodeInstaller::generate_config() in crates/platforms/src/installer/agents/opencode.rs"
+Task: "Write integration test for full OpenCode install flow in crates/platforms/tests/install_opencode_test.rs"
+
+# Then implement sequentially:
+Task: "Implement OpenCodeInstaller::detect()"
+Task: "Implement OpenCodeInstaller::generate_config()"
+Task: "Implement OpenCodeInstaller::validate()"
+Task: "Register in InstallerRegistry"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T004)
+2. Complete Phase 2: Foundational (T005-T031)
+3. Complete Phase 3: US1 — OpenCode (T032-T039)
+4. **STOP and VALIDATE**: `rusty-brain install --agents opencode --project` works end-to-end
+5. All quality gates pass: `cargo test`, `cargo clippy`, `cargo fmt`
+
+### Incremental Delivery
+
+1. Setup + Foundational -> Foundation ready
+2. Add US1 (OpenCode) -> Test independently -> MVP complete
+3. Add US2 (Copilot) -> Test independently (after Spike-1)
+4. Add US3 (Codex) -> Test independently (after Spike-2)
+5. Add US5 (Multi-Agent) -> Test auto-detection with all installed agents
+6. Add US4 (Gemini) -> Test independently (after Spike-3)
+7. Add US6 (Self-Install) -> Test JSON output and non-TTY mode
+8. Polish -> Quality gates, security hardening
+
+### Spike Research Required
+
+Before implementing US2, US3, US4:
+- **Spike-1**: Research Copilot CLI extension mechanism (blocks US2)
+- **Spike-2**: Research Codex CLI extension mechanism (blocks US3)
+- **Spike-3**: Research Gemini CLI extension mechanism (blocks US4)
+
+These spikes can run in parallel with US1 implementation.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution V: Tests MUST be written and fail before implementation
+- SEC requirements mapped to specific tasks: SEC-1 (T020), SEC-2 (T073), SEC-3 (T073), SEC-4 (T017-T018), SEC-5 (T026), SEC-6 (T035), SEC-7 (T016), SEC-8 (T021), SEC-9 (T020), SEC-10 (T072)
+- Global scope path resolution (T018a-T018b) is foundational — each agent's `generate_config()` uses it for `--global` scope
+- S-3 (version detection for compatible config): each agent installer's `detect()` should return version info; `generate_config()` should use version to select compatible template when multiple formats exist
+- Agents with unconfirmed extension mechanisms (Copilot, Codex, Gemini) should be stubbed with clear "not yet supported" messaging if spike research is incomplete

--- a/tests/fixtures/medium_100obs.stats.json
+++ b/tests/fixtures/medium_100obs.stats.json
@@ -1,1 +1,1 @@
-{"totalObservations":100,"totalSessions":0,"oldestMemory":"2026-03-05T01:56:40.816116Z","newestMemory":"2026-03-05T01:57:15.078628Z","fileSize":369315,"topTypes":{"success":25,"discovery":25,"problem":25,"decision":25}}
+{"totalObservations":100,"totalSessions":0,"oldestMemory":"2026-03-05T01:56:40.816116Z","newestMemory":"2026-03-05T01:57:15.078628Z","fileSize":369315,"topTypes":{"success":25,"decision":25,"problem":25,"discovery":25}}

--- a/tests/fixtures/small_10obs.stats.json
+++ b/tests/fixtures/small_10obs.stats.json
@@ -1,1 +1,1 @@
-{"totalObservations":10,"totalSessions":0,"oldestMemory":"2026-03-05T01:56:37.361583Z","newestMemory":"2026-03-05T01:56:40.427759Z","fileSize":99099,"topTypes":{"problem":2,"success":2,"discovery":3,"decision":3}}
+{"totalObservations":10,"totalSessions":0,"oldestMemory":"2026-03-05T01:56:37.361583Z","newestMemory":"2026-03-05T01:56:40.427759Z","fileSize":99099,"topTypes":{"success":2,"problem":2,"decision":3,"discovery":3}}


### PR DESCRIPTION
## Summary
- Adds `rusty-brain install` CLI subcommand that auto-detects AI agents (opencode, copilot, codex, gemini) and writes plugin config files
- Includes all 7 code review fixes: shared version detection/validation helpers, thread leak fix, ReportStatus enum, Result-returning memory_store_path, validated config paths, removed unused config_dir

## Code Review Fixes
| # | Issue | Fix |
|---|-------|-----|
| 1 | Duplicated version detection & validation | Extracted `detect_binary_version()`, `parse_version_string()`, `validate_json_config()` into shared helpers |
| 2 | `config_dir` parsed but unused | Removed field, CLI arg, and parameter entirely |
| 3 | Thread + process leak on timeout | `Command::spawn()` + `child.kill()` + `child.wait()` on timeout |
| 4 | `is_valid_agent` allocates unnecessarily | `eq_ignore_ascii_case` instead of `to_lowercase()` |
| 5 | `InstallReport.status` is a String | New `ReportStatus` enum with `Serialize` |
| 6 | `memory_store_path()` silently falls back to "." | Returns `Result<PathBuf, InstallError>` |
| 7 | `validate_config_path()` never called | Wired into `ConfigWriter::write()` |

## Test plan
- [x] `cargo test` — 475 tests pass in affected crates (types, platforms, cli)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted
- [ ] Manual: `rusty-brain install --project --json` produces valid JSON output
- [ ] Manual: `rusty-brain install --global --json` with HOME unset returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an install command to detect and configure supported agents (OpenCode, Copilot, Codex, Gemini); supports --project/--global scopes, multi-agent installs, reconfigure with backups, and consistent shared memory store.

* **User Experience**
  * Non-interactive JSON output when appropriate plus human-readable reports; structured error codes for failures.

* **Documentation**
  * Extensive architecture, spec, plan, quickstart, research, and security docs; notes configs are local filesystem-only.

* **Tests**
  * Added unit and integration tests covering detection, config generation, backups, JSON output, and multi-agent flows.

* **Chores**
  * Promoted/updated test/tooling dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->