### PR TITLE
feat: add agent install subsystem (011)

### DIFF
--- a/crates/cli/src/install_cmd.rs
+++ b/crates/cli/src/install_cmd.rs
@@ -35,8 +35,8 @@ pub fn run_install(
         return Err(CliError::Install(InstallError::ScopeRequired));
     };
 
-    // Auto-enable JSON when stdin is not a TTY (M-7, AC-12).
-    let json = json || !std::io::stdin().is_terminal();
+    // Auto-enable JSON when stdout is not a TTY (M-7, AC-12).
+    let json = json || !std::io::stdout().is_terminal();
 
     let config = InstallConfig {
         agents,

--- a/crates/platforms/src/installer/agents/copilot.rs
+++ b/crates/platforms/src/installer/agents/copilot.rs
@@ -6,6 +6,7 @@
 
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
 
@@ -27,13 +28,34 @@ impl AgentInstaller for CopilotInstaller {
         let binary_path = find_binary_on_path("gh")?;
 
         // Verify `gh copilot` subcommand is available (gh may exist without copilot).
-        let copilot_check = Command::new(&binary_path)
+        // Use spawn + timeout to avoid blocking indefinitely if gh hangs.
+        let mut child = Command::new(&binary_path)
             .args(["help", "copilot"])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status();
-        if !copilot_check.is_ok_and(|s| s.success()) {
-            return None;
+            .spawn()
+            .ok()?;
+
+        let start = Instant::now();
+        let timeout = Duration::from_secs(2);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        return None;
+                    }
+                    break;
+                }
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return None;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => return None,
+            }
         }
 
         let version = detect_binary_version(&binary_path);

--- a/crates/platforms/src/installer/agents/copilot.rs
+++ b/crates/platforms/src/installer/agents/copilot.rs
@@ -48,8 +48,14 @@ impl AgentInstaller for CopilotInstaller {
                 }
                 Ok(None) => {
                     if start.elapsed() >= timeout {
-                        let _ = child.kill();
-                        let _ = child.wait();
+                        match child.kill() {
+                            Ok(()) => {
+                                let _ = child.wait();
+                            }
+                            Err(_) => {
+                                // If we cannot kill the child, avoid blocking indefinitely on wait.
+                            }
+                        }
                         return None;
                     }
                     std::thread::sleep(Duration::from_millis(10));

--- a/crates/platforms/src/installer/agents/opencode.rs
+++ b/crates/platforms/src/installer/agents/opencode.rs
@@ -189,4 +189,10 @@ mod tests {
         assert_eq!(parse_version_string(""), None);
         assert_eq!(parse_version_string("   "), None);
     }
+
+    #[test]
+    fn parse_version_no_semver_returns_none() {
+        assert_eq!(parse_version_string("no version here"), None);
+        assert_eq!(parse_version_string("License: MIT"), None);
+    }
 }

--- a/crates/platforms/src/installer/mod.rs
+++ b/crates/platforms/src/installer/mod.rs
@@ -147,6 +147,7 @@ pub fn detect_binary_version(binary_path: &Path) -> Option<String> {
 /// Parse a version string from command output.
 ///
 /// Handles formats like "opencode 1.2.3" or "v1.2.3" or just "1.2.3".
+/// Returns `None` if no semver-like pattern is found.
 #[must_use]
 pub fn parse_version_string(output: &str) -> Option<String> {
     let trimmed = output.trim();
@@ -161,7 +162,7 @@ pub fn parse_version_string(output: &str) -> Option<String> {
         }
     }
 
-    Some(trimmed.to_string())
+    None
 }
 
 /// Validate that a JSON config file exists and is parseable.

--- a/crates/platforms/src/installer/registry.rs
+++ b/crates/platforms/src/installer/registry.rs
@@ -72,22 +72,18 @@ mod tests {
     use types::install::{AgentInfo, ConfigFile, InstallError, InstallScope};
 
     struct MockInstaller {
-        name: String,
+        name: &'static str,
     }
 
     impl MockInstaller {
-        fn new(name: &str) -> Box<dyn AgentInstaller> {
-            Box::new(Self {
-                name: name.to_string(),
-            })
+        fn new(name: &'static str) -> Box<dyn AgentInstaller> {
+            Box::new(Self { name })
         }
     }
 
     impl AgentInstaller for MockInstaller {
-        #[allow(clippy::unnecessary_literal_bound)]
         fn agent_name(&self) -> &'static str {
-            // Leak the string for test purposes — the name lives for the test's lifetime.
-            Box::leak(self.name.clone().into_boxed_str())
+            self.name
         }
         fn detect(&self) -> Option<AgentInfo> {
             None

--- a/crates/platforms/src/lib.rs
+++ b/crates/platforms/src/lib.rs
@@ -36,7 +36,7 @@ pub use registry::AdapterRegistry;
 pub mod bootstrap;
 /// Agent installer subsystem for configuring external AI agents.
 pub mod installer;
+pub use installer::AgentInstaller;
 pub use installer::orchestrator::InstallOrchestrator;
 pub use installer::registry::InstallerRegistry;
 pub use installer::writer::ConfigWriter;
-pub use installer::{AgentInstaller, SUPPORTED_AGENTS, find_binary_on_path, is_valid_agent};

--- a/crates/platforms/tests/install_opencode_test.rs
+++ b/crates/platforms/tests/install_opencode_test.rs
@@ -162,11 +162,7 @@ fn upgrade_creates_backup_of_existing_config() {
     assert_eq!(report1.results[0].status, InstallStatus::Configured);
 
     // Second install (should be upgrade with backup).
-    let mut registry2 = InstallerRegistry::new();
-    registry2.register(Box::new(FakeOpenCodeInstaller));
-    let orch2 = InstallOrchestrator::new(registry2);
-
-    let report2 = orch2.run(&config).unwrap();
+    let report2 = orch.run(&config).unwrap();
     assert_eq!(report2.results[0].status, InstallStatus::Upgraded);
 
     // Verify backup exists.


### PR DESCRIPTION
## Summary

- Adds the agent install subsystem (`rusty-brain install`) for configuring external AI agents (opencode, codex, copilot) with rusty-brain integration
- Implements installer registry, orchestrator, config writer, and per-agent installers with detect/generate/validate lifecycle
- Includes CLI subcommand with JSON output mode, auto-TTY detection, path traversal protection, and upgrade-with-backup support
- Full spec-driven development: spec, PRD, architecture review, security review, plan, and tasks

## Changes across 6 commits

- `feat`: Core install subsystem — `AgentInstaller` trait, `InstallerRegistry`, `InstallOrchestrator`, `ConfigWriter`, per-agent installers (opencode, codex, copilot), CLI `install` subcommand
- `fix` (4 rounds): Code review feedback from CodeRabbit, Copilot, and manual review — Box::leak removal, stdout-based auto-JSON detection, version parse fallback fix, copilot timeout, test cleanup, trimmed re-exports
- `docs`: Scoped error messages and sec.md linkage

## Test plan

- [x] `cargo test` — 112 tests pass (3 ignored)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] CodeRabbit review — no findings
- [ ] Manual smoke test: `cargo run -- install --project opencode --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Copilot agent detection using a non-blocking check with timeout to avoid hangs.

* **Refactor**
  * Version detection tightened to require semver-like patterns for more accurate results.
  * JSON output auto-detection adjusted to trigger based on stdout state.

* **Tests**
  * Added a unit test ensuring non-semver inputs do not produce a version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->