### PR TITLE
fix: address second-round CodeRabbit review feedback

### DIFF
--- a/crates/hooks/tests/legacy_path_test.rs
+++ b/crates/hooks/tests/legacy_path_test.rs
@@ -42,7 +42,9 @@ fn agent_brain_only_suggests_migration() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].level, DiagnosticLevel::Info);
     assert!(
-        result[0].message.contains("mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"),
+        result[0]
+            .message
+            .contains("mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"),
         "diagnostic should contain safe file-level mv command: {}",
         result[0].message
     );

--- a/crates/platforms/src/bootstrap.rs
+++ b/crates/platforms/src/bootstrap.rs
@@ -43,7 +43,7 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
             level: DiagnosticLevel::Info,
             message: format!(
                 "Using legacy memory file at `{}`. Migrate to `{canonical}`: \
-                 `mkdir -p {} && mv .agent-brain/mind.mv2 {canonical}`",
+                 `mkdir -p {} && mv .agent-brain/{MIND_FILENAME} {canonical}`",
                 crate::LEGACY_AGENT_BRAIN_PATH,
                 crate::DEFAULT_MEMORY_DIR
             ),
@@ -62,8 +62,8 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
         diagnostics.push(Diagnostic {
             level: DiagnosticLevel::Warning,
             message: format!(
-                "Legacy memory file at `.claude/mind.mv2`. Migrate to `{canonical}`: \
-                 `mkdir -p {} && mv .claude/mind.mv2 {canonical}`",
+                "Legacy memory file at `.claude/{MIND_FILENAME}`. Migrate to `{canonical}`: \
+                 `mkdir -p {} && mv .claude/{MIND_FILENAME} {canonical}`",
                 crate::DEFAULT_MEMORY_DIR
             ),
         });
@@ -81,7 +81,9 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
 /// 3. `.rusty-brain/mind.mv2` — returned as default for new installations
 #[must_use]
 pub fn resolve_effective_path(project_root: &Path) -> std::path::PathBuf {
-    let rusty_brain = project_root.join(crate::DEFAULT_MEMORY_DIR).join(MIND_FILENAME);
+    let rusty_brain = project_root
+        .join(crate::DEFAULT_MEMORY_DIR)
+        .join(MIND_FILENAME);
     if rusty_brain.exists() {
         return rusty_brain;
     }
@@ -176,7 +178,11 @@ mod tests {
         let result = detect_legacy_paths(dir.path());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].level, DiagnosticLevel::Info);
-        assert!(result[0].message.contains("mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"));
+        assert!(
+            result[0].message.contains(
+                "mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2"
+            )
+        );
     }
 
     #[test]

--- a/crates/platforms/src/bootstrap.rs
+++ b/crates/platforms/src/bootstrap.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 use crate::{AdapterRegistry, EventPipeline, detect_platform, resolve_memory_path};
 use types::{HookInput, MindConfig, RustyBrainError};
 
+/// Memory database filename, shared across path construction.
+const MIND_FILENAME: &str = "mind.mv2";
+
 /// Diagnostic severity level for legacy path warnings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiagnosticLevel {
@@ -25,7 +28,7 @@ pub struct Diagnostic {
 pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
-    let canonical = format!("{}/mind.mv2", crate::DEFAULT_MEMORY_DIR);
+    let canonical = format!("{}/{MIND_FILENAME}", crate::DEFAULT_MEMORY_DIR);
     let rusty_brain = project_root.join(&canonical);
     let agent_brain = project_root.join(crate::LEGACY_AGENT_BRAIN_PATH);
     let claude_legacy = project_root.join(crate::LEGACY_CLAUDE_MEMORY_PATH);
@@ -78,7 +81,7 @@ pub fn detect_legacy_paths(project_root: &Path) -> Vec<Diagnostic> {
 /// 3. `.rusty-brain/mind.mv2` — returned as default for new installations
 #[must_use]
 pub fn resolve_effective_path(project_root: &Path) -> std::path::PathBuf {
-    let rusty_brain = project_root.join(crate::DEFAULT_MEMORY_DIR).join("mind.mv2");
+    let rusty_brain = project_root.join(crate::DEFAULT_MEMORY_DIR).join(MIND_FILENAME);
     if rusty_brain.exists() {
         return rusty_brain;
     }

--- a/specs/012-default-memory-path/plan.md
+++ b/specs/012-default-memory-path/plan.md
@@ -39,7 +39,7 @@ Change the default memory directory from `.agent-brain/` to `.rusty-brain/` acro
 | XII. Simplicity | PASS | Minimal changes to existing patterns; extends existing detection, doesn't introduce new frameworks |
 | XIII. Dependency Policy | PASS | No new dependencies |
 
-**Post-Phase 1 re-check**: All gates still pass. `detect_legacy_path` signature changes from `Option<Diagnostic>` to `Vec<Diagnostic>` but this is a non-breaking internal API change.
+**Post-Phase 1 re-check**: All gates still pass. `detect_legacy_paths` returns `Vec<Diagnostic>` to support multi-path diagnostics; this is a non-breaking internal API change.
 
 ## Project Structure
 
@@ -97,7 +97,7 @@ No constitution violations to justify.
 
 `build_mind_config()` gains a filesystem check: if `.rusty-brain/mind.mv2` doesn't exist but `.agent-brain/mind.mv2` does, use the legacy path. This implements FR-004 (graceful fallback) without auto-migration (FR-008).
 
-### 2. detect_legacy_path → detect_legacy_paths (R-002)
+### 2. detect_legacy_paths (R-002)
 
 Return type changes from `Option<Diagnostic>` to `Vec<Diagnostic>` to handle multiple legacy paths simultaneously. The function now checks both `.agent-brain/` and `.claude/` against the new canonical `.rusty-brain/`.
 
@@ -122,7 +122,7 @@ Return type changes from `Option<Diagnostic>` to `Vec<Diagnostic>` to handle mul
 3. Update all unit tests for new default values
 
 ### Phase B: Legacy Detection & Fallback
-1. Extend `detect_legacy_path` to three-tier chain
+1. Extend `detect_legacy_paths` to three-tier chain
 2. Add `resolve_effective_path` fallback in `bootstrap.rs`
 3. Wire fallback into `build_mind_config`
 4. Update integration tests

--- a/specs/012-default-memory-path/tasks.md
+++ b/specs/012-default-memory-path/tasks.md
@@ -70,7 +70,7 @@
 
 ### Tests for User Story 2
 
-- [X] T015 [US2] Write test `detect_legacy_paths_agent_brain_only_suggests_migration` — `.agent-brain/` exists, no `.rusty-brain/` → returns Info diagnostic with actionable `mv .agent-brain .rusty-brain` command in `crates/platforms/src/bootstrap.rs`
+- [X] T015 [US2] Write test `detect_legacy_paths_agent_brain_only_suggests_migration` — `.agent-brain/` exists, no `.rusty-brain/` → returns Info diagnostic with actionable `mkdir -p .rusty-brain && mv .agent-brain/mind.mv2 .rusty-brain/mind.mv2` command in `crates/platforms/src/bootstrap.rs`
 - [X] T016 [US2] Write test `detect_legacy_paths_both_dirs_warns_duplicate` — both `.agent-brain/` and `.rusty-brain/` exist → returns Warning about duplicate in `crates/platforms/src/bootstrap.rs`
 - [X] T017 [US2] Write test `detect_legacy_paths_rusty_brain_only_returns_empty` — only `.rusty-brain/` exists → returns empty Vec in `crates/platforms/src/bootstrap.rs`
 - [X] T018 [US2] Write test `resolve_effective_path_falls_back_to_agent_brain` — `.agent-brain/mind.mv2` exists, `.rusty-brain/` doesn't → returns `.agent-brain/mind.mv2` in `crates/platforms/src/bootstrap.rs`


### PR DESCRIPTION
- Extract MIND_FILENAME constant in bootstrap.rs to centralize the "mind.mv2" string used in both detect_legacy_paths and resolve_effective_path
- Fix stale detect_legacy_path (singular) references in plan.md
- Fix stale unsafe mv command in tasks.md T015 description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy storage detection to identify multiple legacy locations and surface clear migration guidance.
  * Updated migration instructions to an explicit two-step process: create the new memory directory, then move the legacy memory file.

* **Refactor**
  * Consolidated internal filename/path handling for more consistent user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->