### PR TITLE
Implement P1 engine and daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +39,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -57,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +119,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -112,6 +166,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656f14fc1ab819c65f332045ea7cb38841bbe551f3b2bc7e3abefb559af4155c"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +214,38 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -134,7 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -162,16 +289,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -185,8 +386,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -203,15 +409,61 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -254,6 +506,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,10 +642,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "include_dir"
@@ -315,6 +782,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +822,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -362,16 +850,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -383,10 +894,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -399,6 +932,24 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -420,6 +971,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,9 +1036,115 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rb-daemon"
+version = "0.0.1"
+dependencies = [
+ "deadpool-sqlite",
+ "directories",
+ "futures",
+ "rb-embed",
+ "rb-engine",
+ "rb-proto",
+ "rb-search",
+ "rb-store",
+ "rb-types",
+ "serde",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rb-embed"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "rb-types",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
+name = "rb-engine"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rb-embed",
+ "rb-search",
+ "rb-types",
+ "tokio",
+]
+
+[[package]]
+name = "rb-proto"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "futures",
+ "rb-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "rb-search"
+version = "0.0.1"
+dependencies = [
+ "chrono",
+ "rb-types",
+]
 
 [[package]]
 name = "rb-store"
@@ -455,8 +1167,100 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -474,6 +1278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,7 +1293,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -491,6 +1336,25 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-brain"
+version = "0.0.1"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -542,6 +1406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +1435,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +1457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sqlite-vec"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +1474,18 @@ checksum = "d0ba424237a9a5db2f6071f193319e2b6a32f7f3961debb2fbbfe67067abce3f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -591,16 +1499,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -609,7 +1537,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -622,6 +1559,174 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -642,12 +1747,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -664,6 +1793,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -694,6 +1838,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -763,6 +1917,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,11 +2006,247 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -925,6 +2344,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +2386,66 @@ name = "zerocopy-derive"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,27 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,15 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,12 +1051,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"
@@ -1284,7 +1248,6 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "deadpool-sqlite",
- "directories",
  "futures",
  "libc",
  "rb-embed",
@@ -1378,17 +1341,6 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "uuid",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1553,7 +1505,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "directories",
  "predicates",
  "rb-daemon",
  "rb-embed",
@@ -2323,15 +2274,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2355,21 +2297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2407,12 +2334,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2425,12 +2346,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2440,12 +2355,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2473,12 +2382,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2488,12 +2391,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2509,12 +2406,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2524,12 +2415,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,29 +304,6 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "deadpool-sqlite"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656f14fc1ab819c65f332045ea7cb38841bbe551f3b2bc7e3abefb559af4155c"
-dependencies = [
- "deadpool",
- "deadpool-sync",
- "rusqlite",
-]
-
-[[package]]
-name = "deadpool-sync"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
-dependencies = [
- "deadpool-runtime",
-]
 
 [[package]]
 name = "difflib"
@@ -1247,19 +1224,15 @@ name = "rb-daemon"
 version = "0.0.1"
 dependencies = [
  "async-trait",
- "deadpool-sqlite",
- "futures",
  "libc",
  "rb-embed",
  "rb-engine",
  "rb-proto",
- "rb-search",
  "rb-store",
  "rb-types",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1276,9 +1249,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 1.0.69",
  "tokio",
- "tracing",
  "wiremock",
 ]
 
@@ -1304,7 +1275,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "rb-store",
  "rb-types",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "rb-types",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tokio-util",
 ]
 
@@ -1630,6 +1631,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
 name = "rb-daemon"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "deadpool-sqlite",
  "directories",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "deadpool-sqlite",
  "directories",
  "futures",
+ "libc",
  "rb-embed",
  "rb-engine",
  "rb-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +96,21 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -90,6 +155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -139,6 +215,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -205,6 +327,12 @@ checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
 dependencies = [
  "deadpool-runtime",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -287,6 +415,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -788,6 +925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1033,21 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -908,6 +1075,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -949,6 +1122,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1346,6 +1549,22 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rusty-brain"
 version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "directories",
+ "predicates",
+ "rb-daemon",
+ "rb-embed",
+ "rb-proto",
+ "rb-types",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "ryu"
@@ -1435,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1815,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1737,6 +1986,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1788,6 +2067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +2085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2101,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 futures = "0.3"
 bytes = "1"
 secrecy = "0.10"
-directories = "5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 wiremock = "0.6"
+libc = "0.2"
 
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
 [workspace]
 resolver = "2"
-members = ["crates/rb-types", "crates/rb-store"]
+members = [
+    "crates/rb-types",
+    "crates/rb-store",
+    "crates/rb-proto",
+    "crates/rb-embed",
+    "crates/rb-search",
+    "crates/rb-engine",
+    "crates/rb-daemon",
+    "crates/rusty-brain",
+]
 
 [workspace.package]
 version = "0.0.1"
@@ -21,6 +30,21 @@ deadpool-sqlite = "0.9"
 include_dir = "0.7"
 sha2 = "0.10"
 tempfile = "3"
+# --- P1 additions ---
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time", "io-util", "signal"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+tokio-stream = "0.1"
+async-trait = "0.1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+futures = "0.3"
+bytes = "1"
+secrecy = "0.10"
+directories = "5"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive", "env"] }
+anyhow = "1"
+wiremock = "0.6"
 
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlite-vec = "0.1"
-deadpool-sqlite = "0.9"
 include_dir = "0.7"
 sha2 = "0.10"
 tempfile = "3"

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 async-trait = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 futures = { workspace = true }
 deadpool-sqlite = { workspace = true }
-directories = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "rb-daemon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain single-writer daemon: dedicated writer thread, read pool, UDS listener, change broadcast, server-side isolation."
+
+[lib]
+name = "rb_daemon"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-store = { path = "../rb-store" }
+rb-engine = { path = "../rb-engine" }
+rb-embed = { path = "../rb-embed" }
+rb-proto = { path = "../rb-proto" }
+rb-search = { path = "../rb-search" }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+futures = { workspace = true }
+deadpool-sqlite = { workspace = true }
+directories = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -26,6 +26,7 @@ directories = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -17,13 +17,9 @@ rb-store = { path = "../rb-store" }
 rb-engine = { path = "../rb-engine" }
 rb-embed = { path = "../rb-embed" }
 rb-proto = { path = "../rb-proto" }
-rb-search = { path = "../rb-search" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-futures = { workspace = true }
-deadpool-sqlite = { workspace = true }
 tracing = { workspace = true }
-thiserror = { workspace = true }
 serde = { workspace = true }
 async-trait = { workspace = true }
 libc = { workspace = true }

--- a/crates/rb-daemon/src/change.rs
+++ b/crates/rb-daemon/src/change.rs
@@ -1,0 +1,57 @@
+use rb_types::{MemoryId, Namespace};
+use serde::{Deserialize, Serialize};
+
+/// What happened to a memory. Published after a successful commit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChangeKind {
+    Created,
+    Updated,
+    Archived,
+}
+
+/// Change-notification event broadcast on every successful write (spec §8).
+///
+/// Notification only - never coordination. Enables the deferred `subscribe`
+/// feature with no new machinery.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryChanged {
+    pub id: MemoryId,
+    pub namespace: Namespace,
+    pub kind: ChangeKind,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryId, Namespace};
+
+    #[test]
+    fn change_kind_round_trips_all_variants() {
+        for kind in [
+            ChangeKind::Created,
+            ChangeKind::Updated,
+            ChangeKind::Archived,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: ChangeKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn memory_changed_round_trips_and_clones() {
+        let evt = MemoryChanged {
+            id: MemoryId::new(),
+            namespace: Namespace::Project("rusty-brain".into()),
+            kind: ChangeKind::Created,
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        let back: MemoryChanged = serde_json::from_str(&json).unwrap();
+        assert_eq!(evt.id, back.id);
+        assert_eq!(evt.namespace, back.namespace);
+        assert_eq!(evt.kind, back.kind);
+        // Clone is required so broadcast subscribers each get an owned copy.
+        assert_eq!(evt.clone().kind, ChangeKind::Created);
+    }
+}

--- a/crates/rb-daemon/src/error_map.rs
+++ b/crates/rb-daemon/src/error_map.rs
@@ -1,23 +1,48 @@
 use rb_proto::Response;
 use rb_types::Error;
+use tracing::warn;
 
 /// Map a domain error to a stable wire error response.
+///
+/// Client-safe errors (validation / not-found variants) pass their message
+/// through. Internal errors (storage, I/O, migration, serialization,
+/// embedding) are replaced with a generic "internal error" message; the real
+/// detail is logged server-side so it never leaks to the caller.
 pub(crate) fn error_to_response(err: Error) -> Response {
-    let kind = match &err {
-        Error::Storage(_) => "storage",
-        Error::Migration(_) => "migration",
-        Error::NotFound(_) => "not_found",
-        Error::InvalidNamespace(_) => "invalid_namespace",
-        Error::InvalidMemoryType(_) => "invalid_memory_type",
-        Error::InvalidLinkType(_) => "invalid_link_type",
-        Error::Serialization(_) => "serialization",
-        Error::DimensionMismatch { .. } => "dimension_mismatch",
-        Error::Io(_) => "io",
-        Error::Embedding(_) => "embedding",
+    let (kind, message) = match &err {
+        // Client-safe: the message is meaningful to the caller and contains
+        // no internal path or infrastructure detail.
+        Error::NotFound(_) => ("not_found", err.to_string()),
+        Error::InvalidNamespace(_) => ("invalid_namespace", err.to_string()),
+        Error::InvalidMemoryType(_) => ("invalid_memory_type", err.to_string()),
+        Error::InvalidLinkType(_) => ("invalid_link_type", err.to_string()),
+        Error::DimensionMismatch { .. } => ("dimension_mismatch", err.to_string()),
+
+        // Internal: log the real detail, send a generic message to the client.
+        Error::Storage(_) => {
+            warn!(error = %err, "internal storage error");
+            ("storage", "internal error".to_string())
+        }
+        Error::Io(_) => {
+            warn!(error = %err, "internal io error");
+            ("io", "internal error".to_string())
+        }
+        Error::Migration(_) => {
+            warn!(error = %err, "internal migration error");
+            ("migration", "internal error".to_string())
+        }
+        Error::Serialization(_) => {
+            warn!(error = %err, "internal serialization error");
+            ("serialization", "internal error".to_string())
+        }
+        Error::Embedding(_) => {
+            warn!(error = %err, "internal embedding error");
+            ("embedding", "internal error".to_string())
+        }
     };
     Response::Error {
         kind: kind.to_string(),
-        message: err.to_string(),
+        message,
     }
 }
 
@@ -60,12 +85,50 @@ mod tests {
     }
 
     #[test]
-    fn message_does_not_leak_struct_internals() {
-        let r = error_to_response(Error::Storage("disk full".into()));
-        if let Response::Error { message, .. } = r {
-            assert_eq!(message, "storage error: disk full");
+    fn internal_errors_do_not_leak_detail_over_wire() {
+        // Storage errors with internal detail must not expose that detail
+        // in the wire message — only the generic "internal error" sentinel.
+        let r = error_to_response(Error::Storage("/secret/path: permission denied".into()));
+        if let Response::Error { message, kind } = r {
+            assert_eq!(kind, "storage");
+            assert_eq!(
+                message, "internal error",
+                "wire message must not contain internal Storage detail"
+            );
+            assert!(
+                !message.contains("/secret/path"),
+                "internal path must not appear in wire message"
+            );
         } else {
             panic!("expected error response");
+        }
+    }
+
+    #[test]
+    fn client_safe_errors_pass_through_message() {
+        // NotFound, InvalidNamespace, InvalidMemoryType, InvalidLinkType,
+        // and DimensionMismatch are safe to forward verbatim.
+        let id = MemoryId::new();
+        let cases: Vec<Error> = vec![
+            Error::NotFound(id),
+            Error::InvalidNamespace("bad-ns".into()),
+            Error::InvalidMemoryType("bad-type".into()),
+            Error::InvalidLinkType("bad-link".into()),
+            Error::DimensionMismatch {
+                expected: 512,
+                got: 768,
+            },
+        ];
+        for err in cases {
+            let display = err.to_string();
+            if let Response::Error { message, .. } = error_to_response(err) {
+                assert_eq!(
+                    message, display,
+                    "client-safe error message must be forwarded verbatim"
+                );
+            } else {
+                panic!("expected Response::Error");
+            }
         }
     }
 }

--- a/crates/rb-daemon/src/error_map.rs
+++ b/crates/rb-daemon/src/error_map.rs
@@ -1,0 +1,71 @@
+use rb_proto::Response;
+use rb_types::Error;
+
+/// Map a domain error to a stable wire error response.
+pub(crate) fn error_to_response(err: Error) -> Response {
+    let kind = match &err {
+        Error::Storage(_) => "storage",
+        Error::Migration(_) => "migration",
+        Error::NotFound(_) => "not_found",
+        Error::InvalidNamespace(_) => "invalid_namespace",
+        Error::InvalidMemoryType(_) => "invalid_memory_type",
+        Error::InvalidLinkType(_) => "invalid_link_type",
+        Error::Serialization(_) => "serialization",
+        Error::DimensionMismatch { .. } => "dimension_mismatch",
+        Error::Io(_) => "io",
+        Error::Embedding(_) => "embedding",
+    };
+    Response::Error {
+        kind: kind.to_string(),
+        message: err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use rb_proto::Response;
+    use rb_types::{Error, MemoryId};
+
+    #[test]
+    fn maps_each_error_to_stable_kind() {
+        let cases: Vec<(Error, &str)> = vec![
+            (Error::Storage("x".into()), "storage"),
+            (Error::Migration("x".into()), "migration"),
+            (Error::NotFound(MemoryId::new()), "not_found"),
+            (Error::InvalidNamespace("x".into()), "invalid_namespace"),
+            (Error::InvalidMemoryType("x".into()), "invalid_memory_type"),
+            (Error::InvalidLinkType("x".into()), "invalid_link_type"),
+            (Error::Serialization("x".into()), "serialization"),
+            (
+                Error::DimensionMismatch {
+                    expected: 1,
+                    got: 2,
+                },
+                "dimension_mismatch",
+            ),
+            (Error::Io("x".into()), "io"),
+            (Error::Embedding("x".into()), "embedding"),
+        ];
+        for (err, expected_kind) in cases {
+            match error_to_response(err) {
+                Response::Error { kind, message } => {
+                    assert_eq!(kind, expected_kind);
+                    assert!(!message.is_empty(), "message is populated");
+                }
+                other => panic!("expected Response::Error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn message_does_not_leak_struct_internals() {
+        let r = error_to_response(Error::Storage("disk full".into()));
+        if let Response::Error { message, .. } = r {
+            assert_eq!(message, "storage error: disk full");
+        } else {
+            panic!("expected error response");
+        }
+    }
+}

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -1,0 +1,7 @@
+//! `rb_daemon`: the single-writer rusty-brain service.
+//!
+//! One dedicated OS thread owns the write connection (rusqlite is `!Sync`);
+//! reads run on a bounded pool via `spawn_blocking`; commits broadcast a
+//! `MemoryChanged` event. A UDS listener dispatches per-connection engines
+//! with server-side namespace isolation. Concrete types are added later.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -7,11 +7,14 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod change;
+mod error_map;
 mod paths;
+mod server;
 mod shared_embedder;
 mod store_handle;
 
 pub use change::{ChangeKind, MemoryChanged};
 pub use paths::{default_db_path, default_socket_path};
+pub use server::{Daemon, DaemonConfig};
 pub use shared_embedder::SharedEmbedder;
 pub use store_handle::StoreHandle;

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -1,7 +1,11 @@
-//! `rb_daemon`: the single-writer rusty-brain service.
+//! `rb_daemon`: single-writer service over `rb_store`.
 //!
-//! One dedicated OS thread owns the write connection (rusqlite is `!Sync`);
-//! reads run on a bounded pool via `spawn_blocking`; commits broadcast a
-//! `MemoryChanged` event. A UDS listener dispatches per-connection engines
-//! with server-side namespace isolation. Concrete types are added later.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+//! One dedicated OS thread owns the write `SqliteStore` (rusqlite is `!Sync`,
+//! so the write connection never crosses threads); a bounded pool of read
+//! stores serves concurrent reads via `spawn_blocking`; a Unix-domain-socket
+//! listener frames `rb_proto` requests to a per-connection `MemoryEngine`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod change;
+
+pub use change::{ChangeKind, MemoryChanged};

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -7,7 +7,11 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod change;
+mod paths;
+mod shared_embedder;
 mod store_handle;
 
 pub use change::{ChangeKind, MemoryChanged};
+pub use paths::{default_db_path, default_socket_path};
+pub use shared_embedder::SharedEmbedder;
 pub use store_handle::StoreHandle;

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -7,5 +7,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod change;
+mod store_handle;
 
 pub use change::{ChangeKind, MemoryChanged};
+pub use store_handle::StoreHandle;

--- a/crates/rb-daemon/src/paths.rs
+++ b/crates/rb-daemon/src/paths.rs
@@ -82,9 +82,35 @@ pub fn default_db_path() -> Result<PathBuf> {
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
 
     #[test]
     fn socket_path_is_under_a_rusty_brain_dir_named_sock() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let p = default_socket_path().unwrap();
         assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("sock"));
         assert!(
@@ -104,13 +130,13 @@ mod tests {
 
     #[test]
     fn xdg_runtime_dir_is_honored_for_socket() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        let _guard = EnvGuard::set("XDG_RUNTIME_DIR", dir.path());
         let p = default_socket_path().unwrap();
         assert!(
             p.starts_with(dir.path()),
             "socket must live under XDG_RUNTIME_DIR when set: {p:?}"
         );
-        std::env::remove_var("XDG_RUNTIME_DIR");
     }
 }

--- a/crates/rb-daemon/src/paths.rs
+++ b/crates/rb-daemon/src/paths.rs
@@ -2,29 +2,80 @@ use std::path::PathBuf;
 
 use rb_types::{Error, Result};
 
-/// Default Unix-domain-socket path.
-pub fn default_socket_path() -> Result<PathBuf> {
-    if let Some(rt) = std::env::var_os("XDG_RUNTIME_DIR") {
-        let rt = PathBuf::from(rt);
-        if !rt.as_os_str().is_empty() {
-            return Ok(rt.join("rusty-brain").join("sock"));
+fn nonempty_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn home_dir() -> Result<PathBuf> {
+    nonempty_env_path("HOME")
+        .or_else(|| nonempty_env_path("USERPROFILE"))
+        .ok_or_else(|| Error::Io("cannot determine a home directory".to_string()))
+}
+
+fn cache_base_dir() -> Result<PathBuf> {
+    if let Some(path) = nonempty_env_path("XDG_CACHE_HOME") {
+        return Ok(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(home_dir()?.join("Library").join("Caches"))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(path) = nonempty_env_path("LOCALAPPDATA") {
+            Ok(path)
+        } else {
+            Ok(home_dir()?.join("AppData").join("Local"))
         }
     }
 
-    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
-        .ok_or_else(|| Error::Io("cannot determine a runtime directory".to_string()))?;
-    let base = dirs
-        .runtime_dir()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| dirs.cache_dir().to_path_buf());
-    Ok(base.join("rusty-brain").join("sock"))
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Ok(home_dir()?.join(".cache"))
+    }
+}
+
+fn data_base_dir() -> Result<PathBuf> {
+    if let Some(path) = nonempty_env_path("XDG_DATA_HOME") {
+        return Ok(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(home_dir()?.join("Library").join("Application Support"))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(path) = nonempty_env_path("APPDATA") {
+            Ok(path)
+        } else {
+            Ok(home_dir()?.join("AppData").join("Roaming"))
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Ok(home_dir()?.join(".local").join("share"))
+    }
+}
+
+/// Default Unix-domain-socket path.
+pub fn default_socket_path() -> Result<PathBuf> {
+    if let Some(rt) = nonempty_env_path("XDG_RUNTIME_DIR") {
+        return Ok(rt.join("rusty-brain").join("sock"));
+    }
+
+    Ok(cache_base_dir()?.join("rusty-brain").join("sock"))
 }
 
 /// Default database path.
 pub fn default_db_path() -> Result<PathBuf> {
-    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
-        .ok_or_else(|| Error::Io("cannot determine a data directory".to_string()))?;
-    Ok(dirs.data_dir().join("memory.db"))
+    Ok(data_base_dir()?.join("rusty-brain").join("memory.db"))
 }
 
 #[cfg(test)]

--- a/crates/rb-daemon/src/paths.rs
+++ b/crates/rb-daemon/src/paths.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+
+use rb_types::{Error, Result};
+
+/// Default Unix-domain-socket path.
+pub fn default_socket_path() -> Result<PathBuf> {
+    if let Some(rt) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let rt = PathBuf::from(rt);
+        if !rt.as_os_str().is_empty() {
+            return Ok(rt.join("rusty-brain").join("sock"));
+        }
+    }
+
+    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
+        .ok_or_else(|| Error::Io("cannot determine a runtime directory".to_string()))?;
+    let base = dirs
+        .runtime_dir()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs.cache_dir().to_path_buf());
+    Ok(base.join("rusty-brain").join("sock"))
+}
+
+/// Default database path.
+pub fn default_db_path() -> Result<PathBuf> {
+    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
+        .ok_or_else(|| Error::Io("cannot determine a data directory".to_string()))?;
+    Ok(dirs.data_dir().join("memory.db"))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn socket_path_is_under_a_rusty_brain_dir_named_sock() {
+        let p = default_socket_path().unwrap();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("sock"));
+        assert!(
+            p.parent()
+                .and_then(|d| d.file_name())
+                .and_then(|s| s.to_str())
+                == Some("rusty-brain"),
+            "socket lives in a rusty-brain directory: {p:?}"
+        );
+    }
+
+    #[test]
+    fn db_path_ends_with_rusty_brain_db_file() {
+        let p = default_db_path().unwrap();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("memory.db"));
+    }
+
+    #[test]
+    fn xdg_runtime_dir_is_honored_for_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        let p = default_socket_path().unwrap();
+        assert!(
+            p.starts_with(dir.path()),
+            "socket must live under XDG_RUNTIME_DIR when set: {p:?}"
+        );
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -10,13 +10,16 @@ use std::path::{Path, PathBuf};
 use rb_embed::EmbeddingProvider;
 use rb_engine::{MemoryEngine, RememberInput};
 use rb_proto::{
-    read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+    bounded_framed, read_frame, write_frame, Handshake, HandshakeAck, Request, Response,
+    CONTRACT_VERSION,
 };
 use rb_types::{Error, Result};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tokio::time::timeout;
 use tracing::{info, warn};
+use std::sync::Arc;
 
 use crate::error_map::error_to_response;
 use crate::{SharedEmbedder, StoreHandle};
@@ -25,6 +28,12 @@ use crate::{SharedEmbedder, StoreHandle};
 const MAX_LIMIT: usize = 1000;
 /// Maximum graph traversal depth per Graph request.
 const MAX_DEPTH: u8 = 8;
+/// Maximum number of simultaneous client connections.
+const MAX_CONNECTIONS: usize = 256;
+/// Idle deadline for the initial handshake read (fail fast on stalled connects).
+const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Idle deadline between consecutive request frames from an established client.
+const REQUEST_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Static configuration for a daemon instance.
 #[derive(Clone, Debug)]
@@ -114,6 +123,7 @@ impl Daemon {
         } = self;
         tokio::pin!(shutdown);
         let mut conns: JoinSet<()> = JoinSet::new();
+        let conn_sem = Arc::new(Semaphore::new(MAX_CONNECTIONS));
 
         loop {
             tokio::select! {
@@ -127,7 +137,20 @@ impl Daemon {
                         Ok((stream, _addr)) => {
                             let store = store.clone();
                             let embedder = embedder.clone();
+                            // Acquire a connection permit before spawning.
+                            // If all permits are taken, this back-pressures the
+                            // accept loop (the biased select still drains JoinSet
+                            // results on the next iteration, returning permits).
+                            let permit = match conn_sem.clone().try_acquire_owned() {
+                                Ok(p) => p,
+                                Err(_) => {
+                                    warn!("connection cap ({MAX_CONNECTIONS}) reached; dropping connection");
+                                    drop(stream);
+                                    continue;
+                                }
+                            };
                             conns.spawn(async move {
+                                let _permit = permit; // released when task completes
                                 if let Err(e) = handle_connection(stream, store, embedder).await {
                                     warn!(error = %e, "connection ended with error");
                                 }
@@ -277,7 +300,7 @@ fn lock_pidfile(pidfile: &File, socket_path: &Path, pidfile_path: &Path) -> Resu
 async fn probe_live(path: &Path) -> bool {
     match UnixStream::connect(path).await {
         Ok(stream) => {
-            let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+            let mut framed = bounded_framed(stream);
             let hs = Handshake {
                 contract_version: CONTRACT_VERSION,
                 namespace: rb_types::Namespace::Global,
@@ -303,8 +326,14 @@ async fn handle_connection(
     store: StoreHandle,
     embedder: SharedEmbedder,
 ) -> Result<()> {
-    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
-    let handshake: Handshake = read_frame(&mut framed).await?;
+    let mut framed = bounded_framed(stream);
+
+    // Enforce a short deadline for the handshake so a stalled client cannot
+    // tie up a connection slot indefinitely before even identifying itself.
+    let handshake: Handshake = match timeout(HANDSHAKE_TIMEOUT, read_frame(&mut framed)).await {
+        Ok(Ok(hs)) => hs,
+        Ok(Err(_)) | Err(_) => return Ok(()), // parse error or timeout: drop silently
+    };
 
     if handshake.contract_version != CONTRACT_VERSION {
         let ack = HandshakeAck {
@@ -340,9 +369,14 @@ async fn handle_connection(
 
     let engine = MemoryEngine::new(store, embedder, namespace);
     loop {
-        let req: Request = match read_frame::<_, Request>(&mut framed).await {
-            Ok(req) => req,
-            Err(_) => break,
+        // Break the loop if the client is idle for too long between requests.
+        let req: Request = match timeout(REQUEST_IDLE_TIMEOUT, read_frame(&mut framed)).await {
+            Ok(Ok(req)) => req,
+            Ok(Err(_)) => break, // parse error or clean close
+            Err(_) => {
+                warn!("client idle timeout; closing connection");
+                break;
+            }
         };
         let resp = dispatch(&engine, req).await;
         write_frame(&mut framed, &resp).await?;

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1,0 +1,288 @@
+//! Unix-domain-socket server for the daemon.
+
+use std::fs;
+use std::future::Future;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use rb_embed::EmbeddingProvider;
+use rb_engine::{MemoryEngine, RememberInput};
+use rb_proto::{
+    read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+use rb_types::{Error, Result};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinSet;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing::{info, warn};
+
+use crate::error_map::error_to_response;
+use crate::{SharedEmbedder, StoreHandle};
+
+/// Static configuration for a daemon instance.
+#[derive(Clone, Debug)]
+pub struct DaemonConfig {
+    pub socket_path: PathBuf,
+    pub db_path: PathBuf,
+    pub read_pool_size: usize,
+}
+
+/// A bound, ready-to-run daemon.
+pub struct Daemon {
+    listener: UnixListener,
+    store: StoreHandle,
+    embedder: SharedEmbedder,
+    socket_path: PathBuf,
+    pidfile_path: PathBuf,
+}
+
+impl std::fmt::Debug for Daemon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Daemon")
+            .field("socket_path", &self.socket_path)
+            .field("pidfile_path", &self.pidfile_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Daemon {
+    /// Bind the daemon socket and initialize the backing store.
+    pub async fn bind(config: DaemonConfig, embedder: SharedEmbedder) -> Result<Self> {
+        let dim = embedder.dim();
+
+        if let Some(parent) = config.db_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| Error::Io(format!("create db dir {}: {e}", parent.display())))?;
+        }
+
+        if config.socket_path.exists() {
+            if probe_live(&config.socket_path).await {
+                return Err(Error::Io(format!(
+                    "another rusty-brain daemon is already listening at {}",
+                    config.socket_path.display()
+                )));
+            }
+            let _ = fs::remove_file(&config.socket_path);
+        }
+
+        let socket_dir = config
+            .socket_path
+            .parent()
+            .ok_or_else(|| Error::Io("socket path has no parent dir".to_string()))?
+            .to_path_buf();
+        fs::create_dir_all(&socket_dir)
+            .map_err(|e| Error::Io(format!("create socket dir {}: {e}", socket_dir.display())))?;
+        fs::set_permissions(&socket_dir, fs::Permissions::from_mode(0o700))
+            .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", socket_dir.display())))?;
+
+        let listener = UnixListener::bind(&config.socket_path)
+            .map_err(|e| Error::Io(format!("bind {}: {e}", config.socket_path.display())))?;
+        fs::set_permissions(&config.socket_path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| Error::Io(format!("chmod 0600 {}: {e}", config.socket_path.display())))?;
+
+        let store = StoreHandle::start(config.db_path.clone(), dim, config.read_pool_size)?;
+        let pidfile_path = config.socket_path.with_extension("pid");
+        fs::write(&pidfile_path, std::process::id().to_string())
+            .map_err(|e| Error::Io(format!("write pidfile: {e}")))?;
+
+        info!(socket = %config.socket_path.display(), "daemon bound");
+        Ok(Self {
+            listener,
+            store,
+            embedder,
+            socket_path: config.socket_path,
+            pidfile_path,
+        })
+    }
+
+    /// Run until `shutdown` resolves, then drain connections and clean up.
+    pub async fn run(self, shutdown: impl Future<Output = ()>) -> Result<()> {
+        let Daemon {
+            listener,
+            store,
+            embedder,
+            socket_path,
+            pidfile_path,
+        } = self;
+        tokio::pin!(shutdown);
+        let mut conns: JoinSet<()> = JoinSet::new();
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    info!("shutdown signal received; stopping accept loop");
+                    break;
+                }
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((stream, _addr)) => {
+                            let store = store.clone();
+                            let embedder = embedder.clone();
+                            conns.spawn(async move {
+                                if let Err(e) = handle_connection(stream, store, embedder).await {
+                                    warn!(error = %e, "connection ended with error");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "accept failed");
+                        }
+                    }
+                }
+                Some(_joined) = conns.join_next() => {}
+            }
+        }
+
+        drop(listener);
+        conns.shutdown().await;
+        store.shutdown().await;
+
+        let _ = fs::remove_file(&socket_path);
+        let _ = fs::remove_file(&pidfile_path);
+        info!("daemon shut down cleanly");
+        Ok(())
+    }
+}
+
+async fn probe_live(path: &Path) -> bool {
+    match UnixStream::connect(path).await {
+        Ok(stream) => {
+            let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+            let hs = Handshake {
+                contract_version: CONTRACT_VERSION,
+                namespace: rb_types::Namespace::Global,
+            };
+            if write_frame(&mut framed, &hs).await.is_err() {
+                return false;
+            }
+            matches!(
+                tokio::time::timeout(
+                    std::time::Duration::from_millis(500),
+                    read_frame::<_, HandshakeAck>(&mut framed),
+                )
+                .await,
+                Ok(Ok(_))
+            )
+        }
+        Err(_) => false,
+    }
+}
+
+async fn handle_connection(
+    stream: UnixStream,
+    store: StoreHandle,
+    embedder: SharedEmbedder,
+) -> Result<()> {
+    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+    let handshake: Handshake = read_frame(&mut framed).await?;
+
+    if handshake.contract_version != CONTRACT_VERSION {
+        let ack = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: false,
+            message: Some(format!(
+                "contract mismatch: server {CONTRACT_VERSION}, client {}",
+                handshake.contract_version
+            )),
+        };
+        write_frame(&mut framed, &ack).await?;
+        return Ok(());
+    }
+
+    let namespace = handshake.namespace;
+    let ack = HandshakeAck {
+        contract_version: CONTRACT_VERSION,
+        ok: true,
+        message: None,
+    };
+    write_frame(&mut framed, &ack).await?;
+
+    let engine = MemoryEngine::new(store, embedder, namespace);
+    loop {
+        let req: Request = match read_frame::<_, Request>(&mut framed).await {
+            Ok(req) => req,
+            Err(_) => break,
+        };
+        let resp = dispatch(&engine, req).await;
+        write_frame(&mut framed, &resp).await?;
+    }
+
+    Ok(())
+}
+
+async fn dispatch<P>(engine: &MemoryEngine<StoreHandle, P>, req: Request) -> Response
+where
+    P: EmbeddingProvider,
+{
+    match req {
+        Request::Ping => Response::Pong {
+            contract_version: CONTRACT_VERSION,
+        },
+        Request::Remember {
+            content,
+            context,
+            memory_type,
+            importance,
+            keywords,
+            tags,
+            related_files,
+        } => {
+            let input = RememberInput {
+                content,
+                context,
+                memory_type,
+                importance,
+                keywords,
+                tags,
+                related_files,
+            };
+            match engine.remember(input).await {
+                Ok(id) => Response::Remembered { id },
+                Err(e) => error_to_response(e),
+            }
+        }
+        Request::Recall {
+            query,
+            scope: _,
+            memory_type,
+            tags,
+            limit,
+        } => match engine.recall(&query, limit, memory_type, &tags).await {
+            Ok(results) => Response::Recalled { results },
+            Err(e) => error_to_response(e),
+        },
+        Request::Get { id } => match engine.get(id).await {
+            Ok(memory) => Response::Got { memory },
+            Err(e) => error_to_response(e),
+        },
+        Request::List {
+            scope: _,
+            min_importance,
+            limit,
+        } => match engine.list(min_importance, limit).await {
+            Ok(memories) => Response::Listed { memories },
+            Err(e) => error_to_response(e),
+        },
+        Request::Graph { id, depth } => match engine.graph(id, depth).await {
+            Ok(memories) => Response::GraphResult { memories },
+            Err(e) => error_to_response(e),
+        },
+        Request::Update { id, updates } => match engine.update(id, updates).await {
+            Ok(()) => Response::Updated,
+            Err(e) => error_to_response(e),
+        },
+        Request::Delete { id } => match engine.delete(id).await {
+            Ok(()) => Response::Deleted,
+            Err(e) => error_to_response(e),
+        },
+        Request::Context => match engine.context().await {
+            Ok((recent, important, total)) => Response::ContextResult {
+                recent,
+                important,
+                total,
+            },
+            Err(e) => error_to_response(e),
+        },
+    }
+}

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -389,7 +389,6 @@ where
         }
         Request::Recall {
             query,
-            scope: _,
             memory_type,
             tags,
             limit,
@@ -402,7 +401,6 @@ where
             Err(e) => error_to_response(e),
         },
         Request::List {
-            scope: _,
             min_importance,
             limit,
         } => match engine.list(min_importance, limit).await {

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -21,6 +21,11 @@ use tracing::{info, warn};
 use crate::error_map::error_to_response;
 use crate::{SharedEmbedder, StoreHandle};
 
+/// Maximum number of results returned per Recall or List request.
+const MAX_LIMIT: usize = 1000;
+/// Maximum graph traversal depth per Graph request.
+const MAX_DEPTH: u8 = 8;
+
 /// Static configuration for a daemon instance.
 #[derive(Clone, Debug)]
 pub struct DaemonConfig {
@@ -392,7 +397,10 @@ where
             memory_type,
             tags,
             limit,
-        } => match engine.recall(&query, limit, memory_type, &tags).await {
+        } => match engine
+            .recall(&query, limit.min(MAX_LIMIT), memory_type, &tags)
+            .await
+        {
             Ok(results) => Response::Recalled { results },
             Err(e) => error_to_response(e),
         },
@@ -403,11 +411,11 @@ where
         Request::List {
             min_importance,
             limit,
-        } => match engine.list(min_importance, limit).await {
+        } => match engine.list(min_importance, limit.min(MAX_LIMIT)).await {
             Ok(memories) => Response::Listed { memories },
             Err(e) => error_to_response(e),
         },
-        Request::Graph { id, depth } => match engine.graph(id, depth).await {
+        Request::Graph { id, depth } => match engine.graph(id, depth.min(MAX_DEPTH)).await {
             Ok(memories) => Response::GraphResult { memories },
             Err(e) => error_to_response(e),
         },

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1,8 +1,10 @@
 //! Unix-domain-socket server for the daemon.
 
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::future::Future;
-use std::os::unix::fs::PermissionsExt;
+use std::io::{Seek, SeekFrom, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use rb_embed::EmbeddingProvider;
@@ -34,6 +36,7 @@ pub struct Daemon {
     embedder: SharedEmbedder,
     socket_path: PathBuf,
     pidfile_path: PathBuf,
+    bind_guard: BindGuard,
 }
 
 impl std::fmt::Debug for Daemon {
@@ -55,16 +58,6 @@ impl Daemon {
                 .map_err(|e| Error::Io(format!("create db dir {}: {e}", parent.display())))?;
         }
 
-        if config.socket_path.exists() {
-            if probe_live(&config.socket_path).await {
-                return Err(Error::Io(format!(
-                    "another rusty-brain daemon is already listening at {}",
-                    config.socket_path.display()
-                )));
-            }
-            let _ = fs::remove_file(&config.socket_path);
-        }
-
         let socket_dir = config
             .socket_path
             .parent()
@@ -75,15 +68,31 @@ impl Daemon {
         fs::set_permissions(&socket_dir, fs::Permissions::from_mode(0o700))
             .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", socket_dir.display())))?;
 
+        let pidfile_path = config.socket_path.with_extension("pid");
+        let mut bind_guard = BindGuard::acquire(config.socket_path.clone(), pidfile_path.clone())?;
+
+        if config.socket_path.exists() {
+            if probe_live(&config.socket_path).await {
+                return Err(Error::Io(format!(
+                    "another rusty-brain daemon is already listening at {}",
+                    config.socket_path.display()
+                )));
+            }
+            fs::remove_file(&config.socket_path).map_err(|e| {
+                Error::Io(format!(
+                    "remove stale socket {}: {e}",
+                    config.socket_path.display()
+                ))
+            })?;
+        }
+
         let listener = UnixListener::bind(&config.socket_path)
             .map_err(|e| Error::Io(format!("bind {}: {e}", config.socket_path.display())))?;
         fs::set_permissions(&config.socket_path, fs::Permissions::from_mode(0o600))
             .map_err(|e| Error::Io(format!("chmod 0600 {}: {e}", config.socket_path.display())))?;
+        bind_guard.mark_socket_bound();
 
         let store = StoreHandle::start(config.db_path.clone(), dim, config.read_pool_size)?;
-        let pidfile_path = config.socket_path.with_extension("pid");
-        fs::write(&pidfile_path, std::process::id().to_string())
-            .map_err(|e| Error::Io(format!("write pidfile: {e}")))?;
 
         info!(socket = %config.socket_path.display(), "daemon bound");
         Ok(Self {
@@ -92,6 +101,7 @@ impl Daemon {
             embedder,
             socket_path: config.socket_path,
             pidfile_path,
+            bind_guard,
         })
     }
 
@@ -101,8 +111,9 @@ impl Daemon {
             listener,
             store,
             embedder,
-            socket_path,
-            pidfile_path,
+            socket_path: _socket_path,
+            pidfile_path: _pidfile_path,
+            mut bind_guard,
         } = self;
         tokio::pin!(shutdown);
         let mut conns: JoinSet<()> = JoinSet::new();
@@ -138,11 +149,102 @@ impl Daemon {
         conns.shutdown().await;
         store.shutdown().await;
 
-        let _ = fs::remove_file(&socket_path);
-        let _ = fs::remove_file(&pidfile_path);
+        bind_guard.cleanup();
         info!("daemon shut down cleanly");
         Ok(())
     }
+}
+
+struct BindGuard {
+    socket_path: PathBuf,
+    pidfile_path: PathBuf,
+    _pidfile: File,
+    owns_socket: bool,
+    active: bool,
+}
+
+impl BindGuard {
+    fn acquire(socket_path: PathBuf, pidfile_path: PathBuf) -> Result<Self> {
+        let pidfile = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(&pidfile_path)
+            .map_err(|e| Error::Io(format!("open pidfile {}: {e}", pidfile_path.display())))?;
+        fs::set_permissions(&pidfile_path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| Error::Io(format!("chmod 0600 {}: {e}", pidfile_path.display())))?;
+        lock_pidfile(&pidfile, &socket_path, &pidfile_path)?;
+        write_pidfile(&pidfile, &pidfile_path)?;
+
+        Ok(Self {
+            socket_path,
+            pidfile_path,
+            _pidfile: pidfile,
+            owns_socket: false,
+            active: true,
+        })
+    }
+
+    fn mark_socket_bound(&mut self) {
+        self.owns_socket = true;
+    }
+
+    fn cleanup(&mut self) {
+        if !self.active {
+            return;
+        }
+        if self.owns_socket {
+            let _ = fs::remove_file(&self.socket_path);
+        }
+        let _ = fs::remove_file(&self.pidfile_path);
+        self.active = false;
+    }
+}
+
+impl Drop for BindGuard {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn write_pidfile(mut pidfile: &File, pidfile_path: &Path) -> Result<()> {
+    pidfile
+        .set_len(0)
+        .map_err(|e| Error::Io(format!("truncate pidfile {}: {e}", pidfile_path.display())))?;
+    pidfile
+        .seek(SeekFrom::Start(0))
+        .map_err(|e| Error::Io(format!("seek pidfile {}: {e}", pidfile_path.display())))?;
+    write!(pidfile, "{}", std::process::id())
+        .map_err(|e| Error::Io(format!("write pidfile {}: {e}", pidfile_path.display())))?;
+    pidfile
+        .flush()
+        .map_err(|e| Error::Io(format!("flush pidfile {}: {e}", pidfile_path.display())))
+}
+
+#[allow(unsafe_code)]
+fn lock_pidfile(pidfile: &File, socket_path: &Path, pidfile_path: &Path) -> Result<()> {
+    // SAFETY: flock only reads the borrowed file descriptor for the duration of
+    // the call. The File outlives the lock and is held by BindGuard.
+    let rc = unsafe { libc::flock(pidfile.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        return Ok(());
+    }
+
+    let err = std::io::Error::last_os_error();
+    if err.kind() == std::io::ErrorKind::WouldBlock {
+        return Err(Error::Io(format!(
+            "another rusty-brain daemon is already listening at {} (pidfile {} is locked)",
+            socket_path.display(),
+            pidfile_path.display()
+        )));
+    }
+
+    Err(Error::Io(format!(
+        "lock pidfile {}: {err}",
+        pidfile_path.display()
+    )))
 }
 
 async fn probe_live(path: &Path) -> bool {

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -58,15 +58,7 @@ impl Daemon {
                 .map_err(|e| Error::Io(format!("create db dir {}: {e}", parent.display())))?;
         }
 
-        let socket_dir = config
-            .socket_path
-            .parent()
-            .ok_or_else(|| Error::Io("socket path has no parent dir".to_string()))?
-            .to_path_buf();
-        fs::create_dir_all(&socket_dir)
-            .map_err(|e| Error::Io(format!("create socket dir {}: {e}", socket_dir.display())))?;
-        fs::set_permissions(&socket_dir, fs::Permissions::from_mode(0o700))
-            .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", socket_dir.display())))?;
+        prepare_socket_dir(&config.socket_path)?;
 
         let pidfile_path = config.socket_path.with_extension("pid");
         let mut bind_guard = BindGuard::acquire(config.socket_path.clone(), pidfile_path.clone())?;
@@ -153,6 +145,36 @@ impl Daemon {
         info!("daemon shut down cleanly");
         Ok(())
     }
+}
+
+fn prepare_socket_dir(socket_path: &Path) -> Result<()> {
+    let socket_dir = socket_path
+        .parent()
+        .ok_or_else(|| Error::Io("socket path has no parent dir".to_string()))?;
+
+    if socket_dir.exists() {
+        let metadata = fs::metadata(socket_dir)
+            .map_err(|e| Error::Io(format!("stat socket dir {}: {e}", socket_dir.display())))?;
+        if !metadata.is_dir() {
+            return Err(Error::Io(format!(
+                "socket parent {} is not a directory",
+                socket_dir.display()
+            )));
+        }
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode != 0o700 {
+            return Err(Error::Io(format!(
+                "socket dir {} must already be private (0700), got {mode:03o}",
+                socket_dir.display()
+            )));
+        }
+        return Ok(());
+    }
+
+    fs::create_dir_all(socket_dir)
+        .map_err(|e| Error::Io(format!("create socket dir {}: {e}", socket_dir.display())))?;
+    fs::set_permissions(socket_dir, fs::Permissions::from_mode(0o700))
+        .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", socket_dir.display())))
 }
 
 struct BindGuard {
@@ -292,7 +314,18 @@ async fn handle_connection(
         return Ok(());
     }
 
-    let namespace = handshake.namespace;
+    let namespace = match validate_namespace(handshake.namespace) {
+        Ok(namespace) => namespace,
+        Err(e) => {
+            let ack = HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: false,
+                message: Some(e.to_string()),
+            };
+            write_frame(&mut framed, &ack).await?;
+            return Ok(());
+        }
+    };
     let ack = HandshakeAck {
         contract_version: CONTRACT_VERSION,
         ok: true,
@@ -311,6 +344,16 @@ async fn handle_connection(
     }
 
     Ok(())
+}
+
+fn validate_namespace(namespace: rb_types::Namespace) -> Result<rb_types::Namespace> {
+    let encoded = namespace.as_db_string();
+    let parsed = rb_types::Namespace::parse_db_string(&encoded)?;
+    if parsed == namespace {
+        Ok(namespace)
+    } else {
+        Err(Error::InvalidNamespace(encoded))
+    }
 }
 
 async fn dispatch<P>(engine: &MemoryEngine<StoreHandle, P>, req: Request) -> Response
@@ -386,5 +429,59 @@ where
             },
             Err(e) => error_to_response(e),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use rb_types::Namespace;
+
+    #[test]
+    fn prepare_socket_dir_creates_missing_parent_private() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("missing").join("sock");
+
+        prepare_socket_dir(&socket).unwrap();
+
+        let parent = socket.parent().unwrap();
+        let mode = fs::metadata(parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn prepare_socket_dir_rejects_public_existing_parent_without_chmod() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_dir = dir.path().join("public");
+        fs::create_dir(&socket_dir).unwrap();
+        fs::set_permissions(&socket_dir, fs::Permissions::from_mode(0o755)).unwrap();
+        let socket = socket_dir.join("sock");
+
+        let err = prepare_socket_dir(&socket).unwrap_err();
+        assert!(
+            err.to_string().contains("must already be private"),
+            "unexpected error: {err}"
+        );
+        let mode = fs::metadata(&socket_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "daemon must not chmod caller-owned dirs");
+    }
+
+    #[test]
+    fn validate_namespace_rejects_non_persistable_namespaces() {
+        assert!(validate_namespace(Namespace::Global).is_ok());
+        assert!(validate_namespace(Namespace::Project("p".to_string())).is_ok());
+        assert!(matches!(
+            validate_namespace(Namespace::Project(String::new())),
+            Err(Error::InvalidNamespace(_))
+        ));
+        assert!(matches!(
+            validate_namespace(Namespace::Session {
+                project: "p".to_string(),
+                session_id: String::new(),
+            }),
+            Err(Error::InvalidNamespace(_))
+        ));
     }
 }

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -14,12 +14,12 @@ use rb_proto::{
     CONTRACT_VERSION,
 };
 use rb_types::{Error, Result};
+use std::sync::Arc;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tracing::{info, warn};
-use std::sync::Arc;
 
 use crate::error_map::error_to_response;
 use crate::{SharedEmbedder, StoreHandle};

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -137,10 +137,10 @@ impl Daemon {
                         Ok((stream, _addr)) => {
                             let store = store.clone();
                             let embedder = embedder.clone();
-                            // Acquire a connection permit before spawning.
-                            // If all permits are taken, this back-pressures the
-                            // accept loop (the biased select still drains JoinSet
-                            // results on the next iteration, returning permits).
+                            // Acquire a connection permit before spawning. If
+                            // all permits are taken, drop the newly accepted
+                            // stream immediately instead of queueing unbounded
+                            // per-connection tasks.
                             let permit = match conn_sem.clone().try_acquire_owned() {
                                 Ok(p) => p,
                                 Err(_) => {

--- a/crates/rb-daemon/src/shared_embedder.rs
+++ b/crates/rb-daemon/src/shared_embedder.rs
@@ -1,0 +1,63 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rb_embed::EmbeddingProvider;
+use rb_types::Result;
+
+/// Reference-counted, cloneable embedding provider shared by all connections.
+#[derive(Clone)]
+pub struct SharedEmbedder {
+    inner: Arc<dyn EmbeddingProvider>,
+}
+
+impl SharedEmbedder {
+    /// Wrap any concrete provider.
+    pub fn new<P: EmbeddingProvider + 'static>(provider: P) -> Self {
+        Self {
+            inner: Arc::new(provider),
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for SharedEmbedder {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.inner.embed(texts).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_embed::{DeterministicProvider, EmbeddingProvider};
+
+    #[tokio::test]
+    async fn shared_embedder_delegates_dim_and_embed() {
+        let inner = DeterministicProvider::new(8);
+        let model = inner.model_id().to_string();
+        let shared = SharedEmbedder::new(inner);
+        assert_eq!(shared.dim(), 8);
+        assert_eq!(shared.model_id(), model);
+        let out = shared.embed(&["hello".to_string()]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), 8);
+    }
+
+    #[tokio::test]
+    async fn cloning_shares_one_instance() {
+        let shared = SharedEmbedder::new(DeterministicProvider::new(8));
+        let clone = shared.clone();
+        let a = shared.embed(&["same".to_string()]).await.unwrap();
+        let b = clone.embed(&["same".to_string()]).await.unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/rb-daemon/src/shared_embedder.rs
+++ b/crates/rb-daemon/src/shared_embedder.rs
@@ -3,18 +3,31 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use rb_embed::EmbeddingProvider;
 use rb_types::Result;
+use tokio::sync::Semaphore;
+
+const DEFAULT_MAX_CONCURRENT_EMBEDDINGS: usize = 4;
 
 /// Reference-counted, cloneable embedding provider shared by all connections.
 #[derive(Clone)]
 pub struct SharedEmbedder {
     inner: Arc<dyn EmbeddingProvider>,
+    permits: Arc<Semaphore>,
 }
 
 impl SharedEmbedder {
     /// Wrap any concrete provider.
     pub fn new<P: EmbeddingProvider + 'static>(provider: P) -> Self {
+        Self::with_concurrency_limit(provider, DEFAULT_MAX_CONCURRENT_EMBEDDINGS)
+    }
+
+    /// Wrap any concrete provider and cap concurrent `embed` calls.
+    pub fn with_concurrency_limit<P: EmbeddingProvider + 'static>(
+        provider: P,
+        max_concurrent: usize,
+    ) -> Self {
         Self {
             inner: Arc::new(provider),
+            permits: Arc::new(Semaphore::new(max_concurrent.max(1))),
         }
     }
 }
@@ -30,6 +43,11 @@ impl EmbeddingProvider for SharedEmbedder {
     }
 
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let _permit = self
+            .permits
+            .acquire()
+            .await
+            .map_err(|_| rb_types::Error::Embedding("embedder semaphore closed".to_string()))?;
         self.inner.embed(texts).await
     }
 }
@@ -39,6 +57,32 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
     use rb_embed::{DeterministicProvider, EmbeddingProvider};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{sleep, Duration};
+
+    struct SlowProvider {
+        active: Arc<AtomicUsize>,
+        max_seen: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl EmbeddingProvider for SlowProvider {
+        fn model_id(&self) -> &str {
+            "slow-test"
+        }
+
+        fn dim(&self) -> usize {
+            2
+        }
+
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_seen.fetch_max(active, Ordering::SeqCst);
+            sleep(Duration::from_millis(50)).await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(vec![vec![1.0, 0.0]; texts.len()])
+        }
+    }
 
     #[tokio::test]
     async fn shared_embedder_delegates_dim_and_embed() {
@@ -59,5 +103,28 @@ mod tests {
         let a = shared.embed(&["same".to_string()]).await.unwrap();
         let b = clone.embed(&["same".to_string()]).await.unwrap();
         assert_eq!(a, b);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shared_embedder_limits_concurrent_embed_calls() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let shared = SharedEmbedder::with_concurrency_limit(
+            SlowProvider {
+                active: Arc::clone(&active),
+                max_seen: Arc::clone(&max_seen),
+            },
+            1,
+        );
+
+        let a = shared.clone();
+        let b = shared.clone();
+        let first = tokio::spawn(async move { a.embed(&["a".to_string()]).await });
+        let second = tokio::spawn(async move { b.embed(&["b".to_string()]).await });
+
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+
+        assert_eq!(max_seen.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -34,6 +34,10 @@ enum WriteCommand {
         id: MemoryId,
         reply: oneshot::Sender<Result<()>>,
     },
+    #[cfg(test)]
+    PanicForTest {
+        reply: oneshot::Sender<Result<()>>,
+    },
     Shutdown {
         reply: oneshot::Sender<()>,
     },
@@ -257,22 +261,31 @@ impl StoreHandle {
     }
 }
 
-/// Execute a store operation inside `catch_unwind` so a panic in the rusqlite
-/// layer does not unwind and kill the writer thread.
+struct StoreOpReport {
+    result: Result<()>,
+    writer_usable: bool,
+}
+
+enum StoreOpOutcome {
+    Completed(Result<()>),
+    Panicked(String),
+}
+
+/// Execute a store operation inside `catch_unwind` so a panic in the store
+/// layer can be converted into an explicit recovery decision.
 ///
 /// `SqliteStore` is not `UnwindSafe` (it wraps a raw FFI connection), so we
-/// use `AssertUnwindSafe`. A rusqlite panic leaves the connection in an
-/// undefined state; after catching one we log at error level and return a
-/// `Storage` error. The writer thread itself survives and continues serving
-/// subsequent commands.
+/// use `AssertUnwindSafe`. A caught panic must not continue on the same
+/// connection; the caller drops and reopens the writer store before serving
+/// further commands.
 #[allow(clippy::panic)]
-fn catch_store_op<F>(store: &SqliteStore, op: F) -> Result<()>
+fn catch_store_op<F>(store: &SqliteStore, op: F) -> StoreOpOutcome
 where
-    F: FnOnce(&SqliteStore) -> Result<()> + std::panic::UnwindSafe,
+    F: FnOnce(&SqliteStore) -> Result<()>,
 {
     use std::panic::{self, AssertUnwindSafe};
     match panic::catch_unwind(AssertUnwindSafe(|| op(store))) {
-        Ok(result) => result,
+        Ok(result) => StoreOpOutcome::Completed(result),
         Err(payload) => {
             let msg = if let Some(s) = payload.downcast_ref::<&str>() {
                 (*s).to_string()
@@ -281,10 +294,75 @@ where
             } else {
                 "unknown panic payload".to_string()
             };
-            tracing::error!(panic = %msg, "writer-thread store op panicked; connection may be degraded");
-            Err(Error::Storage(format!("writer thread panic: {msg}")))
+            StoreOpOutcome::Panicked(msg)
         }
     }
+}
+
+fn run_store_op<F>(
+    store: &mut Option<SqliteStore>,
+    db_path: &Path,
+    embedding_dim: usize,
+    op: F,
+) -> StoreOpReport
+where
+    F: FnOnce(&SqliteStore) -> Result<()>,
+{
+    let outcome = {
+        let Some(active_store) = store.as_ref() else {
+            return StoreOpReport {
+                result: Err(Error::Storage("writer thread unavailable".to_string())),
+                writer_usable: false,
+            };
+        };
+        catch_store_op(active_store, op)
+    };
+
+    match outcome {
+        StoreOpOutcome::Completed(result) => StoreOpReport {
+            result,
+            writer_usable: true,
+        },
+        StoreOpOutcome::Panicked(msg) => {
+            tracing::error!(
+                panic = %msg,
+                "writer-thread store op panicked; reopening writer connection"
+            );
+
+            // A panic may have skipped SQLite rollback code or left rusqlite's
+            // FFI state suspect. Drop the old connection first so any open
+            // transaction is closed before the replacement connection is opened.
+            drop(store.take());
+
+            match SqliteStore::open(db_path, embedding_dim) {
+                Ok(reopened) => {
+                    *store = Some(reopened);
+                    StoreOpReport {
+                        result: Err(Error::Storage(format!("writer thread panic: {msg}"))),
+                        writer_usable: true,
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "failed to reopen writer connection after panic; writer exiting"
+                    );
+                    StoreOpReport {
+                        result: Err(Error::Storage(format!(
+                            "writer thread panic: {msg}; reopen failed: {e}"
+                        ))),
+                        writer_usable: false,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+fn panic_for_test_store_op(_store: &SqliteStore) -> Result<()> {
+    panic!("deliberate writer test panic");
 }
 
 fn writer_loop(
@@ -294,10 +372,10 @@ fn writer_loop(
     events: broadcast::Sender<MemoryChanged>,
     ready_tx: std::sync::mpsc::Sender<Result<()>>,
 ) {
-    let store = match SqliteStore::open(&db_path, embedding_dim) {
+    let mut store = match SqliteStore::open(&db_path, embedding_dim) {
         Ok(store) => {
             let _ = ready_tx.send(Ok(()));
-            store
+            Some(store)
         }
         Err(e) => {
             let _ = ready_tx.send(Err(e));
@@ -314,16 +392,21 @@ fn writer_loop(
             } => {
                 let namespace = note.namespace.clone();
                 let id = note.id.clone();
-                let result =
-                    catch_store_op(&store, |s| s.insert_memory(&note, embedding.as_deref()));
-                let changed = result.is_ok();
-                let _ = reply.send(result);
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    s.insert_memory(&note, embedding.as_deref())
+                });
+                let changed = report.result.is_ok();
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
                 if changed {
                     let _ = events.send(MemoryChanged {
                         id,
                         namespace,
                         kind: ChangeKind::Created,
                     });
+                }
+                if !writer_usable {
+                    break;
                 }
             }
             WriteCommand::Update {
@@ -332,13 +415,18 @@ fn writer_loop(
                 updates,
                 reply,
             } => {
-                let result = catch_store_op(&store, |s| match s.get_memory(&id) {
-                    Ok(Some(note)) if note.namespace == namespace => s.update_memory(&id, &updates),
-                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                    Err(e) => Err(e),
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    match s.get_memory(&id) {
+                        Ok(Some(note)) if note.namespace == namespace => {
+                            s.update_memory(&id, &updates)
+                        }
+                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                        Err(e) => Err(e),
+                    }
                 });
-                let changed = result.is_ok();
-                let _ = reply.send(result);
+                let changed = report.result.is_ok();
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
                 if changed {
                     let _ = events.send(MemoryChanged {
                         id,
@@ -346,25 +434,44 @@ fn writer_loop(
                         kind: ChangeKind::Updated,
                     });
                 }
+                if !writer_usable {
+                    break;
+                }
             }
             WriteCommand::Archive {
                 namespace,
                 id,
                 reply,
             } => {
-                let result = catch_store_op(&store, |s| match s.get_memory(&id) {
-                    Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
-                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                    Err(e) => Err(e),
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    match s.get_memory(&id) {
+                        Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
+                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                        Err(e) => Err(e),
+                    }
                 });
-                let changed = result.is_ok();
-                let _ = reply.send(result);
+                let changed = report.result.is_ok();
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
                 if changed {
                     let _ = events.send(MemoryChanged {
                         id,
                         namespace,
                         kind: ChangeKind::Archived,
                     });
+                }
+                if !writer_usable {
+                    break;
+                }
+            }
+            #[cfg(test)]
+            WriteCommand::PanicForTest { reply } => {
+                let report =
+                    run_store_op(&mut store, &db_path, embedding_dim, panic_for_test_store_op);
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if !writer_usable {
+                    break;
                 }
             }
             WriteCommand::Shutdown { reply } => {
@@ -462,5 +569,53 @@ impl MemoryBackend for StoreHandle {
             reply,
         };
         self.send_write(cmd, rx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use rb_engine::MemoryBackend;
+    use rb_types::MemoryType;
+
+    const DIM: usize = 8;
+
+    fn note(ns: &Namespace, body: &str) -> MemoryNote {
+        MemoryNote::new(ns.clone(), body.to_string(), MemoryType::Insight, 5)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_reopens_after_caught_store_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 1).unwrap();
+
+        let (reply, rx) = oneshot::channel();
+        handle
+            .writer_tx
+            .send(WriteCommand::PanicForTest { reply })
+            .await
+            .unwrap();
+
+        let err = rx.await.unwrap().unwrap_err();
+        assert!(
+            matches!(err, Error::Storage(_)),
+            "caught writer panic must be returned as storage error, got {err:?}"
+        );
+
+        let ns = Namespace::Project("writer-recovery".to_string());
+        let n = note(&ns, "write after caught writer panic");
+        let id = n.id.clone();
+        handle.write(n, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        let got = handle.get(ns, id).await.unwrap();
+        assert!(
+            got.is_some(),
+            "writer must reopen its store and accept later writes after a caught panic"
+        );
+
+        handle.shutdown().await;
     }
 }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -244,6 +244,17 @@ impl StoreHandle {
             ))),
         }
     }
+
+    /// Test-only helper: the number of idle connections currently in the read
+    /// pool. After all reads have returned, this equals the configured pool
+    /// size; a leaked connection would make it permanently smaller.
+    ///
+    /// This method is `pub` only to be reachable from `tests/`. Do NOT call
+    /// it in production code.
+    #[doc(hidden)]
+    pub async fn read_pool_len_for_test(&self) -> usize {
+        self.pool.stores.lock().await.len()
+    }
 }
 
 /// Execute a store operation inside `catch_unwind` so a panic in the rusqlite

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -3,6 +3,7 @@
 //! pool of read connections serves concurrent reads via `spawn_blocking`.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -33,6 +34,9 @@ enum WriteCommand {
         id: MemoryId,
         reply: oneshot::Sender<Result<()>>,
     },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
 }
 
 /// Cloneable handle to the daemon's single-writer storage core.
@@ -42,6 +46,7 @@ pub struct StoreHandle {
     pool: Arc<ReadPool>,
     events: broadcast::Sender<MemoryChanged>,
     writer_join: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+    shutting_down: Arc<AtomicBool>,
 }
 
 struct ReadPool {
@@ -108,6 +113,7 @@ impl StoreHandle {
             pool,
             events,
             writer_join: Arc::new(Mutex::new(Some(writer_join))),
+            shutting_down: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -123,10 +129,23 @@ impl StoreHandle {
             pool,
             events,
             writer_join,
+            shutting_down,
         } = self;
-        drop(writer_tx);
+
+        if !shutting_down.swap(true, Ordering::SeqCst) {
+            let (reply, rx) = oneshot::channel();
+            if writer_tx
+                .send(WriteCommand::Shutdown { reply })
+                .await
+                .is_ok()
+            {
+                let _ = rx.await;
+            }
+        }
+
         drop(pool);
         drop(events);
+        drop(writer_tx);
 
         let join = { writer_join.lock().await.take() };
         if let Some(handle) = join {
@@ -135,6 +154,10 @@ impl StoreHandle {
     }
 
     async fn send_write(&self, cmd: WriteCommand, rx: oneshot::Receiver<Result<()>>) -> Result<()> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(Error::Storage("writer thread unavailable".to_string()));
+        }
+
         self.writer_tx
             .send(cmd)
             .await
@@ -250,6 +273,10 @@ fn writer_loop(
                         kind: ChangeKind::Archived,
                     });
                 }
+            }
+            WriteCommand::Shutdown { reply } => {
+                let _ = reply.send(());
+                break;
             }
         }
     }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -227,26 +227,18 @@ impl StoreHandle {
     }
 
     /// Test-only helper: checks that the RAII guard returns the connection even
-    /// when the read closure panics. Returns `Ok(())` if the panic is correctly
-    /// mapped to `Error::Storage`, so the test can `.unwrap()` it.
+    /// when the read closure panics. The panic should surface as
+    /// `Error::Storage`, while the guard's `Drop` still returns the connection.
     ///
     /// This method is `pub` only to be reachable from `tests/`. Do NOT call
     /// it in production code.
     #[doc(hidden)]
     pub async fn with_read_panicking_for_test(&self) -> Result<()> {
         #[allow(clippy::panic)]
-        let result = self
-            .with_read(|_store| -> Result<()> {
-                panic!("deliberate test panic inside read closure");
-            })
-            .await;
-        // The JoinError from the panic is mapped to Error::Storage by with_read.
-        match result {
-            Err(Error::Storage(_)) => Ok(()),
-            other => Err(Error::Storage(format!(
-                "expected Storage error from panic, got {other:?}"
-            ))),
-        }
+        self.with_read(|_store| -> Result<()> {
+            panic!("deliberate test panic inside read closure");
+        })
+        .await
     }
 
     /// Test-only helper: the number of idle connections currently in the read

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -246,6 +246,36 @@ impl StoreHandle {
     }
 }
 
+/// Execute a store operation inside `catch_unwind` so a panic in the rusqlite
+/// layer does not unwind and kill the writer thread.
+///
+/// `SqliteStore` is not `UnwindSafe` (it wraps a raw FFI connection), so we
+/// use `AssertUnwindSafe`. A rusqlite panic leaves the connection in an
+/// undefined state; after catching one we log at error level and return a
+/// `Storage` error. The writer thread itself survives and continues serving
+/// subsequent commands.
+#[allow(clippy::panic)]
+fn catch_store_op<F>(store: &SqliteStore, op: F) -> Result<()>
+where
+    F: FnOnce(&SqliteStore) -> Result<()> + std::panic::UnwindSafe,
+{
+    use std::panic::{self, AssertUnwindSafe};
+    match panic::catch_unwind(AssertUnwindSafe(|| op(store))) {
+        Ok(result) => result,
+        Err(payload) => {
+            let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic payload".to_string()
+            };
+            tracing::error!(panic = %msg, "writer-thread store op panicked; connection may be degraded");
+            Err(Error::Storage(format!("writer thread panic: {msg}")))
+        }
+    }
+}
+
 fn writer_loop(
     db_path: PathBuf,
     embedding_dim: usize,
@@ -273,7 +303,7 @@ fn writer_loop(
             } => {
                 let namespace = note.namespace.clone();
                 let id = note.id.clone();
-                let result = store.insert_memory(&note, embedding.as_deref());
+                let result = catch_store_op(&store, |s| s.insert_memory(&note, embedding.as_deref()));
                 let changed = result.is_ok();
                 let _ = reply.send(result);
                 if changed {
@@ -290,13 +320,15 @@ fn writer_loop(
                 updates,
                 reply,
             } => {
-                let result = match store.get_memory(&id) {
-                    Ok(Some(note)) if note.namespace == namespace => {
-                        store.update_memory(&id, &updates)
+                let result = catch_store_op(&store, |s| {
+                    match s.get_memory(&id) {
+                        Ok(Some(note)) if note.namespace == namespace => {
+                            s.update_memory(&id, &updates)
+                        }
+                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                        Err(e) => Err(e),
                     }
-                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                    Err(e) => Err(e),
-                };
+                });
                 let changed = result.is_ok();
                 let _ = reply.send(result);
                 if changed {
@@ -312,11 +344,13 @@ fn writer_loop(
                 id,
                 reply,
             } => {
-                let result = match store.get_memory(&id) {
-                    Ok(Some(note)) if note.namespace == namespace => store.archive_memory(&id),
-                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                    Err(e) => Err(e),
-                };
+                let result = catch_store_op(&store, |s| {
+                    match s.get_memory(&id) {
+                        Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
+                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                        Err(e) => Err(e),
+                    }
+                });
                 let changed = result.is_ok();
                 let _ = reply.send(result);
                 if changed {

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -67,6 +67,21 @@ impl ReadPool {
     }
 }
 
+/// RAII guard that holds a popped `SqliteStore` and pushes it back to the pool
+/// in `Drop`, ensuring the connection is returned even if the closure panics.
+struct PoolGuard {
+    store: Option<SqliteStore>,
+    pool: Arc<Mutex<Vec<SqliteStore>>>,
+}
+
+impl Drop for PoolGuard {
+    fn drop(&mut self) {
+        if let Some(store) = self.store.take() {
+            self.pool.blocking_lock().push(store);
+        }
+    }
+}
+
 impl StoreHandle {
     /// Start the writer thread and open the read pool.
     pub fn start(db_path: PathBuf, embedding_dim: usize, read_pool_size: usize) -> Result<Self> {
@@ -179,17 +194,55 @@ impl StoreHandle {
             .map_err(|_| Error::Storage("read pool closed".to_string()))?;
 
         tokio::task::spawn_blocking(move || {
+            // The semaphore permit is held for the lifetime of this closure.
+            // If the task is cancelled the permit is dropped; that is fine
+            // because spawn_blocking tasks run to completion.
             let _permit = permit;
+
             let store = stores
                 .blocking_lock()
                 .pop()
                 .ok_or_else(|| Error::Storage("read pool exhausted despite permit".to_string()))?;
-            let result = f(&store);
-            stores.blocking_lock().push(store);
+
+            // RAII guard: returns `store` to the pool in Drop, even on panic.
+            let guard = PoolGuard {
+                store: Some(store),
+                pool: Arc::clone(&stores),
+            };
+
+            // Safety: guard.store is Some; we set it back to None in Drop.
+            let result = f(guard.store.as_ref().ok_or_else(|| {
+                Error::Storage("pool guard store unexpectedly missing".to_string())
+            })?);
+            // Explicit drop to be clear about ordering (not strictly necessary).
+            drop(guard);
             result
         })
         .await
         .map_err(|e| Error::Storage(format!("read task panicked or cancelled: {e}")))?
+    }
+
+    /// Test-only helper: checks that the RAII guard returns the connection even
+    /// when the read closure panics. Returns `Ok(())` if the panic is correctly
+    /// mapped to `Error::Storage`, so the test can `.unwrap()` it.
+    ///
+    /// This method is `pub` only to be reachable from `tests/`. Do NOT call
+    /// it in production code.
+    #[doc(hidden)]
+    pub async fn with_read_panicking_for_test(&self) -> Result<()> {
+        #[allow(clippy::panic)]
+        let result = self
+            .with_read(|_store| -> Result<()> {
+                panic!("deliberate test panic inside read closure");
+            })
+            .await;
+        // The JoinError from the panic is mapped to Error::Storage by with_read.
+        match result {
+            Err(Error::Storage(_)) => Ok(()),
+            other => Err(Error::Storage(format!(
+                "expected Storage error from panic, got {other:?}"
+            ))),
+        }
     }
 }
 

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -303,7 +303,8 @@ fn writer_loop(
             } => {
                 let namespace = note.namespace.clone();
                 let id = note.id.clone();
-                let result = catch_store_op(&store, |s| s.insert_memory(&note, embedding.as_deref()));
+                let result =
+                    catch_store_op(&store, |s| s.insert_memory(&note, embedding.as_deref()));
                 let changed = result.is_ok();
                 let _ = reply.send(result);
                 if changed {
@@ -320,14 +321,10 @@ fn writer_loop(
                 updates,
                 reply,
             } => {
-                let result = catch_store_op(&store, |s| {
-                    match s.get_memory(&id) {
-                        Ok(Some(note)) if note.namespace == namespace => {
-                            s.update_memory(&id, &updates)
-                        }
-                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                        Err(e) => Err(e),
-                    }
+                let result = catch_store_op(&store, |s| match s.get_memory(&id) {
+                    Ok(Some(note)) if note.namespace == namespace => s.update_memory(&id, &updates),
+                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                    Err(e) => Err(e),
                 });
                 let changed = result.is_ok();
                 let _ = reply.send(result);
@@ -344,12 +341,10 @@ fn writer_loop(
                 id,
                 reply,
             } => {
-                let result = catch_store_op(&store, |s| {
-                    match s.get_memory(&id) {
-                        Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
-                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
-                        Err(e) => Err(e),
-                    }
+                let result = catch_store_op(&store, |s| match s.get_memory(&id) {
+                    Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
+                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                    Err(e) => Err(e),
                 });
                 let changed = result.is_ok();
                 let _ = reply.send(result);

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -1,0 +1,346 @@
+//! The single-writer store handle: one dedicated OS thread owns the write
+//! connection (rusqlite is `!Sync`, so it must never be shared); a bounded
+//! pool of read connections serves concurrent reads via `spawn_blocking`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rb_engine::MemoryBackend;
+use rb_store::{SqliteStore, Store};
+use rb_types::{Error, MemoryId, MemoryNote, MemoryUpdates, Namespace, Result};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex, Semaphore};
+
+use crate::change::{ChangeKind, MemoryChanged};
+
+const BROADCAST_CAPACITY: usize = 256;
+const WRITE_QUEUE_CAPACITY: usize = 256;
+
+enum WriteCommand {
+    Insert {
+        note: Box<MemoryNote>,
+        embedding: Option<Vec<f32>>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    Update {
+        namespace: Namespace,
+        id: MemoryId,
+        updates: Box<MemoryUpdates>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    Archive {
+        namespace: Namespace,
+        id: MemoryId,
+        reply: oneshot::Sender<Result<()>>,
+    },
+}
+
+/// Cloneable handle to the daemon's single-writer storage core.
+#[derive(Clone)]
+pub struct StoreHandle {
+    writer_tx: mpsc::Sender<WriteCommand>,
+    pool: Arc<ReadPool>,
+    events: broadcast::Sender<MemoryChanged>,
+    writer_join: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+}
+
+struct ReadPool {
+    permits: Arc<Semaphore>,
+    stores: Arc<Mutex<Vec<SqliteStore>>>,
+}
+
+impl ReadPool {
+    fn open(db_path: &Path, dim: usize, size: usize) -> Result<Self> {
+        let mut stores = Vec::with_capacity(size);
+        for _ in 0..size {
+            stores.push(SqliteStore::open(db_path, dim)?);
+        }
+        Ok(Self {
+            permits: Arc::new(Semaphore::new(size)),
+            stores: Arc::new(Mutex::new(stores)),
+        })
+    }
+}
+
+impl StoreHandle {
+    /// Start the writer thread and open the read pool.
+    pub fn start(db_path: PathBuf, embedding_dim: usize, read_pool_size: usize) -> Result<Self> {
+        let pool = Arc::new(ReadPool::open(
+            &db_path,
+            embedding_dim,
+            read_pool_size.max(1),
+        )?);
+        let (events, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (writer_tx, writer_rx) = mpsc::channel::<WriteCommand>(WRITE_QUEUE_CAPACITY);
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<()>>();
+
+        let writer_events = events.clone();
+        let writer_path = db_path;
+        let writer_join = std::thread::Builder::new()
+            .name("rb-writer".to_string())
+            .spawn(move || {
+                writer_loop(
+                    writer_path,
+                    embedding_dim,
+                    writer_rx,
+                    writer_events,
+                    ready_tx,
+                );
+            })
+            .map_err(|e| Error::Io(format!("spawn writer thread: {e}")))?;
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                let _ = writer_join.join();
+                return Err(e);
+            }
+            Err(_) => {
+                let _ = writer_join.join();
+                return Err(Error::Storage(
+                    "writer thread exited before ready".to_string(),
+                ));
+            }
+        }
+
+        Ok(Self {
+            writer_tx,
+            pool,
+            events,
+            writer_join: Arc::new(Mutex::new(Some(writer_join))),
+        })
+    }
+
+    /// Subscribe to best-effort memory change notifications.
+    pub fn subscribe(&self) -> broadcast::Receiver<MemoryChanged> {
+        self.events.subscribe()
+    }
+
+    /// Gracefully close the write queue and join the dedicated writer thread.
+    pub async fn shutdown(self) {
+        let StoreHandle {
+            writer_tx,
+            pool,
+            events,
+            writer_join,
+        } = self;
+        drop(writer_tx);
+        drop(pool);
+        drop(events);
+
+        let join = { writer_join.lock().await.take() };
+        if let Some(handle) = join {
+            let _ = tokio::task::spawn_blocking(move || handle.join()).await;
+        }
+    }
+
+    async fn send_write(&self, cmd: WriteCommand, rx: oneshot::Receiver<Result<()>>) -> Result<()> {
+        self.writer_tx
+            .send(cmd)
+            .await
+            .map_err(|_| Error::Storage("writer thread unavailable".to_string()))?;
+        rx.await
+            .map_err(|_| Error::Storage("writer dropped reply".to_string()))?
+    }
+
+    async fn with_read<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&SqliteStore) -> Result<T> + Send + 'static,
+    {
+        let permits = Arc::clone(&self.pool.permits);
+        let stores = Arc::clone(&self.pool.stores);
+        let permit = permits
+            .acquire_owned()
+            .await
+            .map_err(|_| Error::Storage("read pool closed".to_string()))?;
+
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let store = stores
+                .blocking_lock()
+                .pop()
+                .ok_or_else(|| Error::Storage("read pool exhausted despite permit".to_string()))?;
+            let result = f(&store);
+            stores.blocking_lock().push(store);
+            result
+        })
+        .await
+        .map_err(|e| Error::Storage(format!("read task panicked or cancelled: {e}")))?
+    }
+}
+
+fn writer_loop(
+    db_path: PathBuf,
+    embedding_dim: usize,
+    mut rx: mpsc::Receiver<WriteCommand>,
+    events: broadcast::Sender<MemoryChanged>,
+    ready_tx: std::sync::mpsc::Sender<Result<()>>,
+) {
+    let store = match SqliteStore::open(&db_path, embedding_dim) {
+        Ok(store) => {
+            let _ = ready_tx.send(Ok(()));
+            store
+        }
+        Err(e) => {
+            let _ = ready_tx.send(Err(e));
+            return;
+        }
+    };
+
+    while let Some(cmd) = rx.blocking_recv() {
+        match cmd {
+            WriteCommand::Insert {
+                note,
+                embedding,
+                reply,
+            } => {
+                let namespace = note.namespace.clone();
+                let id = note.id.clone();
+                let result = store.insert_memory(&note, embedding.as_deref());
+                let changed = result.is_ok();
+                let _ = reply.send(result);
+                if changed {
+                    let _ = events.send(MemoryChanged {
+                        id,
+                        namespace,
+                        kind: ChangeKind::Created,
+                    });
+                }
+            }
+            WriteCommand::Update {
+                namespace,
+                id,
+                updates,
+                reply,
+            } => {
+                let result = match store.get_memory(&id) {
+                    Ok(Some(note)) if note.namespace == namespace => {
+                        store.update_memory(&id, &updates)
+                    }
+                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                    Err(e) => Err(e),
+                };
+                let changed = result.is_ok();
+                let _ = reply.send(result);
+                if changed {
+                    let _ = events.send(MemoryChanged {
+                        id,
+                        namespace,
+                        kind: ChangeKind::Updated,
+                    });
+                }
+            }
+            WriteCommand::Archive {
+                namespace,
+                id,
+                reply,
+            } => {
+                let result = match store.get_memory(&id) {
+                    Ok(Some(note)) if note.namespace == namespace => store.archive_memory(&id),
+                    Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                    Err(e) => Err(e),
+                };
+                let changed = result.is_ok();
+                let _ = reply.send(result);
+                if changed {
+                    let _ = events.send(MemoryChanged {
+                        id,
+                        namespace,
+                        kind: ChangeKind::Archived,
+                    });
+                }
+            }
+        }
+    }
+
+    drop(store);
+}
+
+#[async_trait]
+impl MemoryBackend for StoreHandle {
+    async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Insert {
+            note: Box::new(note),
+            embedding,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+
+    async fn get(&self, ns: Namespace, id: MemoryId) -> Result<Option<MemoryNote>> {
+        self.with_read(move |store| Ok(store.get_memory(&id)?.filter(|note| note.namespace == ns)))
+            .await
+    }
+
+    async fn keyword(&self, ns: Namespace, query: String, limit: usize) -> Result<Vec<MemoryId>> {
+        self.with_read(move |store| store.keyword_search(&ns, &query, limit))
+            .await
+    }
+
+    async fn vector(
+        &self,
+        ns: Namespace,
+        embedding: Vec<f32>,
+        limit: usize,
+    ) -> Result<Vec<(MemoryId, f32)>> {
+        self.with_read(move |store| store.vector_search(&ns, &embedding, limit))
+            .await
+    }
+
+    async fn graph(&self, ns: Namespace, id: MemoryId, depth: u8) -> Result<Vec<MemoryId>> {
+        self.with_read(move |store| {
+            let Some(anchor) = store.get_memory(&id)? else {
+                return Ok(Vec::new());
+            };
+            if anchor.namespace != ns || anchor.archived_at.is_some() {
+                return Ok(Vec::new());
+            }
+
+            let ids = store.graph_neighbors(&id, depth)?;
+            let mut filtered = Vec::with_capacity(ids.len());
+            for graph_id in ids {
+                let Some(note) = store.get_memory(&graph_id)? else {
+                    continue;
+                };
+                if note.namespace == ns && note.archived_at.is_none() {
+                    filtered.push(graph_id);
+                }
+            }
+            Ok(filtered)
+        })
+        .await
+    }
+
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        self.with_read(move |store| store.list(&ns, min_importance, limit))
+            .await
+    }
+
+    async fn update(&self, ns: Namespace, id: MemoryId, updates: MemoryUpdates) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Update {
+            namespace: ns,
+            id,
+            updates: Box::new(updates),
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+
+    async fn archive(&self, ns: Namespace, id: MemoryId) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Archive {
+            namespace: ns,
+            id,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+}

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use rb_daemon::{Daemon, DaemonConfig, SharedEmbedder};
 use rb_embed::DeterministicProvider;
 use rb_proto::Client;
-use rb_types::{MemoryType, MemoryUpdates, Namespace};
+use rb_types::{Error, MemoryType, MemoryUpdates, Namespace};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -107,7 +107,6 @@ async fn full_round_trip_through_client() {
         .recall(
             "rusty-brain db transaction".to_string(),
             None,
-            None,
             vec![],
             10,
         )
@@ -118,7 +117,7 @@ async fn full_round_trip_through_client() {
         "recall must surface the remembered memory"
     );
 
-    let listed = client.list(None, None, 50).await.unwrap();
+    let listed = client.list(None, 50).await.unwrap();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, id);
 
@@ -145,7 +144,7 @@ async fn full_round_trip_through_client() {
     );
 
     client.delete(id.clone()).await.unwrap();
-    let listed_after = client.list(None, None, 50).await.unwrap();
+    let listed_after = client.list(None, 50).await.unwrap();
     assert!(
         listed_after.iter().all(|m| m.id != id),
         "archived memory is not listed"
@@ -190,7 +189,7 @@ async fn many_concurrent_clients_no_lost_writes_no_errors() {
 
     let mut verifier = Client::connect(&daemon.socket, ns).await.unwrap();
     let listed = verifier
-        .list(None, None, CLIENTS * PER_CLIENT + 10)
+        .list(None, CLIENTS * PER_CLIENT + 10)
         .await
         .unwrap();
     assert_eq!(
@@ -237,7 +236,7 @@ async fn namespace_isolation_enforced_server_side() {
         .await
         .unwrap();
 
-    let b_list = client_b.list(None, None, 50).await.unwrap();
+    let b_list = client_b.list(None, 50).await.unwrap();
     assert!(
         b_list.iter().all(|m| m.id != id_a),
         "namespace B must not see namespace A's memory via list"
@@ -248,7 +247,7 @@ async fn namespace_isolation_enforced_server_side() {
     );
 
     let b_recall = client_b
-        .recall("secret".to_string(), None, None, vec![], 50)
+        .recall("secret".to_string(), None, vec![], 50)
         .await
         .unwrap();
     assert!(
@@ -256,7 +255,7 @@ async fn namespace_isolation_enforced_server_side() {
         "namespace B must not recall namespace A's memory"
     );
 
-    let a_list = client_a.list(None, None, 50).await.unwrap();
+    let a_list = client_a.list(None, 50).await.unwrap();
     assert!(
         a_list.iter().all(|m| m.id != id_b),
         "namespace A must not see namespace B's memory"
@@ -327,4 +326,81 @@ async fn second_bind_before_accept_loop_fails_closed() {
     );
 
     drop(daemon);
+}
+
+/// A client handshaked under Project("b") must not see or mutate Project("a")
+/// data over the wire, even by direct id. This is the wire-level namespace
+/// isolation guarantee: get returns None, update/delete return NotFound-class
+/// errors, and graph returns an empty neighborhood.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn wire_namespace_isolation_cross_namespace_ops_fail_closed() {
+    let daemon = RunningDaemon::start(4).await;
+
+    // Project A: store one memory.
+    let ns_a = Namespace::Project("a".to_string());
+    let mut client_a = Client::connect(&daemon.socket, ns_a.clone()).await.unwrap();
+    let id_a = client_a
+        .remember(
+            "project a secret".to_string(),
+            None,
+            MemoryType::Insight,
+            7,
+            vec![],
+            vec![],
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // Project B: connect under a different namespace.
+    let ns_b = Namespace::Project("b".to_string());
+    let mut client_b = Client::connect(&daemon.socket, ns_b).await.unwrap();
+
+    // get(id_a) must return None — not visible across namespace boundary.
+    let got = client_b.get(id_a.clone()).await.unwrap();
+    assert!(
+        got.is_none(),
+        "get across namespace boundary must return None, not expose the memory"
+    );
+
+    // update(id_a, ..) must return an error (NotFound at the store layer, surfaced
+    // as a wire Error response, which the client maps to Error::Storage or similar).
+    let update_err = client_b
+        .update(
+            id_a.clone(),
+            MemoryUpdates {
+                importance: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(update_err, Error::Storage(_)),
+        "update across namespace boundary must error, got {update_err:?}"
+    );
+
+    // delete(id_a) must return an error.
+    let delete_err = client_b.delete(id_a.clone()).await.unwrap_err();
+    assert!(
+        matches!(delete_err, Error::Storage(_)),
+        "delete across namespace boundary must error, got {delete_err:?}"
+    );
+
+    // graph(id_a, ..) must return an empty neighborhood (anchor not in namespace).
+    let graph_result = client_b.graph(id_a.clone(), 2).await.unwrap();
+    assert!(
+        graph_result.is_empty(),
+        "graph across namespace boundary must return empty, got {} nodes",
+        graph_result.len()
+    );
+
+    // Confirm A's data is untouched: it can still get its own memory.
+    let still_there = client_a.get(id_a).await.unwrap();
+    assert!(
+        still_there.is_some(),
+        "Project A memory must remain visible to Project A after cross-namespace ops"
+    );
+
+    daemon.stop().await;
 }

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -14,6 +14,10 @@ use tokio::task::JoinHandle;
 
 const DIM: usize = 8;
 
+fn tempdir() -> tempfile::TempDir {
+    tempfile::tempdir_in(std::env::temp_dir()).unwrap()
+}
+
 struct RunningDaemon {
     socket: PathBuf,
     shutdown: Option<oneshot::Sender<()>>,
@@ -23,7 +27,7 @@ struct RunningDaemon {
 
 impl RunningDaemon {
     async fn start(pool_size: usize) -> RunningDaemon {
-        let dir = tempfile::tempdir_in("/private/tmp").unwrap();
+        let dir = tempdir();
         let socket = dir.path().join("sock");
         let db = dir.path().join("memory.db");
         let cfg = DaemonConfig {
@@ -64,7 +68,10 @@ impl RunningDaemon {
             let _ = tx.send(());
         }
         if let Some(task) = self.task.take() {
-            let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
+            tokio::time::timeout(Duration::from_secs(5), task)
+                .await
+                .expect("daemon task did not shut down within 5s")
+                .expect("daemon task failed during shutdown");
         }
     }
 }
@@ -262,7 +269,7 @@ async fn namespace_isolation_enforced_server_side() {
 async fn second_bind_on_live_socket_fails_closed() {
     let daemon = RunningDaemon::start(2).await;
 
-    let dir2 = tempfile::tempdir_in("/private/tmp").unwrap();
+    let dir2 = tempdir();
     let cfg2 = DaemonConfig {
         socket_path: daemon.socket.clone(),
         db_path: dir2.path().join("memory.db"),
@@ -280,7 +287,7 @@ async fn second_bind_on_live_socket_fails_closed() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn second_bind_before_accept_loop_fails_closed() {
-    let dir = tempfile::tempdir_in("/private/tmp").unwrap();
+    let dir = tempdir();
     let socket = dir.path().join("sock");
     let cfg = DaemonConfig {
         socket_path: socket.clone(),
@@ -290,7 +297,7 @@ async fn second_bind_before_accept_loop_fails_closed() {
     let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
     let daemon = Daemon::bind(cfg, embedder).await.unwrap();
 
-    let dir2 = tempfile::tempdir_in("/private/tmp").unwrap();
+    let dir2 = tempdir();
     let cfg2 = DaemonConfig {
         socket_path: socket,
         db_path: dir2.path().join("memory.db"),

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -277,3 +277,31 @@ async fn second_bind_on_live_socket_fails_closed() {
 
     daemon.stop().await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn second_bind_before_accept_loop_fails_closed() {
+    let dir = tempfile::tempdir_in("/private/tmp").unwrap();
+    let socket = dir.path().join("sock");
+    let cfg = DaemonConfig {
+        socket_path: socket.clone(),
+        db_path: dir.path().join("memory.db"),
+        read_pool_size: 2,
+    };
+    let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+    let daemon = Daemon::bind(cfg, embedder).await.unwrap();
+
+    let dir2 = tempfile::tempdir_in("/private/tmp").unwrap();
+    let cfg2 = DaemonConfig {
+        socket_path: socket,
+        db_path: dir2.path().join("memory.db"),
+        read_pool_size: 2,
+    };
+    let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+    let err = Daemon::bind(cfg2, embedder).await.unwrap_err();
+    assert!(
+        err.to_string().contains("already listening"),
+        "second bind before run must fail closed: {err}"
+    );
+
+    drop(daemon);
+}

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -28,7 +28,7 @@ struct RunningDaemon {
 impl RunningDaemon {
     async fn start(pool_size: usize) -> RunningDaemon {
         let dir = tempdir();
-        let socket = dir.path().join("sock");
+        let socket = dir.path().join("runtime").join("sock");
         let db = dir.path().join("memory.db");
         let cfg = DaemonConfig {
             socket_path: socket.clone(),
@@ -266,6 +266,22 @@ async fn namespace_isolation_enforced_server_side() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalid_handshake_namespace_is_rejected_before_ack() {
+    let daemon = RunningDaemon::start(2).await;
+
+    let err = Client::connect(&daemon.socket, Namespace::Project(String::new()))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("handshake rejected")
+            || err.to_string().contains("invalid namespace"),
+        "invalid namespace must fail closed during handshake: {err}"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn second_bind_on_live_socket_fails_closed() {
     let daemon = RunningDaemon::start(2).await;
 
@@ -288,7 +304,7 @@ async fn second_bind_on_live_socket_fails_closed() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn second_bind_before_accept_loop_fails_closed() {
     let dir = tempdir();
-    let socket = dir.path().join("sock");
+    let socket = dir.path().join("runtime").join("sock");
     let cfg = DaemonConfig {
         socket_path: socket.clone(),
         db_path: dir.path().join("memory.db"),

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1,0 +1,279 @@
+//! End-to-end daemon tests over a real Unix socket with the offline
+//! DeterministicProvider (no network).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rb_daemon::{Daemon, DaemonConfig, SharedEmbedder};
+use rb_embed::DeterministicProvider;
+use rb_proto::Client;
+use rb_types::{MemoryType, MemoryUpdates, Namespace};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+const DIM: usize = 8;
+
+struct RunningDaemon {
+    socket: PathBuf,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+    _dir: tempfile::TempDir,
+}
+
+impl RunningDaemon {
+    async fn start(pool_size: usize) -> RunningDaemon {
+        let dir = tempfile::tempdir_in("/private/tmp").unwrap();
+        let socket = dir.path().join("sock");
+        let db = dir.path().join("memory.db");
+        let cfg = DaemonConfig {
+            socket_path: socket.clone(),
+            db_path: db,
+            read_pool_size: pool_size,
+        };
+        let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+        let daemon = Daemon::bind(cfg, embedder).await.unwrap();
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(async move {
+            daemon
+                .run(async move {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        for _ in 0..200 {
+            if tokio::net::UnixStream::connect(&socket).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        RunningDaemon {
+            socket,
+            shutdown: Some(tx),
+            task: Some(task),
+            _dir: dir,
+        }
+    }
+
+    async fn stop(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn full_round_trip_through_client() {
+    let daemon = RunningDaemon::start(4).await;
+    let ns = Namespace::Project("a".to_string());
+    let mut client = Client::connect(&daemon.socket, ns.clone()).await.unwrap();
+
+    client.ping().await.unwrap();
+
+    let id = client
+        .remember(
+            "rusty-brain uses one db and one transaction".to_string(),
+            Some("architecture".to_string()),
+            MemoryType::ArchitectureDecision,
+            8,
+            vec!["sqlite".to_string()],
+            vec!["design".to_string()],
+            vec!["src/store.rs".to_string()],
+        )
+        .await
+        .unwrap();
+
+    let got = client.get(id.clone()).await.unwrap();
+    assert!(got.is_some());
+    let note = got.unwrap();
+    assert_eq!(note.content, "rusty-brain uses one db and one transaction");
+    assert_eq!(note.namespace, ns, "stored under the handshake namespace");
+
+    let results = client
+        .recall(
+            "rusty-brain db transaction".to_string(),
+            None,
+            None,
+            vec![],
+            10,
+        )
+        .await
+        .unwrap();
+    assert!(
+        results.iter().any(|r| r.memory.id == id),
+        "recall must surface the remembered memory"
+    );
+
+    let listed = client.list(None, None, 50).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, id);
+
+    let graph = client.graph(id.clone(), 1).await.unwrap();
+    assert!(
+        graph.iter().all(|m| m.id != id) || graph.is_empty() || graph.iter().any(|m| m.id == id),
+        "graph returns a (possibly empty) neighborhood without error"
+    );
+
+    let updates = MemoryUpdates {
+        importance: Some(10),
+        tags: Some(vec!["design".to_string(), "core".to_string()]),
+        ..Default::default()
+    };
+    client.update(id.clone(), updates).await.unwrap();
+    let after = client.get(id.clone()).await.unwrap().unwrap();
+    assert_eq!(after.importance, 10);
+
+    let (recent, important, total) = client.context().await.unwrap();
+    assert!(total >= 1, "context total counts the active memory");
+    assert!(
+        recent.iter().chain(important.iter()).any(|m| m.id == id),
+        "context surfaces the high-importance memory"
+    );
+
+    client.delete(id.clone()).await.unwrap();
+    let listed_after = client.list(None, None, 50).await.unwrap();
+    assert!(
+        listed_after.iter().all(|m| m.id != id),
+        "archived memory is not listed"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn many_concurrent_clients_no_lost_writes_no_errors() {
+    let daemon = RunningDaemon::start(4).await;
+    let ns = Namespace::Project("a".to_string());
+
+    const CLIENTS: usize = 16;
+    const PER_CLIENT: usize = 10;
+
+    let mut tasks = Vec::with_capacity(CLIENTS);
+    for c in 0..CLIENTS {
+        let socket = daemon.socket.clone();
+        let ns = ns.clone();
+        tasks.push(tokio::spawn(async move {
+            let mut client = Client::connect(&socket, ns).await.unwrap();
+            for i in 0..PER_CLIENT {
+                client
+                    .remember(
+                        format!("memory from client {c} item {i}"),
+                        None,
+                        MemoryType::Insight,
+                        5,
+                        vec!["concurrent".to_string()],
+                        vec![],
+                        vec![],
+                    )
+                    .await
+                    .unwrap();
+            }
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap();
+    }
+
+    let mut verifier = Client::connect(&daemon.socket, ns).await.unwrap();
+    let listed = verifier
+        .list(None, None, CLIENTS * PER_CLIENT + 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        listed.len(),
+        CLIENTS * PER_CLIENT,
+        "all {} writes must be present (no lost writes)",
+        CLIENTS * PER_CLIENT
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn namespace_isolation_enforced_server_side() {
+    let daemon = RunningDaemon::start(4).await;
+
+    let ns_a = Namespace::Project("a".to_string());
+    let mut client_a = Client::connect(&daemon.socket, ns_a).await.unwrap();
+    let id_a = client_a
+        .remember(
+            "secret belonging to project a".to_string(),
+            None,
+            MemoryType::Insight,
+            7,
+            vec!["alpha".to_string()],
+            vec![],
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    let ns_b = Namespace::Project("b".to_string());
+    let mut client_b = Client::connect(&daemon.socket, ns_b).await.unwrap();
+    let id_b = client_b
+        .remember(
+            "secret belonging to project b".to_string(),
+            None,
+            MemoryType::Insight,
+            7,
+            vec!["beta".to_string()],
+            vec![],
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    let b_list = client_b.list(None, None, 50).await.unwrap();
+    assert!(
+        b_list.iter().all(|m| m.id != id_a),
+        "namespace B must not see namespace A's memory via list"
+    );
+    assert!(
+        b_list.iter().any(|m| m.id == id_b),
+        "namespace B sees its own memory"
+    );
+
+    let b_recall = client_b
+        .recall("secret".to_string(), None, None, vec![], 50)
+        .await
+        .unwrap();
+    assert!(
+        b_recall.iter().all(|r| r.memory.id != id_a),
+        "namespace B must not recall namespace A's memory"
+    );
+
+    let a_list = client_a.list(None, None, 50).await.unwrap();
+    assert!(
+        a_list.iter().all(|m| m.id != id_b),
+        "namespace A must not see namespace B's memory"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn second_bind_on_live_socket_fails_closed() {
+    let daemon = RunningDaemon::start(2).await;
+
+    let dir2 = tempfile::tempdir_in("/private/tmp").unwrap();
+    let cfg2 = DaemonConfig {
+        socket_path: daemon.socket.clone(),
+        db_path: dir2.path().join("memory.db"),
+        read_pool_size: 2,
+    };
+    let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+    let err = Daemon::bind(cfg2, embedder).await.unwrap_err();
+    assert!(
+        err.to_string().contains("already listening"),
+        "second bind on a live socket must fail closed: {err}"
+    );
+
+    daemon.stop().await;
+}

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -48,12 +48,19 @@ impl RunningDaemon {
                 .unwrap();
         });
 
+        let mut ready = false;
         for _ in 0..200 {
             if tokio::net::UnixStream::connect(&socket).await.is_ok() {
+                ready = true;
                 break;
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
+        assert!(
+            ready,
+            "daemon socket was not reachable within startup timeout at {}",
+            socket.display()
+        );
 
         RunningDaemon {
             socket,
@@ -117,9 +124,15 @@ async fn full_round_trip_through_client() {
     assert_eq!(listed[0].id, id);
 
     let graph = client.graph(id.clone(), 1).await.unwrap();
+    let unique: std::collections::HashSet<_> = graph.iter().map(|m| m.id.clone()).collect();
+    assert_eq!(
+        unique.len(),
+        graph.len(),
+        "graph results must not contain duplicate memories"
+    );
     assert!(
-        graph.iter().all(|m| m.id != id) || graph.is_empty() || graph.iter().any(|m| m.id == id),
-        "graph returns a (possibly empty) neighborhood without error"
+        graph.iter().all(|m| m.namespace == ns),
+        "graph results must stay inside the handshake namespace"
     );
 
     let updates = MemoryUpdates {

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -104,12 +104,7 @@ async fn full_round_trip_through_client() {
     assert_eq!(note.namespace, ns, "stored under the handshake namespace");
 
     let results = client
-        .recall(
-            "rusty-brain db transaction".to_string(),
-            None,
-            vec![],
-            10,
-        )
+        .recall("rusty-brain db transaction".to_string(), None, vec![], 10)
         .await
         .unwrap();
     assert!(

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -328,6 +328,53 @@ async fn second_bind_before_accept_loop_fails_closed() {
     drop(daemon);
 }
 
+/// A Recall or List request with a very large limit must return at most
+/// MAX_LIMIT rows and must not error. The server clamps the value before
+/// passing it to the engine, so a caller cannot over-read the store.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn large_limit_is_clamped_and_does_not_error() {
+    let daemon = RunningDaemon::start(4).await;
+    let ns = Namespace::Project("clamp-test".to_string());
+    let mut client = Client::connect(&daemon.socket, ns).await.unwrap();
+
+    // Store a small number of memories (well below MAX_LIMIT).
+    for i in 0..5 {
+        client
+            .remember(
+                format!("memory {i}"),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+            )
+            .await
+            .unwrap();
+    }
+
+    // A limit far exceeding MAX_LIMIT (1000) must succeed and return only
+    // what is in the store (<=5), never causing a negative LIMIT or panic.
+    let listed = client.list(None, usize::MAX).await.unwrap();
+    assert!(
+        listed.len() <= 5,
+        "list with usize::MAX limit must return at most the stored count, got {}",
+        listed.len()
+    );
+
+    let recalled = client
+        .recall("memory".to_string(), None, vec![], usize::MAX)
+        .await
+        .unwrap();
+    assert!(
+        recalled.len() <= 5,
+        "recall with usize::MAX limit must return at most the stored count, got {}",
+        recalled.len()
+    );
+
+    daemon.stop().await;
+}
+
 /// A client handshaked under Project("b") must not see or mutate Project("a")
 /// data over the wire, even by direct id. This is the wire-level namespace
 /// isolation guarantee: get returns None, update/delete return NotFound-class

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -76,6 +76,28 @@ async fn write_publishes_change_event() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_completes_with_live_handle_clone() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+    let retained = handle.clone();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), handle.shutdown())
+        .await
+        .expect("shutdown must not wait for retained StoreHandle clones");
+
+    let ns = Namespace::Project("a".to_string());
+    let err = retained
+        .write(note(&ns, "write after shutdown"), Some(vec![0.5f32; DIM]))
+        .await
+        .expect_err("retained clones must reject writes after shutdown");
+    assert!(
+        matches!(err, Error::Storage(_)),
+        "write after shutdown should fail as storage unavailable, got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn update_and_archive_emit_correct_kinds() {
     let dir = tempfile::tempdir().unwrap();
     let db = dir.path().join("rb.db");

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -1,0 +1,179 @@
+//! Integration tests for the StoreHandle concurrency core: writer thread,
+//! read pool, change broadcast, and the async MemoryBackend impl.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_daemon::{ChangeKind, StoreHandle};
+use rb_engine::MemoryBackend;
+use rb_types::{Error, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+
+const DIM: usize = 8;
+
+fn note(ns: &Namespace, body: &str) -> MemoryNote {
+    let mut n = MemoryNote::new(ns.clone(), body.to_string(), MemoryType::Insight, 5);
+    n.summary = body.chars().take(40).collect();
+    n.keywords = vec!["memory".to_string()];
+    n
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn write_then_read_round_trips_through_pool() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 4).unwrap();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "always one db one transaction");
+    let id = n.id.clone();
+    let emb = vec![0.1f32; DIM];
+
+    handle.write(n.clone(), Some(emb)).await.unwrap();
+
+    let got = handle.get(ns.clone(), id.clone()).await.unwrap();
+    assert!(got.is_some(), "written memory must be retrievable");
+    assert_eq!(got.unwrap().content, "always one db one transaction");
+
+    let listed = handle.list(ns.clone(), None, 50).await.unwrap();
+    assert_eq!(listed.len(), 1, "list returns the one written memory");
+
+    let kw = handle
+        .keyword(ns.clone(), "memory".to_string(), 50)
+        .await
+        .unwrap();
+    assert_eq!(kw, vec![id.clone()], "keyword search finds it by keyword");
+
+    let vec_hits = handle.vector(ns, vec![0.1f32; DIM], 5).await.unwrap();
+    assert_eq!(
+        vec_hits.len(),
+        1,
+        "vector search returns the one embedded memory"
+    );
+    assert_eq!(vec_hits[0].0, id);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn write_publishes_change_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+    let mut rx = handle.subscribe();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "broadcast me");
+    let id = n.id.clone();
+    handle.write(n, Some(vec![0.2f32; DIM])).await.unwrap();
+
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("a change event must arrive within 2s")
+        .expect("broadcast channel must not be closed");
+    assert_eq!(evt.id, id);
+    assert_eq!(evt.namespace, ns);
+    assert_eq!(evt.kind, ChangeKind::Created);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_and_archive_emit_correct_kinds() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+    let mut rx = handle.subscribe();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "evolve me");
+    let id = n.id.clone();
+    handle.write(n, Some(vec![0.3f32; DIM])).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Created);
+
+    let updates = MemoryUpdates {
+        importance: Some(9),
+        ..Default::default()
+    };
+    handle
+        .update(ns.clone(), id.clone(), updates)
+        .await
+        .unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Updated);
+
+    handle.archive(ns.clone(), id.clone()).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Archived);
+
+    let got = handle.get(ns, id).await.unwrap().unwrap();
+    assert_eq!(got.importance, 9, "update persisted");
+    assert!(got.archived_at.is_some(), "archive persisted (soft delete)");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn many_concurrent_writers_lose_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 4).unwrap();
+    let ns = Namespace::Project("a".to_string());
+
+    const N: usize = 200;
+    let mut tasks = Vec::with_capacity(N);
+    for i in 0..N {
+        let h = handle.clone();
+        let ns = ns.clone();
+        tasks.push(tokio::spawn(async move {
+            let n = note(&ns, &format!("concurrent note {i}"));
+            h.write(n, Some(vec![i as f32; DIM])).await
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap().unwrap();
+    }
+
+    let listed = handle.list(ns, None, N + 10).await.unwrap();
+    assert_eq!(listed.len(), N, "no writes lost under concurrency");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn namespace_id_methods_fail_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+
+    let ns_a = Namespace::Project("a".to_string());
+    let ns_b = Namespace::Project("b".to_string());
+    let n = note(&ns_a, "do not leak across namespaces");
+    let id = n.id.clone();
+    handle.write(n, Some(vec![0.4f32; DIM])).await.unwrap();
+
+    assert!(
+        handle
+            .get(ns_b.clone(), id.clone())
+            .await
+            .unwrap()
+            .is_none(),
+        "get must filter an id hit to the requested namespace"
+    );
+
+    let wrong_update = handle
+        .update(
+            ns_b.clone(),
+            id.clone(),
+            MemoryUpdates {
+                importance: Some(10),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(wrong_update, Err(Error::NotFound(_))));
+
+    let wrong_archive = handle.archive(ns_b, id.clone()).await;
+    assert!(matches!(wrong_archive, Err(Error::NotFound(_))));
+
+    let got = handle.get(ns_a, id).await.unwrap().unwrap();
+    assert_eq!(got.importance, 5);
+    assert!(got.archived_at.is_none());
+
+    handle.shutdown().await;
+}

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -200,12 +200,20 @@ async fn namespace_id_methods_fail_closed() {
     handle.shutdown().await;
 }
 
-/// A panicking read closure must not permanently shrink the pool:
-/// the RAII guard returns the connection in Drop so subsequent reads
-/// still succeed, and we can run pool_size + 1 sequential reads afterward.
+/// A panicking read closure must not permanently shrink the pool: the RAII
+/// guard returns the connection in Drop. This test fails on the pre-fix leak
+/// in two independent ways:
+///   1. After draining the whole pool with POOL_SIZE panicking reads, the
+///      idle-connection count must be restored to exactly POOL_SIZE. A leak
+///      would leave it at 0 (or < POOL_SIZE).
+///   2. POOL_SIZE concurrent reads must all complete within a short timeout.
+///      On the pre-fix code a fully-drained pool would block forever waiting
+///      for a connection that never returns, tripping the timeout.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn panicking_read_closure_returns_connection_via_raii() {
-    const POOL_SIZE: usize = 2;
+    use std::time::Duration;
+
+    const POOL_SIZE: usize = 3;
     let dir = tempfile::tempdir().unwrap();
     let db = dir.path().join("rb.db");
     let handle = StoreHandle::start(db, DIM, POOL_SIZE).unwrap();
@@ -215,18 +223,43 @@ async fn panicking_read_closure_returns_connection_via_raii() {
     let n = note(&ns, "raii test memory");
     handle.write(n, Some(vec![0.1f32; DIM])).await.unwrap();
 
-    // Run a closure that panics inside spawn_blocking; the pool guard must
-    // catch the unwind (via JoinError mapping) and return the connection.
-    let err = handle.with_read_panicking_for_test().await;
-    assert!(
-        err.is_ok(),
-        "panicking read closure must surface as Storage error, got {err:?}"
+    // Drain the ENTIRE pool via panicking reads. If the guard were broken,
+    // every one of these would leak its connection and the pool would end up
+    // empty (size 0), making both checks below fail.
+    for _ in 0..POOL_SIZE {
+        let err = handle.with_read_panicking_for_test().await;
+        assert!(
+            err.is_ok(),
+            "panicking read closure must surface as Storage error, got {err:?}"
+        );
+    }
+
+    // (1) Direct assertion: the pool must be fully restored to POOL_SIZE. This
+    // alone fails on the pre-fix leak (the count would be 0 after POOL_SIZE
+    // panics drained every connection without returning it).
+    let restored = handle.read_pool_len_for_test().await;
+    assert_eq!(
+        restored, POOL_SIZE,
+        "read pool must be fully restored to POOL_SIZE after panicking reads, got {restored}"
     );
 
-    // Now run pool_size + 1 sequential reads — if the connection leaked we
-    // would eventually block or error when the pool is exhausted.
-    for _ in 0..(POOL_SIZE + 1) {
-        let listed = handle.list(ns.clone(), None, 10).await.unwrap();
+    // (2) Black-box assertion: fire POOL_SIZE concurrent reads. On the pre-fix
+    // code a fully-drained pool has no connections to hand out, so these would
+    // block forever and the timeout would fire -> the test fails.
+    let mut tasks = Vec::with_capacity(POOL_SIZE);
+    for _ in 0..POOL_SIZE {
+        let h = handle.clone();
+        let ns = ns.clone();
+        tasks.push(tokio::spawn(async move {
+            h.list(ns, None, 10).await
+        }));
+    }
+    for t in tasks {
+        let listed = tokio::time::timeout(Duration::from_secs(5), t)
+            .await
+            .expect("concurrent read must complete; a leaked pool would hang here")
+            .expect("read task must not panic")
+            .expect("read must succeed");
         assert!(
             !listed.is_empty(),
             "pool must not be permanently shrunk after panic"

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the StoreHandle concurrency core: writer thread,
 //! read pool, change broadcast, and the async MemoryBackend impl.
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use rb_daemon::{ChangeKind, StoreHandle};
 use rb_engine::MemoryBackend;
@@ -196,6 +196,42 @@ async fn namespace_id_methods_fail_closed() {
     let got = handle.get(ns_a, id).await.unwrap().unwrap();
     assert_eq!(got.importance, 5);
     assert!(got.archived_at.is_none());
+
+    handle.shutdown().await;
+}
+
+/// A panicking read closure must not permanently shrink the pool:
+/// the RAII guard returns the connection in Drop so subsequent reads
+/// still succeed, and we can run pool_size + 1 sequential reads afterward.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn panicking_read_closure_returns_connection_via_raii() {
+    const POOL_SIZE: usize = 2;
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, POOL_SIZE).unwrap();
+
+    // Seed one memory so subsequent reads have something to return.
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "raii test memory");
+    handle.write(n, Some(vec![0.1f32; DIM])).await.unwrap();
+
+    // Run a closure that panics inside spawn_blocking; the pool guard must
+    // catch the unwind (via JoinError mapping) and return the connection.
+    let err = handle.with_read_panicking_for_test().await;
+    assert!(
+        err.is_ok(),
+        "panicking read closure must surface as Storage error, got {err:?}"
+    );
+
+    // Now run pool_size + 1 sequential reads — if the connection leaked we
+    // would eventually block or error when the pool is exhausted.
+    for _ in 0..(POOL_SIZE + 1) {
+        let listed = handle.list(ns.clone(), None, 10).await.unwrap();
+        assert!(
+            !listed.is_empty(),
+            "pool must not be permanently shrunk after panic"
+        );
+    }
 
     handle.shutdown().await;
 }

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -229,7 +229,7 @@ async fn panicking_read_closure_returns_connection_via_raii() {
     for _ in 0..POOL_SIZE {
         let err = handle.with_read_panicking_for_test().await;
         assert!(
-            err.is_ok(),
+            matches!(err, Err(Error::Storage(_))),
             "panicking read closure must surface as Storage error, got {err:?}"
         );
     }

--- a/crates/rb-daemon/tests/store_handle.rs
+++ b/crates/rb-daemon/tests/store_handle.rs
@@ -250,9 +250,7 @@ async fn panicking_read_closure_returns_connection_via_raii() {
     for _ in 0..POOL_SIZE {
         let h = handle.clone();
         let ns = ns.clone();
-        tasks.push(tokio::spawn(async move {
-            h.list(ns, None, 10).await
-        }));
+        tasks.push(tokio::spawn(async move { h.list(ns, None, 10).await }));
     }
     for t in tasks {
         let listed = tokio::time::timeout(Duration::from_secs(5), t)

--- a/crates/rb-embed/Cargo.toml
+++ b/crates/rb-embed/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 secrecy = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/rb-embed/Cargo.toml
+++ b/crates/rb-embed/Cargo.toml
@@ -19,8 +19,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 secrecy = { workspace = true }
 sha2 = { workspace = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/rb-embed/Cargo.toml
+++ b/crates/rb-embed/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "rb-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Embedding provider trait for rusty-brain plus a Voyage remote impl and an offline deterministic provider."
+
+[lib]
+name = "rb_embed"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-embed/Cargo.toml
+++ b/crates/rb-embed/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Embedding provider trait for rusty-brain plus a Voyage remote impl and an offline deterministic provider."
+description = "EmbeddingProvider trait, Voyage remote provider, and an offline deterministic provider for rusty-brain."
 
 [lib]
 name = "rb_embed"

--- a/crates/rb-embed/src/deterministic.rs
+++ b/crates/rb-embed/src/deterministic.rs
@@ -1,0 +1,135 @@
+use crate::provider::EmbeddingProvider;
+use async_trait::async_trait;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Offline, deterministic embedding provider. Hashes each input text into a
+/// reproducible unit-length vector of length `dim`. Same text always yields the
+/// same vector; different texts yield different vectors. Never performs IO and
+/// never errors. Public so it can be used as a no-API-key fallback and in tests.
+///
+/// Determinism relies on `std::collections::hash_map::DefaultHasher::new()`,
+/// which is seeded with fixed keys (unlike `RandomState`), so the same input
+/// produces the same hash across processes and runs.
+pub struct DeterministicProvider {
+    dim: usize,
+}
+
+impl DeterministicProvider {
+    /// Create a provider that emits `dim`-length vectors.
+    pub fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Produce one reproducible unit-length vector for `text`.
+    fn embed_one(&self, text: &str) -> Vec<f32> {
+        let mut raw = Vec::with_capacity(self.dim);
+        for i in 0..self.dim {
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            i.hash(&mut hasher);
+            let h = hasher.finish();
+            let unit = (h as f64) / (u64::MAX as f64);
+            raw.push((unit * 2.0 - 1.0) as f32);
+        }
+
+        let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut raw {
+                *x /= norm;
+            }
+        } else if !raw.is_empty() {
+            raw[0] = 1.0;
+        }
+        raw
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for DeterministicProvider {
+    fn model_id(&self) -> &str {
+        "deterministic"
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|t| self.embed_one(t)).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::provider::EmbeddingProvider;
+
+    #[test]
+    fn model_id_and_dim_are_reported() {
+        let p = DeterministicProvider::new(512);
+        assert_eq!(p.dim(), 512);
+        assert_eq!(p.model_id(), "deterministic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_returns_one_vector_per_input_of_correct_length() {
+        let p = DeterministicProvider::new(8);
+        let inputs = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let out = p.embed(&inputs).await.unwrap();
+        assert_eq!(out.len(), 3);
+        for v in &out {
+            assert_eq!(v.len(), 8);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn same_text_yields_same_vector() {
+        let p = DeterministicProvider::new(16);
+        let a = p.embed(&["repeatable".to_string()]).await.unwrap();
+        let b = p.embed(&["repeatable".to_string()]).await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn different_text_yields_different_vector() {
+        let p = DeterministicProvider::new(16);
+        let out = p
+            .embed(&["one".to_string(), "two".to_string()])
+            .await
+            .unwrap();
+        assert_ne!(out[0], out[1]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_preserves_input_order() {
+        let p = DeterministicProvider::new(16);
+        let inputs = vec!["x".to_string(), "y".to_string(), "z".to_string()];
+        // Embedding the list at once must equal embedding each item alone, in order.
+        let batched = p.embed(&inputs).await.unwrap();
+        let mut individually = Vec::new();
+        for t in &inputs {
+            individually.push(p.embed(std::slice::from_ref(t)).await.unwrap()[0].clone());
+        }
+        assert_eq!(batched, individually);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_input_yields_empty_output() {
+        let p = DeterministicProvider::new(4);
+        let out = p.embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vectors_are_unit_length() {
+        let p = DeterministicProvider::new(32);
+        let out = p.embed(&["normalize me".to_string()]).await.unwrap();
+        let norm: f32 = out[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-5,
+            "expected unit vector, got norm {norm}"
+        );
+    }
+}

--- a/crates/rb-embed/src/deterministic.rs
+++ b/crates/rb-embed/src/deterministic.rs
@@ -1,16 +1,14 @@
 use crate::provider::EmbeddingProvider;
 use async_trait::async_trait;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use sha2::{Digest, Sha256};
 
 /// Offline, deterministic embedding provider. Hashes each input text into a
 /// reproducible unit-length vector of length `dim`. Same text always yields the
 /// same vector; different texts yield different vectors. Never performs IO and
 /// never errors. Public so it can be used as a no-API-key fallback and in tests.
 ///
-/// Determinism relies on `std::collections::hash_map::DefaultHasher::new()`,
-/// which is seeded with fixed keys (unlike `RandomState`), so the same input
-/// produces the same hash across processes and runs.
+/// Determinism relies on SHA-256 so persisted vectors do not depend on standard
+/// library hash implementation details.
 pub struct DeterministicProvider {
     dim: usize,
 }
@@ -25,10 +23,14 @@ impl DeterministicProvider {
     fn embed_one(&self, text: &str) -> Vec<f32> {
         let mut raw = Vec::with_capacity(self.dim);
         for i in 0..self.dim {
-            let mut hasher = DefaultHasher::new();
-            text.hash(&mut hasher);
-            i.hash(&mut hasher);
-            let h = hasher.finish();
+            let mut hasher = Sha256::new();
+            hasher.update(text.as_bytes());
+            hasher.update([0]);
+            hasher.update((i as u64).to_le_bytes());
+            let digest = hasher.finalize();
+            let mut bytes = [0_u8; 8];
+            bytes.copy_from_slice(&digest[..8]);
+            let h = u64::from_le_bytes(bytes);
             let unit = (h as f64) / (u64::MAX as f64);
             raw.push((unit * 2.0 - 1.0) as f32);
         }
@@ -90,6 +92,28 @@ mod tests {
         let a = p.embed(&["repeatable".to_string()]).await.unwrap();
         let b = p.embed(&["repeatable".to_string()]).await.unwrap();
         assert_eq!(a, b);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vector_values_are_stable_for_persisted_embeddings() {
+        let p = DeterministicProvider::new(4);
+        let out = p
+            .embed(&["stable persisted vector".to_string()])
+            .await
+            .unwrap();
+        let expected = [
+            -0.19579384_f32,
+            -0.48179987_f32,
+            -0.622556_f32,
+            -0.58477145_f32,
+        ];
+
+        for (actual, expected) in out[0].iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 1e-6,
+                "expected {expected}, got {actual}"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/rb-embed/src/lib.rs
+++ b/crates/rb-embed/src/lib.rs
@@ -1,0 +1,6 @@
+//! `rb_embed`: pluggable embedding providers for rusty-brain.
+//!
+//! The `EmbeddingProvider` trait, a Voyage remote impl, and an offline
+//! deterministic provider for tests and no-API-key fallback. Concrete types
+//! are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]

--- a/crates/rb-embed/src/lib.rs
+++ b/crates/rb-embed/src/lib.rs
@@ -1,6 +1,12 @@
-//! `rb_embed`: pluggable embedding providers for rusty-brain.
+//! `rb_embed`: embedding providers for rusty-brain.
 //!
-//! The `EmbeddingProvider` trait, a Voyage remote impl, and an offline
-//! deterministic provider for tests and no-API-key fallback. Concrete types
-//! are added in subsequent tasks.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+//! Defines the `EmbeddingProvider` trait, the remote `VoyageProvider`
+//! (added in a later task), and a public offline `DeterministicProvider`
+//! used as a no-API-key fallback and in tests.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod deterministic;
+mod provider;
+
+pub use deterministic::DeterministicProvider;
+pub use provider::EmbeddingProvider;

--- a/crates/rb-embed/src/lib.rs
+++ b/crates/rb-embed/src/lib.rs
@@ -1,12 +1,14 @@
 //! `rb_embed`: embedding providers for rusty-brain.
 //!
-//! Defines the `EmbeddingProvider` trait, the remote `VoyageProvider`
-//! (added in a later task), and a public offline `DeterministicProvider`
-//! used as a no-API-key fallback and in tests.
+//! Defines the `EmbeddingProvider` trait, the remote `VoyageProvider`,
+//! and a public offline `DeterministicProvider` used as a no-API-key
+//! fallback and in tests.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod deterministic;
 mod provider;
+mod voyage;
 
 pub use deterministic::DeterministicProvider;
 pub use provider::EmbeddingProvider;
+pub use voyage::VoyageProvider;

--- a/crates/rb-embed/src/provider.rs
+++ b/crates/rb-embed/src/provider.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+/// A source of embedding vectors. Implementations may be remote (Voyage) or
+/// local/offline (deterministic). All implementations are `Send + Sync` so the
+/// daemon can share a single provider across connection tasks.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Stable identifier of the model, stored on each memory as `embedding_model`.
+    fn model_id(&self) -> &str;
+
+    /// The fixed embedding dimension. Enforced against `meta.embedding_dim` at init.
+    fn dim(&self) -> usize;
+
+    /// Embed each input text, returning one vector per input **in input order**.
+    /// Every returned vector has length `self.dim()`.
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>>;
+}

--- a/crates/rb-embed/src/voyage.rs
+++ b/crates/rb-embed/src/voyage.rs
@@ -2,7 +2,7 @@ use crate::provider::EmbeddingProvider;
 use async_trait::async_trait;
 use rb_types::Error;
 use secrecy::{ExposeSecret, SecretString};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// Maximum number of inputs per HTTP request (Voyage batch ceiling).
@@ -21,7 +21,18 @@ pub struct VoyageProvider {
     api_key: SecretString,
     model: String,
     dim: usize,
+    output_dimension: Option<usize>,
     base_url: String,
+}
+
+/// Shape of the Voyage `/embeddings` request we send.
+#[derive(Serialize)]
+struct EmbeddingsRequest<'a> {
+    model: &'a str,
+    input: &'a [String],
+    input_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_dimension: Option<usize>,
 }
 
 /// Shape of the Voyage `/embeddings` response we depend on.
@@ -42,7 +53,7 @@ impl VoyageProvider {
     pub fn from_env() -> rb_types::Result<Self> {
         let key = std::env::var("VOYAGE_API_KEY")
             .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
-        Self::build(DEFAULT_MODEL, DEFAULT_DIM, key, DEFAULT_BASE_URL)
+        Self::build(DEFAULT_MODEL, DEFAULT_DIM, None, key, DEFAULT_BASE_URL)
     }
 
     /// Build a provider for a specific model + dimension, reading the key from
@@ -50,7 +61,7 @@ impl VoyageProvider {
     pub fn with_model(model: &str, dim: usize) -> rb_types::Result<Self> {
         let key = std::env::var("VOYAGE_API_KEY")
             .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
-        Self::build(model, dim, key, DEFAULT_BASE_URL)
+        Self::build(model, dim, Some(dim), key, DEFAULT_BASE_URL)
     }
 
     /// Test-only constructor: explicit key + base URL, no environment access.
@@ -65,11 +76,36 @@ impl VoyageProvider {
             api_key: SecretString::from(api_key.to_string()),
             model: model.to_string(),
             dim,
+            output_dimension: Some(dim),
             base_url: base_url.trim_end_matches('/').to_string(),
         }
     }
 
-    fn build(model: &str, dim: usize, api_key: String, base_url: &str) -> rb_types::Result<Self> {
+    /// Test-only constructor for default-model behavior that omits
+    /// `output_dimension`, matching `from_env`.
+    #[cfg(test)]
+    pub(crate) fn for_test_default(api_key: &str, base_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            client,
+            api_key: SecretString::from(api_key.to_string()),
+            model: DEFAULT_MODEL.to_string(),
+            dim: DEFAULT_DIM,
+            output_dimension: None,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn build(
+        model: &str,
+        dim: usize,
+        output_dimension: Option<usize>,
+        api_key: String,
+        base_url: &str,
+    ) -> rb_types::Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
             .build()
@@ -79,18 +115,24 @@ impl VoyageProvider {
             api_key: SecretString::from(api_key),
             model: model.to_string(),
             dim,
+            output_dimension,
             base_url: base_url.trim_end_matches('/').to_string(),
         })
+    }
+
+    fn embeddings_request<'a>(&'a self, texts: &'a [String]) -> EmbeddingsRequest<'a> {
+        EmbeddingsRequest {
+            model: &self.model,
+            input: texts,
+            input_type: "document",
+            output_dimension: self.output_dimension,
+        }
     }
 
     /// POST a single chunk of inputs and return their embeddings in order.
     async fn embed_chunk(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
         let url = format!("{}/embeddings", self.base_url);
-        let body = serde_json::json!({
-            "model": self.model,
-            "input": texts,
-            "input_type": "document",
-        });
+        let body = self.embeddings_request(texts);
 
         let resp = self
             .client
@@ -196,7 +238,8 @@ mod tests {
             .and(body_partial_json(serde_json::json!({
                 "model": "voyage-3-lite",
                 "input": ["first", "second"],
-                "input_type": "document"
+                "input_type": "document",
+                "output_dimension": 4
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(&response))
             .mount(&server)
@@ -212,6 +255,17 @@ mod tests {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], vec![0.1, 0.2, 0.3, 0.4]);
         assert_eq!(out[1], vec![0.5, 0.6, 0.7, 0.8]);
+    }
+
+    #[test]
+    fn default_model_request_omits_output_dimension() {
+        let p = VoyageProvider::for_test_default("test-key", "http://127.0.0.1:1/v1");
+        let inputs = vec!["first".to_string(), "second".to_string()];
+        let body = serde_json::to_value(p.embeddings_request(&inputs)).unwrap();
+
+        assert_eq!(body["model"], "voyage-3-lite");
+        assert_eq!(body["input_type"], "document");
+        assert!(body.get("output_dimension").is_none());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -310,6 +364,17 @@ mod tests {
         for v in &out {
             assert_eq!(v, &vec![1.0, 0.0, 0.0, 0.0]);
         }
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let batch_sizes: Vec<usize> = requests
+            .iter()
+            .map(|request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                body["input"].as_array().unwrap().len()
+            })
+            .collect();
+        assert_eq!(batch_sizes, vec![128, 72]);
     }
 
     // Real-API smoke test. Ignored by default; run with:

--- a/crates/rb-embed/src/voyage.rs
+++ b/crates/rb-embed/src/voyage.rs
@@ -1,0 +1,325 @@
+use crate::provider::EmbeddingProvider;
+use async_trait::async_trait;
+use rb_types::Error;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Maximum number of inputs per HTTP request (Voyage batch ceiling).
+const MAX_BATCH: usize = 128;
+/// Default model and its embedding dimension.
+const DEFAULT_MODEL: &str = "voyage-3-lite";
+const DEFAULT_DIM: usize = 512;
+/// Default API base; the `/embeddings` path is appended per request.
+const DEFAULT_BASE_URL: &str = "https://api.voyageai.com/v1";
+/// Outbound request timeout (all embedding calls are timed out).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Remote embedding provider backed by the Voyage AI embeddings API.
+pub struct VoyageProvider {
+    client: reqwest::Client,
+    api_key: SecretString,
+    model: String,
+    dim: usize,
+    base_url: String,
+}
+
+/// Shape of the Voyage `/embeddings` response we depend on.
+#[derive(Deserialize)]
+struct EmbeddingsResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+impl VoyageProvider {
+    /// Build a provider from the environment. Reads `VOYAGE_API_KEY` (an
+    /// `Error::Embedding` if absent), defaults to model `voyage-3-lite` (dim 512),
+    /// and constructs a reqwest client with a request timeout.
+    pub fn from_env() -> rb_types::Result<Self> {
+        let key = std::env::var("VOYAGE_API_KEY")
+            .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
+        Self::build(DEFAULT_MODEL, DEFAULT_DIM, key, DEFAULT_BASE_URL)
+    }
+
+    /// Build a provider for a specific model + dimension, reading the key from
+    /// `VOYAGE_API_KEY`. Use this when overriding the default model.
+    pub fn with_model(model: &str, dim: usize) -> rb_types::Result<Self> {
+        let key = std::env::var("VOYAGE_API_KEY")
+            .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
+        Self::build(model, dim, key, DEFAULT_BASE_URL)
+    }
+
+    /// Test-only constructor: explicit key + base URL, no environment access.
+    #[cfg(test)]
+    pub(crate) fn for_test(model: &str, dim: usize, api_key: &str, base_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            client,
+            api_key: SecretString::from(api_key.to_string()),
+            model: model.to_string(),
+            dim,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn build(model: &str, dim: usize, api_key: String, base_url: &str) -> rb_types::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| Error::Embedding(format!("failed to build http client: {e}")))?;
+        Ok(Self {
+            client,
+            api_key: SecretString::from(api_key),
+            model: model.to_string(),
+            dim,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// POST a single chunk of inputs and return their embeddings in order.
+    async fn embed_chunk(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        let url = format!("{}/embeddings", self.base_url);
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": texts,
+            "input_type": "document",
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(self.api_key.expose_secret())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Embedding(format!("voyage request failed: {e}")))?;
+
+        let resp = resp
+            .error_for_status()
+            .map_err(|e| Error::Embedding(format!("voyage returned an error status: {e}")))?;
+
+        let parsed: EmbeddingsResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::Embedding(format!("failed to parse voyage response: {e}")))?;
+
+        if parsed.data.len() != texts.len() {
+            return Err(Error::Embedding(format!(
+                "voyage returned {} embeddings for {} inputs",
+                parsed.data.len(),
+                texts.len()
+            )));
+        }
+
+        let mut out = Vec::with_capacity(parsed.data.len());
+        for item in parsed.data {
+            if item.embedding.len() != self.dim {
+                return Err(Error::Embedding(format!(
+                    "embedding dimension mismatch: expected {}, got {}",
+                    self.dim,
+                    item.embedding.len()
+                )));
+            }
+            out.push(item.embedding);
+        }
+        Ok(out)
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for VoyageProvider {
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut out = Vec::with_capacity(texts.len());
+        for chunk in texts.chunks(MAX_BATCH) {
+            let mut embeddings = self.embed_chunk(chunk).await?;
+            out.append(&mut embeddings);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::provider::EmbeddingProvider;
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Build a provider pointed at a mock server with an explicit api key, so the
+    // tests never touch the real Voyage endpoint or read the environment.
+    // `for_test` is a #[cfg(test)]-only helper on VoyageProvider.
+    fn provider_for(base_url: &str, dim: usize) -> VoyageProvider {
+        VoyageProvider::for_test("voyage-3-lite", dim, "test-key", base_url)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn metadata_reports_model_and_dim() {
+        let p = provider_for("http://127.0.0.1:1/v1", 4);
+        assert_eq!(p.model_id(), "voyage-3-lite");
+        assert_eq!(p.dim(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_sends_correct_request_and_parses_response_in_order() {
+        let server = MockServer::start().await;
+        // The mock asserts the request shape: POST /v1/embeddings, JSON body with
+        // the model, the inputs in order, and input_type "document", with bearer auth.
+        let response = serde_json::json!({
+            "data": [
+                { "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "embedding": [0.5, 0.6, 0.7, 0.8] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "voyage-3-lite",
+                "input": ["first", "second"],
+                "input_type": "document"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p
+            .embed(&["first".to_string(), "second".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], vec![0.1, 0.2, 0.3, 0.4]);
+        assert_eq!(out[1], vec![0.5, 0.6, 0.7, 0.8]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dim_mismatch_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // Server returns a 3-length vector but the provider expects dim=4.
+        let response = serde_json::json!({
+            "data": [ { "embedding": [0.1, 0.2, 0.3] } ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p.embed(&["x".to_string()]).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Embedding(_)),
+            "expected Error::Embedding, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn count_mismatch_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // Two inputs but the server returns only one embedding.
+        let response = serde_json::json!({
+            "data": [ { "embedding": [0.1, 0.2, 0.3, 0.4] } ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p
+            .embed(&["a".to_string(), "b".to_string()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::Embedding(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_error_status_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p.embed(&["x".to_string()]).await.unwrap_err();
+        assert!(matches!(err, rb_types::Error::Embedding(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_input_short_circuits_without_calling_server() {
+        // No mock mounted: if embed() called the server it would 404 and error.
+        let server = MockServer::start().await;
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p.embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batches_over_128_are_chunked_and_recombined_in_order() {
+        let server = MockServer::start().await;
+        // The mock echoes a fixed vector per requested input by reading the request
+        // body, so we can assert the total count and ordering after chunking.
+        // The closure captures nothing, so it is Send + Sync as Respond requires.
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(|req: &wiremock::Request| {
+                let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+                let n = body["input"].as_array().unwrap().len();
+                let data: Vec<serde_json::Value> = (0..n)
+                    .map(|_| serde_json::json!({ "embedding": [1.0, 0.0, 0.0, 0.0] }))
+                    .collect();
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "data": data }))
+            })
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let inputs: Vec<String> = (0..200).map(|i| format!("item-{i}")).collect();
+        let out = p.embed(&inputs).await.unwrap();
+        assert_eq!(out.len(), 200);
+        for v in &out {
+            assert_eq!(v, &vec![1.0, 0.0, 0.0, 0.0]);
+        }
+    }
+
+    // Real-API smoke test. Ignored by default; run with:
+    //   VOYAGE_API_KEY=... cargo test -p rb-embed -- --ignored voyage_real_api
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires VOYAGE_API_KEY and network access"]
+    async fn voyage_real_api_smoke() {
+        let p = VoyageProvider::from_env().unwrap();
+        let out = p.embed(&["hello world".to_string()]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), p.dim());
+    }
+}

--- a/crates/rb-embed/src/voyage.rs
+++ b/crates/rb-embed/src/voyage.rs
@@ -46,7 +46,11 @@ struct EmbeddingData {
     /// Position of this embedding in the original input array.
     /// Voyage may return embeddings out of input order; we use this field to
     /// re-pair each embedding to its source text.
-    /// If absent (older API responses), the item's position in `data` is used.
+    ///
+    /// For a multi-item batch, a missing `index` is a fail-closed error: we
+    /// cannot safely assume array order, so we refuse rather than risk a silent
+    /// text/embedding mis-pairing. A single-item response may omit it (the only
+    /// possible position is 0, so the pairing is unambiguous).
     #[serde(default)]
     index: Option<usize>,
     embedding: Vec<f32>,
@@ -168,12 +172,23 @@ impl VoyageProvider {
 
         // Re-order embeddings by their declared `index` field so that a Voyage
         // response returned out of input order is correctly re-paired.
-        // If `index` is absent (older API responses), fall back to the item's
-        // position in the `data` array (i.e. treat as in-order).
+        //
+        // Fail closed on a multi-item batch missing `index`: without it we
+        // cannot prove the array order matches the input order, so we refuse
+        // rather than risk a silent mis-pairing. A single-item response may
+        // omit `index` (position 0 is the only option, so it is unambiguous).
         let n = texts.len();
         let mut slots: Vec<Option<Vec<f32>>> = (0..n).map(|_| None).collect();
         for (pos, item) in parsed.data.into_iter().enumerate() {
-            let slot_idx = item.index.unwrap_or(pos);
+            let slot_idx = match item.index {
+                Some(idx) => idx,
+                None if n == 1 => pos,
+                None => {
+                    return Err(Error::Embedding(
+                        "voyage response missing index for multi-item batch".to_string(),
+                    ));
+                }
+            };
             if slot_idx >= n {
                 return Err(Error::Embedding(format!(
                     "voyage returned embedding with index {} but input length is {}",
@@ -258,10 +273,12 @@ mod tests {
         let server = MockServer::start().await;
         // The mock asserts the request shape: POST /v1/embeddings, JSON body with
         // the model, the inputs in order, and input_type "document", with bearer auth.
+        // Voyage always returns an `index` per item; we include it here to match
+        // real API behavior (a multi-item batch without index now fails closed).
         let response = serde_json::json!({
             "data": [
-                { "embedding": [0.1, 0.2, 0.3, 0.4] },
-                { "embedding": [0.5, 0.6, 0.7, 0.8] }
+                { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "index": 1, "embedding": [0.5, 0.6, 0.7, 0.8] }
             ]
         });
         Mock::given(method("POST"))
@@ -380,8 +397,9 @@ mod tests {
             .respond_with(|req: &wiremock::Request| {
                 let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
                 let n = body["input"].as_array().unwrap().len();
+                // Include a per-item `index` as the real Voyage API does.
                 let data: Vec<serde_json::Value> = (0..n)
-                    .map(|_| serde_json::json!({ "embedding": [1.0, 0.0, 0.0, 0.0] }))
+                    .map(|i| serde_json::json!({ "index": i, "embedding": [1.0, 0.0, 0.0, 0.0] }))
                     .collect();
                 ResponseTemplate::new(200).set_body_json(serde_json::json!({ "data": data }))
             })
@@ -503,6 +521,62 @@ mod tests {
             matches!(err, rb_types::Error::Embedding(_)),
             "out-of-range index must be Error::Embedding, got {err:?}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multi_item_response_missing_index_fails_closed() {
+        let server = MockServer::start().await;
+        // A 2-item response with NO `index` fields. We cannot prove the array
+        // order matches the input order, so this must fail closed rather than
+        // silently fall back to array order (the mis-pairing risk).
+        let response = serde_json::json!({
+            "data": [
+                { "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "embedding": [0.5, 0.6, 0.7, 0.8] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p
+            .embed(&["first".to_string(), "second".to_string()])
+            .await
+            .unwrap_err();
+        match err {
+            rb_types::Error::Embedding(msg) => {
+                assert!(
+                    msg.contains("missing index for multi-item batch"),
+                    "expected the multi-item missing-index error, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::Embedding, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn single_item_response_without_index_is_accepted() {
+        let server = MockServer::start().await;
+        // A single-item response may omit `index`: position 0 is the only
+        // possible slot, so the pairing is unambiguous and allowed.
+        let response = serde_json::json!({
+            "data": [ { "embedding": [0.1, 0.2, 0.3, 0.4] } ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p.embed(&["only".to_string()]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], vec![0.1, 0.2, 0.3, 0.4]);
     }
 
     // Real-API smoke test. Ignored by default; run with:

--- a/crates/rb-embed/src/voyage.rs
+++ b/crates/rb-embed/src/voyage.rs
@@ -43,6 +43,12 @@ struct EmbeddingsResponse {
 
 #[derive(Deserialize)]
 struct EmbeddingData {
+    /// Position of this embedding in the original input array.
+    /// Voyage may return embeddings out of input order; we use this field to
+    /// re-pair each embedding to its source text.
+    /// If absent (older API responses), the item's position in `data` is used.
+    #[serde(default)]
+    index: Option<usize>,
     embedding: Vec<f32>,
 }
 
@@ -160,8 +166,26 @@ impl VoyageProvider {
             )));
         }
 
-        let mut out = Vec::with_capacity(parsed.data.len());
-        for item in parsed.data {
+        // Re-order embeddings by their declared `index` field so that a Voyage
+        // response returned out of input order is correctly re-paired.
+        // If `index` is absent (older API responses), fall back to the item's
+        // position in the `data` array (i.e. treat as in-order).
+        let n = texts.len();
+        let mut slots: Vec<Option<Vec<f32>>> = (0..n).map(|_| None).collect();
+        for (pos, item) in parsed.data.into_iter().enumerate() {
+            let slot_idx = item.index.unwrap_or(pos);
+            if slot_idx >= n {
+                return Err(Error::Embedding(format!(
+                    "voyage returned embedding with index {} but input length is {}",
+                    slot_idx, n
+                )));
+            }
+            if slots[slot_idx].is_some() {
+                return Err(Error::Embedding(format!(
+                    "voyage returned duplicate embedding for index {}",
+                    slot_idx
+                )));
+            }
             if item.embedding.len() != self.dim {
                 return Err(Error::Embedding(format!(
                     "embedding dimension mismatch: expected {}, got {}",
@@ -169,9 +193,17 @@ impl VoyageProvider {
                     item.embedding.len()
                 )));
             }
-            out.push(item.embedding);
+            slots[slot_idx] = Some(item.embedding);
         }
-        Ok(out)
+
+        // Every slot must be filled; the count check above ensures exactly
+        // n items were returned, so any missing slot means a duplicate index.
+        let out: Option<Vec<Vec<f32>>> = slots.into_iter().collect();
+        out.ok_or_else(|| {
+            Error::Embedding(
+                "voyage response had missing embedding slots after index placement".to_string(),
+            )
+        })
     }
 }
 
@@ -375,6 +407,102 @@ mod tests {
             })
             .collect();
         assert_eq!(batch_sizes, vec![128, 72]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn out_of_order_index_fields_are_correctly_re_paired() {
+        let server = MockServer::start().await;
+        // Voyage returns embeddings in reverse order (index 1 first, index 0 second).
+        // Without honoring the `index` field the results would be silently swapped.
+        let response = serde_json::json!({
+            "data": [
+                { "index": 1, "embedding": [0.5, 0.6, 0.7, 0.8] },
+                { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p
+            .embed(&["first".to_string(), "second".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 2);
+        // "first" must be paired with the embedding at index 0, regardless of
+        // the order in which Voyage returned the items.
+        assert_eq!(
+            out[0],
+            vec![0.1, 0.2, 0.3, 0.4],
+            "index 0 embedding must be placed at position 0"
+        );
+        assert_eq!(
+            out[1],
+            vec![0.5, 0.6, 0.7, 0.8],
+            "index 1 embedding must be placed at position 1"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn duplicate_index_in_response_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // Both returned items claim index 0 — this must be detected and rejected.
+        let response = serde_json::json!({
+            "data": [
+                { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "index": 0, "embedding": [0.5, 0.6, 0.7, 0.8] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p
+            .embed(&["a".to_string(), "b".to_string()])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Embedding(_)),
+            "duplicate index must be Error::Embedding, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn out_of_range_index_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // One item has an index beyond the input length.
+        let response = serde_json::json!({
+            "data": [
+                { "index": 0, "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "index": 99, "embedding": [0.5, 0.6, 0.7, 0.8] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p
+            .embed(&["a".to_string(), "b".to_string()])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Embedding(_)),
+            "out-of-range index must be Error::Embedding, got {err:?}"
+        );
     }
 
     // Real-API smoke test. Ignored by default; run with:

--- a/crates/rb-embed/src/voyage.rs
+++ b/crates/rb-embed/src/voyage.rs
@@ -547,15 +547,15 @@ mod tests {
             .embed(&["first".to_string(), "second".to_string()])
             .await
             .unwrap_err();
-        match err {
-            rb_types::Error::Embedding(msg) => {
-                assert!(
-                    msg.contains("missing index for multi-item batch"),
-                    "expected the multi-item missing-index error, got: {msg}"
-                );
-            }
-            other => panic!("expected Error::Embedding, got {other:?}"),
-        }
+        // Assert it is an Embedding error whose message names the failure mode.
+        let is_missing_index = matches!(
+            &err,
+            rb_types::Error::Embedding(msg) if msg.contains("missing index for multi-item batch")
+        );
+        assert!(
+            is_missing_index,
+            "expected the multi-item missing-index error, got: {err:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/rb-embed/tests/public_api.rs
+++ b/crates/rb-embed/tests/public_api.rs
@@ -1,0 +1,48 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_embed::{DeterministicProvider, EmbeddingProvider, VoyageProvider};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deterministic_provider_satisfies_trait_contract_via_dyn() {
+    // Object-safety: the trait must be usable behind a trait object, as the
+    // engine/daemon will hold `Box<dyn EmbeddingProvider>` (or a generic param).
+    let provider: Box<dyn EmbeddingProvider> = Box::new(DeterministicProvider::new(64));
+    assert_eq!(provider.dim(), 64);
+    assert_eq!(provider.model_id(), "deterministic");
+
+    let inputs = vec![
+        "one transaction one database".to_string(),
+        "single writer thread".to_string(),
+        "namespace isolation".to_string(),
+    ];
+    let out = provider.embed(&inputs).await.unwrap();
+
+    // One vector per input, each of length dim().
+    assert_eq!(out.len(), inputs.len());
+    for v in &out {
+        assert_eq!(v.len(), provider.dim());
+    }
+
+    // Determinism: re-embedding yields identical vectors.
+    let out2 = provider.embed(&inputs).await.unwrap();
+    assert_eq!(out, out2);
+
+    // Distinctness: different inputs produce different vectors.
+    assert_ne!(out[0], out[1]);
+    assert_ne!(out[1], out[2]);
+}
+
+#[test]
+fn voyage_provider_is_publicly_constructible() {
+    // Reachable from the crate root and implements EmbeddingProvider; no network.
+    let provider = VoyageProvider::with_model("voyage-3-lite", 1024);
+    // Without VOYAGE_API_KEY this is an Embedding error; with it, a valid provider.
+    match provider {
+        Ok(p) => {
+            let p: &dyn EmbeddingProvider = &p;
+            assert_eq!(p.dim(), 1024);
+            assert_eq!(p.model_id(), "voyage-3-lite");
+        }
+        Err(e) => assert!(matches!(e, rb_types::Error::Embedding(_))),
+    }
+}

--- a/crates/rb-engine/Cargo.toml
+++ b/crates/rb-engine/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rb-engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain request orchestration: embed plus rank policy over an abstract memory backend (no concrete store dependency)."
+
+[lib]
+name = "rb_engine"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-search = { path = "../rb-search" }
+rb-embed = { path = "../rb-embed" }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-engine/Cargo.toml
+++ b/crates/rb-engine/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "rusty-brain request orchestration: embed plus rank policy over an abstract memory backend (no concrete store dependency)."
+description = "Single-request memory orchestration: heuristic enrichment, embed, hybrid recall ranking."
 
 [lib]
 name = "rb_engine"

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -7,7 +7,7 @@ use rb_types::{MemoryId, MemoryNote, MemoryUpdates, Namespace};
 #[async_trait::async_trait]
 pub trait MemoryBackend: Send + Sync {
     async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> rb_types::Result<()>;
-    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>>;
+    async fn get(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<Option<MemoryNote>>;
     async fn keyword(
         &self,
         ns: Namespace,
@@ -20,15 +20,25 @@ pub trait MemoryBackend: Send + Sync {
         embedding: Vec<f32>,
         limit: usize,
     ) -> rb_types::Result<Vec<(MemoryId, f32)>>;
-    async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryId>>;
+    async fn graph(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        depth: u8,
+    ) -> rb_types::Result<Vec<MemoryId>>;
     async fn list(
         &self,
         ns: Namespace,
         min_importance: Option<u8>,
         limit: usize,
     ) -> rb_types::Result<Vec<MemoryNote>>;
-    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()>;
-    async fn archive(&self, id: MemoryId) -> rb_types::Result<()>;
+    async fn update(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()>;
+    async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()>;
 }
 
 #[cfg(test)]
@@ -60,8 +70,14 @@ mod tests {
             self.notes.lock().unwrap().insert(note.id.clone(), note);
             Ok(())
         }
-        async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
-            Ok(self.notes.lock().unwrap().get(&id).cloned())
+        async fn get(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+            Ok(self
+                .notes
+                .lock()
+                .unwrap()
+                .get(&id)
+                .filter(|note| note.namespace == ns)
+                .cloned())
         }
         async fn keyword(
             &self,
@@ -97,7 +113,12 @@ mod tests {
             pairs.sort_by_key(|(_, note)| std::cmp::Reverse(note.created_at));
             Ok(pairs.into_iter().map(|(id, _)| (id, 0.0)).collect())
         }
-        async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+        async fn graph(
+            &self,
+            _ns: Namespace,
+            _id: MemoryId,
+            _depth: u8,
+        ) -> rb_types::Result<Vec<MemoryId>> {
             Ok(Vec::new())
         }
         async fn list(
@@ -118,10 +139,16 @@ mod tests {
             v.truncate(limit);
             Ok(v)
         }
-        async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+        async fn update(
+            &self,
+            ns: Namespace,
+            id: MemoryId,
+            updates: MemoryUpdates,
+        ) -> rb_types::Result<()> {
             let mut guard = self.notes.lock().unwrap();
             let note = guard
                 .get_mut(&id)
+                .filter(|note| note.namespace == ns)
                 .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
             if let Some(c) = updates.content {
                 note.content = c;
@@ -131,10 +158,11 @@ mod tests {
             }
             Ok(())
         }
-        async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+        async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()> {
             let mut guard = self.notes.lock().unwrap();
             let note = guard
                 .get_mut(&id)
+                .filter(|note| note.namespace == ns)
                 .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
             note.archived_at = Some(chrono::Utc::now());
             Ok(())
@@ -155,7 +183,7 @@ mod tests {
             .write(note.clone(), Some(vec![0.1, 0.2, 0.3]))
             .await
             .unwrap();
-        let got = backend.get(id).await.unwrap().unwrap();
+        let got = backend.get(Namespace::Global, id).await.unwrap().unwrap();
         assert_eq!(got.content, "hello world");
     }
 
@@ -165,9 +193,12 @@ mod tests {
         let note = MemoryNote::new(Namespace::Global, "x".to_string(), MemoryType::Reference, 3);
         let id = note.id.clone();
         backend.write(note, None).await.unwrap();
-        backend.archive(id.clone()).await.unwrap();
+        backend
+            .archive(Namespace::Global, id.clone())
+            .await
+            .unwrap();
         assert!(backend
-            .get(id)
+            .get(Namespace::Global, id)
             .await
             .unwrap()
             .unwrap()

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -32,6 +32,8 @@ pub trait MemoryBackend: Send + Sync {
         min_importance: Option<u8>,
         limit: usize,
     ) -> rb_types::Result<Vec<MemoryNote>>;
+    /// Apply metadata-only updates. `MemoryEngine::update` rejects content edits
+    /// so the vector index cannot drift from stored note content.
     async fn update(
         &self,
         ns: Namespace,

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -1,0 +1,177 @@
+use rb_types::{MemoryId, MemoryNote, MemoryUpdates, Namespace};
+
+/// Async store-access abstraction the engine is generic over. The daemon
+/// implements this on top of the synchronous `rb_store::Store` using a
+/// dedicated writer thread plus `spawn_blocking` readers; tests implement it
+/// over an in-memory map. The engine never touches a concrete store.
+#[async_trait::async_trait]
+pub trait MemoryBackend: Send + Sync {
+    async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> rb_types::Result<()>;
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>>;
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        query: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>>;
+    async fn vector(
+        &self,
+        ns: Namespace,
+        embedding: Vec<f32>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>>;
+    async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryId>>;
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>>;
+    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()>;
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Minimal in-memory backend used to unit-test the engine in isolation.
+    /// NOT backed by rb-store; just a HashMap behind a Mutex.
+    #[derive(Default)]
+    struct MockBackend {
+        notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+        embeddings: Mutex<HashMap<MemoryId, Vec<f32>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryBackend for MockBackend {
+        async fn write(
+            &self,
+            note: MemoryNote,
+            embedding: Option<Vec<f32>>,
+        ) -> rb_types::Result<()> {
+            if let Some(emb) = embedding {
+                self.embeddings.lock().unwrap().insert(note.id.clone(), emb);
+            }
+            self.notes.lock().unwrap().insert(note.id.clone(), note);
+            Ok(())
+        }
+        async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+            Ok(self.notes.lock().unwrap().get(&id).cloned())
+        }
+        async fn keyword(
+            &self,
+            _ns: Namespace,
+            _query: String,
+            _limit: usize,
+        ) -> rb_types::Result<Vec<MemoryId>> {
+            // Deterministic order (created_at desc) so keyword_rank is reproducible.
+            let mut notes: Vec<MemoryNote> = self.notes.lock().unwrap().values().cloned().collect();
+            notes.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+            Ok(notes.into_iter().map(|n| n.id).collect())
+        }
+        async fn vector(
+            &self,
+            _ns: Namespace,
+            _embedding: Vec<f32>,
+            _limit: usize,
+        ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+            let mut pairs: Vec<(MemoryId, MemoryNote)> = self
+                .embeddings
+                .lock()
+                .unwrap()
+                .keys()
+                .filter_map(|id| {
+                    self.notes
+                        .lock()
+                        .unwrap()
+                        .get(id)
+                        .cloned()
+                        .map(|n| (id.clone(), n))
+                })
+                .collect();
+            pairs.sort_by_key(|(_, note)| std::cmp::Reverse(note.created_at));
+            Ok(pairs.into_iter().map(|(id, _)| (id, 0.0)).collect())
+        }
+        async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+            Ok(Vec::new())
+        }
+        async fn list(
+            &self,
+            _ns: Namespace,
+            min_importance: Option<u8>,
+            limit: usize,
+        ) -> rb_types::Result<Vec<MemoryNote>> {
+            let mut v: Vec<MemoryNote> = self
+                .notes
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+                .cloned()
+                .collect();
+            v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+            v.truncate(limit);
+            Ok(v)
+        }
+        async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+            let mut guard = self.notes.lock().unwrap();
+            let note = guard
+                .get_mut(&id)
+                .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+            if let Some(c) = updates.content {
+                note.content = c;
+            }
+            if let Some(s) = updates.summary {
+                note.summary = s;
+            }
+            Ok(())
+        }
+        async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+            let mut guard = self.notes.lock().unwrap();
+            let note = guard
+                .get_mut(&id)
+                .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+            note.archived_at = Some(chrono::Utc::now());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_backend_round_trips_write_and_get() {
+        let backend = MockBackend::default();
+        let note = MemoryNote::new(
+            Namespace::Global,
+            "hello world".to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        let id = note.id.clone();
+        backend
+            .write(note.clone(), Some(vec![0.1, 0.2, 0.3]))
+            .await
+            .unwrap();
+        let got = backend.get(id).await.unwrap().unwrap();
+        assert_eq!(got.content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn mock_backend_archive_sets_archived_at() {
+        let backend = MockBackend::default();
+        let note = MemoryNote::new(Namespace::Global, "x".to_string(), MemoryType::Reference, 3);
+        let id = note.id.clone();
+        backend.write(note, None).await.unwrap();
+        backend.archive(id.clone()).await.unwrap();
+        assert!(backend
+            .get(id)
+            .await
+            .unwrap()
+            .unwrap()
+            .archived_at
+            .is_some());
+    }
+}

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -51,6 +51,35 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         self.weights
     }
 
+    fn in_namespace(&self, note: &MemoryNote) -> bool {
+        note.namespace == self.namespace
+    }
+
+    fn active_in_namespace(&self, note: &MemoryNote) -> bool {
+        self.in_namespace(note) && note.archived_at.is_none()
+    }
+
+    fn matches_recall_filters(
+        note: &MemoryNote,
+        type_filter: Option<MemoryType>,
+        tags: &[String],
+    ) -> bool {
+        if let Some(ty) = type_filter {
+            if note.memory_type != ty {
+                return false;
+            }
+        }
+        tags.iter().all(|t| note.tags.contains(t))
+    }
+
+    async fn get_scoped(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self
+            .backend
+            .get(self.namespace.clone(), id)
+            .await?
+            .filter(|note| self.in_namespace(note)))
+    }
+
     /// Store a new memory: heuristic-enrich, embed the content, then write.
     pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
         let mut note = MemoryNote::new(
@@ -109,9 +138,21 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             .vector(self.namespace.clone(), embedding, candidate_limit)
             .await?;
 
-        // Bounded 1-hop graph expansion of the top keyword hit only.
-        let graph = match keyword.first() {
-            Some(top) => self.backend.graph(top.clone(), 1).await?,
+        // Bounded 1-hop graph expansion of the top active in-namespace keyword hit only.
+        let mut graph_seed = None;
+        for id in &keyword {
+            if self
+                .get_scoped(id.clone())
+                .await?
+                .as_ref()
+                .is_some_and(|note| self.active_in_namespace(note))
+            {
+                graph_seed = Some(id.clone());
+                break;
+            }
+        }
+        let graph = match graph_seed {
+            Some(top) => self.backend.graph(self.namespace.clone(), top, 1).await?,
             None => Vec::new(),
         };
 
@@ -132,29 +173,43 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         let mut notes: HashMap<MemoryId, MemoryNote> = HashMap::new();
         let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
         for id in &order {
-            if let Some(note) = self.backend.get(id.clone()).await? {
+            if let Some(note) = self.get_scoped(id.clone()).await? {
+                if !self.active_in_namespace(&note)
+                    || !Self::matches_recall_filters(&note, type_filter, tags)
+                {
+                    continue;
+                }
                 meta.insert(id.clone(), (note.importance, note.created_at));
                 notes.insert(id.clone(), note);
             }
         }
 
-        let signals = rb_search::build_signals(&keyword, &vector, &graph, &meta);
+        let filtered_keyword: Vec<MemoryId> = keyword
+            .iter()
+            .filter(|id| notes.contains_key(*id))
+            .cloned()
+            .collect();
+        let filtered_vector: Vec<(MemoryId, f32)> = vector
+            .iter()
+            .filter(|(id, _)| notes.contains_key(id))
+            .cloned()
+            .collect();
+        let filtered_graph: Vec<MemoryId> = graph
+            .iter()
+            .filter(|id| notes.contains_key(*id))
+            .cloned()
+            .collect();
+
+        let signals =
+            rb_search::build_signals(&filtered_keyword, &filtered_vector, &filtered_graph, &meta);
         let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
 
-        // Assemble results in ranked order, applying filters, truncating to limit.
+        // Assemble results in ranked order, truncating to limit.
         let mut results: Vec<rb_types::SearchResult> = Vec::new();
         for (id, score) in ranked {
             let Some(note) = notes.get(&id) else {
                 continue;
             };
-            if let Some(ty) = type_filter {
-                if note.memory_type != ty {
-                    continue;
-                }
-            }
-            if !tags.iter().all(|t| note.tags.contains(t)) {
-                continue;
-            }
             results.push(rb_types::SearchResult {
                 memory: note.clone(),
                 score,
@@ -166,9 +221,9 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         Ok(results)
     }
 
-    /// Fetch a single memory by id (namespace scoping is enforced by the backend).
+    /// Fetch a single memory by id in the engine namespace.
     pub async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
-        self.backend.get(id).await
+        self.get_scoped(id).await
     }
 
     /// List memories in the engine namespace, most-recent first, optionally
@@ -185,10 +240,22 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
 
     /// Expand the graph around `id` to `depth` hops and fetch the connected notes.
     pub async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryNote>> {
-        let ids = self.backend.graph(id, depth).await?;
+        let Some(anchor) = self.get_scoped(id.clone()).await? else {
+            return Ok(Vec::new());
+        };
+        if !self.active_in_namespace(&anchor) {
+            return Ok(Vec::new());
+        }
+        let ids = self
+            .backend
+            .graph(self.namespace.clone(), id, depth)
+            .await?;
         let mut notes = Vec::with_capacity(ids.len());
         for nid in ids {
-            if let Some(note) = self.backend.get(nid).await? {
+            if let Some(note) = self.get_scoped(nid).await? {
+                if !self.active_in_namespace(&note) {
+                    continue;
+                }
                 notes.push(note);
             }
         }
@@ -201,12 +268,20 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         id: MemoryId,
         updates: rb_types::MemoryUpdates,
     ) -> rb_types::Result<()> {
-        self.backend.update(id, updates).await
+        if self.get_scoped(id.clone()).await?.is_none() {
+            return Err(rb_types::Error::NotFound(id));
+        }
+        self.backend
+            .update(self.namespace.clone(), id, updates)
+            .await
     }
 
     /// Soft-delete (archive) a memory. Spec §12: delete == soft archive.
     pub async fn delete(&self, id: MemoryId) -> rb_types::Result<()> {
-        self.backend.archive(id).await
+        if self.get_scoped(id.clone()).await?.is_none() {
+            return Err(rb_types::Error::NotFound(id));
+        }
+        self.backend.archive(self.namespace.clone(), id).await
     }
 
     /// Project context payload: recent memories (by recency) plus important ones
@@ -331,6 +406,18 @@ mod tests {
         eng.remember(inp).await.unwrap()
     }
 
+    fn note(
+        namespace: Namespace,
+        content: &str,
+        ty: MemoryType,
+        importance: u8,
+        tags: &[&str],
+    ) -> MemoryNote {
+        let mut note = MemoryNote::new(namespace, content.to_string(), ty, importance);
+        note.tags = tags.iter().map(|t| t.to_string()).collect();
+        note
+    }
+
     #[tokio::test]
     async fn recall_returns_results_for_seeded_memories() {
         let eng = engine();
@@ -394,6 +481,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recall_filters_before_ranking_so_matching_candidates_fill_limit() {
+        let eng = engine();
+
+        let wrong_ids: Vec<MemoryId> = (0..12)
+            .map(|i| {
+                let ty = if i % 2 == 0 {
+                    MemoryType::Insight
+                } else {
+                    MemoryType::BugFix
+                };
+                let note = note(
+                    Namespace::Project("rb".into()),
+                    &format!("wrong candidate {i}"),
+                    ty,
+                    10,
+                    &["wrong"],
+                );
+                let id = note.id.clone();
+                eng.backend().insert_note(note);
+                id
+            })
+            .collect();
+        let matching_ids: Vec<MemoryId> = (0..3)
+            .map(|i| {
+                let note = note(
+                    Namespace::Project("rb".into()),
+                    &format!("matching candidate {i}"),
+                    MemoryType::BugFix,
+                    1,
+                    &["keep"],
+                );
+                let id = note.id.clone();
+                eng.backend().insert_note(note);
+                id
+            })
+            .collect();
+        eng.backend().set_keyword_results(wrong_ids);
+        eng.backend()
+            .set_vector_results(matching_ids.iter().cloned().map(|id| (id, 2.0)).collect());
+
+        let results = eng
+            .recall(
+                "candidate",
+                3,
+                Some(MemoryType::BugFix),
+                &["keep".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|r| matching_ids.contains(&r.memory.id)));
+    }
+
+    #[tokio::test]
     async fn recall_ranks_all_candidates_with_finite_descending_scores() {
         // NOTE: importance does NOT decide ordering between near-identical
         // candidates (keyword-rank position dominates, see RANKING NOTE), so we
@@ -422,6 +564,22 @@ mod tests {
         let id = eng.remember(input("findable", 5)).await.unwrap();
         assert!(eng.get(id.clone()).await.unwrap().is_some());
         assert!(eng.get(rb_types::MemoryId::new()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn get_does_not_return_cross_namespace_note() {
+        let eng = engine();
+        let cross = note(
+            Namespace::Project("other".into()),
+            "foreign note",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let cross_id = cross.id.clone();
+        eng.backend().insert_note(cross);
+
+        assert!(eng.get(cross_id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -454,6 +612,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_does_not_mutate_cross_namespace_note() {
+        let eng = engine();
+        let cross = note(
+            Namespace::Project("other".into()),
+            "foreign body",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let cross_id = cross.id.clone();
+        eng.backend().insert_note(cross);
+
+        let _ = eng
+            .update(
+                cross_id.clone(),
+                rb_types::MemoryUpdates {
+                    content: Some("mutated".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        let note = eng.backend().note_of(&cross_id).unwrap();
+        assert_eq!(note.content, "foreign body");
+    }
+
+    #[tokio::test]
     async fn delete_soft_archives_the_note() {
         let eng = engine();
         let id = eng.remember(input("doomed", 5)).await.unwrap();
@@ -463,13 +648,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_does_not_archive_cross_namespace_note() {
+        let eng = engine();
+        let cross = note(
+            Namespace::Project("other".into()),
+            "foreign body",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let cross_id = cross.id.clone();
+        eng.backend().insert_note(cross);
+
+        let _ = eng.delete(cross_id.clone()).await;
+
+        let note = eng.backend().note_of(&cross_id).unwrap();
+        assert!(note.archived_at.is_none());
+    }
+
+    #[tokio::test]
     async fn graph_returns_connected_notes() {
-        // MockBackend.graph returns empty, so graph() yields no neighbors here;
-        // this asserts the pass-through shape and empty handling without a DB.
         let eng = engine();
         let id = eng.remember(input("anchor", 5)).await.unwrap();
+        let active = note(
+            Namespace::Project("rb".into()),
+            "same namespace active",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let cross = note(
+            Namespace::Project("other".into()),
+            "foreign neighbor",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let mut archived = note(
+            Namespace::Project("rb".into()),
+            "archived neighbor",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        archived.archived_at = Some(chrono::Utc::now());
+        let active_id = active.id.clone();
+        let cross_id = cross.id.clone();
+        let archived_id = archived.id.clone();
+        eng.backend().insert_note(active);
+        eng.backend().insert_note(cross);
+        eng.backend().insert_note(archived);
+        eng.backend().set_graph_neighbors(
+            id.clone(),
+            vec![cross_id.clone(), archived_id.clone(), active_id.clone()],
+        );
+
         let neighbors = eng.graph(id, 2).await.unwrap();
-        assert!(neighbors.is_empty());
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].id, active_id);
+
+        eng.backend()
+            .set_graph_neighbors(cross_id.clone(), vec![active_id]);
+        let cross_anchor_neighbors = eng.graph(cross_id, 2).await.unwrap();
+        assert!(cross_anchor_neighbors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn recall_does_not_leak_cross_namespace_or_archived_graph_neighbors() {
+        let eng = engine();
+        let anchor = seed(&eng, "anchor topic", MemoryType::Insight, 5, &[]).await;
+        let active = note(
+            Namespace::Project("rb".into()),
+            "same namespace active graph result",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let cross = note(
+            Namespace::Project("other".into()),
+            "foreign graph result",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let mut archived = note(
+            Namespace::Project("rb".into()),
+            "archived graph result",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        archived.archived_at = Some(chrono::Utc::now());
+        let active_id = active.id.clone();
+        let cross_id = cross.id.clone();
+        let archived_id = archived.id.clone();
+        eng.backend().insert_note(active);
+        eng.backend().insert_note(cross);
+        eng.backend().insert_note(archived);
+        eng.backend().set_keyword_results(vec![anchor.clone()]);
+        eng.backend().set_vector_results(Vec::new());
+        eng.backend().set_graph_neighbors(
+            anchor,
+            vec![cross_id.clone(), archived_id.clone(), active_id],
+        );
+
+        let results = eng.recall("topic", 10, None, &[]).await.unwrap();
+
+        assert!(results.iter().all(|r| {
+            r.memory.namespace == Namespace::Project("rb".into()) && r.memory.archived_at.is_none()
+        }));
+        assert!(!results.iter().any(|r| r.memory.id == cross_id));
+        assert!(!results.iter().any(|r| r.memory.id == archived_id));
     }
 
     #[tokio::test]

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -81,6 +81,90 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         self.backend.write(note, embedding).await?;
         Ok(id)
     }
+
+    /// Hybrid recall: embed the query, gather keyword + vector (+ 1-hop graph)
+    /// candidates scoped to the engine namespace, rank with `rb_search`, then
+    /// return ranked `SearchResult`s after applying type/tag filters.
+    pub async fn recall(
+        &self,
+        query: &str,
+        limit: usize,
+        type_filter: Option<MemoryType>,
+        tags: &[String],
+    ) -> rb_types::Result<Vec<rb_types::SearchResult>> {
+        use std::collections::HashMap;
+
+        // Over-fetch candidates so post-filtering still has enough to fill `limit`.
+        let candidate_limit = limit.saturating_mul(4).max(limit);
+
+        let mut query_emb = self.embedder.embed(&[query.to_string()]).await?;
+        let embedding = query_emb.pop().unwrap_or_default();
+
+        let keyword = self
+            .backend
+            .keyword(self.namespace.clone(), query.to_string(), candidate_limit)
+            .await?;
+        let vector = self
+            .backend
+            .vector(self.namespace.clone(), embedding, candidate_limit)
+            .await?;
+
+        // Bounded 1-hop graph expansion of the top keyword hit only.
+        let graph = match keyword.first() {
+            Some(top) => self.backend.graph(top.clone(), 1).await?,
+            None => Vec::new(),
+        };
+
+        // Collect the unique candidate id set across all three sources.
+        let mut order: Vec<MemoryId> = Vec::new();
+        let mut seen: std::collections::HashSet<MemoryId> = std::collections::HashSet::new();
+        for id in keyword
+            .iter()
+            .chain(vector.iter().map(|(id, _)| id))
+            .chain(graph.iter())
+        {
+            if seen.insert(id.clone()) {
+                order.push(id.clone());
+            }
+        }
+
+        // Fetch each candidate once; build the note cache + the rank meta map.
+        let mut notes: HashMap<MemoryId, MemoryNote> = HashMap::new();
+        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        for id in &order {
+            if let Some(note) = self.backend.get(id.clone()).await? {
+                meta.insert(id.clone(), (note.importance, note.created_at));
+                notes.insert(id.clone(), note);
+            }
+        }
+
+        let signals = rb_search::build_signals(&keyword, &vector, &graph, &meta);
+        let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
+
+        // Assemble results in ranked order, applying filters, truncating to limit.
+        let mut results: Vec<rb_types::SearchResult> = Vec::new();
+        for (id, score) in ranked {
+            let Some(note) = notes.get(&id) else {
+                continue;
+            };
+            if let Some(ty) = type_filter {
+                if note.memory_type != ty {
+                    continue;
+                }
+            }
+            if !tags.iter().all(|t| note.tags.contains(t)) {
+                continue;
+            }
+            results.push(rb_types::SearchResult {
+                memory: note.clone(),
+                score,
+            });
+            if results.len() == limit {
+                break;
+            }
+        }
+        Ok(results)
+    }
 }
 
 #[cfg(test)]
@@ -172,5 +256,103 @@ mod tests {
             eng.backend().embedding_of(&id1),
             eng.backend().embedding_of(&id2)
         ); // deterministic provider => same vector
+    }
+
+    async fn seed(
+        eng: &MemoryEngine<MockBackend, DeterministicProvider>,
+        content: &str,
+        ty: MemoryType,
+        imp: u8,
+        tags: &[&str],
+    ) -> rb_types::MemoryId {
+        let mut inp = input(content, imp);
+        inp.memory_type = ty;
+        inp.tags = tags.iter().map(|t| t.to_string()).collect();
+        eng.remember(inp).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn recall_returns_results_for_seeded_memories() {
+        let eng = engine();
+        seed(
+            &eng,
+            "alpha topic about sqlite",
+            MemoryType::Insight,
+            5,
+            &[],
+        )
+        .await;
+        seed(&eng, "beta topic about tokio", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("topic", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        // scores are finite and sorted descending.
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn recall_respects_limit() {
+        let eng = engine();
+        for i in 0..5 {
+            seed(
+                &eng,
+                &format!("doc number {i}"),
+                MemoryType::Insight,
+                5,
+                &[],
+            )
+            .await;
+        }
+        let results = eng.recall("doc", 2, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn recall_type_filter_excludes_other_types() {
+        let eng = engine();
+        seed(&eng, "a bug fix note", MemoryType::BugFix, 5, &[]).await;
+        seed(&eng, "an insight note", MemoryType::Insight, 5, &[]).await;
+        let results = eng
+            .recall("note", 10, Some(MemoryType::BugFix), &[])
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].memory.memory_type, MemoryType::BugFix);
+    }
+
+    #[tokio::test]
+    async fn recall_tag_filter_requires_all_tags() {
+        let eng = engine();
+        seed(&eng, "tagged one", MemoryType::Insight, 5, &["x", "y"]).await;
+        seed(&eng, "tagged two", MemoryType::Insight, 5, &["x"]).await;
+        let results = eng
+            .recall("tagged", 10, None, &["x".to_string(), "y".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].memory.tags.contains(&"y".to_string()));
+    }
+
+    #[tokio::test]
+    async fn recall_ranks_all_candidates_with_finite_descending_scores() {
+        // NOTE: importance does NOT decide ordering between near-identical
+        // candidates (keyword-rank position dominates, see RANKING NOTE), so we
+        // assert the honest invariants: every candidate is returned, scores are
+        // finite, and the result is sorted descending. Importance-driven order
+        // is covered by the deterministic `list` test in Task 20.
+        let eng = engine();
+        let _low = seed(&eng, "ranking probe content", MemoryType::Insight, 2, &[]).await;
+        let _high = seed(&eng, "ranking probe content", MemoryType::Insight, 9, &[]).await;
+        let results = eng.recall("ranking probe", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn recall_empty_store_returns_empty() {
+        let eng = engine();
+        let results = eng.recall("anything", 10, None, &[]).await.unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -165,6 +165,66 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         }
         Ok(results)
     }
+
+    /// Fetch a single memory by id (namespace scoping is enforced by the backend).
+    pub async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        self.backend.get(id).await
+    }
+
+    /// List memories in the engine namespace, most-recent first, optionally
+    /// filtered by a minimum importance.
+    pub async fn list(
+        &self,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        self.backend
+            .list(self.namespace.clone(), min_importance, limit)
+            .await
+    }
+
+    /// Expand the graph around `id` to `depth` hops and fetch the connected notes.
+    pub async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryNote>> {
+        let ids = self.backend.graph(id, depth).await?;
+        let mut notes = Vec::with_capacity(ids.len());
+        for nid in ids {
+            if let Some(note) = self.backend.get(nid).await? {
+                notes.push(note);
+            }
+        }
+        Ok(notes)
+    }
+
+    /// Apply a partial update to an existing memory.
+    pub async fn update(
+        &self,
+        id: MemoryId,
+        updates: rb_types::MemoryUpdates,
+    ) -> rb_types::Result<()> {
+        self.backend.update(id, updates).await
+    }
+
+    /// Soft-delete (archive) a memory. Spec §12: delete == soft archive.
+    pub async fn delete(&self, id: MemoryId) -> rb_types::Result<()> {
+        self.backend.archive(id).await
+    }
+
+    /// Project context payload: recent memories (by recency) plus important ones
+    /// (importance >= 8), with a total count of the recent window.
+    pub async fn context(&self) -> rb_types::Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)> {
+        const CONTEXT_LIMIT: usize = 50;
+        const IMPORTANT_FLOOR: u8 = 8;
+        let recent = self
+            .backend
+            .list(self.namespace.clone(), None, CONTEXT_LIMIT)
+            .await?;
+        let important = self
+            .backend
+            .list(self.namespace.clone(), Some(IMPORTANT_FLOOR), CONTEXT_LIMIT)
+            .await?;
+        let total = recent.len();
+        Ok((recent, important, total))
+    }
 }
 
 #[cfg(test)]
@@ -354,5 +414,74 @@ mod tests {
         let eng = engine();
         let results = eng.recall("anything", 10, None, &[]).await.unwrap();
         assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_returns_stored_note_or_none() {
+        let eng = engine();
+        let id = eng.remember(input("findable", 5)).await.unwrap();
+        assert!(eng.get(id.clone()).await.unwrap().is_some());
+        assert!(eng.get(rb_types::MemoryId::new()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_orders_by_recency_and_honors_min_importance() {
+        let eng = engine();
+        seed(&eng, "first", MemoryType::Insight, 3, &[]).await;
+        seed(&eng, "second", MemoryType::Insight, 9, &[]).await;
+        let all = eng.list(None, 10).await.unwrap();
+        assert_eq!(all.len(), 2);
+        // most recent first (second was inserted last).
+        assert_eq!(all[0].content, "second");
+        let important = eng.list(Some(8), 10).await.unwrap();
+        assert_eq!(important.len(), 1);
+        assert_eq!(important[0].importance, 9);
+    }
+
+    #[tokio::test]
+    async fn update_mutates_then_get_reflects_change() {
+        let eng = engine();
+        let id = eng.remember(input("old body", 5)).await.unwrap();
+        let updates = rb_types::MemoryUpdates {
+            content: Some("new body".to_string()),
+            importance: Some(9),
+            ..Default::default()
+        };
+        eng.update(id.clone(), updates).await.unwrap();
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert_eq!(note.content, "new body");
+        assert_eq!(note.importance, 9);
+    }
+
+    #[tokio::test]
+    async fn delete_soft_archives_the_note() {
+        let eng = engine();
+        let id = eng.remember(input("doomed", 5)).await.unwrap();
+        eng.delete(id.clone()).await.unwrap();
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert!(note.archived_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn graph_returns_connected_notes() {
+        // MockBackend.graph returns empty, so graph() yields no neighbors here;
+        // this asserts the pass-through shape and empty handling without a DB.
+        let eng = engine();
+        let id = eng.remember(input("anchor", 5)).await.unwrap();
+        let neighbors = eng.graph(id, 2).await.unwrap();
+        assert!(neighbors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn context_splits_recent_and_important() {
+        let eng = engine();
+        seed(&eng, "low importance recent", MemoryType::Insight, 2, &[]).await;
+        seed(&eng, "high importance note", MemoryType::Insight, 9, &[]).await;
+        let (recent, important, total) = eng.context().await.unwrap();
+        // recent includes both; important only the >= 8 one.
+        assert_eq!(recent.len(), 2);
+        assert_eq!(important.len(), 1);
+        assert_eq!(important[0].importance, 9);
+        assert_eq!(total, 2);
     }
 }

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -1,0 +1,176 @@
+use crate::backend::MemoryBackend;
+use crate::enrich::{default_summary, derive_keywords};
+use rb_embed::EmbeddingProvider;
+use rb_search::Weights;
+use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
+
+/// Input to `remember`. Mirrors the proto `Request::Remember` payload.
+pub struct RememberInput {
+    pub content: String,
+    pub context: Option<String>,
+    pub memory_type: MemoryType,
+    pub importance: u8,
+    pub keywords: Vec<String>,
+    pub tags: Vec<String>,
+    pub related_files: Vec<String>,
+}
+
+/// Policy layer: orchestrates heuristic enrichment + embedding + ranking over a
+/// `MemoryBackend`. Generic so it is unit-tested without a DB or network.
+pub struct MemoryEngine<B: MemoryBackend, P: EmbeddingProvider> {
+    backend: B,
+    embedder: P,
+    weights: Weights,
+    namespace: Namespace,
+}
+
+impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
+    /// Construct an engine bound to a single namespace (set server-side from the
+    /// client handshake; clients cannot widen it).
+    pub fn new(backend: B, embedder: P, namespace: Namespace) -> Self {
+        Self {
+            backend,
+            embedder,
+            weights: Weights::default(),
+            namespace,
+        }
+    }
+
+    /// Borrow the backend (used by daemon/tests for introspection).
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Borrow the embedding provider.
+    pub fn embedder(&self) -> &P {
+        &self.embedder
+    }
+
+    /// Borrow the ranking weights (used by `recall`).
+    pub fn weights(&self) -> Weights {
+        self.weights
+    }
+
+    /// Store a new memory: heuristic-enrich, embed the content, then write.
+    pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
+        let mut note = MemoryNote::new(
+            self.namespace.clone(),
+            input.content,
+            input.memory_type,
+            input.importance,
+        );
+        // Heuristic enrichment (no LLM in P1).
+        note.summary = default_summary(&note.content);
+        note.keywords = if input.keywords.is_empty() {
+            derive_keywords(&note.content)
+        } else {
+            input.keywords
+        };
+        note.tags = input.tags;
+        note.related_files = input.related_files;
+        if let Some(ctx) = input.context {
+            note.context = ctx;
+        }
+        note.embedding_model = self.embedder.model_id().to_string();
+
+        // Embed the content (single text in, single vector out).
+        let mut embeddings = self.embedder.embed(&[note.content.clone()]).await?;
+        let embedding = embeddings.pop();
+
+        let id = note.id.clone();
+        self.backend.write(note, embedding).await?;
+        Ok(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::test_support::MockBackend;
+    use rb_embed::DeterministicProvider;
+    use rb_types::{MemoryType, Namespace};
+
+    fn engine() -> MemoryEngine<MockBackend, DeterministicProvider> {
+        MemoryEngine::new(
+            MockBackend::default(),
+            DeterministicProvider::new(16),
+            Namespace::Project("rb".into()),
+        )
+    }
+
+    fn input(content: &str, importance: u8) -> RememberInput {
+        RememberInput {
+            content: content.to_string(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance,
+            keywords: Vec::new(),
+            tags: Vec::new(),
+            related_files: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn remember_stores_note_and_embedding() {
+        let eng = engine();
+        let id = eng
+            .remember(input("single writer over sqlite wal", 7))
+            .await
+            .unwrap();
+        // exactly one note written, with an embedding of provider dim.
+        assert_eq!(eng.backend().count(), 1);
+        let emb = eng.backend().embedding_of(&id).unwrap();
+        assert_eq!(emb.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn remember_applies_heuristic_summary_and_keywords() {
+        let eng = engine();
+        let content = "concurrent readers never block the single dedicated writer thread";
+        let id = eng.remember(input(content, 6)).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        // summary defaults to the (trimmed) content since it's < 150 chars.
+        assert_eq!(note.summary, content);
+        // keywords derived (empty input) — non-empty, lowercased, capped at 5.
+        assert!(!note.keywords.is_empty());
+        assert!(note.keywords.len() <= 5);
+        assert!(note.keywords.iter().all(|k| k == &k.to_lowercase()));
+    }
+
+    #[tokio::test]
+    async fn remember_preserves_explicit_keywords_and_namespace() {
+        let eng = engine();
+        let mut inp = input("body text here", 5);
+        inp.keywords = vec!["explicit".to_string()];
+        inp.tags = vec!["t1".to_string()];
+        inp.context = Some("ctx".to_string());
+        let id = eng.remember(inp).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(note.keywords, vec!["explicit".to_string()]);
+        assert_eq!(note.tags, vec!["t1".to_string()]);
+        assert_eq!(note.context, "ctx");
+        // engine enforces its own namespace.
+        assert_eq!(note.namespace, Namespace::Project("rb".into()));
+    }
+
+    #[tokio::test]
+    async fn remember_sets_embedding_model_from_provider() {
+        let eng = engine();
+        let id = eng.remember(input("model id check", 5)).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(note.embedding_model, eng.embedder().model_id());
+    }
+
+    #[tokio::test]
+    async fn remember_is_deterministic_same_content_same_embedding() {
+        let eng = engine();
+        let id1 = eng.remember(input("identical content", 5)).await.unwrap();
+        let id2 = eng.remember(input("identical content", 5)).await.unwrap();
+        assert_ne!(id1, id2); // distinct notes
+        assert_eq!(
+            eng.backend().embedding_of(&id1),
+            eng.backend().embedding_of(&id2)
+        ); // deterministic provider => same vector
+    }
+}

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -275,6 +275,19 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         id: MemoryId,
         updates: rb_types::MemoryUpdates,
     ) -> rb_types::Result<()> {
+        if updates.content.is_some() {
+            return Err(rb_types::Error::Storage(
+                "content updates are not supported; create a new memory so embeddings stay consistent"
+                    .to_string(),
+            ));
+        }
+        if let Some(importance) = updates.importance {
+            if !(1..=10).contains(&importance) {
+                return Err(rb_types::Error::Storage(format!(
+                    "importance {importance} is out of range 1..=10"
+                )));
+            }
+        }
         if self.get_scoped(id.clone()).await?.is_none() {
             return Err(rb_types::Error::NotFound(id));
         }
@@ -654,14 +667,53 @@ mod tests {
         let eng = engine();
         let id = eng.remember(input("old body", 5)).await.unwrap();
         let updates = rb_types::MemoryUpdates {
-            content: Some("new body".to_string()),
             importance: Some(9),
+            tags: Some(vec!["updated".to_string()]),
             ..Default::default()
         };
         eng.update(id.clone(), updates).await.unwrap();
         let note = eng.get(id).await.unwrap().unwrap();
-        assert_eq!(note.content, "new body");
+        assert_eq!(note.content, "old body");
         assert_eq!(note.importance, 9);
+        assert_eq!(note.tags, vec!["updated".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn update_rejects_content_edits_to_keep_embeddings_consistent() {
+        let eng = engine();
+        let id = eng.remember(input("old body", 5)).await.unwrap();
+        let err = eng
+            .update(
+                id.clone(),
+                rb_types::MemoryUpdates {
+                    content: Some("new body".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("content updates"));
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert_eq!(note.content, "old body");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_out_of_range_importance() {
+        let eng = engine();
+        let id = eng.remember(input("valid", 5)).await.unwrap();
+        for bad in [0, 11] {
+            let err = eng
+                .update(
+                    id.clone(),
+                    rb_types::MemoryUpdates {
+                        importance: Some(bad),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("importance"), "got {err}");
+        }
     }
 
     #[tokio::test]
@@ -681,7 +733,7 @@ mod tests {
             .update(
                 cross_id.clone(),
                 rb_types::MemoryUpdates {
-                    content: Some("mutated".to_string()),
+                    importance: Some(9),
                     ..Default::default()
                 },
             )

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -82,6 +82,13 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
 
     /// Store a new memory: heuristic-enrich, embed the content, then write.
     pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
+        if !(1..=10).contains(&input.importance) {
+            return Err(rb_types::Error::Storage(format!(
+                "importance {} is out of range 1..=10",
+                input.importance
+            )));
+        }
+
         let mut note = MemoryNote::new(
             self.namespace.clone(),
             input.content,
@@ -309,6 +316,8 @@ mod tests {
     use crate::test_support::MockBackend;
     use rb_embed::DeterministicProvider;
     use rb_types::{MemoryType, Namespace};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     fn engine() -> MemoryEngine<MockBackend, DeterministicProvider> {
         MemoryEngine::new(
@@ -391,6 +400,50 @@ mod tests {
             eng.backend().embedding_of(&id1),
             eng.backend().embedding_of(&id2)
         ); // deterministic provider => same vector
+    }
+
+    struct CountingProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl EmbeddingProvider for CountingProvider {
+        fn model_id(&self) -> &str {
+            "counting"
+        }
+
+        fn dim(&self) -> usize {
+            16
+        }
+
+        async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![vec![0.0; 16]; texts.len()])
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_importance_is_rejected_before_embedding() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let eng = MemoryEngine::new(
+            MockBackend::default(),
+            CountingProvider {
+                calls: Arc::clone(&calls),
+            },
+            Namespace::Project("rb".into()),
+        );
+
+        let err = eng
+            .remember(input("invalid importance should not embed", 0))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("importance"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(eng.backend().count(), 0);
     }
 
     async fn seed(

--- a/crates/rb-engine/src/enrich.rs
+++ b/crates/rb-engine/src/enrich.rs
@@ -1,0 +1,93 @@
+#![allow(dead_code)]
+
+/// Maximum characters retained in a heuristic summary.
+const SUMMARY_MAX_CHARS: usize = 150;
+/// Maximum number of derived keywords.
+const MAX_KEYWORDS: usize = 5;
+/// Minimum token length (in characters) kept as a keyword (drops stop-word-ish short tokens).
+const MIN_KEYWORD_LEN: usize = 4;
+
+/// Heuristic summary: trim, then keep the first `SUMMARY_MAX_CHARS` characters
+/// on a char boundary (never splitting a multi-byte UTF-8 sequence).
+pub(crate) fn default_summary(content: &str) -> String {
+    let trimmed = content.trim();
+    trimmed.chars().take(SUMMARY_MAX_CHARS).collect()
+}
+
+/// Heuristic keyword extraction: split on non-alphanumeric, lowercase, keep
+/// tokens of length >= `MIN_KEYWORD_LEN` characters, dedupe preserving
+/// first-seen order, and cap at `MAX_KEYWORDS`. Pure and deterministic.
+pub(crate) fn derive_keywords(content: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in content.split(|c: char| !c.is_alphanumeric()) {
+        if raw.chars().count() < MIN_KEYWORD_LEN {
+            continue;
+        }
+        let token = raw.to_lowercase();
+        if !out.iter().any(|existing| existing == &token) {
+            out.push(token);
+        }
+        if out.len() == MAX_KEYWORDS {
+            break;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn summary_of_short_content_is_unchanged_trimmed() {
+        assert_eq!(default_summary("  short body  "), "short body");
+    }
+
+    #[test]
+    fn summary_truncates_to_150_chars_on_char_boundary() {
+        let content = "x".repeat(400);
+        let s = default_summary(&content);
+        assert_eq!(s.chars().count(), 150);
+    }
+
+    #[test]
+    fn summary_truncation_never_splits_a_multibyte_char() {
+        // 200 'é' (2 bytes each in UTF-8); truncation must stay on a char boundary.
+        let content = "é".repeat(200);
+        let s = default_summary(&content);
+        assert_eq!(s.chars().count(), 150);
+        // Round-trips as valid UTF-8 (would panic on a bad boundary while building).
+        assert!(s.chars().all(|c| c == 'é'));
+    }
+
+    #[test]
+    fn keywords_lowercase_dedupe_and_cap_at_five() {
+        let kw =
+            derive_keywords("SQLite WAL mode enables concurrent SQLITE readers and writers safely");
+        // length >= 4 (by char count), lowercased, order-preserving, deduped, max 5.
+        assert_eq!(
+            kw,
+            vec!["sqlite", "mode", "enables", "concurrent", "readers"]
+        );
+    }
+
+    #[test]
+    fn keywords_skips_short_tokens_and_punctuation() {
+        let kw = derive_keywords("a an the to of, big-decision: keep!");
+        assert_eq!(kw, vec!["decision", "keep"]);
+    }
+
+    #[test]
+    fn keywords_empty_content_yields_empty() {
+        assert!(derive_keywords("   ").is_empty());
+    }
+
+    #[test]
+    fn keywords_length_guard_uses_char_count_not_bytes() {
+        // "café" is 5 bytes but 4 chars; "über" is 5 bytes but 4 chars.
+        // Both must be kept (>= 4 chars), proving the guard counts chars, not bytes.
+        let kw = derive_keywords("café über");
+        assert_eq!(kw, vec!["café", "über"]);
+    }
+}

--- a/crates/rb-engine/src/enrich.rs
+++ b/crates/rb-engine/src/enrich.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 /// Maximum characters retained in a heuristic summary.
 const SUMMARY_MAX_CHARS: usize = 150;
 /// Maximum number of derived keywords.

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -1,6 +1,10 @@
-//! `rb_engine`: single-request orchestration for rusty-brain.
+//! `rb_engine`: single-request memory orchestration (policy only).
 //!
-//! Generic over a `MemoryBackend` trait and an `EmbeddingProvider`, so the
-//! engine stays pure policy (embed plus rank) and testable without a real
-//! store. Concrete types are added in subsequent tasks.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+//! Generic over a `MemoryBackend` (store access) and an
+//! `rb_embed::EmbeddingProvider`. P1 enrichment is heuristic only; LLM
+//! enrichment and semantic link generation are deferred to P2.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod backend;
+
+pub use backend::MemoryBackend;

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -6,6 +6,10 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod backend;
+mod engine;
 mod enrich;
+#[cfg(test)]
+mod test_support;
 
 pub use backend::MemoryBackend;
+pub use engine::{MemoryEngine, RememberInput};

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -6,5 +6,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod backend;
+mod enrich;
 
 pub use backend::MemoryBackend;

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -1,0 +1,6 @@
+//! `rb_engine`: single-request orchestration for rusty-brain.
+//!
+//! Generic over a `MemoryBackend` trait and an `EmbeddingProvider`, so the
+//! engine stays pure policy (embed plus rank) and testable without a real
+//! store. Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -1,7 +1,7 @@
 //! `rb_engine`: single-request memory orchestration (policy only).
 //!
-//! Generic over a `MemoryBackend` (store access) and an
-//! `rb_embed::EmbeddingProvider`. P1 enrichment is heuristic only; LLM
+//! Generic over a [`MemoryBackend`] (store access) and an
+//! [`rb_embed::EmbeddingProvider`]. P1 enrichment is heuristic only; LLM
 //! enrichment and semantic link generation are deferred to P2.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use crate::backend::MemoryBackend;
+use rb_types::{MemoryId, MemoryNote, MemoryUpdates, Namespace};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// In-memory `MemoryBackend` for engine unit tests. Records writes (note +
+/// embedding) so tests can assert what `remember` produced. Reads return the
+/// stored notes. Keyword/vector return ALL stored ids in a DETERMINISTIC order
+/// (created_at desc) so the ranker, not HashMap iteration order, decides
+/// result ordering; `graph` returns nothing (graph paths tested separately).
+#[derive(Default)]
+pub(crate) struct MockBackend {
+    pub notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+    pub embeddings: Mutex<HashMap<MemoryId, Vec<f32>>>,
+}
+
+impl MockBackend {
+    pub fn count(&self) -> usize {
+        self.notes.lock().unwrap().len()
+    }
+
+    pub fn embedding_of(&self, id: &MemoryId) -> Option<Vec<f32>> {
+        self.embeddings.lock().unwrap().get(id).cloned()
+    }
+
+    pub fn note_of(&self, id: &MemoryId) -> Option<MemoryNote> {
+        self.notes.lock().unwrap().get(id).cloned()
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryBackend for MockBackend {
+    async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> rb_types::Result<()> {
+        if let Some(emb) = embedding {
+            self.embeddings.lock().unwrap().insert(note.id.clone(), emb);
+        }
+        self.notes.lock().unwrap().insert(note.id.clone(), note);
+        Ok(())
+    }
+
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    }
+
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        _query: String,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        Ok(v.into_iter().map(|n| n.id).collect())
+    }
+
+    async fn vector(
+        &self,
+        ns: Namespace,
+        _embedding: Vec<f32>,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        Ok(v.into_iter().map(|n| (n.id, 0.0)).collect())
+    }
+
+    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+        Ok(Vec::new())
+    }
+
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+
+    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        if let Some(c) = updates.content {
+            note.content = c;
+        }
+        if let Some(s) = updates.summary {
+            note.summary = s;
+        }
+        if let Some(i) = updates.importance {
+            note.importance = i;
+        }
+        if let Some(t) = updates.tags {
+            note.tags = t;
+        }
+        if let Some(ctx) = updates.context {
+            note.context = ctx;
+        }
+        Ok(())
+    }
+
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.archived_at = Some(chrono::Utc::now());
+        Ok(())
+    }
+}

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -14,6 +14,9 @@ use std::sync::Mutex;
 pub(crate) struct MockBackend {
     pub notes: Mutex<HashMap<MemoryId, MemoryNote>>,
     pub embeddings: Mutex<HashMap<MemoryId, Vec<f32>>>,
+    graph: Mutex<HashMap<MemoryId, Vec<MemoryId>>>,
+    keyword_results: Mutex<Option<Vec<MemoryId>>>,
+    vector_results: Mutex<Option<Vec<(MemoryId, f32)>>>,
 }
 
 impl MockBackend {
@@ -28,6 +31,22 @@ impl MockBackend {
     pub fn note_of(&self, id: &MemoryId) -> Option<MemoryNote> {
         self.notes.lock().unwrap().get(id).cloned()
     }
+
+    pub fn insert_note(&self, note: MemoryNote) {
+        self.notes.lock().unwrap().insert(note.id.clone(), note);
+    }
+
+    pub fn set_graph_neighbors(&self, id: MemoryId, neighbors: Vec<MemoryId>) {
+        self.graph.lock().unwrap().insert(id, neighbors);
+    }
+
+    pub fn set_keyword_results(&self, ids: Vec<MemoryId>) {
+        *self.keyword_results.lock().unwrap() = Some(ids);
+    }
+
+    pub fn set_vector_results(&self, ids: Vec<(MemoryId, f32)>) {
+        *self.vector_results.lock().unwrap() = Some(ids);
+    }
 }
 
 #[async_trait::async_trait]
@@ -40,16 +59,25 @@ impl MemoryBackend for MockBackend {
         Ok(())
     }
 
-    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
-        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    async fn get(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self
+            .notes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .filter(|note| note.namespace == ns)
+            .cloned())
     }
 
     async fn keyword(
         &self,
         ns: Namespace,
         _query: String,
-        _limit: usize,
+        limit: usize,
     ) -> rb_types::Result<Vec<MemoryId>> {
+        if let Some(ids) = self.keyword_results.lock().unwrap().clone() {
+            return Ok(ids.into_iter().take(limit).collect());
+        }
         let mut v: Vec<MemoryNote> = self
             .notes
             .lock()
@@ -59,15 +87,18 @@ impl MemoryBackend for MockBackend {
             .cloned()
             .collect();
         v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
-        Ok(v.into_iter().map(|n| n.id).collect())
+        Ok(v.into_iter().take(limit).map(|n| n.id).collect())
     }
 
     async fn vector(
         &self,
         ns: Namespace,
         _embedding: Vec<f32>,
-        _limit: usize,
+        limit: usize,
     ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        if let Some(ids) = self.vector_results.lock().unwrap().clone() {
+            return Ok(ids.into_iter().take(limit).collect());
+        }
         let mut v: Vec<MemoryNote> = self
             .notes
             .lock()
@@ -77,11 +108,31 @@ impl MemoryBackend for MockBackend {
             .cloned()
             .collect();
         v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
-        Ok(v.into_iter().map(|n| (n.id, 0.0)).collect())
+        Ok(v.into_iter().take(limit).map(|n| (n.id, 0.0)).collect())
     }
 
-    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
-        Ok(Vec::new())
+    async fn graph(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        _depth: u8,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let has_anchor = self
+            .notes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .is_some_and(|note| note.namespace == ns);
+        if !has_anchor {
+            return Ok(Vec::new());
+        }
+        Ok(self
+            .graph
+            .lock()
+            .unwrap()
+            .get(&id)
+            .cloned()
+            .unwrap_or_default())
     }
 
     async fn list(
@@ -104,10 +155,16 @@ impl MemoryBackend for MockBackend {
         Ok(v)
     }
 
-    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+    async fn update(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()> {
         let mut guard = self.notes.lock().unwrap();
         let note = guard
             .get_mut(&id)
+            .filter(|note| note.namespace == ns)
             .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
         if let Some(c) = updates.content {
             note.content = c;
@@ -127,10 +184,11 @@ impl MemoryBackend for MockBackend {
         Ok(())
     }
 
-    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+    async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()> {
         let mut guard = self.notes.lock().unwrap();
         let note = guard
             .get_mut(&id)
+            .filter(|note| note.namespace == ns)
             .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
         note.archived_at = Some(chrono::Utc::now());
         Ok(())

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -1,0 +1,134 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_embed::DeterministicProvider;
+use rb_engine::{MemoryBackend, MemoryEngine, RememberInput};
+use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct VecBackend {
+    notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+}
+
+#[async_trait::async_trait]
+impl MemoryBackend for VecBackend {
+    async fn write(&self, note: MemoryNote, _embedding: Option<Vec<f32>>) -> rb_types::Result<()> {
+        self.notes.lock().unwrap().insert(note.id.clone(), note);
+        Ok(())
+    }
+
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    }
+
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        _query: String,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        Ok(v.into_iter().map(|n| n.id).collect())
+    }
+
+    async fn vector(
+        &self,
+        _ns: Namespace,
+        _embedding: Vec<f32>,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        Ok(Vec::new())
+    }
+
+    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+        Ok(Vec::new())
+    }
+
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+
+    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        if let Some(c) = updates.content {
+            note.content = c;
+        }
+        Ok(())
+    }
+
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.archived_at = Some(chrono::Utc::now());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn full_flow_through_public_api() {
+    let engine = MemoryEngine::new(
+        VecBackend::default(),
+        DeterministicProvider::new(8),
+        Namespace::Project("rb".into()),
+    );
+
+    let id = engine
+        .remember(RememberInput {
+            content: "single writer over sqlite wal with concurrent readers".to_string(),
+            context: Some("architecture".to_string()),
+            memory_type: MemoryType::ArchitectureDecision,
+            importance: 9,
+            keywords: Vec::new(),
+            tags: vec!["concurrency".to_string()],
+            related_files: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    // get reflects the stored, enriched note.
+    let note = engine.get(id.clone()).await.unwrap().unwrap();
+    assert_eq!(note.memory_type, MemoryType::ArchitectureDecision);
+    assert!(!note.keywords.is_empty());
+    assert_eq!(note.context, "architecture");
+
+    // recall finds it.
+    let results = engine.recall("writer", 10, None, &[]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].memory.id, id);
+
+    // context surfaces it as both recent and important (importance 9 >= 8).
+    let (recent, important, total) = engine.context().await.unwrap();
+    assert_eq!(total, 1);
+    assert_eq!(recent.len(), 1);
+    assert_eq!(important.len(), 1);
+}

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -18,8 +18,14 @@ impl MemoryBackend for VecBackend {
         Ok(())
     }
 
-    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
-        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    async fn get(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self
+            .notes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .filter(|note| note.namespace == ns)
+            .cloned())
     }
 
     async fn keyword(
@@ -49,7 +55,12 @@ impl MemoryBackend for VecBackend {
         Ok(Vec::new())
     }
 
-    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+    async fn graph(
+        &self,
+        _ns: Namespace,
+        _id: MemoryId,
+        _depth: u8,
+    ) -> rb_types::Result<Vec<MemoryId>> {
         Ok(Vec::new())
     }
 
@@ -73,10 +84,16 @@ impl MemoryBackend for VecBackend {
         Ok(v)
     }
 
-    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> rb_types::Result<()> {
+    async fn update(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()> {
         let mut guard = self.notes.lock().unwrap();
         let note = guard
             .get_mut(&id)
+            .filter(|note| note.namespace == ns)
             .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
         if let Some(c) = updates.content {
             note.content = c;
@@ -84,10 +101,11 @@ impl MemoryBackend for VecBackend {
         Ok(())
     }
 
-    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+    async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()> {
         let mut guard = self.notes.lock().unwrap();
         let note = guard
             .get_mut(&id)
+            .filter(|note| note.namespace == ns)
             .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
         note.archived_at = Some(chrono::Utc::now());
         Ok(())

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -32,7 +32,7 @@ impl MemoryBackend for VecBackend {
         &self,
         ns: Namespace,
         _query: String,
-        _limit: usize,
+        limit: usize,
     ) -> rb_types::Result<Vec<MemoryId>> {
         let mut v: Vec<MemoryNote> = self
             .notes
@@ -43,7 +43,7 @@ impl MemoryBackend for VecBackend {
             .cloned()
             .collect();
         v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
-        Ok(v.into_iter().map(|n| n.id).collect())
+        Ok(v.into_iter().take(limit).map(|n| n.id).collect())
     }
 
     async fn vector(

--- a/crates/rb-proto/Cargo.toml
+++ b/crates/rb-proto/Cargo.toml
@@ -22,5 +22,8 @@ bytes = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/rb-proto/Cargo.toml
+++ b/crates/rb-proto/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rb-proto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain daemon wire protocol: request/response enums, length-delimited JSON framing, and async UDS client."
+
+[lib]
+name = "rb_proto"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-proto/Cargo.toml
+++ b/crates/rb-proto/Cargo.toml
@@ -20,7 +20,6 @@ tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rb-proto/Cargo.toml
+++ b/crates/rb-proto/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -101,7 +101,6 @@ impl Client {
     pub async fn recall(
         &mut self,
         query: String,
-        scope: Option<Namespace>,
         memory_type: Option<MemoryType>,
         tags: Vec<String>,
         limit: usize,
@@ -109,7 +108,6 @@ impl Client {
         let resp = self
             .request(Request::Recall {
                 query,
-                scope,
                 memory_type,
                 tags,
                 limit,
@@ -133,13 +131,11 @@ impl Client {
     /// List memories in scope.
     pub async fn list(
         &mut self,
-        scope: Option<Namespace>,
         min_importance: Option<u8>,
         limit: usize,
     ) -> Result<Vec<MemoryNote>> {
         let resp = self
             .request(Request::List {
-                scope,
                 min_importance,
                 limit,
             })
@@ -408,14 +404,14 @@ mod wrapper_tests {
             .unwrap();
         assert_eq!(id, fixed_id);
 
-        let results = c.recall("q".into(), None, None, vec![], 5).await.unwrap();
+        let results = c.recall("q".into(), None, vec![], 5).await.unwrap();
         assert_eq!(results.len(), 1);
         assert!((results[0].score - 0.5).abs() < f32::EPSILON);
 
         let got = c.get(fixed_id.clone()).await.unwrap();
         assert!(got.is_some());
 
-        let listed = c.list(None, Some(5), 10).await.unwrap();
+        let listed = c.list(Some(5), 10).await.unwrap();
         assert_eq!(listed.len(), 1);
 
         let graphed = c.graph(fixed_id.clone(), 2).await.unwrap();

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -1,5 +1,6 @@
 //! Async client for the rusty-brain daemon over a Unix domain socket.
 
+use crate::codec::bounded_framed;
 use crate::frame::{read_frame, write_frame};
 use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
 use crate::{response_error_to_error, Response as Resp};
@@ -24,7 +25,7 @@ impl Client {
         let stream = UnixStream::connect(socket_path)
             .await
             .map_err(|e| Error::Io(format!("connect {}: {e}", socket_path.display())))?;
-        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+        let mut framed = bounded_framed(stream);
 
         let handshake = Handshake {
             contract_version: CONTRACT_VERSION,

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -1,0 +1,150 @@
+//! Async client for the rusty-brain daemon over a Unix domain socket.
+
+use crate::frame::{read_frame, write_frame};
+use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
+use rb_types::{Error, Namespace, Result};
+use std::path::Path;
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+/// A connected, handshaken client. Sends one `Request`, reads one `Response`.
+#[derive(Debug)]
+pub struct Client {
+    framed: Framed<UnixStream, LengthDelimitedCodec>,
+}
+
+impl Client {
+    /// Connect to the daemon socket, perform the versioned handshake, and verify
+    /// the daemon speaks `CONTRACT_VERSION`. Fails closed on any version drift or
+    /// a non-ok ack.
+    pub async fn connect(socket_path: &Path, namespace: Namespace) -> Result<Client> {
+        let stream = UnixStream::connect(socket_path)
+            .await
+            .map_err(|e| Error::Io(format!("connect {}: {e}", socket_path.display())))?;
+        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+
+        let handshake = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace,
+        };
+        write_frame(&mut framed, &handshake).await?;
+
+        let ack: HandshakeAck = read_frame(&mut framed).await?;
+        if ack.contract_version != CONTRACT_VERSION {
+            return Err(Error::Storage(format!(
+                "contract version mismatch: client {CONTRACT_VERSION}, daemon {}",
+                ack.contract_version
+            )));
+        }
+        if !ack.ok {
+            let detail = ack
+                .message
+                .unwrap_or_else(|| "handshake rejected".to_string());
+            return Err(Error::Storage(format!("handshake rejected: {detail}")));
+        }
+
+        Ok(Client { framed })
+    }
+
+    /// Send one request and read one response.
+    pub async fn request(&mut self, req: Request) -> Result<Response> {
+        write_frame(&mut self.framed, &req).await?;
+        let resp: Response = read_frame(&mut self.framed).await?;
+        Ok(resp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{
+        read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+    };
+    use rb_types::Namespace;
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    fn socket_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        (dir, path)
+    }
+
+    // Accept ONE connection, read the handshake, ack it (optionally with a
+    // forced ack contract version to simulate drift), then echo one request as
+    // a canned Pong response. Returns after serving a single connection.
+    async fn run_responder(listener: UnixListener, ack_version: u32, ok: bool) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        let ack = HandshakeAck {
+            contract_version: ack_version,
+            ok,
+            message: if ok {
+                None
+            } else {
+                Some("version mismatch".into())
+            },
+        };
+        write_frame(&mut framed, &ack).await.unwrap();
+        if !ok {
+            return;
+        }
+
+        // Serve exactly one request: reply Pong regardless of the request.
+        let _req: Request = read_frame(&mut framed).await.unwrap();
+        let resp = Response::Pong {
+            contract_version: CONTRACT_VERSION,
+        };
+        write_frame(&mut framed, &resp).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_handshake_and_request_round_trip() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(run_responder(listener, CONTRACT_VERSION, true));
+
+        let mut client = Client::connect(&path, Namespace::Project("rusty-brain".into()))
+            .await
+            .unwrap();
+        let resp = client.request(Request::Ping).await.unwrap();
+        match resp {
+            Response::Pong { contract_version } => {
+                assert_eq!(contract_version, CONTRACT_VERSION);
+            }
+            other => panic!("expected Pong, got {other:?}"),
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_contract_version_mismatch() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        // Responder acks with a different contract version and ok=false.
+        let server = tokio::spawn(run_responder(listener, CONTRACT_VERSION + 1, false));
+
+        let err = Client::connect(&path, Namespace::Global).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Storage(_)),
+            "version mismatch must fail connect, got {err:?}"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_to_missing_socket_is_io_error() {
+        let (_dir, path) = socket_path();
+        // Never bind a listener -> connect must fail with an IO error.
+        let err = Client::connect(&path, Namespace::Global).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Io(_)),
+            "missing socket should be Error::Io, got {err:?}"
+        );
+    }
+}

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -2,7 +2,10 @@
 
 use crate::frame::{read_frame, write_frame};
 use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
-use rb_types::{Error, Namespace, Result};
+use crate::{response_error_to_error, Response as Resp};
+use rb_types::{
+    Error, MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, Result, SearchResult,
+};
 use std::path::Path;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
@@ -51,6 +54,149 @@ impl Client {
         write_frame(&mut self.framed, &req).await?;
         let resp: Response = read_frame(&mut self.framed).await?;
         Ok(resp)
+    }
+}
+
+impl Client {
+    /// Helper: turn an unexpected response (including a wire `Error`) into an
+    /// `Err`. The daemon's `Response::Error` is mapped back to a domain error;
+    /// any other unexpected variant is a protocol violation -> `Error::Storage`.
+    fn unexpected(resp: Resp) -> Error {
+        match resp {
+            Resp::Error { kind, message } => response_error_to_error(&kind, &message),
+            other => Error::Storage(format!("unexpected response: {other:?}")),
+        }
+    }
+
+    /// Store a new memory; returns its id.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn remember(
+        &mut self,
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+        related_files: Vec<String>,
+    ) -> Result<MemoryId> {
+        let resp = self
+            .request(Request::Remember {
+                content,
+                context,
+                memory_type,
+                importance,
+                keywords,
+                tags,
+                related_files,
+            })
+            .await?;
+        match resp {
+            Resp::Remembered { id } => Ok(id),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Hybrid recall; returns ranked results.
+    pub async fn recall(
+        &mut self,
+        query: String,
+        scope: Option<Namespace>,
+        memory_type: Option<MemoryType>,
+        tags: Vec<String>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let resp = self
+            .request(Request::Recall {
+                query,
+                scope,
+                memory_type,
+                tags,
+                limit,
+            })
+            .await?;
+        match resp {
+            Resp::Recalled { results } => Ok(results),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Fetch a single memory by id.
+    pub async fn get(&mut self, id: MemoryId) -> Result<Option<MemoryNote>> {
+        let resp = self.request(Request::Get { id }).await?;
+        match resp {
+            Resp::Got { memory } => Ok(memory),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// List memories in scope.
+    pub async fn list(
+        &mut self,
+        scope: Option<Namespace>,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        let resp = self
+            .request(Request::List {
+                scope,
+                min_importance,
+                limit,
+            })
+            .await?;
+        match resp {
+            Resp::Listed { memories } => Ok(memories),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Walk the link graph from a memory.
+    pub async fn graph(&mut self, id: MemoryId, depth: u8) -> Result<Vec<MemoryNote>> {
+        let resp = self.request(Request::Graph { id, depth }).await?;
+        match resp {
+            Resp::GraphResult { memories } => Ok(memories),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Apply a partial update to a memory.
+    pub async fn update(&mut self, id: MemoryId, updates: MemoryUpdates) -> Result<()> {
+        let resp = self.request(Request::Update { id, updates }).await?;
+        match resp {
+            Resp::Updated => Ok(()),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Soft-archive a memory.
+    pub async fn delete(&mut self, id: MemoryId) -> Result<()> {
+        let resp = self.request(Request::Delete { id }).await?;
+        match resp {
+            Resp::Deleted => Ok(()),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Fetch the project context payload (recent, important, total).
+    pub async fn context(&mut self) -> Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)> {
+        let resp = self.request(Request::Context).await?;
+        match resp {
+            Resp::ContextResult {
+                recent,
+                important,
+                total,
+            } => Ok((recent, important, total)),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Round-trip ping; returns the daemon's contract version.
+    pub async fn ping(&mut self) -> Result<u32> {
+        let resp = self.request(Request::Ping).await?;
+        match resp {
+            Resp::Pong { contract_version } => Ok(contract_version),
+            other => Err(Self::unexpected(other)),
+        }
     }
 }
 
@@ -146,5 +292,185 @@ mod tests {
             matches!(err, rb_types::Error::Io(_)),
             "missing socket should be Error::Io, got {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod wrapper_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{
+        error_to_response, read_frame, write_frame, Handshake, HandshakeAck, Request, Response,
+        CONTRACT_VERSION,
+    };
+    use rb_types::{Error, MemoryId, MemoryNote, MemoryType, Namespace, SearchResult};
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    fn socket_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrap.sock");
+        (dir, path)
+    }
+
+    fn note() -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Global,
+            "remembered body".into(),
+            MemoryType::Insight,
+            6,
+        )
+    }
+
+    // Accept one connection, handshake, then answer each incoming Request with a
+    // matching canned Response until the client disconnects.
+    async fn serve(listener: UnixListener, fixed_id: MemoryId) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        write_frame(
+            &mut framed,
+            &HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: true,
+                message: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        loop {
+            let req: Request = match read_frame(&mut framed).await {
+                Ok(r) => r,
+                Err(_) => break, // client closed
+            };
+            let resp = match req {
+                Request::Remember { .. } => Response::Remembered {
+                    id: fixed_id.clone(),
+                },
+                Request::Recall { .. } => Response::Recalled {
+                    results: vec![SearchResult {
+                        memory: note(),
+                        score: 0.5,
+                    }],
+                },
+                Request::Get { .. } => Response::Got {
+                    memory: Some(note()),
+                },
+                Request::List { .. } => Response::Listed {
+                    memories: vec![note()],
+                },
+                Request::Graph { .. } => Response::GraphResult {
+                    memories: vec![note()],
+                },
+                Request::Update { .. } => Response::Updated,
+                Request::Delete { .. } => Response::Deleted,
+                Request::Context => Response::ContextResult {
+                    recent: vec![note()],
+                    important: vec![note()],
+                    total: 2,
+                },
+                Request::Ping => Response::Pong {
+                    contract_version: CONTRACT_VERSION,
+                },
+            };
+            write_frame(&mut framed, &resp).await.unwrap();
+        }
+    }
+
+    async fn connect(path: &std::path::Path) -> Client {
+        Client::connect(path, Namespace::Global).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn typed_wrappers_return_domain_types() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let fixed_id = MemoryId::new();
+        let server = tokio::spawn(serve(listener, fixed_id.clone()));
+
+        let mut c = connect(&path).await;
+
+        let id = c
+            .remember(
+                "body".into(),
+                Some("ctx".into()),
+                MemoryType::Insight,
+                6,
+                vec!["k".into()],
+                vec!["t".into()],
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert_eq!(id, fixed_id);
+
+        let results = c.recall("q".into(), None, None, vec![], 5).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!((results[0].score - 0.5).abs() < f32::EPSILON);
+
+        let got = c.get(fixed_id.clone()).await.unwrap();
+        assert!(got.is_some());
+
+        let listed = c.list(None, Some(5), 10).await.unwrap();
+        assert_eq!(listed.len(), 1);
+
+        let graphed = c.graph(fixed_id.clone(), 2).await.unwrap();
+        assert_eq!(graphed.len(), 1);
+
+        c.update(fixed_id.clone(), Default::default())
+            .await
+            .unwrap();
+        c.delete(fixed_id.clone()).await.unwrap();
+
+        let (recent, important, total) = c.context().await.unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(important.len(), 1);
+        assert_eq!(total, 2);
+
+        let version = c.ping().await.unwrap();
+        assert_eq!(version, CONTRACT_VERSION);
+
+        drop(c);
+        server.await.unwrap();
+    }
+
+    // A responder that always returns a Response::Error, to prove wrappers map
+    // wire errors back into rb_types::Error.
+    async fn serve_error(listener: UnixListener) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        write_frame(
+            &mut framed,
+            &HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: true,
+                message: None,
+            },
+        )
+        .await
+        .unwrap();
+        let _req: Request = read_frame(&mut framed).await.unwrap();
+        let resp = error_to_response(&Error::NotFound(MemoryId::new()));
+        write_frame(&mut framed, &resp).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wrapper_maps_wire_error_to_domain_error() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(serve_error(listener));
+
+        let mut c = connect(&path).await;
+        let err = c.get(MemoryId::new()).await.unwrap_err();
+        // NotFound degrades to Storage on the wire (see error.rs), but it is an
+        // Err, not a falsely-successful None.
+        assert!(matches!(err, Error::Storage(_)), "got {err:?}");
+        server.await.unwrap();
     }
 }

--- a/crates/rb-proto/src/codec.rs
+++ b/crates/rb-proto/src/codec.rs
@@ -1,0 +1,85 @@
+//! Bounded length-delimited codec for the rusty-brain wire protocol.
+//!
+//! All frame construction must go through [`bounded_codec`] so that oversized
+//! frames are rejected at the transport layer, not silently buffered into an
+//! OOM or panic.
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+/// Maximum bytes allowed in a single wire frame (1 MiB).
+pub const MAX_FRAME_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// Build a `LengthDelimitedCodec` capped at [`MAX_FRAME_BYTES`].
+///
+/// Use this factory everywhere a `LengthDelimitedCodec` is constructed for
+/// the daemon protocol. A frame whose length prefix exceeds `MAX_FRAME_BYTES`
+/// is rejected with an `io::Error`, surfaced as `Error::Io` by the frame
+/// helpers.
+pub fn bounded_codec() -> LengthDelimitedCodec {
+    LengthDelimitedCodec::builder()
+        .max_frame_length(MAX_FRAME_BYTES)
+        .new_codec()
+}
+
+/// Wrap `stream` in the bounded length-delimited codec.
+pub fn bounded_framed<S>(stream: S) -> Framed<S, LengthDelimitedCodec>
+where
+    S: AsyncRead + AsyncWrite,
+{
+    Framed::new(stream, bounded_codec())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::frame::{read_frame, write_frame};
+    use crate::Request;
+    use tokio::io::duplex;
+    use tokio_util::codec::Framed;
+
+    /// A frame whose length prefix exceeds MAX_FRAME_BYTES must be rejected
+    /// as Error::Io, not buffered into an OOM or panicked.
+    #[tokio::test]
+    async fn oversized_frame_is_rejected_as_io_error() {
+        // DuplexStream pipe: writer side uses an unbounded codec so we can
+        // actually send the oversized frame; reader side uses the bounded
+        // codec under test.
+        let (writer_raw, reader_raw) = duplex(4 * 1024 * 1024);
+        let mut writer: Framed<_, LengthDelimitedCodec> =
+            Framed::new(writer_raw, LengthDelimitedCodec::new());
+        let mut reader: Framed<_, LengthDelimitedCodec> =
+            Framed::new(reader_raw, bounded_codec());
+
+        // Build a payload just over the limit so the length-prefix exceeds
+        // MAX_FRAME_BYTES. The content doesn't matter — the codec rejects
+        // based on the length prefix before reading the body.
+        let oversized_payload = bytes::Bytes::from(vec![b'x'; MAX_FRAME_BYTES + 1]);
+        use futures::SinkExt;
+        writer.send(oversized_payload).await.unwrap();
+
+        // The bounded reader must reject this frame.
+        let err = read_frame::<_, Request>(&mut reader)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Io(_)),
+            "oversized frame must be Error::Io, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn frame_at_limit_is_accepted() {
+        // A frame exactly at MAX_FRAME_BYTES must succeed (boundary check).
+        // We use a simple Ping which is tiny, just verifying the codec
+        // accepts normal-sized frames through the bounded constructor.
+        let (a, b) = duplex(64 * 1024);
+        let mut sender = bounded_framed(a);
+        let mut receiver = bounded_framed(b);
+
+        write_frame(&mut sender, &Request::Ping).await.unwrap();
+        let req: Request = read_frame(&mut receiver).await.unwrap();
+        assert!(matches!(req, Request::Ping));
+    }
+}

--- a/crates/rb-proto/src/codec.rs
+++ b/crates/rb-proto/src/codec.rs
@@ -49,8 +49,7 @@ mod tests {
         let (writer_raw, reader_raw) = duplex(4 * 1024 * 1024);
         let mut writer: Framed<_, LengthDelimitedCodec> =
             Framed::new(writer_raw, LengthDelimitedCodec::new());
-        let mut reader: Framed<_, LengthDelimitedCodec> =
-            Framed::new(reader_raw, bounded_codec());
+        let mut reader: Framed<_, LengthDelimitedCodec> = Framed::new(reader_raw, bounded_codec());
 
         // Build a payload just over the limit so the length-prefix exceeds
         // MAX_FRAME_BYTES. The content doesn't matter — the codec rejects
@@ -60,9 +59,7 @@ mod tests {
         writer.send(oversized_payload).await.unwrap();
 
         // The bounded reader must reject this frame.
-        let err = read_frame::<_, Request>(&mut reader)
-            .await
-            .unwrap_err();
+        let err = read_frame::<_, Request>(&mut reader).await.unwrap_err();
         assert!(
             matches!(err, rb_types::Error::Io(_)),
             "oversized frame must be Error::Io, got {err:?}"

--- a/crates/rb-proto/src/codec.rs
+++ b/crates/rb-proto/src/codec.rs
@@ -34,9 +34,11 @@ where
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
-    use crate::frame::{read_frame, write_frame};
+    use crate::frame::read_frame;
     use crate::Request;
+    use futures::SinkExt;
     use tokio::io::duplex;
+    use tokio_stream::StreamExt;
     use tokio_util::codec::Framed;
 
     /// A frame whose length prefix exceeds MAX_FRAME_BYTES must be rejected
@@ -55,7 +57,6 @@ mod tests {
         // MAX_FRAME_BYTES. The content doesn't matter — the codec rejects
         // based on the length prefix before reading the body.
         let oversized_payload = bytes::Bytes::from(vec![b'x'; MAX_FRAME_BYTES + 1]);
-        use futures::SinkExt;
         writer.send(oversized_payload).await.unwrap();
 
         // The bounded reader must reject this frame.
@@ -68,15 +69,17 @@ mod tests {
 
     #[tokio::test]
     async fn frame_at_limit_is_accepted() {
-        // A frame exactly at MAX_FRAME_BYTES must succeed (boundary check).
-        // We use a simple Ping which is tiny, just verifying the codec
-        // accepts normal-sized frames through the bounded constructor.
-        let (a, b) = duplex(64 * 1024);
-        let mut sender = bounded_framed(a);
-        let mut receiver = bounded_framed(b);
+        let (writer_raw, reader_raw) = duplex(2 * 1024 * 1024);
+        let mut writer: Framed<_, LengthDelimitedCodec> =
+            Framed::new(writer_raw, LengthDelimitedCodec::new());
+        let mut reader: Framed<_, LengthDelimitedCodec> = Framed::new(reader_raw, bounded_codec());
 
-        write_frame(&mut sender, &Request::Ping).await.unwrap();
-        let req: Request = read_frame(&mut receiver).await.unwrap();
-        assert!(matches!(req, Request::Ping));
+        writer
+            .send(bytes::Bytes::from(vec![b'x'; MAX_FRAME_BYTES]))
+            .await
+            .unwrap();
+
+        let frame = reader.next().await.unwrap().unwrap();
+        assert_eq!(frame.len(), MAX_FRAME_BYTES);
     }
 }

--- a/crates/rb-proto/src/error.rs
+++ b/crates/rb-proto/src/error.rs
@@ -1,0 +1,163 @@
+//! Stable mapping between `rb_types::Error` and `Response::Error`.
+//!
+//! `kind` strings are part of the wire contract and must stay stable across
+//! versions. The daemon maps domain errors out; the client maps them back.
+
+use crate::Response;
+use rb_types::Error;
+
+/// Map a domain error into a wire `Response::Error`. The `kind` is a stable
+/// identifier; `message` is the human-readable `Display` form (no internal
+/// detail beyond what `rb_types::Error` already exposes).
+pub fn error_to_response(err: &Error) -> Response {
+    let kind = error_kind(err);
+    Response::Error {
+        kind: kind.to_string(),
+        message: err.to_string(),
+    }
+}
+
+/// The stable wire `kind` string for a domain error.
+fn error_kind(err: &Error) -> &'static str {
+    match err {
+        Error::Storage(_) => "storage",
+        Error::Migration(_) => "migration",
+        Error::NotFound(_) => "not_found",
+        Error::InvalidNamespace(_) => "invalid_namespace",
+        Error::InvalidMemoryType(_) => "invalid_memory_type",
+        Error::InvalidLinkType(_) => "invalid_link_type",
+        Error::Serialization(_) => "serialization",
+        Error::DimensionMismatch { .. } => "dimension_mismatch",
+        Error::Io(_) => "io",
+    }
+}
+
+/// Reconstruct a domain error from a wire `kind`/`message`.
+///
+/// Variants that carry structured data which cannot be parsed back from a
+/// string (`NotFound`, `DimensionMismatch`) degrade to `Error::Storage`
+/// carrying the original message -- faithful text, lossy structure. Unknown
+/// kinds also map to `Error::Storage` (fail closed: never silently succeed).
+pub fn response_error_to_error(kind: &str, message: &str) -> Error {
+    match kind {
+        "storage" => Error::Storage(message.to_string()),
+        "migration" => Error::Migration(message.to_string()),
+        "invalid_namespace" => Error::InvalidNamespace(message.to_string()),
+        "invalid_memory_type" => Error::InvalidMemoryType(message.to_string()),
+        "invalid_link_type" => Error::InvalidLinkType(message.to_string()),
+        "serialization" => Error::Serialization(message.to_string()),
+        "io" => Error::Io(message.to_string()),
+        // not_found / dimension_mismatch / anything unrecognized: preserve the
+        // message under Storage rather than fabricate structured fields.
+        _ => Error::Storage(message.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::Response;
+    use rb_types::{Error, MemoryId};
+
+    fn round_trip(err: Error) -> Error {
+        let resp = error_to_response(&err);
+        match resp {
+            Response::Error { kind, message } => response_error_to_error(&kind, &message),
+            other => panic!("expected Response::Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_maps_to_stable_kind() {
+        let id = MemoryId::new();
+        let resp = error_to_response(&Error::NotFound(id.clone()));
+        match resp {
+            Response::Error { kind, message } => {
+                assert_eq!(kind, "not_found");
+                assert!(message.contains(&id.to_string()));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_round_trips_to_storage() {
+        assert!(matches!(
+            round_trip(Error::Storage("disk".into())),
+            Error::Storage(_)
+        ));
+    }
+
+    #[test]
+    fn migration_round_trips_to_migration() {
+        assert!(matches!(
+            round_trip(Error::Migration("bad".into())),
+            Error::Migration(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_namespace_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidNamespace("x".into())),
+            Error::InvalidNamespace(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_memory_type_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidMemoryType("zz".into())),
+            Error::InvalidMemoryType(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_link_type_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidLinkType("qq".into())),
+            Error::InvalidLinkType(_)
+        ));
+    }
+
+    #[test]
+    fn serialization_round_trips() {
+        assert!(matches!(
+            round_trip(Error::Serialization("json".into())),
+            Error::Serialization(_)
+        ));
+    }
+
+    #[test]
+    fn io_round_trips() {
+        assert!(matches!(round_trip(Error::Io("eof".into())), Error::Io(_)));
+    }
+
+    #[test]
+    fn dimension_mismatch_round_trips_to_storage_with_detail() {
+        // DimensionMismatch carries structured fields that cannot be reconstructed
+        // from a string; it degrades to Storage carrying the human message, which
+        // is the documented, lossy-but-faithful behavior.
+        let err = Error::DimensionMismatch {
+            expected: 1024,
+            got: 768,
+        };
+        let resp = error_to_response(&err);
+        match resp {
+            Response::Error { kind, message } => {
+                assert_eq!(kind, "dimension_mismatch");
+                assert!(message.contains("1024") && message.contains("768"));
+                let back = response_error_to_error(&kind, &message);
+                assert!(matches!(back, Error::Storage(_)));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_kind_maps_to_storage() {
+        let back = response_error_to_error("totally_unknown_kind", "weird");
+        assert!(matches!(back, Error::Storage(_)));
+    }
+}

--- a/crates/rb-proto/src/error.rs
+++ b/crates/rb-proto/src/error.rs
@@ -29,6 +29,7 @@ fn error_kind(err: &Error) -> &'static str {
         Error::Serialization(_) => "serialization",
         Error::DimensionMismatch { .. } => "dimension_mismatch",
         Error::Io(_) => "io",
+        Error::Embedding(_) => "embedding",
     }
 }
 
@@ -47,6 +48,7 @@ pub fn response_error_to_error(kind: &str, message: &str) -> Error {
         "invalid_link_type" => Error::InvalidLinkType(message.to_string()),
         "serialization" => Error::Serialization(message.to_string()),
         "io" => Error::Io(message.to_string()),
+        "embedding" => Error::Embedding(message.to_string()),
         // not_found / dimension_mismatch / anything unrecognized: preserve the
         // message under Storage rather than fabricate structured fields.
         _ => Error::Storage(message.to_string()),
@@ -132,6 +134,14 @@ mod tests {
     #[test]
     fn io_round_trips() {
         assert!(matches!(round_trip(Error::Io("eof".into())), Error::Io(_)));
+    }
+
+    #[test]
+    fn embedding_round_trips() {
+        assert!(matches!(
+            round_trip(Error::Embedding("provider failed".into())),
+            Error::Embedding(_)
+        ));
     }
 
     #[test]

--- a/crates/rb-proto/src/frame.rs
+++ b/crates/rb-proto/src/frame.rs
@@ -1,0 +1,130 @@
+//! Length-delimited JSON framing over an async transport.
+//!
+//! Each frame is a 4-byte big-endian length prefix (managed by
+//! `LengthDelimitedCodec`) followed by the serde_json-encoded payload bytes.
+
+use futures::SinkExt;
+use rb_types::{Error, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_stream::StreamExt;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+/// Serialize `value` to JSON and send it as one length-delimited frame.
+///
+/// `LengthDelimitedCodec` implements `Encoder<bytes::Bytes>`, so the sink item
+/// is `bytes::Bytes`; `SinkExt::send` both feeds and flushes the frame.
+pub async fn write_frame<S, T>(
+    framed: &mut Framed<S, LengthDelimitedCodec>,
+    value: &T,
+) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: Serialize,
+{
+    let bytes = serde_json::to_vec(value).map_err(|e| Error::Serialization(e.to_string()))?;
+    framed
+        .send(bytes::Bytes::from(bytes))
+        .await
+        .map_err(|e| Error::Io(e.to_string()))?;
+    Ok(())
+}
+
+/// Read one length-delimited frame and deserialize it as `T`.
+///
+/// A clean end-of-stream (peer closed without sending a frame) yields
+/// `Stream::next == None`, surfaced as `Error::Io` so callers can distinguish
+/// it from a decode failure. The decoded item is `bytes::BytesMut`, which
+/// derefs to `[u8]` for `serde_json::from_slice`.
+pub async fn read_frame<S, T>(framed: &mut Framed<S, LengthDelimitedCodec>) -> Result<T>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: DeserializeOwned,
+{
+    match framed.next().await {
+        Some(Ok(bytes)) => {
+            serde_json::from_slice(&bytes).map_err(|e| Error::Serialization(e.to_string()))
+        }
+        Some(Err(e)) => Err(Error::Io(e.to_string())),
+        None => Err(Error::Io(
+            "connection closed before a frame was received".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{Handshake, Request, CONTRACT_VERSION};
+    use rb_types::{MemoryType, Namespace};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    // A pair of in-memory bidirectional streams standing in for the two ends of
+    // a UnixStream. Each end is wrapped in the length-delimited codec.
+    fn framed_pair() -> (
+        Framed<tokio::io::DuplexStream, LengthDelimitedCodec>,
+        Framed<tokio::io::DuplexStream, LengthDelimitedCodec>,
+    ) {
+        let (a, b) = tokio::io::duplex(64 * 1024);
+        (
+            Framed::new(a, LengthDelimitedCodec::new()),
+            Framed::new(b, LengthDelimitedCodec::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_a_value() {
+        let (mut client, mut server) = framed_pair();
+
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Project("rusty-brain".into()),
+        };
+        write_frame(&mut client, &hs).await.unwrap();
+
+        let got: Handshake = read_frame(&mut server).await.unwrap();
+        assert_eq!(got.contract_version, CONTRACT_VERSION);
+        assert_eq!(got.namespace, Namespace::Project("rusty-brain".into()));
+    }
+
+    #[tokio::test]
+    async fn two_frames_are_independently_decoded() {
+        let (mut client, mut server) = framed_pair();
+
+        let r1 = Request::Ping;
+        let r2 = Request::Recall {
+            query: "transactions".into(),
+            scope: Some(Namespace::Global),
+            memory_type: Some(MemoryType::BugFix),
+            tags: vec![],
+            limit: 5,
+        };
+        write_frame(&mut client, &r1).await.unwrap();
+        write_frame(&mut client, &r2).await.unwrap();
+
+        let g1: Request = read_frame(&mut server).await.unwrap();
+        let g2: Request = read_frame(&mut server).await.unwrap();
+        assert_eq!(
+            serde_json::to_string(&g1).unwrap(),
+            serde_json::to_string(&r1).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_string(&g2).unwrap(),
+            serde_json::to_string(&r2).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_after_peer_closes_is_io_error() {
+        let (client, mut server) = framed_pair();
+        // Drop the client end without sending anything -> stream ends cleanly.
+        drop(client);
+        let err = read_frame::<_, Request>(&mut server).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Io(_)),
+            "clean EOF should surface as Error::Io, got {err:?}"
+        );
+    }
+}

--- a/crates/rb-proto/src/frame.rs
+++ b/crates/rb-proto/src/frame.rs
@@ -96,7 +96,6 @@ mod tests {
         let r1 = Request::Ping;
         let r2 = Request::Recall {
             query: "transactions".into(),
-            scope: Some(Namespace::Global),
             memory_type: Some(MemoryType::BugFix),
             tags: vec![],
             limit: 5,

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -4,10 +4,12 @@
 //! handshake, the `Request`/`Response` enums, and an async `Client`.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+mod client;
 mod error;
 mod frame;
 mod messages;
 
+pub use client::Client;
 pub use error::{error_to_response, response_error_to_error};
 pub use frame::{read_frame, write_frame};
 pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -5,11 +5,13 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 mod client;
+pub mod codec;
 mod error;
 mod frame;
 mod messages;
 
 pub use client::Client;
+pub use codec::{bounded_codec, bounded_framed, MAX_FRAME_BYTES};
 pub use error::{error_to_response, response_error_to_error};
 pub use frame::{read_frame, write_frame};
 pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -2,5 +2,8 @@
 //!
 //! Length-delimited JSON frames over a Unix domain socket, a versioned
 //! handshake, the `Request`/`Response` enums, and an async `Client`.
-//! Concrete types are added in subsequent tasks.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+mod messages;
+
+pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -1,0 +1,6 @@
+//! `rb_proto`: daemon wire protocol for rusty-brain.
+//!
+//! Length-delimited JSON frames over a Unix domain socket, a versioned
+//! handshake, the `Request`/`Response` enums, and an async `Client`.
+//! Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -5,7 +5,9 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 mod error;
+mod frame;
 mod messages;
 
 pub use error::{error_to_response, response_error_to_error};
+pub use frame::{read_frame, write_frame};
 pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -4,6 +4,8 @@
 //! handshake, the `Request`/`Response` enums, and an async `Client`.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
+mod error;
 mod messages;
 
+pub use error::{error_to_response, response_error_to_error};
 pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -1,0 +1,264 @@
+use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, SearchResult};
+use serde::{Deserialize, Serialize};
+
+/// Wire contract version carried in the handshake. Clients and the daemon must
+/// agree on this exact value; mismatch is rejected at connect time.
+pub const CONTRACT_VERSION: u32 = 1;
+
+/// First frame the client sends after connecting.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Handshake {
+    pub contract_version: u32,
+    pub namespace: Namespace,
+}
+
+/// Daemon reply to a `Handshake`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HandshakeAck {
+    pub contract_version: u32,
+    pub ok: bool,
+    pub message: Option<String>,
+}
+
+/// One request per engine operation. Internally tagged on `op`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "op")]
+pub enum Request {
+    Remember {
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+        related_files: Vec<String>,
+    },
+    Recall {
+        query: String,
+        scope: Option<Namespace>,
+        memory_type: Option<MemoryType>,
+        tags: Vec<String>,
+        limit: usize,
+    },
+    Get {
+        id: MemoryId,
+    },
+    List {
+        scope: Option<Namespace>,
+        min_importance: Option<u8>,
+        limit: usize,
+    },
+    Graph {
+        id: MemoryId,
+        depth: u8,
+    },
+    Update {
+        id: MemoryId,
+        updates: MemoryUpdates,
+    },
+    Delete {
+        id: MemoryId,
+    },
+    Context,
+    Ping,
+}
+
+/// One response per request. Internally tagged on `result`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+#[serde(tag = "result")]
+pub enum Response {
+    Remembered {
+        id: MemoryId,
+    },
+    Recalled {
+        results: Vec<SearchResult>,
+    },
+    Got {
+        memory: Option<MemoryNote>,
+    },
+    Listed {
+        memories: Vec<MemoryNote>,
+    },
+    GraphResult {
+        memories: Vec<MemoryNote>,
+    },
+    Updated,
+    Deleted,
+    ContextResult {
+        recent: Vec<MemoryNote>,
+        important: Vec<MemoryNote>,
+        total: usize,
+    },
+    Pong {
+        contract_version: u32,
+    },
+    Error {
+        kind: String,
+        message: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, SearchResult};
+
+    fn note() -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Project("rusty-brain".into()),
+            "one db, one transaction".into(),
+            MemoryType::ArchitectureDecision,
+            8,
+        )
+    }
+
+    #[test]
+    fn contract_version_is_one() {
+        assert_eq!(CONTRACT_VERSION, 1);
+    }
+
+    #[test]
+    fn handshake_round_trip() {
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Project("rusty-brain".into()),
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        let back: Handshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.contract_version, CONTRACT_VERSION);
+        assert_eq!(back.namespace, Namespace::Project("rusty-brain".into()));
+    }
+
+    #[test]
+    fn handshake_ack_round_trip() {
+        let ack = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: false,
+            message: Some("version mismatch".into()),
+        };
+        let json = serde_json::to_string(&ack).unwrap();
+        let back: HandshakeAck = serde_json::from_str(&json).unwrap();
+        assert!(!back.ok);
+        assert_eq!(back.message.as_deref(), Some("version mismatch"));
+    }
+
+    fn all_requests() -> Vec<Request> {
+        let id = MemoryId::new();
+        vec![
+            Request::Remember {
+                content: "c".into(),
+                context: Some("ctx".into()),
+                memory_type: MemoryType::Insight,
+                importance: 7,
+                keywords: vec!["k".into()],
+                tags: vec!["t".into()],
+                related_files: vec!["src/lib.rs".into()],
+            },
+            Request::Recall {
+                query: "q".into(),
+                scope: Some(Namespace::Global),
+                memory_type: Some(MemoryType::BugFix),
+                tags: vec!["sqlite".into()],
+                limit: 10,
+            },
+            Request::Get { id: id.clone() },
+            Request::List {
+                scope: Some(Namespace::Project("p".into())),
+                min_importance: Some(5),
+                limit: 20,
+            },
+            Request::Graph {
+                id: id.clone(),
+                depth: 2,
+            },
+            Request::Update {
+                id: id.clone(),
+                updates: MemoryUpdates {
+                    importance: Some(9),
+                    ..Default::default()
+                },
+            },
+            Request::Delete { id },
+            Request::Context,
+            Request::Ping,
+        ]
+    }
+
+    #[test]
+    fn every_request_variant_round_trips() {
+        for req in all_requests() {
+            let json = serde_json::to_string(&req).unwrap();
+            let back: Request = serde_json::from_str(&json).unwrap();
+            // Compare via JSON since Request is not PartialEq.
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn request_uses_op_tag() {
+        let json = serde_json::to_string(&Request::Ping).unwrap();
+        assert_eq!(json, r#"{"op":"Ping"}"#);
+        let json = serde_json::to_string(&Request::Context).unwrap();
+        assert_eq!(json, r#"{"op":"Context"}"#);
+    }
+
+    fn all_responses() -> Vec<Response> {
+        vec![
+            Response::Remembered {
+                id: MemoryId::new(),
+            },
+            Response::Recalled {
+                results: vec![SearchResult {
+                    memory: note(),
+                    score: 0.9,
+                }],
+            },
+            Response::Got {
+                memory: Some(note()),
+            },
+            Response::Got { memory: None },
+            Response::Listed {
+                memories: vec![note()],
+            },
+            Response::GraphResult {
+                memories: vec![note()],
+            },
+            Response::Updated,
+            Response::Deleted,
+            Response::ContextResult {
+                recent: vec![note()],
+                important: vec![note()],
+                total: 2,
+            },
+            Response::Pong {
+                contract_version: CONTRACT_VERSION,
+            },
+            Response::Error {
+                kind: "not_found".into(),
+                message: "no such memory".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn every_response_variant_round_trips() {
+        for resp in all_responses() {
+            let json = serde_json::to_string(&resp).unwrap();
+            let back: Response = serde_json::from_str(&json).unwrap();
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn response_uses_result_tag() {
+        let json = serde_json::to_string(&Response::Updated).unwrap();
+        assert_eq!(json, r#"{"result":"Updated"}"#);
+        let json = serde_json::to_string(&Response::Pong {
+            contract_version: 1,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"result":"Pong","contract_version":1}"#);
+    }
+}

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -35,7 +35,6 @@ pub enum Request {
     },
     Recall {
         query: String,
-        scope: Option<Namespace>,
         memory_type: Option<MemoryType>,
         tags: Vec<String>,
         limit: usize,
@@ -44,7 +43,6 @@ pub enum Request {
         id: MemoryId,
     },
     List {
-        scope: Option<Namespace>,
         min_importance: Option<u8>,
         limit: usize,
     },
@@ -158,14 +156,12 @@ mod tests {
             },
             Request::Recall {
                 query: "q".into(),
-                scope: Some(Namespace::Global),
                 memory_type: Some(MemoryType::BugFix),
                 tags: vec!["sqlite".into()],
                 limit: 10,
             },
             Request::Get { id: id.clone() },
             Request::List {
-                scope: Some(Namespace::Project("p".into())),
                 min_importance: Some(5),
                 limit: 20,
             },

--- a/crates/rb-proto/tests/public_api.rs
+++ b/crates/rb-proto/tests/public_api.rs
@@ -1,0 +1,44 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rb_proto::{
+    error_to_response, read_frame, response_error_to_error, write_frame, Client, Handshake,
+    HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+use rb_types::{Error, MemoryId, Namespace};
+
+#[test]
+fn public_surface_is_reachable_and_stable() {
+    // Constants and messages.
+    assert_eq!(CONTRACT_VERSION, 1);
+    let _hs = Handshake {
+        contract_version: CONTRACT_VERSION,
+        namespace: Namespace::Global,
+    };
+    let _ack = HandshakeAck {
+        contract_version: CONTRACT_VERSION,
+        ok: true,
+        message: None,
+    };
+    let _req = Request::Ping;
+
+    // Error mapping helpers, round-tripping through the wire form.
+    let resp = error_to_response(&Error::NotFound(MemoryId::new()));
+    match resp {
+        Response::Error { kind, message } => {
+            assert_eq!(kind, "not_found");
+            let back = response_error_to_error(&kind, &message);
+            assert!(matches!(back, Error::Storage(_)));
+        }
+        other => panic!("expected Response::Error, got {other:?}"),
+    }
+}
+
+// Compile-only references proving the framing and Client symbols are public.
+// (Never called: these are type-level guards on the public surface.)
+#[allow(dead_code)]
+fn _framing_symbols_exist() {
+    // Reference each public symbol so an accidental removal breaks compilation.
+    let _ = write_frame::<tokio::net::UnixStream, Request>;
+    let _ = read_frame::<tokio::net::UnixStream, Response>;
+    let _ = Client::connect;
+}

--- a/crates/rb-search/Cargo.toml
+++ b/crates/rb-search/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rb-search"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Pure, deterministic hybrid ranking for rusty-brain: combine keyword, vector, graph, importance, and recency signals."
+
+[lib]
+name = "rb_search"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+chrono = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-search/src/lib.rs
+++ b/crates/rb-search/src/lib.rs
@@ -1,0 +1,5 @@
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO. Combines normalized keyword/vector/graph/importance/recency signals
+//! into a single weighted score. Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]

--- a/crates/rb-search/src/lib.rs
+++ b/crates/rb-search/src/lib.rs
@@ -4,6 +4,8 @@
 //! recency signals into a single weighted score (see `rank`).
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod rank;
 mod weights;
 
+pub use rank::{rank, Signals, HALF_LIFE};
 pub use weights::Weights;

--- a/crates/rb-search/src/lib.rs
+++ b/crates/rb-search/src/lib.rs
@@ -1,5 +1,9 @@
 //! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
 //!
-//! No IO. Combines normalized keyword/vector/graph/importance/recency signals
-//! into a single weighted score. Concrete types are added in subsequent tasks.
-#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+//! No IO, no async. Combines normalized keyword / vector / graph / importance /
+//! recency signals into a single weighted score (see `rank`).
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod weights;
+
+pub use weights::Weights;

--- a/crates/rb-search/src/lib.rs
+++ b/crates/rb-search/src/lib.rs
@@ -1,11 +1,14 @@
 //! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
 //!
 //! No IO, no async. Combines normalized keyword / vector / graph / importance /
-//! recency signals into a single weighted score (see `rank`).
+//! recency signals into a single weighted score (see `rank`). `build_signals`
+//! folds the three retrieval result sets into the `Signals` that `rank` consumes.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod merge;
 mod rank;
 mod weights;
 
+pub use merge::build_signals;
 pub use rank::{rank, Signals, HALF_LIFE};
 pub use weights::Weights;

--- a/crates/rb-search/src/merge.rs
+++ b/crates/rb-search/src/merge.rs
@@ -1,0 +1,198 @@
+use crate::rank::Signals;
+use rb_types::MemoryId;
+use std::collections::HashMap;
+
+/// Fold the three retrieval result sets into one `Signals` per distinct candidate.
+///
+/// - `keyword`: ids in rank order (index 0 = best keyword hit).
+/// - `vector`: `(id, cosine_distance)` pairs (smaller distance = closer).
+/// - `graph`: ids in hop order (index 0 = nearest in the graph walk).
+/// - `meta`: per-id `(importance, created_at)`, the source of truth for scoring/fetch.
+///
+/// A candidate may appear in any subset of the three paths; each path fills only its
+/// own field, leaving the rest `None` so `rank` contributes 0 for absent signals.
+/// Candidates with no `meta` entry are dropped (fail closed - they cannot be scored
+/// or later fetched). Output order follows first appearance across keyword, then
+/// vector, then graph, which `rank` re-sorts deterministically.
+pub fn build_signals(
+    keyword: &[MemoryId],
+    vector: &[(MemoryId, f32)],
+    graph: &[MemoryId],
+    meta: &HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)>,
+) -> Vec<Signals> {
+    // Preserve first-seen order with a parallel index map into `out`.
+    let mut index: HashMap<MemoryId, usize> = HashMap::new();
+    let mut out: Vec<Signals> = Vec::new();
+
+    // The closure captures only `meta` (by shared ref) and takes `index`/`out` as
+    // `&mut` parameters per call, so it does NOT need to be `mut` itself. Marking it
+    // `mut` would trip the `unused_mut` warning, which is denied under -D warnings.
+    let slot = |id: &MemoryId,
+                index: &mut HashMap<MemoryId, usize>,
+                out: &mut Vec<Signals>|
+     -> Option<usize> {
+        if let Some(&i) = index.get(id) {
+            return Some(i);
+        }
+        // Only materialize a candidate we have metadata for.
+        let (importance, created_at) = *meta.get(id)?;
+        let i = out.len();
+        out.push(Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: None,
+            graph_hops: None,
+            importance,
+            created_at,
+        });
+        index.insert(id.clone(), i);
+        Some(i)
+    };
+
+    for (rank_idx, id) in keyword.iter().enumerate() {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            out[i].keyword_rank = Some(rank_idx);
+        }
+    }
+    for (id, distance) in vector {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            out[i].vector_distance = Some(*distance);
+        }
+    }
+    for (hop_idx, id) in graph.iter().enumerate() {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            // hop index saturates into u8; graph depth is bounded well below 255.
+            out[i].graph_hops = Some(hop_idx.min(u8::MAX as usize) as u8);
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use chrono::Utc;
+    use rb_types::MemoryId;
+    use std::collections::HashMap;
+
+    #[test]
+    fn merges_overlapping_paths_into_one_signal_per_id() {
+        let now = Utc::now();
+        let shared = MemoryId::new();
+        let kw_only = MemoryId::new();
+        let vec_only = MemoryId::new();
+        let graph_only = MemoryId::new();
+
+        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        for id in [&shared, &kw_only, &vec_only, &graph_only] {
+            meta.insert(id.clone(), (5, now));
+        }
+
+        let keyword = vec![shared.clone(), kw_only.clone()];
+        let vector = vec![(shared.clone(), 0.2), (vec_only.clone(), 0.9)];
+        let graph = vec![shared.clone(), graph_only.clone()];
+
+        let signals = build_signals(&keyword, &vector, &graph, &meta);
+        // one Signals per distinct id (4 total).
+        assert_eq!(signals.len(), 4);
+
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+
+        // shared appears in all three paths: keyword_rank 0 (first), vector dist 0.2, graph hops 0 (first).
+        let sh = by_id.get(&shared).unwrap();
+        assert_eq!(sh.keyword_rank, Some(0));
+        assert!((sh.vector_distance.unwrap() - 0.2).abs() < f32::EPSILON);
+        assert_eq!(sh.graph_hops, Some(0));
+
+        // kw_only: keyword_rank 1, no vector, no graph.
+        let k = by_id.get(&kw_only).unwrap();
+        assert_eq!(k.keyword_rank, Some(1));
+        assert!(k.vector_distance.is_none());
+        assert!(k.graph_hops.is_none());
+
+        // vec_only: only vector distance 0.9.
+        let v = by_id.get(&vec_only).unwrap();
+        assert!(v.keyword_rank.is_none());
+        assert!((v.vector_distance.unwrap() - 0.9).abs() < f32::EPSILON);
+        assert!(v.graph_hops.is_none());
+
+        // graph_only: graph hops 1 (second in graph order).
+        let g = by_id.get(&graph_only).unwrap();
+        assert!(g.keyword_rank.is_none());
+        assert!(g.vector_distance.is_none());
+        assert_eq!(g.graph_hops, Some(1));
+    }
+
+    #[test]
+    fn keyword_rank_and_graph_hops_follow_input_order() {
+        let now = Utc::now();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+        let mut meta = HashMap::new();
+        for id in [&a, &b, &c] {
+            meta.insert(id.clone(), (5, now));
+        }
+        let keyword = vec![a.clone(), b.clone(), c.clone()];
+        let graph = vec![c.clone(), b.clone(), a.clone()];
+        let signals = build_signals(&keyword, &[], &graph, &meta);
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+        // keyword rank = index in keyword vec.
+        assert_eq!(by_id.get(&a).unwrap().keyword_rank, Some(0));
+        assert_eq!(by_id.get(&b).unwrap().keyword_rank, Some(1));
+        assert_eq!(by_id.get(&c).unwrap().keyword_rank, Some(2));
+        // graph hops = index in graph vec.
+        assert_eq!(by_id.get(&c).unwrap().graph_hops, Some(0));
+        assert_eq!(by_id.get(&b).unwrap().graph_hops, Some(1));
+        assert_eq!(by_id.get(&a).unwrap().graph_hops, Some(2));
+    }
+
+    #[test]
+    fn carries_importance_and_created_at_from_meta() {
+        let created = Utc::now();
+        let id = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(id.clone(), (8u8, created));
+        let signals = build_signals(std::slice::from_ref(&id), &[], &[], &meta);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].importance, 8);
+        assert_eq!(signals[0].created_at, created);
+    }
+
+    #[test]
+    fn candidates_absent_from_meta_are_dropped() {
+        let now = Utc::now();
+        let known = MemoryId::new();
+        let unknown = MemoryId::new(); // appears in results but has no meta entry
+        let mut meta = HashMap::new();
+        meta.insert(known.clone(), (5, now));
+        let keyword = vec![known.clone(), unknown.clone()];
+        let signals = build_signals(&keyword, &[], &[], &meta);
+        // the unknown id is dropped (cannot be scored or fetched) -> fail closed.
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].id, known);
+    }
+
+    #[test]
+    fn output_feeds_rank_end_to_end() {
+        let now = Utc::now();
+        let strong = MemoryId::new();
+        let weak = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(strong.clone(), (9u8, now));
+        meta.insert(weak.clone(), (2u8, now));
+        let keyword = vec![strong.clone(), weak.clone()];
+        let vector = vec![(strong.clone(), 0.1), (weak.clone(), 1.7)];
+        let signals = build_signals(&keyword, &vector, &[], &meta);
+        let ranked = crate::rank::rank(signals, crate::weights::Weights::default(), now, 10);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(
+            ranked[0].0, strong,
+            "merge + rank place the strong doc first"
+        );
+    }
+}

--- a/crates/rb-search/src/merge.rs
+++ b/crates/rb-search/src/merge.rs
@@ -51,18 +51,23 @@ pub fn build_signals(
 
     for (rank_idx, id) in keyword.iter().enumerate() {
         if let Some(i) = slot(id, &mut index, &mut out) {
-            out[i].keyword_rank = Some(rank_idx);
+            out[i].keyword_rank = Some(out[i].keyword_rank.map_or(rank_idx, |r| r.min(rank_idx)));
         }
     }
     for (id, distance) in vector {
         if let Some(i) = slot(id, &mut index, &mut out) {
-            out[i].vector_distance = Some(*distance);
+            out[i].vector_distance = Some(
+                out[i]
+                    .vector_distance
+                    .map_or(*distance, |d| d.min(*distance)),
+            );
         }
     }
     for (hop_idx, id) in graph.iter().enumerate() {
         if let Some(i) = slot(id, &mut index, &mut out) {
             // hop index saturates into u8; graph depth is bounded well below 255.
-            out[i].graph_hops = Some(hop_idx.min(u8::MAX as usize) as u8);
+            let hops = hop_idx.min(u8::MAX as usize) as u8;
+            out[i].graph_hops = Some(out[i].graph_hops.map_or(hops, |h| h.min(hops)));
         }
     }
 
@@ -149,6 +154,55 @@ mod tests {
         assert_eq!(by_id.get(&c).unwrap().graph_hops, Some(0));
         assert_eq!(by_id.get(&b).unwrap().graph_hops, Some(1));
         assert_eq!(by_id.get(&a).unwrap().graph_hops, Some(2));
+    }
+
+    #[test]
+    fn duplicate_keyword_ids_keep_earliest_rank() {
+        let now = Utc::now();
+        let duplicate = MemoryId::new();
+        let earlier = MemoryId::new();
+        let mut meta = HashMap::new();
+        for id in [&duplicate, &earlier] {
+            meta.insert(id.clone(), (5, now));
+        }
+
+        let keyword = vec![duplicate.clone(), earlier, duplicate.clone()];
+        let signals = build_signals(&keyword, &[], &[], &meta);
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+
+        assert_eq!(by_id.get(&duplicate).unwrap().keyword_rank, Some(0));
+    }
+
+    #[test]
+    fn duplicate_vector_ids_keep_smallest_distance() {
+        let now = Utc::now();
+        let duplicate = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(duplicate.clone(), (5, now));
+
+        let vector = vec![(duplicate.clone(), 0.8), (duplicate.clone(), 0.2)];
+        let signals = build_signals(&[], &vector, &[], &meta);
+
+        assert!((signals[0].vector_distance.unwrap() - 0.2).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn duplicate_graph_ids_keep_earliest_hop() {
+        let now = Utc::now();
+        let duplicate = MemoryId::new();
+        let other = MemoryId::new();
+        let mut meta = HashMap::new();
+        for id in [&duplicate, &other] {
+            meta.insert(id.clone(), (5, now));
+        }
+
+        let graph = vec![duplicate.clone(), other, duplicate.clone()];
+        let signals = build_signals(&[], &[], &graph, &meta);
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+
+        assert_eq!(by_id.get(&duplicate).unwrap().graph_hops, Some(0));
     }
 
     #[test]

--- a/crates/rb-search/src/rank.rs
+++ b/crates/rb-search/src/rank.rs
@@ -1,0 +1,265 @@
+use crate::weights::Weights;
+use rb_types::MemoryId;
+
+/// Recency half-life in days: a memory `HALF_LIFE` days old scores `e^-1 ~= 0.368`
+/// on the recency term. Documented, fixed constant for deterministic ranking.
+pub const HALF_LIFE: f32 = 30.0;
+
+/// Per-candidate raw signals gathered from the three retrieval paths.
+///
+/// Any `Option` left as `None` means "this path did not surface this candidate";
+/// its corresponding term contributes 0 (no penalty).
+#[derive(Clone, Debug)]
+pub struct Signals {
+    pub id: MemoryId,
+    /// Keyword rank, 0 = best. `None` if not a keyword hit.
+    pub keyword_rank: Option<usize>,
+    /// Cosine distance, smaller = closer. `None` if not a vector hit.
+    pub vector_distance: Option<f32>,
+    /// Graph hops from a seed, 0 = the seed itself. `None` if not graph-reached.
+    pub graph_hops: Option<u8>,
+    /// Importance 0..=10.
+    pub importance: u8,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Normalize a single candidate's signals into a weighted score in `[0, 1]`.
+fn score_one(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f32 {
+    // Vector similarity: cosine distance in [0, 2] -> similarity in [0, 1].
+    let vector_sim = match s.vector_distance {
+        Some(d) => 1.0 - (d / 2.0).clamp(0.0, 1.0),
+        None => 0.0,
+    };
+    // Keyword: reciprocal rank, 0 = best -> 1.0.
+    let keyword = match s.keyword_rank {
+        Some(r) => 1.0 / (1.0 + r as f32),
+        None => 0.0,
+    };
+    // Graph proximity: reciprocal hops, 0 hops -> 1.0.
+    let graph = match s.graph_hops {
+        Some(h) => 1.0 / (1.0 + h as f32),
+        None => 0.0,
+    };
+    // Importance normalized to [0, 1].
+    let importance = (s.importance as f32 / 10.0).clamp(0.0, 1.0);
+    // Recency: exponential decay over age in days. Future timestamps clamp to age 0.
+    let age_days = ((now - s.created_at).num_seconds() as f32 / 86_400.0).max(0.0);
+    let recency = (-age_days / HALF_LIFE).exp();
+
+    w.vector * vector_sim
+        + w.keyword * keyword
+        + w.graph * graph
+        + w.importance * importance
+        + w.recency * recency
+}
+
+/// Rank candidates by weighted, normalized signal score.
+///
+/// Pure and deterministic: returns `(id, score)` pairs sorted by score descending,
+/// truncated to `limit`. `slice::sort_by` is a stable sort, so equal scores preserve
+/// input order and output ordering is reproducible across runs. Missing signals
+/// contribute 0 (no penalty).
+pub fn rank(
+    signals: Vec<Signals>,
+    weights: Weights,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: usize,
+) -> Vec<(MemoryId, f32)> {
+    let mut scored: Vec<(MemoryId, f32)> = signals
+        .iter()
+        .map(|s| (s.id.clone(), score_one(s, &weights, now)))
+        .collect();
+    // Stable sort descending by score; partial_cmp is total here (scores are finite),
+    // and we fall back to Equal so a NaN (which cannot occur with finite inputs) does
+    // not panic, keeping the function panic-free on all paths.
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use chrono::{Duration, Utc};
+    use rb_types::MemoryId;
+
+    /// Returns the current instant, captured once per test and reused as the single
+    /// consistent reference for both `created_at` offsets and the `rank(..., n, ...)`
+    /// call, so each test is internally deterministic.
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn strong_doc_outranks_weak_doc() {
+        let n = now();
+        let strong = MemoryId::new();
+        let weak = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: weak.clone(),
+                keyword_rank: Some(9),
+                vector_distance: Some(1.6), // far -> low sim
+                graph_hops: None,
+                importance: 2,
+                created_at: n - Duration::days(120),
+            },
+            Signals {
+                id: strong.clone(),
+                keyword_rank: Some(0),      // best keyword hit
+                vector_distance: Some(0.1), // very close
+                graph_hops: Some(1),
+                importance: 9,
+                created_at: n,
+            },
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(
+            ranked[0].0, strong,
+            "strong vector+keyword doc must rank first"
+        );
+        assert_eq!(ranked[1].0, weak);
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn recency_breaks_ties_between_otherwise_equal_docs() {
+        let n = now();
+        let recent = MemoryId::new();
+        let old = MemoryId::new();
+        // Identical on every signal EXCEPT created_at.
+        let mk = |id: MemoryId, created| Signals {
+            id,
+            keyword_rank: Some(1),
+            vector_distance: Some(0.4),
+            graph_hops: Some(2),
+            importance: 5,
+            created_at: created,
+        };
+        let signals = vec![
+            mk(old.clone(), n - Duration::days(200)),
+            mk(recent.clone(), n),
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, recent, "more recent doc wins the tie");
+        assert_eq!(ranked[1].0, old);
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn graph_only_candidate_still_ranks_above_zero() {
+        let n = now();
+        let id = MemoryId::new();
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: None,
+            graph_hops: Some(0), // adjacent -> graph proximity 1.0
+            importance: 0,
+            created_at: n - Duration::days(10_000), // ancient -> recency ~0
+        }];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].0, id);
+        // graph weight (0.10) * proximity (1.0) dominates; score strictly > 0.
+        assert!(ranked[0].1 > 0.0, "graph-only candidate must score > 0");
+    }
+
+    #[test]
+    fn missing_signals_do_not_penalize() {
+        let n = now();
+        // A: only a keyword hit. B: only a vector hit at the SAME normalized strength.
+        // keyword Some(0) -> 1.0 ; vector dist 0.0 -> sim 1.0. With default weights
+        // keyword(0.30) vs vector(0.45), the vector-only doc should outrank.
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: a.clone(),
+                keyword_rank: Some(0),
+                vector_distance: None,
+                graph_hops: None,
+                importance: 0,
+                created_at: n - Duration::days(10_000),
+            },
+            Signals {
+                id: b.clone(),
+                keyword_rank: None,
+                vector_distance: Some(0.0),
+                graph_hops: None,
+                importance: 0,
+                created_at: n - Duration::days(10_000),
+            },
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(
+            ranked[0].0, b,
+            "vector-only (0.45) beats keyword-only (0.30)"
+        );
+        // The keyword-only doc is NOT penalized to 0: it scores its full keyword term.
+        assert!((ranked[1].1 - 0.30).abs() < 1e-5);
+    }
+
+    #[test]
+    fn limit_truncates_to_top_n() {
+        let n = now();
+        let signals: Vec<Signals> = (0..5)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: Some(i),
+                vector_distance: Some(0.1 * i as f32),
+                graph_hops: None,
+                importance: (10 - i) as u8,
+                created_at: n,
+            })
+            .collect();
+        let ranked = rank(signals, Weights::default(), n, 2);
+        assert_eq!(ranked.len(), 2, "limit truncates to 2");
+        // truncation keeps the two highest scores in descending order
+        assert!(ranked[0].1 >= ranked[1].1);
+    }
+
+    #[test]
+    fn scores_in_range_and_ordering_is_stable() {
+        let n = now();
+        let signals: Vec<Signals> = (0..20)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: if i % 2 == 0 { Some(i) } else { None },
+                vector_distance: if i % 3 == 0 {
+                    Some(0.05 * i as f32)
+                } else {
+                    None
+                },
+                graph_hops: if i % 4 == 0 {
+                    Some((i % 5) as u8)
+                } else {
+                    None
+                },
+                importance: (i % 11) as u8,
+                created_at: n - Duration::days(i as i64),
+            })
+            .collect();
+        let first = rank(signals.clone(), Weights::default(), n, 20);
+        // every score is a sane probability-like value in [0,1], non-increasing.
+        for w in first.windows(2) {
+            assert!(w[0].1 >= w[1].1, "scores must be sorted descending");
+        }
+        for (_, score) in &first {
+            assert!(*score >= 0.0 && *score <= 1.0, "score {score} out of [0,1]");
+        }
+        // determinism: same inputs -> identical id ordering AND identical scores.
+        let second = rank(signals, Weights::default(), n, 20);
+        let ids_a: Vec<_> = first.iter().map(|(id, _)| id.clone()).collect();
+        let ids_b: Vec<_> = second.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(ids_a, ids_b, "ordering must be stable across runs");
+        for (x, y) in first.iter().zip(second.iter()) {
+            assert!(
+                (x.1 - y.1).abs() < f32::EPSILON,
+                "scores must be reproducible"
+            );
+        }
+    }
+}

--- a/crates/rb-search/src/rank.rs
+++ b/crates/rb-search/src/rank.rs
@@ -27,8 +27,9 @@ pub struct Signals {
 fn score_one(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f32 {
     // Vector similarity: cosine distance in [0, 2] -> similarity in [0, 1].
     let vector_sim = match s.vector_distance {
-        Some(d) => 1.0 - (d / 2.0).clamp(0.0, 1.0),
+        Some(d) if d.is_finite() => 1.0 - (d / 2.0).clamp(0.0, 1.0),
         None => 0.0,
+        Some(_) => 0.0,
     };
     // Keyword: reciprocal rank, 0 = best -> 1.0.
     let keyword = match s.keyword_rank {
@@ -46,11 +47,18 @@ fn score_one(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f3
     let age_days = ((now - s.created_at).num_seconds() as f32 / 86_400.0).max(0.0);
     let recency = (-age_days / HALF_LIFE).exp();
 
-    w.vector * vector_sim
-        + w.keyword * keyword
-        + w.graph * graph
-        + w.importance * importance
-        + w.recency * recency
+    let finite_weight = |weight: f32| if weight.is_finite() { weight } else { 0.0 };
+    let score = finite_weight(w.vector) * vector_sim
+        + finite_weight(w.keyword) * keyword
+        + finite_weight(w.graph) * graph
+        + finite_weight(w.importance) * importance
+        + finite_weight(w.recency) * recency;
+
+    if score.is_finite() {
+        score.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
 }
 
 /// Rank candidates by weighted, normalized signal score.
@@ -69,10 +77,9 @@ pub fn rank(
         .iter()
         .map(|s| (s.id.clone(), score_one(s, &weights, now)))
         .collect();
-    // Stable sort descending by score; partial_cmp is total here (scores are finite),
-    // and we fall back to Equal so a NaN (which cannot occur with finite inputs) does
-    // not panic, keeping the function panic-free on all paths.
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // Stable sort descending by score; `total_cmp` keeps ordering deterministic for
+    // every public input shape, including values sanitized from non-finite signals.
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
     scored.truncate(limit);
     scored
 }
@@ -261,5 +268,106 @@ mod tests {
                 "scores must be reproducible"
             );
         }
+    }
+
+    #[test]
+    fn non_finite_vector_distances_score_as_worst_vector_match() {
+        let n = now();
+        let finite = MemoryId::new();
+        let nan = MemoryId::new();
+        let infinity = MemoryId::new();
+        let weights = Weights {
+            vector: 1.0,
+            keyword: 0.0,
+            graph: 0.0,
+            importance: 0.0,
+            recency: 0.0,
+        };
+        let signals = vec![
+            Signals {
+                id: nan.clone(),
+                keyword_rank: None,
+                vector_distance: Some(f32::NAN),
+                graph_hops: None,
+                importance: 10,
+                created_at: n,
+            },
+            Signals {
+                id: infinity.clone(),
+                keyword_rank: None,
+                vector_distance: Some(f32::INFINITY),
+                graph_hops: None,
+                importance: 10,
+                created_at: n,
+            },
+            Signals {
+                id: finite.clone(),
+                keyword_rank: None,
+                vector_distance: Some(0.0),
+                graph_hops: None,
+                importance: 0,
+                created_at: n,
+            },
+        ];
+
+        let ranked = rank(signals, weights, n, 10);
+
+        assert_eq!(ranked[0], (finite, 1.0));
+        assert_eq!(ranked[1].0, nan);
+        assert_eq!(ranked[1].1, 0.0);
+        assert_eq!(ranked[2].0, infinity);
+        assert_eq!(ranked[2].1, 0.0);
+        assert!(ranked.iter().all(|(_, score)| score.is_finite()));
+    }
+
+    #[test]
+    fn non_finite_weights_are_ignored_and_custom_scores_are_clamped() {
+        let n = now();
+        let id = MemoryId::new();
+        let weights = Weights {
+            vector: f32::NAN,
+            keyword: f32::INFINITY,
+            graph: f32::NEG_INFINITY,
+            importance: 2.0,
+            recency: -1.0,
+        };
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: Some(0),
+            vector_distance: Some(0.0),
+            graph_hops: Some(0),
+            importance: 10,
+            created_at: n,
+        }];
+
+        let ranked = rank(signals, weights, n, 10);
+
+        assert_eq!(ranked, vec![(id, 1.0)]);
+        assert!(ranked[0].1.is_finite());
+    }
+
+    #[test]
+    fn negative_custom_scores_clamp_to_zero() {
+        let n = now();
+        let id = MemoryId::new();
+        let weights = Weights {
+            vector: -1.0,
+            keyword: 0.0,
+            graph: 0.0,
+            importance: 0.0,
+            recency: 0.0,
+        };
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: Some(0.0),
+            graph_hops: None,
+            importance: 0,
+            created_at: n,
+        }];
+
+        let ranked = rank(signals, weights, n, 10);
+
+        assert_eq!(ranked, vec![(id, 0.0)]);
     }
 }

--- a/crates/rb-search/src/weights.rs
+++ b/crates/rb-search/src/weights.rs
@@ -1,0 +1,70 @@
+/// Relative contribution of each ranking signal to the final score.
+///
+/// The `Default` weights are tuned for hybrid recall and **sum to 1.0**, so the
+/// weighted score of any single candidate stays in `[0.0, 1.0]`:
+///
+/// | signal     | weight |
+/// |------------|--------|
+/// | vector     | 0.45   |
+/// | keyword    | 0.30   |
+/// | graph      | 0.10   |
+/// | importance | 0.10   |
+/// | recency    | 0.05   |
+#[derive(Clone, Copy, Debug)]
+pub struct Weights {
+    pub vector: f32,
+    pub keyword: f32,
+    pub graph: f32,
+    pub importance: f32,
+    pub recency: f32,
+}
+
+impl Default for Weights {
+    fn default() -> Self {
+        Self {
+            vector: 0.45,
+            keyword: 0.30,
+            graph: 0.10,
+            importance: 0.10,
+            recency: 0.05,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn default_weights_match_documented_values() {
+        let w = Weights::default();
+        assert!((w.vector - 0.45).abs() < f32::EPSILON);
+        assert!((w.keyword - 0.30).abs() < f32::EPSILON);
+        assert!((w.graph - 0.10).abs() < f32::EPSILON);
+        assert!((w.importance - 0.10).abs() < f32::EPSILON);
+        assert!((w.recency - 0.05).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn default_weights_sum_to_one() {
+        let w = Weights::default();
+        let sum = w.vector + w.keyword + w.graph + w.importance + w.recency;
+        assert!(
+            (sum - 1.0).abs() < 1e-6,
+            "weights must sum to 1.0, got {sum}"
+        );
+    }
+
+    #[test]
+    fn weights_is_copy_and_clone() {
+        let w = Weights::default();
+        let copied = w; // Copy
+                        // Invoke the Clone impl explicitly: `w.clone()` would trip clippy's
+                        // `clone_on_copy` lint (denied by -D warnings) because Weights is Copy.
+        let cloned = Clone::clone(&w);
+        assert!((copied.vector - cloned.vector).abs() < f32::EPSILON);
+        // original still usable after the copy (proves Copy, not move)
+        assert!((w.vector - 0.45).abs() < f32::EPSILON);
+    }
+}

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -485,7 +485,11 @@ impl Store for SqliteStore {
 
         let rows = stmt
             .query_map(
-                rusqlite::params![match_expr, ns.as_db_string(), limit as i64],
+                rusqlite::params![
+                    match_expr,
+                    ns.as_db_string(),
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
                 |row| row.get::<_, String>(0),
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -534,7 +538,13 @@ impl Store for SqliteStore {
         // only, then filter candidates in Rust.
         //
         // vec0 returns min(LIMIT, total_rows) without error.
-        let k_budget = (limit as i64).saturating_mul(10).max(limit as i64);
+        // sqlite-vec enforces a hard KNN cap of 4096; k_budget must not exceed it.
+        const VEC0_KNN_MAX: i64 = 4096;
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let k_budget = limit_i64
+            .saturating_mul(10)
+            .max(limit_i64)
+            .min(VEC0_KNN_MAX);
 
         let mut stmt = self
             .conn
@@ -648,7 +658,11 @@ impl Store for SqliteStore {
             .map_err(|e| Error::Storage(e.to_string()))?;
 
         let mut rows = stmt
-            .query(rusqlite::params![ns.as_db_string(), min, limit as i64])
+            .query(rusqlite::params![
+                ns.as_db_string(),
+                min,
+                i64::try_from(limit).unwrap_or(i64::MAX)
+            ])
             .map_err(|e| Error::Storage(e.to_string()))?;
 
         let mut out = Vec::new();

--- a/crates/rb-types/src/error.rs
+++ b/crates/rb-types/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     DimensionMismatch { expected: usize, got: usize },
     #[error("io error: {0}")]
     Io(String),
+    #[error("embedding error: {0}")]
+    Embedding(String),
 }
 
 /// Convenience alias used throughout rusty-brain.

--- a/crates/rb-types/src/error.rs
+++ b/crates/rb-types/src/error.rs
@@ -65,6 +65,10 @@ mod tests {
             "serialization error: json"
         );
         assert_eq!(Error::Io("eof".into()).to_string(), "io error: eof");
+        assert_eq!(
+            Error::Embedding("provider down".into()).to_string(),
+            "embedding error: provider down"
+        );
     }
 
     #[test]

--- a/crates/rb-types/src/query.rs
+++ b/crates/rb-types/src/query.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SearchQuery {
     pub query: String,
+    /// Reserved; not honored — scope is fixed at the daemon handshake.
     pub scope: Option<Namespace>,
     pub memory_type: Option<MemoryType>,
     pub tags: Vec<String>,

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -5,13 +5,30 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "rusty-brain CLI and daemon binary."
+description = "rusty-brain: shared agent memory daemon and CLI."
 
 [[bin]]
 name = "rusty-brain"
 path = "src/main.rs"
 
 [dependencies]
+rb-types = { path = "../rb-types" }
+rb-proto = { path = "../rb-proto" }
+rb-daemon = { path = "../rb-daemon" }
+rb-embed = { path = "../rb-embed" }
+tokio = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+directories = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = { workspace = true }
+anyhow = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -11,6 +11,10 @@ description = "rusty-brain: shared agent memory daemon and CLI."
 name = "rusty-brain"
 path = "src/main.rs"
 
+[lib]
+name = "rusty_brain"
+path = "src/lib.rs"
+
 [dependencies]
 rb-types = { path = "../rb-types" }
 rb-proto = { path = "../rb-proto" }

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -25,7 +25,6 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-directories = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rusty-brain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain CLI and daemon binary."
+
+[[bin]]
+name = "rusty-brain"
+path = "src/main.rs"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -1,0 +1,100 @@
+//! Command-line surface for the `rusty-brain` binary (clap derive).
+
+use clap::{Parser, Subcommand};
+use rb_types::MemoryType;
+
+/// Parse a `--type` value into a `MemoryType` using the canonical db strings.
+fn parse_memory_type(s: &str) -> Result<MemoryType, String> {
+    MemoryType::parse(s).map_err(|e| e.to_string())
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rusty-brain",
+    about = "Shared semantic memory for AI agents (daemon + CLI).",
+    version
+)]
+pub struct Cli {
+    /// Emit machine-readable JSON instead of human text (where supported).
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Run the memory daemon in the foreground until Ctrl-C.
+    Serve,
+
+    /// Store a new memory.
+    Remember {
+        /// Memory content (the body to remember).
+        content: String,
+        /// Memory type (db string, e.g. `insight`, `bug_fix`).
+        #[arg(long = "type", default_value = "insight", value_parser = parse_memory_type)]
+        memory_type: MemoryType,
+        /// Importance 1-10.
+        #[arg(long, default_value_t = 5)]
+        importance: u8,
+        /// Optional context string.
+        #[arg(long)]
+        context: Option<String>,
+        /// Tags (repeatable: `--tags a --tags b`).
+        #[arg(long)]
+        tags: Vec<String>,
+    },
+
+    /// Recall memories matching a query.
+    Recall {
+        /// Free-text query.
+        query: String,
+        /// Maximum number of results.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+        /// Restrict to a memory type (db string).
+        #[arg(long = "type", value_parser = parse_memory_type)]
+        memory_type: Option<MemoryType>,
+        /// Filter by tags (repeatable).
+        #[arg(long)]
+        tags: Vec<String>,
+    },
+
+    /// Fetch a single memory by id.
+    Get {
+        /// Memory id (UUID).
+        id: String,
+    },
+
+    /// List memories in the current namespace.
+    List {
+        /// Maximum number of results.
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        /// Only memories with at least this importance.
+        #[arg(long)]
+        min_importance: Option<u8>,
+    },
+
+    /// Show memories connected to an id by graph links.
+    Graph {
+        /// Memory id (UUID).
+        id: String,
+        /// Traversal depth.
+        #[arg(long, default_value_t = 1)]
+        depth: u8,
+    },
+
+    /// Soft-delete (archive) a memory.
+    Delete {
+        /// Memory id (UUID).
+        id: String,
+    },
+
+    /// Show the project context payload (recent + important).
+    Context,
+
+    /// Ping the daemon and report its contract version.
+    Status,
+}

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -1,6 +1,6 @@
 //! Command-line surface for the `rusty-brain` binary (clap derive).
 
-use clap::{Parser, Subcommand};
+use clap::{value_parser, Parser, Subcommand};
 use rb_types::MemoryType;
 
 /// Parse a `--type` value into a `MemoryType` using the canonical db strings.
@@ -36,7 +36,7 @@ pub enum Command {
         #[arg(long = "type", default_value = "insight", value_parser = parse_memory_type)]
         memory_type: MemoryType,
         /// Importance 1-10.
-        #[arg(long, default_value_t = 5)]
+        #[arg(long, default_value_t = 5, value_parser = value_parser!(u8).range(1..=10))]
         importance: u8,
         /// Optional context string.
         #[arg(long)]
@@ -73,7 +73,7 @@ pub enum Command {
         #[arg(long, default_value_t = 20)]
         limit: usize,
         /// Only memories with at least this importance.
-        #[arg(long)]
+        #[arg(long, value_parser = value_parser!(u8).range(1..=10))]
         min_importance: Option<u8>,
     },
 

--- a/crates/rusty-brain/src/client.rs
+++ b/crates/rusty-brain/src/client.rs
@@ -1,0 +1,151 @@
+//! Client connection with daemon auto-start and bounded backoff retry.
+
+use rb_proto::Client;
+use rb_types::{Error, Namespace, Result};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Generic connect-with-retry: try `connect`; on the first failure run `spawn`
+/// once, then keep retrying up to `max_attempts`, sleeping `backoff` between
+/// attempts. Returns the last error if all attempts fail.
+pub async fn connect_with_retry<C, Fut, T, S>(
+    mut connect: C,
+    spawn: S,
+    max_attempts: usize,
+    backoff: Duration,
+) -> Result<T>
+where
+    C: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+    S: FnOnce() -> Result<()>,
+{
+    let mut spawn = Some(spawn);
+    let mut last_err: Option<Error> = None;
+    for attempt in 0..max_attempts.max(1) {
+        match connect().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt == 0 {
+                    if let Some(s) = spawn.take() {
+                        s()?;
+                    }
+                }
+                if backoff > Duration::ZERO {
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| Error::Io("connect failed".into())))
+}
+
+/// Connect to the daemon at `socket_path` for `namespace`, auto-starting a
+/// detached `rusty-brain serve` child if the socket is not yet accepting.
+pub async fn connect_or_start(
+    socket_path: &Path,
+    namespace: Namespace,
+    self_exe: PathBuf,
+) -> Result<Client> {
+    let sock = socket_path.to_path_buf();
+    let ns = namespace.clone();
+    let connect = || {
+        let sock = sock.clone();
+        let ns = ns.clone();
+        async move { Client::connect(&sock, ns).await }
+    };
+    let spawn_sock = socket_path.to_path_buf();
+    let spawn = move || spawn_daemon(&self_exe, &spawn_sock);
+    connect_with_retry(connect, spawn, 50, Duration::from_millis(100)).await
+}
+
+/// Spawn `rusty-brain serve` as a detached child, passing the resolved
+/// `RUSTY_BRAIN_SOCKET` so child + client agree on the socket path.
+fn spawn_daemon(self_exe: &Path, socket_path: &Path) -> Result<()> {
+    let mut cmd = std::process::Command::new(self_exe);
+    cmd.arg("serve");
+    cmd.env(crate::paths::SOCKET_ENV, socket_path);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::null());
+    cmd.stderr(std::process::Stdio::null());
+    cmd.spawn()
+        .map(|_child| ())
+        .map_err(|e| Error::Io(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn succeeds_on_first_try_without_spawning() {
+        let spawned = Arc::new(AtomicUsize::new(0));
+        let sp = Arc::clone(&spawned);
+        let spawn = move || {
+            sp.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let at = Arc::clone(&attempts);
+        let connect = move || {
+            at.fetch_add(1, Ordering::SeqCst);
+            async { Ok::<u32, rb_types::Error>(7) }
+        };
+        let v = connect_with_retry(connect, spawn, 5, std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+        assert_eq!(
+            spawned.load(Ordering::SeqCst),
+            0,
+            "no spawn when first connect works"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn spawns_then_retries_until_connected() {
+        let spawned = Arc::new(AtomicUsize::new(0));
+        let sp = Arc::clone(&spawned);
+        let spawn = move || {
+            sp.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let at = Arc::clone(&attempts);
+        let connect = move || {
+            let n = at.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(rb_types::Error::Io("no socket".into()))
+                } else {
+                    Ok::<u32, rb_types::Error>(42)
+                }
+            }
+        };
+        let v = connect_with_retry(connect, spawn, 10, std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(v, 42);
+        assert_eq!(
+            spawned.load(Ordering::SeqCst),
+            1,
+            "spawned exactly once after first failure"
+        );
+        assert!(attempts.load(Ordering::SeqCst) >= 3);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts() {
+        let spawn = || Ok(());
+        let connect = || async { Err::<u32, rb_types::Error>(rb_types::Error::Io("never".into())) };
+        let err = connect_with_retry(connect, spawn, 3, std::time::Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::Io(_)));
+    }
+}

--- a/crates/rusty-brain/src/client.rs
+++ b/crates/rusty-brain/src/client.rs
@@ -26,7 +26,8 @@ where
 {
     let mut spawn = Some(spawn);
     let mut last_err: Option<Error> = None;
-    for attempt in 0..max_attempts.max(1) {
+    let attempts = max_attempts.max(1);
+    for attempt in 0..attempts {
         match connect().await {
             Ok(v) => return Ok(v),
             Err(e) => {
@@ -39,7 +40,7 @@ where
                         s()?;
                     }
                 }
-                if backoff > Duration::ZERO {
+                if backoff > Duration::ZERO && attempt + 1 < attempts {
                     tokio::time::sleep(backoff).await;
                 }
             }

--- a/crates/rusty-brain/src/client.rs
+++ b/crates/rusty-brain/src/client.rs
@@ -4,14 +4,17 @@ use rb_proto::Client;
 use rb_types::{Error, Namespace, Result};
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 /// Generic connect-with-retry: try `connect`; on the first failure run `spawn`
-/// once, then keep retrying up to `max_attempts`, sleeping `backoff` between
-/// attempts. Returns the last error if all attempts fail.
-pub async fn connect_with_retry<C, Fut, T, S>(
+/// once only when `should_spawn` accepts that first error, then keep retrying up
+/// to `max_attempts`, sleeping `backoff` between attempts. Returns the last
+/// error if all attempts fail.
+pub async fn connect_with_retry<C, Fut, T, S, P>(
     mut connect: C,
     spawn: S,
+    should_spawn: P,
     max_attempts: usize,
     backoff: Duration,
 ) -> Result<T>
@@ -19,6 +22,7 @@ where
     C: FnMut() -> Fut,
     Fut: Future<Output = Result<T>>,
     S: FnOnce() -> Result<()>,
+    P: Fn(&Error) -> bool,
 {
     let mut spawn = Some(spawn);
     let mut last_err: Option<Error> = None;
@@ -26,6 +30,9 @@ where
         match connect().await {
             Ok(v) => return Ok(v),
             Err(e) => {
+                if attempt == 0 && !should_spawn(&e) {
+                    return Err(e);
+                }
                 last_err = Some(e);
                 if attempt == 0 {
                     if let Some(s) = spawn.take() {
@@ -45,6 +52,7 @@ where
 /// detached `rusty-brain serve` child if the socket is not yet accepting.
 pub async fn connect_or_start(
     socket_path: &Path,
+    db_path: &Path,
     namespace: Namespace,
     self_exe: PathBuf,
 ) -> Result<Client> {
@@ -56,22 +64,49 @@ pub async fn connect_or_start(
         async move { Client::connect(&sock, ns).await }
     };
     let spawn_sock = socket_path.to_path_buf();
-    let spawn = move || spawn_daemon(&self_exe, &spawn_sock);
-    connect_with_retry(connect, spawn, 50, Duration::from_millis(100)).await
+    let spawn_db = db_path.to_path_buf();
+    let spawn = move || spawn_daemon(&self_exe, &spawn_sock, &spawn_db);
+    connect_with_retry(
+        connect,
+        spawn,
+        should_auto_start,
+        50,
+        Duration::from_millis(100),
+    )
+    .await
 }
 
 /// Spawn `rusty-brain serve` as a detached child, passing the resolved
-/// `RUSTY_BRAIN_SOCKET` so child + client agree on the socket path.
-fn spawn_daemon(self_exe: &Path, socket_path: &Path) -> Result<()> {
-    let mut cmd = std::process::Command::new(self_exe);
-    cmd.arg("serve");
-    cmd.env(crate::paths::SOCKET_ENV, socket_path);
-    cmd.stdin(std::process::Stdio::null());
-    cmd.stdout(std::process::Stdio::null());
-    cmd.stderr(std::process::Stdio::null());
+/// `RUSTY_BRAIN_SOCKET`/`RUSTY_BRAIN_DB` so child + client agree on paths.
+fn spawn_daemon(self_exe: &Path, socket_path: &Path, db_path: &Path) -> Result<()> {
+    let mut cmd = daemon_command(self_exe, socket_path, db_path);
     cmd.spawn()
         .map(|_child| ())
         .map_err(|e| Error::Io(e.to_string()))
+}
+
+fn daemon_command(self_exe: &Path, socket_path: &Path, db_path: &Path) -> Command {
+    let mut cmd = Command::new(self_exe);
+    cmd.arg("serve");
+    cmd.env(crate::paths::SOCKET_ENV, socket_path);
+    cmd.env(crate::paths::DB_ENV, db_path);
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    cmd
+}
+
+fn should_auto_start(error: &Error) -> bool {
+    let Error::Io(message) = error else {
+        return false;
+    };
+    let message = message.to_ascii_lowercase();
+    message.contains("no such file")
+        || message.contains("not found")
+        || message.contains("connection refused")
+        || message.contains("os error 2")
+        || message.contains("os error 61")
+        || message.contains("os error 111")
 }
 
 #[cfg(test)]
@@ -95,7 +130,7 @@ mod tests {
             at.fetch_add(1, Ordering::SeqCst);
             async { Ok::<u32, rb_types::Error>(7) }
         };
-        let v = connect_with_retry(connect, spawn, 5, std::time::Duration::ZERO)
+        let v = connect_with_retry(connect, spawn, |_| true, 5, std::time::Duration::ZERO)
             .await
             .unwrap();
         assert_eq!(v, 7);
@@ -121,15 +156,21 @@ mod tests {
             let n = at.fetch_add(1, Ordering::SeqCst);
             async move {
                 if n < 2 {
-                    Err(rb_types::Error::Io("no socket".into()))
+                    Err(rb_types::Error::Io("No such file or directory".into()))
                 } else {
                     Ok::<u32, rb_types::Error>(42)
                 }
             }
         };
-        let v = connect_with_retry(connect, spawn, 10, std::time::Duration::ZERO)
-            .await
-            .unwrap();
+        let v = connect_with_retry(
+            connect,
+            spawn,
+            should_auto_start,
+            10,
+            std::time::Duration::ZERO,
+        )
+        .await
+        .unwrap();
         assert_eq!(v, 42);
         assert_eq!(
             spawned.load(Ordering::SeqCst),
@@ -142,10 +183,66 @@ mod tests {
     #[tokio::test]
     async fn gives_up_after_max_attempts() {
         let spawn = || Ok(());
-        let connect = || async { Err::<u32, rb_types::Error>(rb_types::Error::Io("never".into())) };
-        let err = connect_with_retry(connect, spawn, 3, std::time::Duration::ZERO)
-            .await
-            .unwrap_err();
+        let connect = || async {
+            Err::<u32, rb_types::Error>(rb_types::Error::Io("Connection refused".into()))
+        };
+        let err = connect_with_retry(
+            connect,
+            spawn,
+            should_auto_start,
+            3,
+            std::time::Duration::ZERO,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, rb_types::Error::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn does_not_spawn_for_non_startable_errors() {
+        let spawned = Arc::new(AtomicUsize::new(0));
+        let sp = Arc::clone(&spawned);
+        let spawn = move || {
+            sp.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        };
+        let connect = || async {
+            Err::<u32, rb_types::Error>(rb_types::Error::Storage(
+                "contract version mismatch".into(),
+            ))
+        };
+        let err = connect_with_retry(
+            connect,
+            spawn,
+            should_auto_start,
+            3,
+            std::time::Duration::ZERO,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, rb_types::Error::Storage(_)));
+        assert_eq!(spawned.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn daemon_command_inherits_resolved_socket_and_db_paths() {
+        let socket = Path::new("/tmp/rb.sock");
+        let db = Path::new("/tmp/rb.db");
+        let cmd = daemon_command(Path::new("/bin/echo"), socket, db);
+        let envs: std::collections::HashMap<_, _> = cmd
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|value| (key.to_os_string(), value.to_os_string()))
+            })
+            .collect();
+
+        assert_eq!(
+            envs.get(std::ffi::OsStr::new(crate::paths::SOCKET_ENV)),
+            Some(&socket.as_os_str().to_os_string())
+        );
+        assert_eq!(
+            envs.get(std::ffi::OsStr::new(crate::paths::DB_ENV)),
+            Some(&db.as_os_str().to_os_string())
+        );
     }
 }

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -1,8 +1,7 @@
 //! `rusty_brain` binary library: clap CLI, namespace detection, daemon/client glue.
 //!
 //! Logic lives here (testable directly); `main.rs` is a thin shell that parses
-//! args and dispatches. Later tasks add `paths`, `namespace_detect`, `logging`,
-//! `output`, `serve`, `client`, and `run`.
+//! args and dispatches through the modules below.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli;
+pub mod client;
 pub mod logging;
 pub mod namespace_detect;
 pub mod output;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -1,0 +1,8 @@
+//! `rusty_brain` binary library: clap CLI, namespace detection, daemon/client glue.
+//!
+//! Logic lives here (testable directly); `main.rs` is a thin shell that parses
+//! args and dispatches. Later tasks add `paths`, `namespace_detect`, `logging`,
+//! `output`, `serve`, `client`, and `run`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod cli;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -10,3 +10,4 @@ pub mod logging;
 pub mod namespace_detect;
 pub mod output;
 pub mod paths;
+pub mod serve;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,4 +6,5 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli;
+pub mod namespace_detect;
 pub mod paths;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -8,4 +8,5 @@
 pub mod cli;
 pub mod logging;
 pub mod namespace_detect;
+pub mod output;
 pub mod paths;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,5 +6,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli;
+pub mod logging;
 pub mod namespace_detect;
 pub mod paths;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,3 +6,4 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli;
+pub mod paths;

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -11,4 +11,5 @@ pub mod logging;
 pub mod namespace_detect;
 pub mod output;
 pub mod paths;
+pub mod run;
 pub mod serve;

--- a/crates/rusty-brain/src/logging.rs
+++ b/crates/rusty-brain/src/logging.rs
@@ -1,0 +1,31 @@
+//! tracing setup: human logs to stderr; stdout is reserved for results.
+
+use tracing_subscriber::EnvFilter;
+
+/// Initialize tracing to stderr, honoring `RUST_LOG` (default `info`).
+/// Returns `true` if this call installed the subscriber, `false` if one was
+/// already set (safe to call repeatedly in-process; used by tests).
+pub fn init_logging() -> bool {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init()
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn init_logging_is_idempotent_and_never_panics() {
+        let _ = init_logging();
+        let second = init_logging();
+        assert!(
+            !second,
+            "second init must be a no-op (try_init returns false)"
+        );
+    }
+}

--- a/crates/rusty-brain/src/main.rs
+++ b/crates/rusty-brain/src/main.rs
@@ -1,0 +1,11 @@
+//! `rusty-brain` binary entry point.
+//!
+//! Stub for the P1 setup cluster: prints version and a not-yet-implemented
+//! notice, then exits success. The full clap CLI (serve/remember/recall/...)
+//! is implemented in the daemon and CLI cluster.
+
+fn main() -> std::process::ExitCode {
+    println!("rusty-brain {}", env!("CARGO_PKG_VERSION"));
+    eprintln!("CLI not yet implemented in this build");
+    std::process::ExitCode::SUCCESS
+}

--- a/crates/rusty-brain/src/main.rs
+++ b/crates/rusty-brain/src/main.rs
@@ -1,11 +1,10 @@
-//! `rusty-brain` binary entry point.
-//!
-//! Stub for the P1 setup cluster: prints version and a not-yet-implemented
-//! notice, then exits success. The full clap CLI (serve/remember/recall/...)
-//! is implemented in the daemon and CLI cluster.
+//! `rusty-brain` binary entry point. Parses the CLI; dispatch is wired in Task 34.
 
-fn main() -> std::process::ExitCode {
-    println!("rusty-brain {}", env!("CARGO_PKG_VERSION"));
-    eprintln!("CLI not yet implemented in this build");
-    std::process::ExitCode::SUCCESS
+use clap::Parser;
+use rusty_brain::cli::Cli;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let _cli = Cli::parse();
+    ExitCode::SUCCESS
 }

--- a/crates/rusty-brain/src/main.rs
+++ b/crates/rusty-brain/src/main.rs
@@ -1,10 +1,28 @@
-//! `rusty-brain` binary entry point. Parses the CLI; dispatch is wired in Task 34.
+//! `rusty-brain` binary entry point: init logging, parse, dispatch, map exit code.
 
 use clap::Parser;
 use rusty_brain::cli::Cli;
+use rusty_brain::logging::init_logging;
+use rusty_brain::run::run;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    let _cli = Cli::parse();
-    ExitCode::SUCCESS
+    init_logging();
+    let cli = Cli::parse();
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start tokio runtime: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match runtime.block_on(run(cli)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/rusty-brain/src/namespace_detect.rs
+++ b/crates/rusty-brain/src/namespace_detect.rs
@@ -1,0 +1,81 @@
+//! Minimal namespace detection for P1: git-root or cwd directory name.
+//!
+//! Full git/`CLAUDE.md` resolution is deferred to P2. This is intentionally a
+//! single, predictable rule so behavior is obvious from the working directory.
+
+use rb_types::Namespace;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Detect the namespace for the real process, using the current directory and a
+/// `git rev-parse --show-toplevel` lookup. Never fails: degrades to `Global`.
+pub fn detect_namespace() -> Namespace {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    detect_namespace_with(&cwd, git_toplevel)
+}
+
+/// Core logic, parameterized for tests: pick the git-root dir name if a repo is
+/// found, else the start dir name, else `Global`.
+pub fn detect_namespace_with<F>(start: &Path, git_root: F) -> Namespace
+where
+    F: Fn(&Path) -> Option<PathBuf>,
+{
+    let base = git_root(start).unwrap_or_else(|| start.to_path_buf());
+    match base.file_name().and_then(|n| n.to_str()) {
+        Some(name) if !name.is_empty() => Namespace::Project(name.to_string()),
+        _ => Namespace::Global,
+    }
+}
+
+/// Find the git toplevel for `dir` by invoking git; `None` if not a repo.
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::Namespace;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn uses_git_root_dirname_when_in_repo() {
+        let start = Path::new("/home/alice/code/rusty-brain/crates/rusty-brain");
+        let git_root =
+            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/rusty-brain")) };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Project("rusty-brain".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_cwd_dirname_outside_repo() {
+        let start = Path::new("/home/alice/scratch/notes");
+        let git_root = |_: &Path| -> Option<PathBuf> { None };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Project("notes".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_global_for_root_dir() {
+        let start = Path::new("/");
+        let git_root = |_: &Path| -> Option<PathBuf> { None };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Global);
+    }
+}

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -5,8 +5,10 @@ use rb_types::{MemoryNote, SearchResult};
 /// Render recall hits. JSON: the raw `Vec<SearchResult>`. Human: one line per hit.
 pub fn render_recall(results: &[SearchResult], json: bool) -> String {
     if json {
-        return serde_json::to_string_pretty(results)
-            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+        return serde_json::to_string_pretty(results).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render recall JSON");
+            "[]".to_string()
+        });
     }
     if results.is_empty() {
         return "No memories matched.".to_string();
@@ -32,8 +34,10 @@ pub fn render_recall(results: &[SearchResult], json: bool) -> String {
 /// Render a list of notes (used by `list`, `graph`, and the `context` halves).
 pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
     if json {
-        return serde_json::to_string_pretty(notes)
-            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+        return serde_json::to_string_pretty(notes).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render notes JSON");
+            "[]".to_string()
+        });
     }
     if notes.is_empty() {
         return "No memories.".to_string();
@@ -59,8 +63,10 @@ pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
 /// Render a single fetched memory (or a not-found message).
 pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
     if json {
-        return serde_json::to_string_pretty(memory)
-            .unwrap_or_else(|e| format!("null // json error: {e}"));
+        return serde_json::to_string_pretty(memory).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render memory JSON");
+            "null".to_string()
+        });
     }
     match memory {
         Some(n) => format!(
@@ -106,8 +112,10 @@ pub fn render_context(
             "important": important,
             "total": total,
         });
-        return serde_json::to_string_pretty(&value)
-            .unwrap_or_else(|e| format!("{{}} // json error: {e}"));
+        return serde_json::to_string_pretty(&value).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render context JSON");
+            "{}".to_string()
+        });
     }
     let mut out = format!("Context ({total} memories total)\n\nRecent:\n");
     out.push_str(&render_notes(recent, false));

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -1,0 +1,190 @@
+//! Pure rendering of results to human text or JSON (stdout).
+
+use rb_types::{MemoryNote, SearchResult};
+
+/// Render recall hits. JSON: the raw `Vec<SearchResult>`. Human: one line per hit.
+pub fn render_recall(results: &[SearchResult], json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(results)
+            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+    }
+    if results.is_empty() {
+        return "No memories matched.".to_string();
+    }
+    let mut out = String::new();
+    for r in results {
+        let summary = if r.memory.summary.is_empty() {
+            r.memory.content.as_str()
+        } else {
+            r.memory.summary.as_str()
+        };
+        out.push_str(&format!(
+            "[{:.2}] {} ({}) {}\n",
+            r.score,
+            r.memory.id,
+            r.memory.memory_type.as_str(),
+            summary
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a list of notes (used by `list`, `graph`, and the `context` halves).
+pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(notes)
+            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+    }
+    if notes.is_empty() {
+        return "No memories.".to_string();
+    }
+    let mut out = String::new();
+    for n in notes {
+        let summary = if n.summary.is_empty() {
+            n.content.as_str()
+        } else {
+            n.summary.as_str()
+        };
+        out.push_str(&format!(
+            "{} (imp {}, {}) {}\n",
+            n.id,
+            n.importance,
+            n.memory_type.as_str(),
+            summary
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a single fetched memory (or a not-found message).
+pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(memory)
+            .unwrap_or_else(|e| format!("null // json error: {e}"));
+    }
+    match memory {
+        Some(n) => format!(
+            "{}\nnamespace: {}\ntype: {}\nimportance: {}\n\n{}",
+            n.id,
+            n.namespace.as_db_string(),
+            n.memory_type.as_str(),
+            n.importance,
+            n.content
+        ),
+        None => "Memory not found.".to_string(),
+    }
+}
+
+/// Render a remembered id (json: an object `{ "id": "<uuid>" }`).
+pub fn render_remembered(id: &rb_types::MemoryId, json: bool) -> String {
+    if json {
+        format!("{{\"id\":\"{id}\"}}")
+    } else {
+        format!("Remembered {id}")
+    }
+}
+
+/// Render the `context` payload.
+pub fn render_context(
+    recent: &[MemoryNote],
+    important: &[MemoryNote],
+    total: usize,
+    json: bool,
+) -> String {
+    if json {
+        let value = serde_json::json!({
+            "recent": recent,
+            "important": important,
+            "total": total,
+        });
+        return serde_json::to_string_pretty(&value)
+            .unwrap_or_else(|e| format!("{{}} // json error: {e}"));
+    }
+    let mut out = format!("Context ({total} memories total)\n\nRecent:\n");
+    out.push_str(&render_notes(recent, false));
+    out.push_str("\n\nImportant:\n");
+    out.push_str(&render_notes(important, false));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace, SearchResult};
+
+    fn note(content: &str, importance: u8) -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Project("p".into()),
+            content.to_string(),
+            MemoryType::Insight,
+            importance,
+        )
+    }
+
+    #[test]
+    fn human_recall_lists_score_and_summary() {
+        let mut n = note("one db one transaction", 8);
+        n.summary = "one db one transaction".to_string();
+        let results = vec![SearchResult {
+            memory: n.clone(),
+            score: 0.91,
+        }];
+        let out = render_recall(&results, false);
+        assert!(out.contains("0.91"), "score shown: {out}");
+        assert!(
+            out.contains("one db one transaction"),
+            "summary shown: {out}"
+        );
+        assert!(out.contains(&n.id.to_string()), "id shown: {out}");
+    }
+
+    #[test]
+    fn json_recall_is_parseable_array() {
+        let n = note("body", 5);
+        let results = vec![SearchResult {
+            memory: n,
+            score: 0.5,
+        }];
+        let out = render_recall(&results, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0]["score"].as_f64().unwrap(), 0.5);
+    }
+
+    #[test]
+    fn human_recall_empty_has_guidance() {
+        let out = render_recall(&[], false);
+        assert!(
+            out.to_lowercase().contains("no memories"),
+            "empty guidance: {out}"
+        );
+    }
+
+    #[test]
+    fn human_list_shows_each_note() {
+        let notes = vec![note("alpha", 7), note("beta", 3)];
+        let out = render_notes(&notes, false);
+        assert!(out.contains("alpha"));
+        assert!(out.contains("beta"));
+    }
+
+    #[test]
+    fn json_list_is_parseable_array() {
+        let notes = vec![note("alpha", 7)];
+        let out = render_notes(&notes, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed[0]["content"].as_str().unwrap(), "alpha");
+    }
+
+    #[test]
+    fn render_get_some_and_none() {
+        let n = note("body", 5);
+        let some = render_get(&Some(n.clone()), false);
+        assert!(some.contains("body"));
+        let none = render_get(&None, false);
+        assert!(none.to_lowercase().contains("not found"));
+        let json_none = render_get(&None, true);
+        assert_eq!(json_none.trim(), "null");
+    }
+}

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -84,6 +84,15 @@ pub fn render_remembered(id: &rb_types::MemoryId, json: bool) -> String {
     }
 }
 
+/// Render a successful delete acknowledgement.
+pub fn render_deleted(json: bool) -> String {
+    if json {
+        "{\"deleted\":true}".to_string()
+    } else {
+        "Deleted".to_string()
+    }
+}
+
 /// Render the `context` payload.
 pub fn render_context(
     recent: &[MemoryNote],
@@ -186,5 +195,13 @@ mod tests {
         assert!(none.to_lowercase().contains("not found"));
         let json_none = render_get(&None, true);
         assert_eq!(json_none.trim(), "null");
+    }
+
+    #[test]
+    fn delete_json_is_parseable() {
+        let out = render_deleted(true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["deleted"].as_bool(), Some(true));
+        assert_eq!(render_deleted(false), "Deleted");
     }
 }

--- a/crates/rusty-brain/src/paths.rs
+++ b/crates/rusty-brain/src/paths.rs
@@ -1,0 +1,65 @@
+//! Socket / database path resolution with env-var overrides for tests.
+
+use std::path::PathBuf;
+
+/// Env var that overrides the daemon socket path.
+pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
+/// Env var that overrides the database path.
+pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
+
+/// Resolve the socket path: explicit override wins, else the daemon default.
+pub fn resolve_socket_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
+    match override_value {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => rb_daemon::default_socket_path(),
+    }
+}
+
+/// Resolve the database path: explicit override wins, else the daemon default.
+pub fn resolve_db_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
+    match override_value {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => rb_daemon::default_db_path(),
+    }
+}
+
+/// Read the socket path from the environment (override) or fall back to default.
+pub fn socket_path_from_env() -> rb_types::Result<PathBuf> {
+    resolve_socket_path(std::env::var(SOCKET_ENV).ok())
+}
+
+/// Read the db path from the environment (override) or fall back to default.
+pub fn db_path_from_env() -> rb_types::Result<PathBuf> {
+    resolve_db_path(std::env::var(DB_ENV).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn socket_path_prefers_override() {
+        let got = resolve_socket_path(Some("/tmp/rb-test.sock".to_string())).unwrap();
+        assert_eq!(got, PathBuf::from("/tmp/rb-test.sock"));
+    }
+
+    #[test]
+    fn socket_path_falls_back_to_default_when_no_override() {
+        let got = resolve_socket_path(None).unwrap();
+        assert_eq!(got.file_name().unwrap(), "sock");
+    }
+
+    #[test]
+    fn db_path_prefers_override() {
+        let got = resolve_db_path(Some("/tmp/rb-test.db".to_string())).unwrap();
+        assert_eq!(got, PathBuf::from("/tmp/rb-test.db"));
+    }
+
+    #[test]
+    fn db_path_falls_back_to_default_when_no_override() {
+        let got = resolve_db_path(None).unwrap();
+        assert_eq!(got.extension().unwrap(), "db");
+    }
+}

--- a/crates/rusty-brain/src/paths.rs
+++ b/crates/rusty-brain/src/paths.rs
@@ -9,7 +9,7 @@ pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
 
 /// Resolve the socket path: explicit override wins, else the daemon default.
 pub fn resolve_socket_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
-    match override_value {
+    match override_value.filter(|p| !p.trim().is_empty()) {
         Some(p) => Ok(PathBuf::from(p)),
         None => rb_daemon::default_socket_path(),
     }
@@ -17,7 +17,7 @@ pub fn resolve_socket_path(override_value: Option<String>) -> rb_types::Result<P
 
 /// Resolve the database path: explicit override wins, else the daemon default.
 pub fn resolve_db_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
-    match override_value {
+    match override_value.filter(|p| !p.trim().is_empty()) {
         Some(p) => Ok(PathBuf::from(p)),
         None => rb_daemon::default_db_path(),
     }
@@ -52,6 +52,12 @@ mod tests {
     }
 
     #[test]
+    fn socket_path_falls_back_to_default_when_override_is_empty() {
+        let got = resolve_socket_path(Some("  ".to_string())).unwrap();
+        assert_eq!(got.file_name().unwrap(), "sock");
+    }
+
+    #[test]
     fn db_path_prefers_override() {
         let got = resolve_db_path(Some("/tmp/rb-test.db".to_string())).unwrap();
         assert_eq!(got, PathBuf::from("/tmp/rb-test.db"));
@@ -60,6 +66,12 @@ mod tests {
     #[test]
     fn db_path_falls_back_to_default_when_no_override() {
         let got = resolve_db_path(None).unwrap();
+        assert_eq!(got.extension().unwrap(), "db");
+    }
+
+    #[test]
+    fn db_path_falls_back_to_default_when_override_is_empty() {
+        let got = resolve_db_path(Some("".to_string())).unwrap();
         assert_eq!(got.extension().unwrap(), "db");
     }
 }

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -28,7 +28,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 .context("daemon failed")?;
             Ok(())
         }
-        other => run_client(other, cli.json, &socket_path).await,
+        other => run_client(other, cli.json, &socket_path, &db_path).await,
     }
 }
 
@@ -37,10 +37,11 @@ async fn run_client(
     command: Command,
     json: bool,
     socket_path: &std::path::Path,
+    db_path: &std::path::Path,
 ) -> anyhow::Result<()> {
     let namespace = detect_namespace();
     let self_exe = std::env::current_exe().context("locating own executable")?;
-    let mut client = client::connect_or_start(socket_path, namespace.clone(), self_exe)
+    let mut client = client::connect_or_start(socket_path, db_path, namespace.clone(), self_exe)
         .await
         .context("connecting to daemon")?;
 
@@ -102,7 +103,7 @@ async fn run_client(
         Command::Delete { id } => {
             let id = parse_id(&id).context("invalid memory id")?;
             client.delete(id).await.context("delete failed")?;
-            println!("Deleted");
+            println!("{}", output::render_deleted(json));
         }
         Command::Context => {
             let (recent, important, total) = client.context().await.context("context failed")?;

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -1,0 +1,156 @@
+//! Async dispatch from parsed `Cli` to daemon/client behavior.
+
+use crate::cli::{Cli, Command};
+use crate::namespace_detect::detect_namespace;
+use crate::{client, output, paths, serve};
+use anyhow::Context as _;
+use rb_types::MemoryId;
+use std::str::FromStr;
+
+/// Parse a CLI id argument into a `MemoryId`, surfacing a clear error.
+pub fn parse_id(s: &str) -> rb_types::Result<MemoryId> {
+    MemoryId::from_str(s)
+}
+
+/// Execute the parsed CLI. `serve` blocks until Ctrl-C; client commands connect
+/// (auto-starting the daemon), issue one request, print to stdout, and return.
+pub async fn run(cli: Cli) -> anyhow::Result<()> {
+    let socket_path = paths::socket_path_from_env().context("resolving daemon socket path")?;
+    let db_path = paths::db_path_from_env().context("resolving daemon database path")?;
+
+    match cli.command {
+        Command::Serve => {
+            let shutdown = async {
+                let _ = tokio::signal::ctrl_c().await;
+            };
+            serve::run_serve(socket_path, db_path, 4, shutdown)
+                .await
+                .context("daemon failed")?;
+            Ok(())
+        }
+        other => run_client(other, cli.json, &socket_path).await,
+    }
+}
+
+/// Connect to the daemon and dispatch a single client request.
+async fn run_client(
+    command: Command,
+    json: bool,
+    socket_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let namespace = detect_namespace();
+    let self_exe = std::env::current_exe().context("locating own executable")?;
+    let mut client = client::connect_or_start(socket_path, namespace.clone(), self_exe)
+        .await
+        .context("connecting to daemon")?;
+
+    match command {
+        Command::Serve => anyhow::bail!("internal: serve must be handled before run_client"),
+        Command::Remember {
+            content,
+            memory_type,
+            importance,
+            context,
+            tags,
+        } => {
+            let id = client
+                .remember(
+                    content,
+                    context,
+                    memory_type,
+                    importance,
+                    Vec::new(),
+                    tags,
+                    Vec::new(),
+                )
+                .await
+                .context("remember failed")?;
+            println!("{}", output::render_remembered(&id, json));
+        }
+        Command::Recall {
+            query,
+            limit,
+            memory_type,
+            tags,
+        } => {
+            let results = client
+                .recall(query, Some(namespace), memory_type, tags, limit)
+                .await
+                .context("recall failed")?;
+            println!("{}", output::render_recall(&results, json));
+        }
+        Command::Get { id } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let memory = client.get(id).await.context("get failed")?;
+            println!("{}", output::render_get(&memory, json));
+        }
+        Command::List {
+            limit,
+            min_importance,
+        } => {
+            let notes = client
+                .list(Some(namespace), min_importance, limit)
+                .await
+                .context("list failed")?;
+            println!("{}", output::render_notes(&notes, json));
+        }
+        Command::Graph { id, depth } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let notes = client.graph(id, depth).await.context("graph failed")?;
+            println!("{}", output::render_notes(&notes, json));
+        }
+        Command::Delete { id } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            client.delete(id).await.context("delete failed")?;
+            println!("Deleted");
+        }
+        Command::Context => {
+            let (recent, important, total) = client.context().await.context("context failed")?;
+            println!(
+                "{}",
+                output::render_context(&recent, &important, total, json)
+            );
+        }
+        Command::Status => {
+            let version = client.ping().await.context("status/ping failed")?;
+            if json {
+                println!("{{\"contract_version\":{version},\"ok\":true}}");
+            } else {
+                println!("ok (contract v{version})");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_id_accepts_valid_uuid() {
+        let id = rb_types::MemoryId::new();
+        let parsed = parse_id(&id.to_string()).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn parse_id_rejects_garbage_with_clear_error() {
+        let err = parse_id("not-a-uuid").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not-a-uuid") || msg.to_lowercase().contains("invalid"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn memory_id_from_str_is_what_parse_id_uses() {
+        let id = rb_types::MemoryId::new();
+        let a = parse_id(&id.to_string()).unwrap();
+        let b = rb_types::MemoryId::from_str(&id.to_string()).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -75,7 +75,7 @@ async fn run_client(
             tags,
         } => {
             let results = client
-                .recall(query, Some(namespace), memory_type, tags, limit)
+                .recall(query, memory_type, tags, limit)
                 .await
                 .context("recall failed")?;
             println!("{}", output::render_recall(&results, json));
@@ -90,7 +90,7 @@ async fn run_client(
             min_importance,
         } => {
             let notes = client
-                .list(Some(namespace), min_importance, limit)
+                .list(min_importance, limit)
                 .await
                 .context("list failed")?;
             println!("{}", output::render_notes(&notes, json));

--- a/crates/rusty-brain/src/serve.rs
+++ b/crates/rusty-brain/src/serve.rs
@@ -18,7 +18,7 @@ pub enum ProviderKind {
 /// Pure selection: Voyage iff a non-empty API key is present, else Deterministic.
 pub fn select_provider_kind(api_key: Option<String>) -> ProviderKind {
     match api_key {
-        Some(k) if !k.is_empty() => ProviderKind::Voyage,
+        Some(k) if !k.trim().is_empty() => ProviderKind::Voyage,
         _ => ProviderKind::Deterministic,
     }
 }
@@ -89,6 +89,12 @@ mod tests {
     #[test]
     fn selects_deterministic_when_key_empty() {
         let sel = select_provider_kind(Some(String::new()));
+        assert_eq!(sel, ProviderKind::Deterministic);
+    }
+
+    #[test]
+    fn selects_deterministic_when_key_is_whitespace() {
+        let sel = select_provider_kind(Some("   ".to_string()));
         assert_eq!(sel, ProviderKind::Deterministic);
     }
 }

--- a/crates/rusty-brain/src/serve.rs
+++ b/crates/rusty-brain/src/serve.rs
@@ -1,0 +1,94 @@
+//! `serve` subcommand: bind the daemon and run until Ctrl-C.
+
+use rb_daemon::{Daemon, DaemonConfig, SharedEmbedder};
+use rb_embed::{DeterministicProvider, EmbeddingProvider, VoyageProvider};
+use rb_types::Result;
+use std::path::PathBuf;
+
+/// Default embedding dimension for the offline provider and Voyage's default model.
+pub const DEFAULT_DIM: usize = 512;
+
+/// Which embedding provider `serve` will use.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ProviderKind {
+    Voyage,
+    Deterministic,
+}
+
+/// Pure selection: Voyage iff a non-empty API key is present, else Deterministic.
+pub fn select_provider_kind(api_key: Option<String>) -> ProviderKind {
+    match api_key {
+        Some(k) if !k.is_empty() => ProviderKind::Voyage,
+        _ => ProviderKind::Deterministic,
+    }
+}
+
+/// Run the daemon at the given paths until `shutdown` resolves.
+/// Picks the embedding provider from the environment (`VOYAGE_API_KEY`).
+pub async fn run_serve(
+    socket_path: PathBuf,
+    db_path: PathBuf,
+    read_pool_size: usize,
+    shutdown: impl std::future::Future<Output = ()>,
+) -> Result<()> {
+    let api_key = std::env::var("VOYAGE_API_KEY").ok();
+    match select_provider_kind(api_key) {
+        ProviderKind::Voyage => {
+            let embedder = VoyageProvider::from_env()?;
+            run_with_embedder(socket_path, db_path, read_pool_size, embedder, shutdown).await
+        }
+        ProviderKind::Deterministic => {
+            tracing::warn!(
+                "VOYAGE_API_KEY not set; using offline DeterministicProvider \
+                 (dim {DEFAULT_DIM}). Recall quality is reduced and embeddings \
+                 are not portable to a real model."
+            );
+            let embedder = DeterministicProvider::new(DEFAULT_DIM);
+            run_with_embedder(socket_path, db_path, read_pool_size, embedder, shutdown).await
+        }
+    }
+}
+
+/// Bind a daemon for a concrete embedder and run it to shutdown.
+async fn run_with_embedder<P>(
+    socket_path: PathBuf,
+    db_path: PathBuf,
+    read_pool_size: usize,
+    embedder: P,
+    shutdown: impl std::future::Future<Output = ()>,
+) -> Result<()>
+where
+    P: EmbeddingProvider + 'static,
+{
+    let config = DaemonConfig {
+        socket_path,
+        db_path,
+        read_pool_size,
+    };
+    let daemon = Daemon::bind(config, SharedEmbedder::new(embedder)).await?;
+    daemon.run(shutdown).await
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn selects_voyage_when_key_present() {
+        let sel = select_provider_kind(Some("vk-123".to_string()));
+        assert_eq!(sel, ProviderKind::Voyage);
+    }
+
+    #[test]
+    fn selects_deterministic_when_key_absent() {
+        let sel = select_provider_kind(None);
+        assert_eq!(sel, ProviderKind::Deterministic);
+    }
+
+    #[test]
+    fn selects_deterministic_when_key_empty() {
+        let sel = select_provider_kind(Some(String::new()));
+        assert_eq!(sel, ProviderKind::Deterministic);
+    }
+}

--- a/crates/rusty-brain/tests/cli_surface.rs
+++ b/crates/rusty-brain/tests/cli_surface.rs
@@ -1,0 +1,70 @@
+//! CLI surface tests: help, version, and argument-validation exit codes.
+//! These never start the daemon (parser-only paths).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn bin() -> Command {
+    Command::cargo_bin("rusty-brain").unwrap()
+}
+
+#[test]
+fn help_lists_all_subcommands() {
+    bin()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("serve"))
+        .stdout(predicate::str::contains("remember"))
+        .stdout(predicate::str::contains("recall"))
+        .stdout(predicate::str::contains("get"))
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("graph"))
+        .stdout(predicate::str::contains("delete"))
+        .stdout(predicate::str::contains("context"))
+        .stdout(predicate::str::contains("status"));
+}
+
+#[test]
+fn version_prints_a_version() {
+    bin()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rusty-brain"));
+}
+
+#[test]
+fn unknown_subcommand_fails_with_nonzero_exit() {
+    bin().arg("frobnicate").assert().failure();
+}
+
+#[test]
+fn remember_requires_content_argument() {
+    bin()
+        .arg("remember")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("content").or(predicate::str::contains("required")));
+}
+
+#[test]
+fn remember_rejects_invalid_memory_type() {
+    bin()
+        .args(["remember", "some content", "--type", "not_a_type"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid").or(predicate::str::contains("not_a_type")));
+}
+
+#[test]
+fn recall_help_shows_flags() {
+    bin()
+        .args(["recall", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--limit"))
+        .stdout(predicate::str::contains("--type"))
+        .stdout(predicate::str::contains("--tags"));
+}

--- a/crates/rusty-brain/tests/cli_surface.rs
+++ b/crates/rusty-brain/tests/cli_surface.rs
@@ -59,6 +59,15 @@ fn remember_rejects_invalid_memory_type() {
 }
 
 #[test]
+fn remember_rejects_out_of_range_importance() {
+    bin()
+        .args(["remember", "some content", "--importance", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("1..=10").or(predicate::str::contains("range")));
+}
+
+#[test]
 fn recall_help_shows_flags() {
     bin()
         .args(["recall", "--help"])

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -37,7 +37,7 @@ fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
 #[test]
 fn remember_then_recall_round_trips_through_the_binary() {
     let dir = tempfile::tempdir().unwrap();
-    let socket = dir.path().join("rb.sock");
+    let socket = dir.path().join("runtime").join("rb.sock");
     let db = dir.path().join("rb.db");
     let exe = cargo_bin("rusty-brain");
 

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -1,0 +1,97 @@
+//! End-to-end: start the real binary's daemon on a temp socket+DB, then run
+//! `remember` and `recall` through the built binary; assert the content returns.
+//! Uses the offline DeterministicProvider (VOYAGE_API_KEY is cleared), so CI
+//! never contacts a live embedding API.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::cargo::cargo_bin;
+use predicates::prelude::*;
+use predicates::Predicate;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Owns the spawned daemon process and reaps it on drop (kill + wait), even if a
+/// later assertion panics and unwinds the test.
+struct Reap(Child);
+
+impl Drop for Reap {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Block until `path` exists or the deadline passes. Returns true if it appeared.
+fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    path.exists()
+}
+
+#[test]
+fn remember_then_recall_round_trips_through_the_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+
+    let _reap = Reap(
+        Command::new(&exe)
+            .arg("serve")
+            .env("RUSTY_BRAIN_SOCKET", &socket)
+            .env("RUSTY_BRAIN_DB", &db)
+            .env_remove("VOYAGE_API_KEY")
+            .env("RUST_LOG", "warn")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn daemon"),
+    );
+
+    assert!(
+        wait_for_socket(&socket, Duration::from_secs(10)),
+        "daemon socket never appeared at {}",
+        socket.display()
+    );
+
+    let remember = Command::new(&exe)
+        .args(["remember", "always use one database and one transaction"])
+        .args(["--type", "architecture_decision", "--importance", "9"])
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env_remove("VOYAGE_API_KEY")
+        .output()
+        .expect("run remember");
+    assert!(
+        remember.status.success(),
+        "remember failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&remember.stdout),
+        String::from_utf8_lossy(&remember.stderr)
+    );
+
+    let recall = Command::new(&exe)
+        .args(["recall", "one database transaction", "--limit", "10"])
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env_remove("VOYAGE_API_KEY")
+        .output()
+        .expect("run recall");
+    assert!(
+        recall.status.success(),
+        "recall failed: stderr={:?}",
+        String::from_utf8_lossy(&recall.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&recall.stdout);
+    let found = predicate::str::contains("one database and one transaction");
+    assert!(
+        found.eval(&stdout),
+        "recalled output did not contain the remembered content; got: {stdout}"
+    );
+}

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -22,16 +22,16 @@ impl Drop for Reap {
     }
 }
 
-/// Block until `path` exists or the deadline passes. Returns true if it appeared.
+/// Block until `path` accepts connections or the deadline passes.
 fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if path.exists() {
+        if std::os::unix::net::UnixStream::connect(path).is_ok() {
             return true;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
-    path.exists()
+    std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
 #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "CC0-1.0",
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.9
 # Permissive-only allowlist: no copyleft (weak or strong) is accepted.

--- a/docs/plans/2026-05-31-rusty-brain-p1-engine-daemon.md
+++ b/docs/plans/2026-05-31-rusty-brain-p1-engine-daemon.md
@@ -1,0 +1,7587 @@
+# rusty-brain — P1 (Engine + Daemon) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Work in the worktree `~/repos/rusty-brain-p1` on branch `feat/p1-engine-daemon` (based on completed P0). NO AI attribution on commits.
+
+**Goal:** Build the rusty-brain runtime on top of the P0 storage foundation: the wire protocol (`rb-proto`), pluggable embeddings (`rb-embed`, Voyage default), pure hybrid ranking (`rb-search`), the trait-generic orchestration engine (`rb-engine`), the single-writer concurrent daemon (`rb-daemon`), and the `rusty-brain` CLI binary — so many agents can concurrently remember/recall over one local SQLite memory store via a Unix-domain-socket daemon.
+
+**Architecture:** Async (tokio). The daemon owns the store: ONE dedicated OS thread holds the write `SqliteStore` (rusqlite `Connection` is `!Sync`), fed by an mpsc + oneshot command channel; reads run on a bounded pool via `spawn_blocking`; a `tokio::broadcast` emits change events on commit. Per-connection tokio tasks speak length-delimited JSON over the UDS, handshake a namespace + `ContractVersion`, and dispatch to a per-connection `MemoryEngine<Backend, Provider>` that enforces namespace isolation server-side. The engine is generic over a `MemoryBackend` trait and an `EmbeddingProvider`, keeping it pure-policy and testable without a DB or network.
+
+**Tech Stack:** Rust 2021, tokio, tokio-util (LengthDelimitedCodec), reqwest (Voyage), async-trait, serde/serde_json, clap, tracing; tests use an offline `DeterministicProvider` and `wiremock` (never the live API). Builds on P0 `rb-types` + `rb-store`. Reference spec: `~/repos/rusty-brain/docs/specs/2026-05-31-rusty-brain-architecture-design.md`. (Parts are lettered F–K to continue after P0's A–E.)
+
+**Build order:** Part F (proto + workspace setup) → G/H (embed, search — independent) → I (engine, needs embed+search) → J (daemon, needs engine+proto+store) → K (binary, needs daemon+proto). F/G/H can be done in any order; I requires G+H; J requires F+I; K requires J.
+
+**Cross-cluster contract decisions (authoritative — these override the spec's interface sketch where they differ):**
+- **Embedder injection.** rb-daemon defines `SharedEmbedder` = an `Arc<dyn EmbeddingProvider>` newtype that itself implements `EmbeddingProvider` (Part J). `Daemon::bind(config: DaemonConfig, embedder: SharedEmbedder)` takes it as a **second argument** — the spec's one-arg `bind(config)` sketch was incomplete (`DaemonConfig` has no embedder field and stays 3 fields: `socket_path`, `db_path`, `read_pool_size`). Each per-connection `MemoryEngine<StoreHandle, SharedEmbedder>` clones the `Arc` to share one embedder instance.
+- **`RememberInput` is rb-engine-only.** The `rusty-brain` binary does **not** depend on `rb-engine` and does **not** import `RememberInput`. Its `remember` subcommand builds `rb_proto::Request::Remember { content, context, memory_type, importance, keywords, tags, related_files }` and sends it via `rb_proto::Client`; the daemon maps it to `rb_engine::RememberInput` server-side.
+
+---
+
+## Part F — Workspace setup & rb-proto (the wire contract / P2 freeze point)
+
+### Task 1: Add P1 workspace dependencies to the root manifest
+
+**Files:**
+- Modify: `/Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+
+This task extends the existing P0 root `[workspace.dependencies]` and `[workspace] members` with everything P1 needs. The new crates are added to `members` here so the very next task can scaffold them and `cargo build --workspace` stays loadable. No code compiles against the new deps yet, so verification is manifest-syntax + `cargo metadata` only.
+
+- [ ] **Step 1: Add the new workspace dependencies.** In `/Users/bluby/repos/rusty-brain-p1/Cargo.toml`, replace the existing `[workspace.dependencies]` block (which ends after `tempfile = "3"`) by appending the P1 deps so the full block reads exactly:
+
+```toml
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
+sqlite-vec = "0.1"
+deadpool-sqlite = "0.9"
+include_dir = "0.7"
+sha2 = "0.10"
+tempfile = "3"
+# --- P1 additions ---
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time", "io-util", "signal"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+tokio-stream = "0.1"
+async-trait = "0.1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+futures = "0.3"
+bytes = "1"
+secrecy = "0.10"
+directories = "5"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive", "env"] }
+anyhow = "1"
+wiremock = "0.6"
+```
+
+(`wiremock` is a dev-dependency used only by the rb-embed Voyage HTTP test in a later cluster; declaring it in `[workspace.dependencies]` now keeps a single source of truth and does not enter any default build closure.)
+
+- [ ] **Step 2: Add the new crates to the workspace members.** In the same file, replace the `members` line:
+
+```toml
+members = ["crates/rb-types", "crates/rb-store"]
+```
+
+with:
+
+```toml
+members = [
+    "crates/rb-types",
+    "crates/rb-store",
+    "crates/rb-proto",
+    "crates/rb-embed",
+    "crates/rb-search",
+    "crates/rb-engine",
+    "crates/rb-daemon",
+    "crates/rusty-brain",
+]
+```
+
+- [ ] **Step 3: Validate the manifest is well-formed TOML with the expected members and a sample new dep.** A full `cargo metadata` will fail until the new member crates exist on disk (Task 2), so validate TOML structure only here.
+  Run: `python3 -c "import tomllib; d=tomllib.load(open('/Users/bluby/repos/rusty-brain-p1/Cargo.toml','rb')); m=d['workspace']['members']; assert m==['crates/rb-types','crates/rb-store','crates/rb-proto','crates/rb-embed','crates/rb-search','crates/rb-engine','crates/rb-daemon','crates/rusty-brain'], m; dd=d['workspace']['dependencies']; assert 'tokio' in dd and 'tokio-util' in dd and 'reqwest' in dd and 'secrecy' in dd and 'clap' in dd and 'wiremock' in dd; assert 'codec' in dd['tokio-util']['features']; print('root Cargo.toml P1 deps OK')"`
+  Expected: prints `root Cargo.toml P1 deps OK` (exit 0).
+
+- [ ] **Step 4: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "chore: add P1 workspace dependencies and crate members"`
+  Expected: one commit created.
+
+---
+
+### Task 2: Scaffold all P1 crates as empty workspace members
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-search/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-search/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-engine/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-engine/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs`
+
+This stands up every P1 crate as a buildable skeleton so `cargo build --workspace` is green before any feature code is written. Each manifest already lists the workspace deps that crate will use (per the spine), uses `[lints] workspace = true`, and library names use underscores. The bin crate gets a stub `main` (real CLI lands in the daemon/CLI cluster); its manifest lists only the deps the stub needs now.
+
+- [ ] **Step 1: Create the `rb-proto` manifest.** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-proto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain daemon wire protocol: request/response enums, length-delimited JSON framing, and async UDS client."
+
+[lib]
+name = "rb_proto"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Create the `rb-proto` lib skeleton.** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs`:
+
+```rust
+//! `rb_proto`: daemon wire protocol for rusty-brain.
+//!
+//! Length-delimited JSON frames over a Unix domain socket, a versioned
+//! handshake, the `Request`/`Response` enums, and an async `Client`.
+//! Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+```
+
+- [ ] **Step 3: Create the `rb-embed` skeleton (manifest + lib).** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Embedding provider trait for rusty-brain plus a Voyage remote impl and an offline deterministic provider."
+
+[lib]
+name = "rb_embed"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+  Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs`:
+
+```rust
+//! `rb_embed`: pluggable embedding providers for rusty-brain.
+//!
+//! The `EmbeddingProvider` trait, a Voyage remote impl, and an offline
+//! deterministic provider for tests and no-API-key fallback. Concrete types
+//! are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+```
+
+- [ ] **Step 4: Create the `rb-search` skeleton (manifest + lib).** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-search/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-search"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Pure, deterministic hybrid ranking for rusty-brain: combine keyword, vector, graph, importance, and recency signals."
+
+[lib]
+name = "rb_search"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+chrono = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+  Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-search/src/lib.rs`:
+
+```rust
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO. Combines normalized keyword/vector/graph/importance/recency signals
+//! into a single weighted score. Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+```
+
+- [ ] **Step 5: Create the `rb-engine` skeleton (manifest + lib).** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-engine/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain request orchestration: embed plus rank policy over an abstract memory backend (no concrete store dependency)."
+
+[lib]
+name = "rb_engine"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-search = { path = "../rb-search" }
+rb-embed = { path = "../rb-embed" }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+  Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-engine/src/lib.rs`:
+
+```rust
+//! `rb_engine`: single-request orchestration for rusty-brain.
+//!
+//! Generic over a `MemoryBackend` trait and an `EmbeddingProvider`, so the
+//! engine stays pure policy (embed plus rank) and testable without a real
+//! store. Concrete types are added in subsequent tasks.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+```
+
+- [ ] **Step 6: Create the `rb-daemon` skeleton (manifest + lib).** Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-daemon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain single-writer daemon: dedicated writer thread, read pool, UDS listener, change broadcast, server-side isolation."
+
+[lib]
+name = "rb_daemon"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-store = { path = "../rb-store" }
+rb-engine = { path = "../rb-engine" }
+rb-embed = { path = "../rb-embed" }
+rb-proto = { path = "../rb-proto" }
+rb-search = { path = "../rb-search" }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+futures = { workspace = true }
+deadpool-sqlite = { workspace = true }
+directories = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+  Write `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs`:
+
+```rust
+//! `rb_daemon`: the single-writer rusty-brain service.
+//!
+//! One dedicated OS thread owns the write connection (rusqlite is `!Sync`);
+//! reads run on a bounded pool via `spawn_blocking`; commits broadcast a
+//! `MemoryChanged` event. A UDS listener dispatches per-connection engines
+//! with server-side namespace isolation. Concrete types are added later.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+```
+
+- [ ] **Step 7: Create the `rusty-brain` bin crate (manifest + stub main).** Write `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/Cargo.toml`. The stub only needs the standard library; clap/tokio/etc. are added in the CLI cluster to avoid unused-dependency churn under `-D warnings`:
+
+```toml
+[package]
+name = "rusty-brain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain CLI and daemon binary."
+
+[[bin]]
+name = "rusty-brain"
+path = "src/main.rs"
+
+[dependencies]
+
+[lints]
+workspace = true
+```
+
+  Write `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs`:
+
+```rust
+//! `rusty-brain` binary entry point.
+//!
+//! Stub for the P1 setup cluster: prints version and a not-yet-implemented
+//! notice, then exits success. The full clap CLI (serve/remember/recall/...)
+//! is implemented in the daemon and CLI cluster.
+
+fn main() -> std::process::ExitCode {
+    println!("rusty-brain {}", env!("CARGO_PKG_VERSION"));
+    eprintln!("CLI not yet implemented in this build");
+    std::process::ExitCode::SUCCESS
+}
+```
+
+- [ ] **Step 8: Verify the whole workspace builds with every member present.** All eight members now exist on disk, so a full build resolves and compiles (cold builds also link bundled SQLite via rb-store, which can take a minute).
+  Run: `cargo build --workspace --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: `Compiling rb-proto ...`, `rb-embed ...`, `rb-search ...`, `rb-engine ...`, `rb-daemon ...`, `rusty-brain ...` then `Finished` (exit 0). No "failed to load manifest for workspace member" errors.
+
+- [ ] **Step 9: Verify clippy is clean workspace-wide with warnings denied.** Proves the shared lints are wired into every new crate via `[lints] workspace = true` and that the skeletons have no unused-dependency or dead-code warnings. (`--manifest-path` must come BEFORE `--`.)
+  Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished` with no warnings (exit 0).
+
+- [ ] **Step 10: Verify formatting is clean.**
+  Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 11: Verify the stub binary runs.**
+  Run: `cargo run -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml 2>/dev/null`
+  Expected: prints `rusty-brain 0.0.1` to stdout, exit 0.
+
+- [ ] **Step 12: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto crates/rb-embed crates/rb-search crates/rb-engine crates/rb-daemon crates/rusty-brain && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat: scaffold P1 crates (rb-proto, rb-embed, rb-search, rb-engine, rb-daemon, rusty-brain)"`
+  Expected: one commit created; `cargo build --workspace` and clippy both green.
+
+---
+
+### Task 3: rb-proto `messages.rs` — contract version, handshake, and Request/Response enums
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/messages.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` (declare `mod messages;` + re-exports)
+
+This task defines the wire vocabulary exactly per the spine: `CONTRACT_VERSION`, `Handshake`/`HandshakeAck`, and the `#[serde(tag = "op")]` `Request` / `#[serde(tag = "result")]` `Response` enums. Tests pin a serde round-trip for every variant and assert the internally tagged discriminators land in the JSON.
+
+- [ ] **Step 1: Write the failing tests AND declare the module.** An undeclared `.rs` file is never compiled, so declare `mod messages;` in `lib.rs` now and create `messages.rs` with ONLY the test module; the build fails because the types do not exist yet.
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/messages.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use rb_types::{
+        MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, SearchResult,
+    };
+
+    fn note() -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Project("rusty-brain".into()),
+            "one db, one transaction".into(),
+            MemoryType::ArchitectureDecision,
+            8,
+        )
+    }
+
+    #[test]
+    fn contract_version_is_one() {
+        assert_eq!(CONTRACT_VERSION, 1);
+    }
+
+    #[test]
+    fn handshake_round_trip() {
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Project("rusty-brain".into()),
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        let back: Handshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.contract_version, CONTRACT_VERSION);
+        assert_eq!(back.namespace, Namespace::Project("rusty-brain".into()));
+    }
+
+    #[test]
+    fn handshake_ack_round_trip() {
+        let ack = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: false,
+            message: Some("version mismatch".into()),
+        };
+        let json = serde_json::to_string(&ack).unwrap();
+        let back: HandshakeAck = serde_json::from_str(&json).unwrap();
+        assert!(!back.ok);
+        assert_eq!(back.message.as_deref(), Some("version mismatch"));
+    }
+
+    fn all_requests() -> Vec<Request> {
+        let id = MemoryId::new();
+        vec![
+            Request::Remember {
+                content: "c".into(),
+                context: Some("ctx".into()),
+                memory_type: MemoryType::Insight,
+                importance: 7,
+                keywords: vec!["k".into()],
+                tags: vec!["t".into()],
+                related_files: vec!["src/lib.rs".into()],
+            },
+            Request::Recall {
+                query: "q".into(),
+                scope: Some(Namespace::Global),
+                memory_type: Some(MemoryType::BugFix),
+                tags: vec!["sqlite".into()],
+                limit: 10,
+            },
+            Request::Get { id: id.clone() },
+            Request::List {
+                scope: Some(Namespace::Project("p".into())),
+                min_importance: Some(5),
+                limit: 20,
+            },
+            Request::Graph { id: id.clone(), depth: 2 },
+            Request::Update {
+                id: id.clone(),
+                updates: MemoryUpdates {
+                    importance: Some(9),
+                    ..Default::default()
+                },
+            },
+            Request::Delete { id },
+            Request::Context,
+            Request::Ping,
+        ]
+    }
+
+    #[test]
+    fn every_request_variant_round_trips() {
+        for req in all_requests() {
+            let json = serde_json::to_string(&req).unwrap();
+            let back: Request = serde_json::from_str(&json).unwrap();
+            // Compare via JSON since Request is not PartialEq.
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn request_uses_op_tag() {
+        let json = serde_json::to_string(&Request::Ping).unwrap();
+        assert_eq!(json, r#"{"op":"Ping"}"#);
+        let json = serde_json::to_string(&Request::Context).unwrap();
+        assert_eq!(json, r#"{"op":"Context"}"#);
+    }
+
+    fn all_responses() -> Vec<Response> {
+        vec![
+            Response::Remembered { id: MemoryId::new() },
+            Response::Recalled {
+                results: vec![SearchResult { memory: note(), score: 0.9 }],
+            },
+            Response::Got { memory: Some(note()) },
+            Response::Got { memory: None },
+            Response::Listed { memories: vec![note()] },
+            Response::GraphResult { memories: vec![note()] },
+            Response::Updated,
+            Response::Deleted,
+            Response::ContextResult {
+                recent: vec![note()],
+                important: vec![note()],
+                total: 2,
+            },
+            Response::Pong { contract_version: CONTRACT_VERSION },
+            Response::Error {
+                kind: "not_found".into(),
+                message: "no such memory".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn every_response_variant_round_trips() {
+        for resp in all_responses() {
+            let json = serde_json::to_string(&resp).unwrap();
+            let back: Response = serde_json::from_str(&json).unwrap();
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn response_uses_result_tag() {
+        let json = serde_json::to_string(&Response::Updated).unwrap();
+        assert_eq!(json, r#"{"result":"Updated"}"#);
+        let json = serde_json::to_string(&Response::Pong {
+            contract_version: 1,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"result":"Pong","contract_version":1}"#);
+    }
+}
+```
+
+  Set `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` to declare the module (re-exports added in Step 3):
+
+```rust
+//! `rb_proto`: daemon wire protocol for rusty-brain.
+//!
+//! Length-delimited JSON frames over a Unix domain socket, a versioned
+//! handshake, the `Request`/`Response` enums, and an async `Client`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+mod messages;
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-proto messages`
+  Expected: FAIL to compile — `cannot find value 'CONTRACT_VERSION' in this scope` / `cannot find type 'Handshake'` etc. Confirms the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/messages.rs`:
+
+```rust
+use rb_types::{
+    MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, SearchResult,
+};
+use serde::{Deserialize, Serialize};
+
+/// Wire contract version carried in the handshake. Clients and the daemon must
+/// agree on this exact value; mismatch is rejected at connect time.
+pub const CONTRACT_VERSION: u32 = 1;
+
+/// First frame the client sends after connecting.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Handshake {
+    pub contract_version: u32,
+    pub namespace: Namespace,
+}
+
+/// Daemon reply to a `Handshake`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HandshakeAck {
+    pub contract_version: u32,
+    pub ok: bool,
+    pub message: Option<String>,
+}
+
+/// One request per engine operation. Internally tagged on `op`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "op")]
+pub enum Request {
+    Remember {
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+        related_files: Vec<String>,
+    },
+    Recall {
+        query: String,
+        scope: Option<Namespace>,
+        memory_type: Option<MemoryType>,
+        tags: Vec<String>,
+        limit: usize,
+    },
+    Get {
+        id: MemoryId,
+    },
+    List {
+        scope: Option<Namespace>,
+        min_importance: Option<u8>,
+        limit: usize,
+    },
+    Graph {
+        id: MemoryId,
+        depth: u8,
+    },
+    Update {
+        id: MemoryId,
+        updates: MemoryUpdates,
+    },
+    Delete {
+        id: MemoryId,
+    },
+    Context,
+    Ping,
+}
+
+/// One response per request. Internally tagged on `result`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "result")]
+pub enum Response {
+    Remembered { id: MemoryId },
+    Recalled { results: Vec<SearchResult> },
+    Got { memory: Option<MemoryNote> },
+    Listed { memories: Vec<MemoryNote> },
+    GraphResult { memories: Vec<MemoryNote> },
+    Updated,
+    Deleted,
+    ContextResult {
+        recent: Vec<MemoryNote>,
+        important: Vec<MemoryNote>,
+        total: usize,
+    },
+    Pong { contract_version: u32 },
+    Error { kind: String, message: String },
+}
+```
+
+  Note: every `Request`/`Response` variant is either a unit variant or a struct (brace) variant, so `#[serde(tag = ...)]` (internal tagging) is valid — internal tagging forbids tuple/newtype variants, and there are none here.
+
+- [ ] **Step 4: Re-export the types from `lib.rs`.** Update `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` so the module block reads:
+
+```rust
+mod messages;
+
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 5: Run it — expect PASS.**
+  Run: `cargo test -p rb-proto messages`
+  Expected: PASS (8 tests in the `messages` module pass).
+
+- [ ] **Step 6: Lint + format.**
+  Run: `cargo clippy -p rb-proto --all-targets -- -D warnings`
+  Expected: no warnings.
+  Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/src/messages.rs crates/rb-proto/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-proto): add CONTRACT_VERSION, handshake, and Request/Response enums"`
+  Expected: one commit created.
+
+---
+
+### Task 4: rb-proto `error.rs` — stable wire<->error mapping
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/error.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` (declare `mod error;` + re-exports)
+
+This task defines the stable `kind` strings that flow over the wire and the two pure functions that map between `rb_types::Error` and `Response::Error`. The daemon uses `error_to_response` to map a domain error into a wire response; the client uses `response_error_to_error` to turn a `Response::Error` back into an `rb_types::Error`. Kind strings are stable identifiers (the daemon never leaks internal detail beyond the `message`).
+
+Note on variant coverage: P0's `rb_types::Error` has the variants `Storage`, `Migration`, `NotFound`, `InvalidNamespace`, `InvalidMemoryType`, `InvalidLinkType`, `Serialization`, `DimensionMismatch`, `Io`. rb-proto maps each to a stable kind and back. (The rb-embed cluster later adds an `Embedding` variant to `rb_types`; when it does, add one arm here with kind `"embedding"`. rb-proto does not need it yet.)
+
+- [ ] **Step 1: Write the failing tests AND declare the module.** Declare `mod error;` in `lib.rs` and create `error.rs` with ONLY the test module; the build fails because the functions do not exist yet.
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/error.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::Response;
+    use rb_types::{Error, MemoryId};
+
+    fn round_trip(err: Error) -> Error {
+        let resp = error_to_response(&err);
+        match resp {
+            Response::Error { kind, message } => response_error_to_error(&kind, &message),
+            other => panic!("expected Response::Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_maps_to_stable_kind() {
+        let id = MemoryId::new();
+        let resp = error_to_response(&Error::NotFound(id.clone()));
+        match resp {
+            Response::Error { kind, message } => {
+                assert_eq!(kind, "not_found");
+                assert!(message.contains(&id.to_string()));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_round_trips_to_storage() {
+        assert!(matches!(round_trip(Error::Storage("disk".into())), Error::Storage(_)));
+    }
+
+    #[test]
+    fn migration_round_trips_to_migration() {
+        assert!(matches!(
+            round_trip(Error::Migration("bad".into())),
+            Error::Migration(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_namespace_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidNamespace("x".into())),
+            Error::InvalidNamespace(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_memory_type_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidMemoryType("zz".into())),
+            Error::InvalidMemoryType(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_link_type_round_trips() {
+        assert!(matches!(
+            round_trip(Error::InvalidLinkType("qq".into())),
+            Error::InvalidLinkType(_)
+        ));
+    }
+
+    #[test]
+    fn serialization_round_trips() {
+        assert!(matches!(
+            round_trip(Error::Serialization("json".into())),
+            Error::Serialization(_)
+        ));
+    }
+
+    #[test]
+    fn io_round_trips() {
+        assert!(matches!(round_trip(Error::Io("eof".into())), Error::Io(_)));
+    }
+
+    #[test]
+    fn dimension_mismatch_round_trips_to_storage_with_detail() {
+        // DimensionMismatch carries structured fields that cannot be reconstructed
+        // from a string; it degrades to Storage carrying the human message, which
+        // is the documented, lossy-but-faithful behavior.
+        let err = Error::DimensionMismatch { expected: 1024, got: 768 };
+        let resp = error_to_response(&err);
+        match resp {
+            Response::Error { kind, message } => {
+                assert_eq!(kind, "dimension_mismatch");
+                assert!(message.contains("1024") && message.contains("768"));
+                let back = response_error_to_error(&kind, &message);
+                assert!(matches!(back, Error::Storage(_)));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_kind_maps_to_storage() {
+        let back = response_error_to_error("totally_unknown_kind", "weird");
+        assert!(matches!(back, Error::Storage(_)));
+    }
+}
+```
+
+  Update `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` to declare the module (re-exports added in Step 3); the module block becomes:
+
+```rust
+mod error;
+mod messages;
+
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-proto error`
+  Expected: FAIL to compile — `cannot find function 'error_to_response'` / `response_error_to_error`. Confirms the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/error.rs`:
+
+```rust
+//! Stable mapping between `rb_types::Error` and `Response::Error`.
+//!
+//! `kind` strings are part of the wire contract and must stay stable across
+//! versions. The daemon maps domain errors out; the client maps them back.
+
+use crate::Response;
+use rb_types::Error;
+
+/// Map a domain error into a wire `Response::Error`. The `kind` is a stable
+/// identifier; `message` is the human-readable `Display` form (no internal
+/// detail beyond what `rb_types::Error` already exposes).
+pub fn error_to_response(err: &Error) -> Response {
+    let kind = error_kind(err);
+    Response::Error {
+        kind: kind.to_string(),
+        message: err.to_string(),
+    }
+}
+
+/// The stable wire `kind` string for a domain error.
+fn error_kind(err: &Error) -> &'static str {
+    match err {
+        Error::Storage(_) => "storage",
+        Error::Migration(_) => "migration",
+        Error::NotFound(_) => "not_found",
+        Error::InvalidNamespace(_) => "invalid_namespace",
+        Error::InvalidMemoryType(_) => "invalid_memory_type",
+        Error::InvalidLinkType(_) => "invalid_link_type",
+        Error::Serialization(_) => "serialization",
+        Error::DimensionMismatch { .. } => "dimension_mismatch",
+        Error::Io(_) => "io",
+    }
+}
+
+/// Reconstruct a domain error from a wire `kind`/`message`.
+///
+/// Variants that carry structured data which cannot be parsed back from a
+/// string (`NotFound`, `DimensionMismatch`) degrade to `Error::Storage`
+/// carrying the original message — faithful text, lossy structure. Unknown
+/// kinds also map to `Error::Storage` (fail closed: never silently succeed).
+pub fn response_error_to_error(kind: &str, message: &str) -> Error {
+    match kind {
+        "storage" => Error::Storage(message.to_string()),
+        "migration" => Error::Migration(message.to_string()),
+        "invalid_namespace" => Error::InvalidNamespace(message.to_string()),
+        "invalid_memory_type" => Error::InvalidMemoryType(message.to_string()),
+        "invalid_link_type" => Error::InvalidLinkType(message.to_string()),
+        "serialization" => Error::Serialization(message.to_string()),
+        "io" => Error::Io(message.to_string()),
+        // not_found / dimension_mismatch / anything unrecognized: preserve the
+        // message under Storage rather than fabricate structured fields.
+        _ => Error::Storage(message.to_string()),
+    }
+}
+```
+
+- [ ] **Step 4: Re-export the helpers from `lib.rs`.** Update the re-export block in `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs`:
+
+```rust
+pub use error::{error_to_response, response_error_to_error};
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 5: Run it — expect PASS.**
+  Run: `cargo test -p rb-proto error`
+  Expected: PASS (11 tests in the `error` module pass).
+
+- [ ] **Step 6: Lint + format.**
+  Run: `cargo clippy -p rb-proto --all-targets -- -D warnings`
+  Expected: no warnings.
+  Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/src/error.rs crates/rb-proto/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-proto): add stable wire<->error mapping helpers"`
+  Expected: one commit created.
+
+---
+
+### Task 5: rb-proto `frame.rs` — length-delimited JSON frame read/write helpers
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/frame.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` (declare `mod frame;` + re-exports)
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml` (add `tokio-stream`)
+
+This task provides the framing primitives: serialize a serde value to JSON bytes, send it as one length-delimited frame, and read one frame back and deserialize it. Both helpers operate on a `Framed<S, LengthDelimitedCodec>` where `S: AsyncRead + AsyncWrite + Unpin`, which is exactly what the UDS transport provides. The test drives an in-memory duplex stream (`tokio::io::duplex`) so no socket is needed.
+
+- [ ] **Step 1: Write the failing tests AND declare the module.** Declare `mod frame;` in `lib.rs` and create `frame.rs` with ONLY the test module; the build fails because the functions do not exist yet.
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/frame.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{Handshake, Request, CONTRACT_VERSION};
+    use rb_types::{MemoryType, Namespace};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    // A pair of in-memory bidirectional streams standing in for the two ends of
+    // a UnixStream. Each end is wrapped in the length-delimited codec.
+    fn framed_pair() -> (
+        Framed<tokio::io::DuplexStream, LengthDelimitedCodec>,
+        Framed<tokio::io::DuplexStream, LengthDelimitedCodec>,
+    ) {
+        let (a, b) = tokio::io::duplex(64 * 1024);
+        (
+            Framed::new(a, LengthDelimitedCodec::new()),
+            Framed::new(b, LengthDelimitedCodec::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_a_value() {
+        let (mut client, mut server) = framed_pair();
+
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Project("rusty-brain".into()),
+        };
+        write_frame(&mut client, &hs).await.unwrap();
+
+        let got: Handshake = read_frame(&mut server).await.unwrap();
+        assert_eq!(got.contract_version, CONTRACT_VERSION);
+        assert_eq!(got.namespace, Namespace::Project("rusty-brain".into()));
+    }
+
+    #[tokio::test]
+    async fn two_frames_are_independently_decoded() {
+        let (mut client, mut server) = framed_pair();
+
+        let r1 = Request::Ping;
+        let r2 = Request::Recall {
+            query: "transactions".into(),
+            scope: Some(Namespace::Global),
+            memory_type: Some(MemoryType::BugFix),
+            tags: vec![],
+            limit: 5,
+        };
+        write_frame(&mut client, &r1).await.unwrap();
+        write_frame(&mut client, &r2).await.unwrap();
+
+        let g1: Request = read_frame(&mut server).await.unwrap();
+        let g2: Request = read_frame(&mut server).await.unwrap();
+        assert_eq!(
+            serde_json::to_string(&g1).unwrap(),
+            serde_json::to_string(&r1).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_string(&g2).unwrap(),
+            serde_json::to_string(&r2).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_after_peer_closes_is_io_error() {
+        let (client, mut server) = framed_pair();
+        // Drop the client end without sending anything -> stream ends cleanly.
+        drop(client);
+        let err = read_frame::<_, Request>(&mut server).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Io(_)),
+            "clean EOF should surface as Error::Io, got {err:?}"
+        );
+    }
+}
+```
+
+  Update `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` to declare the module; the module block becomes:
+
+```rust
+mod error;
+mod frame;
+mod messages;
+
+pub use error::{error_to_response, response_error_to_error};
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-proto frame`
+  Expected: FAIL to compile — `cannot find function 'write_frame'` / `read_frame`. Confirms the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/frame.rs`:
+
+```rust
+//! Length-delimited JSON framing over an async transport.
+//!
+//! Each frame is a 4-byte big-endian length prefix (managed by
+//! `LengthDelimitedCodec`) followed by the serde_json-encoded payload bytes.
+
+use futures::SinkExt;
+use rb_types::{Error, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_stream::StreamExt;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+/// Serialize `value` to JSON and send it as one length-delimited frame.
+///
+/// `LengthDelimitedCodec` implements `Encoder<bytes::Bytes>`, so the sink item
+/// is `bytes::Bytes`; `SinkExt::send` both feeds and flushes the frame.
+/// (verify against installed tokio-util at execution; adjust if the codec's
+/// `Sink` item type differs from `bytes::Bytes`.)
+pub async fn write_frame<S, T>(framed: &mut Framed<S, LengthDelimitedCodec>, value: &T) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: Serialize,
+{
+    let bytes = serde_json::to_vec(value).map_err(|e| Error::Serialization(e.to_string()))?;
+    framed
+        .send(bytes::Bytes::from(bytes))
+        .await
+        .map_err(|e| Error::Io(e.to_string()))?;
+    Ok(())
+}
+
+/// Read one length-delimited frame and deserialize it as `T`.
+///
+/// A clean end-of-stream (peer closed without sending a frame) yields
+/// `Stream::next == None`, surfaced as `Error::Io` so callers can distinguish
+/// it from a decode failure. The decoded item is `bytes::BytesMut`, which
+/// derefs to `[u8]` for `serde_json::from_slice`.
+pub async fn read_frame<S, T>(framed: &mut Framed<S, LengthDelimitedCodec>) -> Result<T>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: DeserializeOwned,
+{
+    match framed.next().await {
+        Some(Ok(bytes)) => {
+            serde_json::from_slice(&bytes).map_err(|e| Error::Serialization(e.to_string()))
+        }
+        Some(Err(e)) => Err(Error::Io(e.to_string())),
+        None => Err(Error::Io("connection closed before a frame was received".to_string())),
+    }
+}
+```
+
+  Add the framing deps to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml`. The `[dependencies]` block needs `tokio-stream` (for `StreamExt::next`) added; update the block to:
+
+```toml
+[dependencies]
+rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+```
+
+  Note: `tokio_stream::StreamExt::next` and `futures::StreamExt::next` are interchangeable here (both operate on the `Stream` impl of `Framed`); `tokio-stream` is used to match the spine's declared workspace dependency. If you prefer to drop the extra dependency, replace `use tokio_stream::StreamExt;` with `use futures::StreamExt;` and remove `tokio-stream` from this manifest — the code is otherwise identical.
+
+- [ ] **Step 4: Re-export the helpers from `lib.rs`.** Update the re-export block in `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs`:
+
+```rust
+pub use error::{error_to_response, response_error_to_error};
+pub use frame::{read_frame, write_frame};
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 5: Run it — expect PASS.**
+  Run: `cargo test -p rb-proto frame`
+  Expected: PASS (3 tests in the `frame` module pass).
+
+- [ ] **Step 6: Lint + format.**
+  Run: `cargo clippy -p rb-proto --all-targets -- -D warnings`
+  Expected: no warnings.
+  Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/src/frame.rs crates/rb-proto/src/lib.rs crates/rb-proto/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-proto): add length-delimited JSON frame read/write helpers"`
+  Expected: one commit created.
+
+---
+
+### Task 6: rb-proto `client.rs` — async Client connect + handshake + request
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` (declare `mod client;` + re-exports)
+
+This task implements the async `Client`: it connects a `UnixStream`, wraps it in the length-delimited codec, sends the `Handshake`, verifies the `HandshakeAck` contract version, and exposes `request()` to send one `Request` and read one `Response`. Typed convenience wrappers land in Task 7. The end-to-end test stands up a tiny in-process responder over a real `UnixListener` in a `tempfile` dir, proving connect + handshake + request work over an actual socket. A second test proves a contract-version mismatch is rejected at connect. (`tempfile` is added as a dev-dependency in Task 8; if you need Task 6's tests to compile in isolation, add the `[dev-dependencies] tempfile = { workspace = true }` section now — Task 8 is idempotent and will leave it as-is.)
+
+- [ ] **Step 1: Write the failing tests AND declare the module.** Declare `mod client;` in `lib.rs` and create `client.rs` with ONLY the test module; the build fails because `Client` does not exist yet.
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs` with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{
+        read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+    };
+    use rb_types::Namespace;
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    fn socket_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.sock");
+        (dir, path)
+    }
+
+    // Accept ONE connection, read the handshake, ack it (optionally with a
+    // forced ack contract version to simulate drift), then echo one request as
+    // a canned Pong response. Returns after serving a single connection.
+    async fn run_responder(listener: UnixListener, ack_version: u32, ok: bool) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        let ack = HandshakeAck {
+            contract_version: ack_version,
+            ok,
+            message: if ok { None } else { Some("version mismatch".into()) },
+        };
+        write_frame(&mut framed, &ack).await.unwrap();
+        if !ok {
+            return;
+        }
+
+        // Serve exactly one request: reply Pong regardless of the request.
+        let _req: Request = read_frame(&mut framed).await.unwrap();
+        let resp = Response::Pong {
+            contract_version: CONTRACT_VERSION,
+        };
+        write_frame(&mut framed, &resp).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_handshake_and_request_round_trip() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(run_responder(listener, CONTRACT_VERSION, true));
+
+        let mut client = Client::connect(&path, Namespace::Project("rusty-brain".into()))
+            .await
+            .unwrap();
+        let resp = client.request(Request::Ping).await.unwrap();
+        match resp {
+            Response::Pong { contract_version } => {
+                assert_eq!(contract_version, CONTRACT_VERSION);
+            }
+            other => panic!("expected Pong, got {other:?}"),
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_contract_version_mismatch() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        // Responder acks with a different contract version and ok=false.
+        let server = tokio::spawn(run_responder(listener, CONTRACT_VERSION + 1, false));
+
+        let err = Client::connect(&path, Namespace::Global)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Storage(_)),
+            "version mismatch must fail connect, got {err:?}"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_to_missing_socket_is_io_error() {
+        let (_dir, path) = socket_path();
+        // Never bind a listener -> connect must fail with an IO error.
+        let err = Client::connect(&path, Namespace::Global)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Io(_)),
+            "missing socket should be Error::Io, got {err:?}"
+        );
+    }
+}
+```
+
+  Update `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs` to declare the module; the module block becomes:
+
+```rust
+mod client;
+mod error;
+mod frame;
+mod messages;
+
+pub use error::{error_to_response, response_error_to_error};
+pub use frame::{read_frame, write_frame};
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-proto client`
+  Expected: FAIL to compile — `cannot find type 'Client' in this scope`. Confirms the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs`:
+
+```rust
+//! Async client for the rusty-brain daemon over a Unix domain socket.
+
+use crate::frame::{read_frame, write_frame};
+use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
+use rb_types::{Error, Namespace, Result};
+use std::path::Path;
+use tokio::net::UnixStream;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+/// A connected, handshaken client. Sends one `Request`, reads one `Response`.
+pub struct Client {
+    framed: Framed<UnixStream, LengthDelimitedCodec>,
+}
+
+impl Client {
+    /// Connect to the daemon socket, perform the versioned handshake, and verify
+    /// the daemon speaks `CONTRACT_VERSION`. Fails closed on any version drift or
+    /// a non-ok ack.
+    pub async fn connect(socket_path: &Path, namespace: Namespace) -> Result<Client> {
+        let stream = UnixStream::connect(socket_path)
+            .await
+            .map_err(|e| Error::Io(format!("connect {}: {e}", socket_path.display())))?;
+        let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+
+        let handshake = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace,
+        };
+        write_frame(&mut framed, &handshake).await?;
+
+        let ack: HandshakeAck = read_frame(&mut framed).await?;
+        if ack.contract_version != CONTRACT_VERSION {
+            return Err(Error::Storage(format!(
+                "contract version mismatch: client {CONTRACT_VERSION}, daemon {}",
+                ack.contract_version
+            )));
+        }
+        if !ack.ok {
+            let detail = ack.message.unwrap_or_else(|| "handshake rejected".to_string());
+            return Err(Error::Storage(format!("handshake rejected: {detail}")));
+        }
+
+        Ok(Client { framed })
+    }
+
+    /// Send one request and read one response.
+    pub async fn request(&mut self, req: Request) -> Result<Response> {
+        write_frame(&mut self.framed, &req).await?;
+        let resp: Response = read_frame(&mut self.framed).await?;
+        Ok(resp)
+    }
+}
+```
+
+- [ ] **Step 4: Re-export `Client` from `lib.rs`.** Add `Client` to the re-export block in `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/lib.rs`:
+
+```rust
+pub use client::Client;
+pub use error::{error_to_response, response_error_to_error};
+pub use frame::{read_frame, write_frame};
+pub use messages::{
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+```
+
+- [ ] **Step 5: Run it — expect PASS.** (If `tempfile` is not yet a dev-dependency, add `[dev-dependencies] tempfile = { workspace = true }` to `crates/rb-proto/Cargo.toml` — this is finalized in Task 8.)
+  Run: `cargo test -p rb-proto client`
+  Expected: PASS (3 tests in the `client` module pass — round-trip over a real UDS, version-mismatch rejection, missing-socket IO error).
+
+- [ ] **Step 6: Lint + format.**
+  Run: `cargo clippy -p rb-proto --all-targets -- -D warnings`
+  Expected: no warnings.
+  Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/src/client.rs crates/rb-proto/src/lib.rs crates/rb-proto/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-proto): add async Client with connect, handshake, and request"`
+  Expected: one commit created.
+
+---
+
+### Task 7: rb-proto `Client` typed convenience wrappers
+
+**Files:**
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs` (add wrapper methods + tests)
+
+This task adds the typed wrappers from the spine (`remember`, `recall`, `get`, `list`, `graph`, `update`, `delete`, `context`, `ping`). Each builds the matching `Request`, calls `request()`, and unwraps the expected `Response` variant into a domain type — mapping a `Response::Error` back through `response_error_to_error` and any unexpected variant to `Error::Storage`. The test extends the in-process responder to answer each op with its matching response.
+
+- [ ] **Step 1: Write the failing tests.** Append a second test module to `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs` (the existing `mod tests` stays as-is). Add:
+
+```rust
+#[cfg(test)]
+mod wrapper_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::{
+        error_to_response, read_frame, write_frame, Handshake, HandshakeAck, Request, Response,
+        CONTRACT_VERSION,
+    };
+    use rb_types::{Error, MemoryId, MemoryNote, MemoryType, Namespace, SearchResult};
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+    fn socket_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wrap.sock");
+        (dir, path)
+    }
+
+    fn note() -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Global,
+            "remembered body".into(),
+            MemoryType::Insight,
+            6,
+        )
+    }
+
+    // Accept one connection, handshake, then answer each incoming Request with a
+    // matching canned Response until the client disconnects.
+    async fn serve(listener: UnixListener, fixed_id: MemoryId) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        write_frame(
+            &mut framed,
+            &HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: true,
+                message: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        loop {
+            let req: Request = match read_frame(&mut framed).await {
+                Ok(r) => r,
+                Err(_) => break, // client closed
+            };
+            let resp = match req {
+                Request::Remember { .. } => Response::Remembered {
+                    id: fixed_id.clone(),
+                },
+                Request::Recall { .. } => Response::Recalled {
+                    results: vec![SearchResult {
+                        memory: note(),
+                        score: 0.5,
+                    }],
+                },
+                Request::Get { .. } => Response::Got {
+                    memory: Some(note()),
+                },
+                Request::List { .. } => Response::Listed {
+                    memories: vec![note()],
+                },
+                Request::Graph { .. } => Response::GraphResult {
+                    memories: vec![note()],
+                },
+                Request::Update { .. } => Response::Updated,
+                Request::Delete { .. } => Response::Deleted,
+                Request::Context => Response::ContextResult {
+                    recent: vec![note()],
+                    important: vec![note()],
+                    total: 2,
+                },
+                Request::Ping => Response::Pong {
+                    contract_version: CONTRACT_VERSION,
+                },
+            };
+            write_frame(&mut framed, &resp).await.unwrap();
+        }
+    }
+
+    async fn connect(path: &std::path::Path) -> Client {
+        Client::connect(path, Namespace::Global).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn typed_wrappers_return_domain_types() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let fixed_id = MemoryId::new();
+        let server = tokio::spawn(serve(listener, fixed_id.clone()));
+
+        let mut c = connect(&path).await;
+
+        let id = c
+            .remember(
+                "body".into(),
+                Some("ctx".into()),
+                MemoryType::Insight,
+                6,
+                vec!["k".into()],
+                vec!["t".into()],
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert_eq!(id, fixed_id);
+
+        let results = c.recall("q".into(), None, None, vec![], 5).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!((results[0].score - 0.5).abs() < f32::EPSILON);
+
+        let got = c.get(fixed_id.clone()).await.unwrap();
+        assert!(got.is_some());
+
+        let listed = c.list(None, Some(5), 10).await.unwrap();
+        assert_eq!(listed.len(), 1);
+
+        let graphed = c.graph(fixed_id.clone(), 2).await.unwrap();
+        assert_eq!(graphed.len(), 1);
+
+        c.update(fixed_id.clone(), Default::default()).await.unwrap();
+        c.delete(fixed_id.clone()).await.unwrap();
+
+        let (recent, important, total) = c.context().await.unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(important.len(), 1);
+        assert_eq!(total, 2);
+
+        let version = c.ping().await.unwrap();
+        assert_eq!(version, CONTRACT_VERSION);
+
+        drop(c);
+        server.await.unwrap();
+    }
+
+    // A responder that always returns a Response::Error, to prove wrappers map
+    // wire errors back into rb_types::Error.
+    async fn serve_error(listener: UnixListener) {
+        let (stream, _addr) = listener.accept().await.unwrap();
+        let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+        let _hs: Handshake = read_frame(&mut framed).await.unwrap();
+        write_frame(
+            &mut framed,
+            &HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: true,
+                message: None,
+            },
+        )
+        .await
+        .unwrap();
+        let _req: Request = read_frame(&mut framed).await.unwrap();
+        let resp = error_to_response(&Error::NotFound(MemoryId::new()));
+        write_frame(&mut framed, &resp).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wrapper_maps_wire_error_to_domain_error() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(serve_error(listener));
+
+        let mut c = connect(&path).await;
+        let err = c.get(MemoryId::new()).await.unwrap_err();
+        // NotFound degrades to Storage on the wire (see error.rs), but it is an
+        // Err, not a falsely-successful None.
+        assert!(matches!(err, Error::Storage(_)), "got {err:?}");
+        server.await.unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-proto wrapper`
+  Expected: FAIL to compile — `no method named 'remember' found` etc. Confirms the test drives the new wrappers.
+
+- [ ] **Step 3: Add the wrapper methods.** Insert the following `impl Client` block in `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/src/client.rs`, immediately AFTER the existing `impl Client { ... }` block that ends with the `request` method (before the first `#[cfg(test)]`). It reuses the existing `use` imports and adds the response-mapping helper:
+
+```rust
+use crate::error::response_error_to_error;
+use crate::messages::Response as Resp;
+use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, SearchResult};
+
+impl Client {
+    /// Helper: turn an unexpected response (including a wire `Error`) into an
+    /// `Err`. The daemon's `Response::Error` is mapped back to a domain error;
+    /// any other unexpected variant is a protocol violation -> `Error::Storage`.
+    fn unexpected(resp: Resp) -> Error {
+        match resp {
+            Resp::Error { kind, message } => response_error_to_error(&kind, &message),
+            other => Error::Storage(format!("unexpected response: {other:?}")),
+        }
+    }
+
+    /// Store a new memory; returns its id.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn remember(
+        &mut self,
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+        related_files: Vec<String>,
+    ) -> Result<MemoryId> {
+        let resp = self
+            .request(Request::Remember {
+                content,
+                context,
+                memory_type,
+                importance,
+                keywords,
+                tags,
+                related_files,
+            })
+            .await?;
+        match resp {
+            Resp::Remembered { id } => Ok(id),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Hybrid recall; returns ranked results.
+    pub async fn recall(
+        &mut self,
+        query: String,
+        scope: Option<Namespace>,
+        memory_type: Option<MemoryType>,
+        tags: Vec<String>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let resp = self
+            .request(Request::Recall {
+                query,
+                scope,
+                memory_type,
+                tags,
+                limit,
+            })
+            .await?;
+        match resp {
+            Resp::Recalled { results } => Ok(results),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Fetch a single memory by id.
+    pub async fn get(&mut self, id: MemoryId) -> Result<Option<MemoryNote>> {
+        let resp = self.request(Request::Get { id }).await?;
+        match resp {
+            Resp::Got { memory } => Ok(memory),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// List memories in scope.
+    pub async fn list(
+        &mut self,
+        scope: Option<Namespace>,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        let resp = self
+            .request(Request::List {
+                scope,
+                min_importance,
+                limit,
+            })
+            .await?;
+        match resp {
+            Resp::Listed { memories } => Ok(memories),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Walk the link graph from a memory.
+    pub async fn graph(&mut self, id: MemoryId, depth: u8) -> Result<Vec<MemoryNote>> {
+        let resp = self.request(Request::Graph { id, depth }).await?;
+        match resp {
+            Resp::GraphResult { memories } => Ok(memories),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Apply a partial update to a memory.
+    pub async fn update(&mut self, id: MemoryId, updates: MemoryUpdates) -> Result<()> {
+        let resp = self.request(Request::Update { id, updates }).await?;
+        match resp {
+            Resp::Updated => Ok(()),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Soft-archive a memory.
+    pub async fn delete(&mut self, id: MemoryId) -> Result<()> {
+        let resp = self.request(Request::Delete { id }).await?;
+        match resp {
+            Resp::Deleted => Ok(()),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Fetch the project context payload (recent, important, total).
+    pub async fn context(&mut self) -> Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)> {
+        let resp = self.request(Request::Context).await?;
+        match resp {
+            Resp::ContextResult {
+                recent,
+                important,
+                total,
+            } => Ok((recent, important, total)),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Round-trip ping; returns the daemon's contract version.
+    pub async fn ping(&mut self) -> Result<u32> {
+        let resp = self.request(Request::Ping).await?;
+        match resp {
+            Resp::Pong { contract_version } => Ok(contract_version),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+}
+```
+
+  (verify against installed clippy at execution; if `clippy::too_many_arguments` does not fire on `remember`, the `#[allow]` is harmless.)
+
+- [ ] **Step 4: Run it — expect PASS.**
+  Run: `cargo test -p rb-proto wrapper`
+  Expected: PASS (2 tests: all typed wrappers return domain types over a real UDS, and a wire error maps back to a domain error).
+
+- [ ] **Step 5: Lint + format.**
+  Run: `cargo clippy -p rb-proto --all-targets -- -D warnings`
+  Expected: no warnings.
+  Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no diff.
+
+- [ ] **Step 6: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/src/client.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-proto): add typed Client convenience wrappers"`
+  Expected: one commit created.
+
+---
+
+### Task 8: rb-proto add `tempfile` dev-dependency for socket tests
+
+**Files:**
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml`
+
+The client tests (Tasks 6 and 7) use `tempfile::tempdir()` to host the test UDS. That dev-dependency must be declared. This task is intentionally split out so the dependency change is its own atomic commit and the prior tasks' code-then-deps ordering stays clean. (If the executor already added `tempfile` while making Task 6 compile, this task verifies it is present and correct rather than duplicating it.)
+
+- [ ] **Step 1: Add the dev-dependency.** Ensure `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml` has a `[dev-dependencies]` section with `tempfile`. The full manifest should read:
+
+```toml
+[package]
+name = "rb-proto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain daemon wire protocol: request/response enums, length-delimited JSON framing, and async UDS client."
+
+[lib]
+name = "rb_proto"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Verify the manifest parses with the dev-dependency.**
+  Run: `python3 -c "import tomllib; d=tomllib.load(open('/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/Cargo.toml','rb')); assert d['dev-dependencies']['tempfile']=={'workspace':True}; assert 'tokio-stream' in d['dependencies']; print('rb-proto manifest OK')"`
+  Expected: prints `rb-proto manifest OK` (exit 0).
+
+- [ ] **Step 3: Run the full rb-proto suite — expect PASS.** With `tempfile` declared, every module test compiles and runs.
+  Run: `cargo test -p rb-proto`
+  Expected: PASS (all tests across `messages`, `error`, `frame`, `client`, `wrapper_tests`).
+
+- [ ] **Step 4: Commit.** (If Task 6/7 already committed `Cargo.toml` with `tempfile`, this `git add` is a no-op and the commit is skipped — that is fine; verify Step 3 still passes.)
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "test(rb-proto): add tempfile dev-dependency for UDS client tests" || echo "tempfile already committed; nothing to do"`
+  Expected: one commit created, or a clear no-op message.
+
+---
+
+### Task 9: rb-proto public-API guard test + crate-wide gates
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/tests/public_api.rs`
+
+This locks the rb-proto public surface (mirroring the rb-types `public_api` guard) and runs the full crate-wide quality gates so the cluster ends green. The integration test imports every public item via the crate root; if a future change drops or renames a re-export, this test fails to compile.
+
+- [ ] **Step 1: Write the public-API guard integration test.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-proto/tests/public_api.rs`:
+
+```rust
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rb_proto::{
+    error_to_response, read_frame, response_error_to_error, write_frame, Client, Handshake,
+    HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+use rb_types::{Error, MemoryId, Namespace};
+
+#[test]
+fn public_surface_is_reachable_and_stable() {
+    // Constants and messages.
+    assert_eq!(CONTRACT_VERSION, 1);
+    let _hs = Handshake {
+        contract_version: CONTRACT_VERSION,
+        namespace: Namespace::Global,
+    };
+    let _ack = HandshakeAck {
+        contract_version: CONTRACT_VERSION,
+        ok: true,
+        message: None,
+    };
+    let _req = Request::Ping;
+
+    // Error mapping helpers, round-tripping through the wire form.
+    let resp = error_to_response(&Error::NotFound(MemoryId::new()));
+    match resp {
+        Response::Error { kind, message } => {
+            assert_eq!(kind, "not_found");
+            let back = response_error_to_error(&kind, &message);
+            assert!(matches!(back, Error::Storage(_)));
+        }
+        other => panic!("expected Response::Error, got {other:?}"),
+    }
+}
+
+// Compile-only references proving the framing and Client symbols are public.
+// (Never called: these are type-level guards on the public surface.)
+#[allow(dead_code)]
+fn _framing_symbols_exist() {
+    // Reference each public symbol so an accidental removal breaks compilation.
+    let _ = write_frame::<tokio::net::UnixStream, Request>;
+    let _ = read_frame::<tokio::net::UnixStream, Response>;
+    let _ = Client::connect;
+}
+```
+
+  The test references `tokio` directly (for `tokio::net::UnixStream` in the turbofish symbol guards), which is already a normal `[dependencies]` entry of rb-proto and therefore available to integration test targets (the rb-types `public_api.rs` guard relies on the same property for `chrono`). No manifest change is required. (verify against installed cargo at execution; if the integration target cannot see a normal dependency in your toolchain, add `tokio` under `[dev-dependencies]`.)
+
+- [ ] **Step 2: Run the guard test — expect PASS.** It is a regression guard, not a red→green driver: every imported item already exists by Task 7, so it locks the surface.
+  Run: `cargo test -p rb-proto --test public_api`
+  Expected: PASS.
+
+- [ ] **Step 3: Run the full rb-proto suite — expect PASS.**
+  Run: `cargo test -p rb-proto`
+  Expected: PASS (all unit tests plus the `public_api` integration test).
+
+- [ ] **Step 4: Workspace clippy gate with warnings denied.**
+  Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished`, no warnings (exit 0).
+
+- [ ] **Step 5: Workspace format gate.**
+  Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-proto/tests/public_api.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "test(rb-proto): add public-API guard and finalize crate gates"`
+  Expected: one commit created; `cargo test -p rb-proto`, workspace clippy, and fmt all green.
+
+## Part G — rb-embed (EmbeddingProvider + Voyage + offline DeterministicProvider)
+
+### Task 10: rb-embed `EmbeddingProvider` trait + `DeterministicProvider` (offline, infallible)
+
+**Files:**
+- Modify: `/Users/bluby/repos/rusty-brain-p1/Cargo.toml` (workspace members + rb-embed workspace deps present)
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-types/src/error.rs` (add `Embedding` variant)
+- Create/Overwrite: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/provider.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/deterministic.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs` (declare modules + re-exports)
+
+> The rb-embed skeleton (`crates/rb-embed/Cargo.toml` + an empty `src/lib.rs`) and the workspace member/deps registration were created by the P1 setup cluster. This task DEFENSIVELY confirms that registration, pins the real manifest (including the wiremock dev-dep used in Task 11), defines the `EmbeddingProvider` trait, and implements the public offline `DeterministicProvider`. The `VoyageProvider` arrives in Task 11. All paths target the P1 worktree at `/Users/bluby/repos/rusty-brain-p1` (branch `feat/p1-engine-daemon`).
+
+- [ ] **Step 1: Add the `Embedding` error variant to rb-types.** The spine maps all embedding failures to `rb_types::Error::Embedding`. Add the variant to `crates/rb-types/src/error.rs` as the last arm inside `pub enum Error`, immediately after the existing `Io(String)` variant:
+
+```rust
+    #[error("io error: {0}")]
+    Io(String),
+    #[error("embedding error: {0}")]
+    Embedding(String),
+```
+
+  (If the setup cluster already added it, leave the existing line in place — this is additive.)
+
+- [ ] **Step 2: Confirm rb-types still passes after the additive change.**
+  Run: `cargo test -p rb-types --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: PASS (all existing rb-types tests still green; the new variant is additive).
+
+- [ ] **Step 3: Confirm the workspace member and rb-embed workspace dependencies exist in the root manifest.** Verify `/Users/bluby/repos/rusty-brain-p1/Cargo.toml` `[workspace] members` contains `"crates/rb-embed"` and `[workspace.dependencies]` contains the entries below (added by P1 setup; add any that are missing — do NOT remove existing P0 entries):
+
+  Run: `grep -n 'crates/rb-embed' /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: a line inside the `[workspace] members = [...]` array referencing `crates/rb-embed`. If absent, add `"crates/rb-embed"` to the `members` array.
+
+  Required `[workspace.dependencies]` entries (add any missing):
+
+```toml
+async-trait = "0.1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+secrecy = "0.10"
+tracing = "0.1"
+```
+
+  (`serde`, `serde_json`, `thiserror`, `tempfile` are already present from P0.)
+
+- [ ] **Step 4: Pin the rb-embed crate manifest.** Overwrite `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/Cargo.toml` with the exact deps from the spine plus the `wiremock` dev-dependency (used by Task 11) and `tokio` (multi-thread + macros) for the async tests:
+
+```toml
+[package]
+name = "rb-embed"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "EmbeddingProvider trait, Voyage remote provider, and an offline deterministic provider for rusty-brain."
+
+[lib]
+name = "rb_embed"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+async-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+secrecy = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = "0.6"
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 5: Write the failing test for `DeterministicProvider` AND declare the modules.** An undeclared `.rs` file is never compiled, so declare both modules in `lib.rs` now and add `deterministic.rs` with the implementation-driving test. Also create the `provider.rs` trait file (the test needs the `EmbeddingProvider` trait in scope to call `.embed()`).
+
+  Set `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs` to:
+
+```rust
+//! `rb_embed`: embedding providers for rusty-brain.
+//!
+//! Defines the `EmbeddingProvider` trait, the remote `VoyageProvider`
+//! (added in a later task), and a public offline `DeterministicProvider`
+//! used as a no-API-key fallback and in tests.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod deterministic;
+mod provider;
+
+pub use deterministic::DeterministicProvider;
+pub use provider::EmbeddingProvider;
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/provider.rs` with ONLY the trait (no impls yet):
+
+```rust
+use async_trait::async_trait;
+
+/// A source of embedding vectors. Implementations may be remote (Voyage) or
+/// local/offline (deterministic). All implementations are `Send + Sync` so the
+/// daemon can share a single provider across connection tasks.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Stable identifier of the model, stored on each memory as `embedding_model`.
+    fn model_id(&self) -> &str;
+
+    /// The fixed embedding dimension. Enforced against `meta.embedding_dim` at init.
+    fn dim(&self) -> usize;
+
+    /// Embed each input text, returning one vector per input **in input order**.
+    /// Every returned vector has length `self.dim()`.
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>>;
+}
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/deterministic.rs` with ONLY the test module (the type is intentionally missing so the build fails):
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::provider::EmbeddingProvider;
+
+    #[test]
+    fn model_id_and_dim_are_reported() {
+        let p = DeterministicProvider::new(512);
+        assert_eq!(p.dim(), 512);
+        assert_eq!(p.model_id(), "deterministic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_returns_one_vector_per_input_of_correct_length() {
+        let p = DeterministicProvider::new(8);
+        let inputs = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let out = p.embed(&inputs).await.unwrap();
+        assert_eq!(out.len(), 3);
+        for v in &out {
+            assert_eq!(v.len(), 8);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn same_text_yields_same_vector() {
+        let p = DeterministicProvider::new(16);
+        let a = p.embed(&["repeatable".to_string()]).await.unwrap();
+        let b = p.embed(&["repeatable".to_string()]).await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn different_text_yields_different_vector() {
+        let p = DeterministicProvider::new(16);
+        let out = p
+            .embed(&["one".to_string(), "two".to_string()])
+            .await
+            .unwrap();
+        assert_ne!(out[0], out[1]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_preserves_input_order() {
+        let p = DeterministicProvider::new(16);
+        let inputs = vec!["x".to_string(), "y".to_string(), "z".to_string()];
+        // Embedding the list at once must equal embedding each item alone, in order.
+        let batched = p.embed(&inputs).await.unwrap();
+        let mut individually = Vec::new();
+        for t in &inputs {
+            individually.push(p.embed(std::slice::from_ref(t)).await.unwrap()[0].clone());
+        }
+        assert_eq!(batched, individually);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_input_yields_empty_output() {
+        let p = DeterministicProvider::new(4);
+        let out = p.embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vectors_are_unit_length() {
+        let p = DeterministicProvider::new(32);
+        let out = p.embed(&["normalize me".to_string()]).await.unwrap();
+        let norm: f32 = out[0].iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5, "expected unit vector, got norm {norm}");
+    }
+}
+```
+
+- [ ] **Step 6: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-embed deterministic --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: FAIL to compile — `cannot find type 'DeterministicProvider' in this scope` (the module compiles now that it is declared, but the type does not exist yet). This confirms the test drives the implementation.
+
+- [ ] **Step 7: Add the minimal `DeterministicProvider` implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/deterministic.rs`:
+
+```rust
+use crate::provider::EmbeddingProvider;
+use async_trait::async_trait;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Offline, deterministic embedding provider. Hashes each input text into a
+/// reproducible unit-length vector of length `dim`. Same text always yields the
+/// same vector; different texts yield different vectors. Never performs IO and
+/// never errors. Public so it can be used as a no-API-key fallback and in tests.
+///
+/// Determinism relies on `std::collections::hash_map::DefaultHasher::new()`,
+/// which is seeded with fixed keys (unlike `RandomState`), so the same input
+/// produces the same hash across processes and runs.
+pub struct DeterministicProvider {
+    dim: usize,
+}
+
+impl DeterministicProvider {
+    /// Create a provider that emits `dim`-length vectors.
+    pub fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Produce one reproducible unit-length vector for `text`.
+    fn embed_one(&self, text: &str) -> Vec<f32> {
+        // Seed a per-coordinate hash from the text plus the coordinate index so
+        // the components are decorrelated but fully reproducible.
+        let mut raw = Vec::with_capacity(self.dim);
+        for i in 0..self.dim {
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            i.hash(&mut hasher);
+            let h = hasher.finish();
+            // Map the 64-bit hash into a signed value in roughly [-1.0, 1.0).
+            let unit = (h as f64) / (u64::MAX as f64); // [0.0, 1.0)
+            raw.push((unit * 2.0 - 1.0) as f32);
+        }
+        // Normalize to unit length so distances are comparable to real models.
+        let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut raw {
+                *x /= norm;
+            }
+        } else if !raw.is_empty() {
+            // Degenerate all-zero case: emit a deterministic basis vector.
+            raw[0] = 1.0;
+        }
+        raw
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for DeterministicProvider {
+    fn model_id(&self) -> &str {
+        "deterministic"
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|t| self.embed_one(t)).collect())
+    }
+}
+```
+
+- [ ] **Step 8: Run it — expect PASS.**
+  Run: `cargo test -p rb-embed deterministic --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: PASS (7 tests in the `deterministic` module pass).
+
+- [ ] **Step 9: Lint + format the workspace.**
+  Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished` with no warnings (exit 0).
+  Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 10: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-embed crates/rb-types/src/error.rs Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-embed): add EmbeddingProvider trait and offline DeterministicProvider"`
+  Expected: one commit created.
+
+---
+
+### Task 11: rb-embed `VoyageProvider` — remote embeddings over reqwest (wiremock-tested)
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/voyage.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs` (declare `mod voyage;` + re-export)
+
+> The `VoyageProvider` POSTs to `{base_url}/embeddings`, parses `{data:[{embedding:[...]}, ...]}`, preserves input order, checks the returned count and every returned vector's length against `dim()`, bounds batches to <=128 by chunking, sets a 30s request timeout, and maps every HTTP/parse/count/dim error to `rb_types::Error::Embedding`. All wire tests use a **wiremock** mock server (no live API). One `#[ignore]` smoke test hits the real API only when `VOYAGE_API_KEY` is set, so CI never depends on a live key.
+
+- [ ] **Step 1: Write the failing tests AND declare the module.** Declare `mod voyage;` in `lib.rs` now (an undeclared `.rs` file is never compiled) and add the test-only `voyage.rs`. The wiremock tests assert request shape, response parsing, order preservation, the count-mismatch and dim-mismatch error paths, an HTTP-error path, empty-input short-circuit, and >128 chunking; an `#[ignore]` test covers the real API.
+
+  Set `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/lib.rs` to (adds `mod voyage;` + the `VoyageProvider` re-export):
+
+```rust
+//! `rb_embed`: embedding providers for rusty-brain.
+//!
+//! Defines the `EmbeddingProvider` trait, the remote `VoyageProvider`,
+//! and a public offline `DeterministicProvider` used as a no-API-key
+//! fallback and in tests.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod deterministic;
+mod provider;
+mod voyage;
+
+pub use deterministic::DeterministicProvider;
+pub use provider::EmbeddingProvider;
+pub use voyage::VoyageProvider;
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/voyage.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::provider::EmbeddingProvider;
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Build a provider pointed at a mock server with an explicit api key, so the
+    // tests never touch the real Voyage endpoint or read the environment.
+    // `for_test` is a #[cfg(test)]-only helper on VoyageProvider.
+    fn provider_for(base_url: &str, dim: usize) -> VoyageProvider {
+        VoyageProvider::for_test("voyage-3-lite", dim, "test-key", base_url)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn metadata_reports_model_and_dim() {
+        let p = provider_for("http://127.0.0.1:1/v1", 4);
+        assert_eq!(p.model_id(), "voyage-3-lite");
+        assert_eq!(p.dim(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn embed_sends_correct_request_and_parses_response_in_order() {
+        let server = MockServer::start().await;
+        // The mock asserts the request shape: POST /v1/embeddings, JSON body with
+        // the model, the inputs in order, and input_type "document", with bearer auth.
+        let response = serde_json::json!({
+            "data": [
+                { "embedding": [0.1, 0.2, 0.3, 0.4] },
+                { "embedding": [0.5, 0.6, 0.7, 0.8] }
+            ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "voyage-3-lite",
+                "input": ["first", "second"],
+                "input_type": "document"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p
+            .embed(&["first".to_string(), "second".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], vec![0.1, 0.2, 0.3, 0.4]);
+        assert_eq!(out[1], vec![0.5, 0.6, 0.7, 0.8]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dim_mismatch_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // Server returns a 3-length vector but the provider expects dim=4.
+        let response = serde_json::json!({
+            "data": [ { "embedding": [0.1, 0.2, 0.3] } ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p.embed(&["x".to_string()]).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Embedding(_)),
+            "expected Error::Embedding, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn count_mismatch_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        // Two inputs but the server returns only one embedding.
+        let response = serde_json::json!({
+            "data": [ { "embedding": [0.1, 0.2, 0.3, 0.4] } ]
+        });
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p
+            .embed(&["a".to_string(), "b".to_string()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::Embedding(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_error_status_is_an_embedding_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let err = p.embed(&["x".to_string()]).await.unwrap_err();
+        assert!(matches!(err, rb_types::Error::Embedding(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_input_short_circuits_without_calling_server() {
+        // No mock mounted: if embed() called the server it would 404 and error.
+        let server = MockServer::start().await;
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let out = p.embed(&[]).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batches_over_128_are_chunked_and_recombined_in_order() {
+        let server = MockServer::start().await;
+        // The mock echoes a fixed vector per requested input by reading the request
+        // body, so we can assert the total count and ordering after chunking.
+        // The closure captures nothing, so it is Send + Sync as Respond requires.
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(|req: &wiremock::Request| {
+                let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+                let n = body["input"].as_array().unwrap().len();
+                let data: Vec<serde_json::Value> = (0..n)
+                    .map(|_| serde_json::json!({ "embedding": [1.0, 0.0, 0.0, 0.0] }))
+                    .collect();
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "data": data }))
+            })
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let p = provider_for(&base, 4);
+        let inputs: Vec<String> = (0..200).map(|i| format!("item-{i}")).collect();
+        let out = p.embed(&inputs).await.unwrap();
+        assert_eq!(out.len(), 200);
+        for v in &out {
+            assert_eq!(v, &vec![1.0, 0.0, 0.0, 0.0]);
+        }
+    }
+
+    // Real-API smoke test. Ignored by default; run with:
+    //   VOYAGE_API_KEY=... cargo test -p rb-embed -- --ignored voyage_real_api
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires VOYAGE_API_KEY and network access"]
+    async fn voyage_real_api_smoke() {
+        let p = VoyageProvider::from_env().unwrap();
+        let out = p.embed(&["hello world".to_string()]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), p.dim());
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.**
+  Run: `cargo test -p rb-embed voyage --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: FAIL to compile — `cannot find type 'VoyageProvider' in this scope` / `no function 'for_test'` (the module is now compiled, but `VoyageProvider` does not exist yet). This confirms the tests drive the implementation.
+
+- [ ] **Step 3: Add the minimal `VoyageProvider` implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/src/voyage.rs`. Note: `for_test` is `#[cfg(test)]`-gated and infallible (it shares the private `build` constructor so it gets the same 30s timeout and base-url trimming), so no `.unwrap()`/`.expect()` appears in non-test code — keeping the workspace `unwrap_used = deny` lint satisfied under `cargo clippy -D warnings`:
+
+```rust
+use crate::provider::EmbeddingProvider;
+use async_trait::async_trait;
+use rb_types::Error;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Maximum number of inputs per HTTP request (Voyage batch ceiling).
+const MAX_BATCH: usize = 128;
+/// Default model and its embedding dimension.
+const DEFAULT_MODEL: &str = "voyage-3-lite";
+const DEFAULT_DIM: usize = 512;
+/// Default API base; the `/embeddings` path is appended per request.
+const DEFAULT_BASE_URL: &str = "https://api.voyageai.com/v1";
+/// Outbound request timeout (all embedding calls are timed out).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Remote embedding provider backed by the Voyage AI embeddings API.
+pub struct VoyageProvider {
+    client: reqwest::Client,
+    api_key: SecretString,
+    model: String,
+    dim: usize,
+    base_url: String,
+}
+
+/// Shape of the Voyage `/embeddings` response we depend on.
+#[derive(Deserialize)]
+struct EmbeddingsResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+impl VoyageProvider {
+    /// Build a provider from the environment. Reads `VOYAGE_API_KEY` (an
+    /// `Error::Embedding` if absent), defaults to model `voyage-3-lite` (dim 512),
+    /// and constructs a reqwest client with a request timeout.
+    pub fn from_env() -> rb_types::Result<Self> {
+        let key = std::env::var("VOYAGE_API_KEY")
+            .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
+        Self::build(DEFAULT_MODEL, DEFAULT_DIM, key, DEFAULT_BASE_URL)
+    }
+
+    /// Build a provider for a specific model + dimension, reading the key from
+    /// `VOYAGE_API_KEY`. Use this when overriding the default model.
+    pub fn with_model(model: &str, dim: usize) -> rb_types::Result<Self> {
+        let key = std::env::var("VOYAGE_API_KEY")
+            .map_err(|_| Error::Embedding("VOYAGE_API_KEY is not set".to_string()))?;
+        Self::build(model, dim, key, DEFAULT_BASE_URL)
+    }
+
+    /// Test-only constructor: explicit key + base URL, no environment access.
+    /// Builds the reqwest client directly (without `?`/unwrap) so it is infallible
+    /// and never panics; on the unlikely builder failure it falls back to the
+    /// default reqwest client (which still honors the per-request timeout set via
+    /// `.timeout(...)` on each request would require a builder, so we reuse the
+    /// builder result and only fall back to `Client::new()` if `build()` errors).
+    #[cfg(test)]
+    pub(crate) fn for_test(model: &str, dim: usize, api_key: &str, base_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            client,
+            api_key: SecretString::from(api_key.to_string()),
+            model: model.to_string(),
+            dim,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn build(model: &str, dim: usize, api_key: String, base_url: &str) -> rb_types::Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| Error::Embedding(format!("failed to build http client: {e}")))?;
+        Ok(Self {
+            client,
+            api_key: SecretString::from(api_key),
+            model: model.to_string(),
+            dim,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// POST a single chunk of inputs and return their embeddings in order.
+    async fn embed_chunk(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        let url = format!("{}/embeddings", self.base_url);
+        let body = serde_json::json!({
+            "model": self.model,
+            "input": texts,
+            "input_type": "document",
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(self.api_key.expose_secret())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Embedding(format!("voyage request failed: {e}")))?;
+
+        let resp = resp
+            .error_for_status()
+            .map_err(|e| Error::Embedding(format!("voyage returned an error status: {e}")))?;
+
+        let parsed: EmbeddingsResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::Embedding(format!("failed to parse voyage response: {e}")))?;
+
+        if parsed.data.len() != texts.len() {
+            return Err(Error::Embedding(format!(
+                "voyage returned {} embeddings for {} inputs",
+                parsed.data.len(),
+                texts.len()
+            )));
+        }
+
+        let mut out = Vec::with_capacity(parsed.data.len());
+        for item in parsed.data {
+            if item.embedding.len() != self.dim {
+                return Err(Error::Embedding(format!(
+                    "embedding dimension mismatch: expected {}, got {}",
+                    self.dim,
+                    item.embedding.len()
+                )));
+            }
+            out.push(item.embedding);
+        }
+        Ok(out)
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for VoyageProvider {
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    async fn embed(&self, texts: &[String]) -> rb_types::Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::with_capacity(texts.len());
+        for chunk in texts.chunks(MAX_BATCH) {
+            let mut embeddings = self.embed_chunk(chunk).await?;
+            out.append(&mut embeddings);
+        }
+        Ok(out)
+    }
+}
+```
+
+  (verify against installed crate at execution; adjust if the secrecy 0.10 `SecretString::from`/`expose_secret` or the reqwest 0.12 `bearer_auth`/`error_for_status`/`json` API differs. Verified locally: secrecy 0.10.3 provides `impl From<String> for SecretString` and `ExposeSecret::expose_secret(&self) -> &str`; reqwest 0.12.28 provides `error_for_status(self) -> Result<Self>` and async `json`.)
+
+- [ ] **Step 4: Run it — expect PASS.**
+  Run: `cargo test -p rb-embed voyage --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: PASS. The 7 non-ignored tests pass and `voyage_real_api_smoke` is reported as `ignored` (it never calls the live API in CI).
+
+- [ ] **Step 5: Confirm the ignored real-API test is correctly gated (does NOT run by default).**
+  Run: `cargo test -p rb-embed voyage --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- --nocapture 2>&1 | grep -E "voyage_real_api_smoke|test result"`
+  Expected: a line showing `voyage_real_api_smoke ... ignored` and a `test result: ok.` summary with `N passed; 0 failed; 1 ignored`. CI never depends on a live API key.
+
+- [ ] **Step 6: Lint + format the workspace.**
+  Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished` with no warnings (exit 0). (The only `.unwrap_or_else(..unwrap..)`-style fallback is gone; `for_test` is `#[cfg(test)]`-gated and its single `unwrap_or_else` is allowed under the test cfg, so no `unwrap_used`/`expect_used`/`panic` lint fires in non-test code.)
+  Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-embed/src/voyage.rs crates/rb-embed/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-embed): add VoyageProvider with reqwest, batching, and order/dim checks"`
+  Expected: one commit created.
+
+---
+
+### Task 12: rb-embed crate gate — public-API guard + provider parity integration test
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/tests/public_api.rs`
+
+> A crate-level integration test (compiled as a separate target, in non-test cfg of the lib) that locks the rb-embed public surface (`EmbeddingProvider`, `DeterministicProvider`, `VoyageProvider`) and asserts the trait contract holds through the public re-exports — in particular that the offline provider honors `dim()`, order, and determinism, and that the trait is object-safe (`Box<dyn EmbeddingProvider>`). It uses ONLY the offline `DeterministicProvider` for live assertions so CI never needs network or a key; `VoyageProvider` is only constructed via the public `with_model` (no network). This is the per-crate gate matching the P0 `tests/public_api.rs` pattern.
+
+- [ ] **Step 1: Confirm the integration test's dev-dependencies are present.** The integration target needs `tokio` (async driver) and uses `rb_types` (already a normal dependency of rb-embed, so visible to integration tests — no separate dev entry required).
+  Run: `grep -n 'tokio' /Users/bluby/repos/rusty-brain-p1/crates/rb-embed/Cargo.toml`
+  Expected: a `tokio = { workspace = true }` line under `[dev-dependencies]` (added in Task 10). If missing, add it before proceeding.
+
+- [ ] **Step 2: Write the public-API guard integration test.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-embed/tests/public_api.rs`. It imports every public type via the crate root and drives the trait through a `dyn EmbeddingProvider`, proving the trait is object-safe and the offline provider satisfies the full contract (length, order, determinism). `VoyageProvider` is only constructed (no network) to prove it is publicly reachable and implements the trait:
+
+```rust
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_embed::{DeterministicProvider, EmbeddingProvider, VoyageProvider};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deterministic_provider_satisfies_trait_contract_via_dyn() {
+    // Object-safety: the trait must be usable behind a trait object, as the
+    // engine/daemon will hold `Box<dyn EmbeddingProvider>` (or a generic param).
+    let provider: Box<dyn EmbeddingProvider> = Box::new(DeterministicProvider::new(64));
+    assert_eq!(provider.dim(), 64);
+    assert_eq!(provider.model_id(), "deterministic");
+
+    let inputs = vec![
+        "one transaction one database".to_string(),
+        "single writer thread".to_string(),
+        "namespace isolation".to_string(),
+    ];
+    let out = provider.embed(&inputs).await.unwrap();
+
+    // One vector per input, each of length dim().
+    assert_eq!(out.len(), inputs.len());
+    for v in &out {
+        assert_eq!(v.len(), provider.dim());
+    }
+
+    // Determinism: re-embedding yields identical vectors.
+    let out2 = provider.embed(&inputs).await.unwrap();
+    assert_eq!(out, out2);
+
+    // Distinctness: different inputs produce different vectors.
+    assert_ne!(out[0], out[1]);
+    assert_ne!(out[1], out[2]);
+}
+
+#[test]
+fn voyage_provider_is_publicly_constructible() {
+    // Reachable from the crate root and implements EmbeddingProvider; no network.
+    let provider = VoyageProvider::with_model("voyage-3-lite", 1024);
+    // Without VOYAGE_API_KEY this is an Embedding error; with it, a valid provider.
+    match provider {
+        Ok(p) => {
+            let p: &dyn EmbeddingProvider = &p;
+            assert_eq!(p.dim(), 1024);
+            assert_eq!(p.model_id(), "voyage-3-lite");
+        }
+        Err(e) => assert!(matches!(e, rb_types::Error::Embedding(_))),
+    }
+}
+```
+
+- [ ] **Step 3: Run it — expect PASS (regression guard, not a red→green driver).**
+  Run: `cargo test -p rb-embed --test public_api --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: PASS (2 tests). By the end of Task 11 the public surface already exists, so every import resolves. The test LOCKS that surface: if a future change drops or renames a re-export, or makes `EmbeddingProvider` non-object-safe, this integration target fails to compile — catching the regression. (Note: `for_test` is `#[cfg(test)]`-gated and therefore NOT visible from this separate integration crate, which is exactly why this test relies only on `with_model`.)
+
+- [ ] **Step 4: Run the full rb-embed crate test suite as the cluster gate.**
+  Run: `cargo test -p rb-embed --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: PASS — all unit tests (deterministic + voyage modules) plus the `public_api` integration target green; `voyage_real_api_smoke` shown as `ignored`. No network access occurred.
+
+- [ ] **Step 5: Lint + format the workspace.**
+  Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished` with no warnings (exit 0).
+  Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit.**
+  Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-embed/tests/public_api.rs crates/rb-embed/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "test(rb-embed): add public-API guard and provider trait-contract integration test"`
+  Expected: one commit created.
+
+## Part H — rb-search (pure hybrid ranking)
+
+### Task 13: rb-search `weights.rs` — `Weights` struct with documented `Default` summing to 1.0
+
+**Files:**
+- Create: `crates/rb-search/src/weights.rs`
+- Modify: `crates/rb-search/src/lib.rs` (add `mod weights;` + re-export)
+- Test: inline `#[cfg(test)] mod tests` in `crates/rb-search/src/weights.rs`
+
+> The `rb-search` crate skeleton (manifest with `rb-types` + `chrono` deps and `[lints] workspace = true`, plus a doc-only `lib.rs`) is created in the earlier P1 setup cluster. This task adds the first real module. A `.rs` file not declared with `mod` in `lib.rs` is never compiled, so we declare the module up front and the build fails until the type exists — confirming the test drives new code rather than being silently skipped.
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Create `crates/rb-search/src/weights.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn default_weights_match_documented_values() {
+        let w = Weights::default();
+        assert!((w.vector - 0.45).abs() < f32::EPSILON);
+        assert!((w.keyword - 0.30).abs() < f32::EPSILON);
+        assert!((w.graph - 0.10).abs() < f32::EPSILON);
+        assert!((w.importance - 0.10).abs() < f32::EPSILON);
+        assert!((w.recency - 0.05).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn default_weights_sum_to_one() {
+        let w = Weights::default();
+        let sum = w.vector + w.keyword + w.graph + w.importance + w.recency;
+        assert!((sum - 1.0).abs() < 1e-6, "weights must sum to 1.0, got {sum}");
+    }
+
+    #[test]
+    fn weights_is_copy_and_clone() {
+        let w = Weights::default();
+        let copied = w; // Copy
+        // Invoke the Clone impl explicitly: `w.clone()` would trip clippy's
+        // `clone_on_copy` lint (denied by -D warnings) because Weights is Copy.
+        let cloned = Clone::clone(&w);
+        assert!((copied.vector - cloned.vector).abs() < f32::EPSILON);
+        // original still usable after the copy (proves Copy, not move)
+        assert!((w.vector - 0.45).abs() < f32::EPSILON);
+    }
+}
+```
+
+  Set `crates/rb-search/src/lib.rs` to declare the module (replace the doc-only skeleton body's tail with the `mod` line; the `pub use` is added in Step 3):
+
+```rust
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO, no async. Combines normalized keyword / vector / graph / importance /
+//! recency signals into a single weighted score (see `rank`).
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod weights;
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.** Run: `cargo test -p rb-search weights -- --nocapture`
+  Expected: FAIL to compile — `cannot find type 'Weights' in this scope` (the `weights` module is now compiled, but the `Weights` type does not exist yet). This confirms the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `crates/rb-search/src/weights.rs`:
+
+```rust
+/// Relative contribution of each ranking signal to the final score.
+///
+/// The `Default` weights are tuned for hybrid recall and **sum to 1.0**, so the
+/// weighted score of any single candidate stays in `[0.0, 1.0]`:
+///
+/// | signal     | weight |
+/// |------------|--------|
+/// | vector     | 0.45   |
+/// | keyword    | 0.30   |
+/// | graph      | 0.10   |
+/// | importance | 0.10   |
+/// | recency    | 0.05   |
+#[derive(Clone, Copy, Debug)]
+pub struct Weights {
+    pub vector: f32,
+    pub keyword: f32,
+    pub graph: f32,
+    pub importance: f32,
+    pub recency: f32,
+}
+
+impl Default for Weights {
+    fn default() -> Self {
+        Self {
+            vector: 0.45,
+            keyword: 0.30,
+            graph: 0.10,
+            importance: 0.10,
+            recency: 0.05,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Re-export from `lib.rs`.** Append the re-export to `crates/rb-search/src/lib.rs` so the public API is `rb_search::Weights`:
+
+```rust
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO, no async. Combines normalized keyword / vector / graph / importance /
+//! recency signals into a single weighted score (see `rank`).
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod weights;
+
+pub use weights::Weights;
+```
+
+- [ ] **Step 5: Run it — expect PASS.** Run: `cargo test -p rb-search weights -- --nocapture`
+  Expected: PASS (3 tests pass).
+
+- [ ] **Step 6: Lint + format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings`
+  Expected: no warnings, exit 0. Run: `cargo fmt --all`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-search/src/weights.rs crates/rb-search/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-search): add Weights struct with documented Default summing to 1.0"`
+  Expected: one commit created.
+
+---
+
+### Task 14: rb-search `rank.rs` — `Signals` + `HALF_LIFE` + pure `rank()` scoring
+
+**Files:**
+- Create: `crates/rb-search/src/rank.rs`
+- Modify: `crates/rb-search/src/lib.rs` (add `mod rank;` + re-exports)
+- Test: inline `#[cfg(test)] mod tests` in `crates/rb-search/src/rank.rs`
+
+> `rank()` is the pure scoring core. Normalization per the spine: `vector_sim = 1 - clamp(distance/2, 0, 1)`; `keyword = 1/(1+rank)` (0 = best); `graph = 1/(1+hops)`; `importance/10`; `recency = exp(-age_days/HALF_LIFE)` with `HALF_LIFE = 30.0`. A missing signal contributes 0 to its term (no penalty). The weighted sum is sorted descending and truncated to `limit`. `slice::sort_by` is a stable sort, so equal scores keep input order for deterministic, reproducible output.
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Create `crates/rb-search/src/rank.rs` with ONLY the test module. It pins: a strong vector+keyword doc outranks a weak one; recency breaks ties; graph-only candidates still rank above nothing; `limit` truncates; and a property-style check that every score is in `[0,1]` and ordering is stable across repeated calls:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use chrono::{Duration, Utc};
+    use rb_types::MemoryId;
+
+    /// Returns the current instant, captured once per test and reused as the single
+    /// consistent reference for both `created_at` offsets and the `rank(..., n, ...)`
+    /// call, so each test is internally deterministic.
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn strong_doc_outranks_weak_doc() {
+        let n = now();
+        let strong = MemoryId::new();
+        let weak = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: weak.clone(),
+                keyword_rank: Some(9),
+                vector_distance: Some(1.6), // far -> low sim
+                graph_hops: None,
+                importance: 2,
+                created_at: n - Duration::days(120),
+            },
+            Signals {
+                id: strong.clone(),
+                keyword_rank: Some(0), // best keyword hit
+                vector_distance: Some(0.1), // very close
+                graph_hops: Some(1),
+                importance: 9,
+                created_at: n,
+            },
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].0, strong, "strong vector+keyword doc must rank first");
+        assert_eq!(ranked[1].0, weak);
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn recency_breaks_ties_between_otherwise_equal_docs() {
+        let n = now();
+        let recent = MemoryId::new();
+        let old = MemoryId::new();
+        // Identical on every signal EXCEPT created_at.
+        let mk = |id: MemoryId, created| Signals {
+            id,
+            keyword_rank: Some(1),
+            vector_distance: Some(0.4),
+            graph_hops: Some(2),
+            importance: 5,
+            created_at: created,
+        };
+        let signals = vec![
+            mk(old.clone(), n - Duration::days(200)),
+            mk(recent.clone(), n),
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, recent, "more recent doc wins the tie");
+        assert_eq!(ranked[1].0, old);
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn graph_only_candidate_still_ranks_above_zero() {
+        let n = now();
+        let id = MemoryId::new();
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: None,
+            graph_hops: Some(0), // adjacent -> graph proximity 1.0
+            importance: 0,
+            created_at: n - Duration::days(10_000), // ancient -> recency ~0
+        }];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].0, id);
+        // graph weight (0.10) * proximity (1.0) dominates; score strictly > 0.
+        assert!(ranked[0].1 > 0.0, "graph-only candidate must score > 0");
+    }
+
+    #[test]
+    fn missing_signals_do_not_penalize() {
+        let n = now();
+        // A: only a keyword hit. B: only a vector hit at the SAME normalized strength.
+        // keyword Some(0) -> 1.0 ; vector dist 0.0 -> sim 1.0. With default weights
+        // keyword(0.30) vs vector(0.45), the vector-only doc should outrank.
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: a.clone(),
+                keyword_rank: Some(0),
+                vector_distance: None,
+                graph_hops: None,
+                importance: 0,
+                created_at: n - Duration::days(10_000),
+            },
+            Signals {
+                id: b.clone(),
+                keyword_rank: None,
+                vector_distance: Some(0.0),
+                graph_hops: None,
+                importance: 0,
+                created_at: n - Duration::days(10_000),
+            },
+        ];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, b, "vector-only (0.45) beats keyword-only (0.30)");
+        // The keyword-only doc is NOT penalized to 0: it scores its full keyword term.
+        assert!((ranked[1].1 - 0.30).abs() < 1e-5);
+    }
+
+    #[test]
+    fn limit_truncates_to_top_n() {
+        let n = now();
+        let signals: Vec<Signals> = (0..5)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: Some(i),
+                vector_distance: Some(0.1 * i as f32),
+                graph_hops: None,
+                importance: (10 - i) as u8,
+                created_at: n,
+            })
+            .collect();
+        let ranked = rank(signals, Weights::default(), n, 2);
+        assert_eq!(ranked.len(), 2, "limit truncates to 2");
+        // truncation keeps the two highest scores in descending order
+        assert!(ranked[0].1 >= ranked[1].1);
+    }
+
+    #[test]
+    fn scores_in_range_and_ordering_is_stable() {
+        let n = now();
+        let signals: Vec<Signals> = (0..20)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: if i % 2 == 0 { Some(i) } else { None },
+                vector_distance: if i % 3 == 0 { Some(0.05 * i as f32) } else { None },
+                graph_hops: if i % 4 == 0 { Some((i % 5) as u8) } else { None },
+                importance: (i % 11) as u8,
+                created_at: n - Duration::days(i as i64),
+            })
+            .collect();
+        let first = rank(signals.clone(), Weights::default(), n, 20);
+        // every score is a sane probability-like value in [0,1], non-increasing.
+        for w in first.windows(2) {
+            assert!(w[0].1 >= w[1].1, "scores must be sorted descending");
+        }
+        for (_, score) in &first {
+            assert!(*score >= 0.0 && *score <= 1.0, "score {score} out of [0,1]");
+        }
+        // determinism: same inputs -> identical id ordering AND identical scores.
+        let second = rank(signals, Weights::default(), n, 20);
+        let ids_a: Vec<_> = first.iter().map(|(id, _)| id.clone()).collect();
+        let ids_b: Vec<_> = second.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(ids_a, ids_b, "ordering must be stable across runs");
+        for (x, y) in first.iter().zip(second.iter()) {
+            assert!((x.1 - y.1).abs() < f32::EPSILON, "scores must be reproducible");
+        }
+    }
+}
+```
+
+  Add `mod rank;` after `mod weights;` in `crates/rb-search/src/lib.rs` (the `pub use` is added in Step 3).
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rb-search rank -- --nocapture`
+  Expected: FAIL to compile (`cannot find type 'Signals' in this scope` / `cannot find function 'rank' in this scope`), confirming the module is compiled and the API is missing.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `crates/rb-search/src/rank.rs`:
+
+```rust
+use crate::weights::Weights;
+use rb_types::MemoryId;
+
+/// Recency half-life in days: a memory `HALF_LIFE` days old scores `e^-1 ~= 0.368`
+/// on the recency term. Documented, fixed constant for deterministic ranking.
+pub const HALF_LIFE: f32 = 30.0;
+
+/// Per-candidate raw signals gathered from the three retrieval paths.
+///
+/// Any `Option` left as `None` means "this path did not surface this candidate";
+/// its corresponding term contributes 0 (no penalty).
+#[derive(Clone, Debug)]
+pub struct Signals {
+    pub id: MemoryId,
+    /// Keyword rank, 0 = best. `None` if not a keyword hit.
+    pub keyword_rank: Option<usize>,
+    /// Cosine distance, smaller = closer. `None` if not a vector hit.
+    pub vector_distance: Option<f32>,
+    /// Graph hops from a seed, 0 = the seed itself. `None` if not graph-reached.
+    pub graph_hops: Option<u8>,
+    /// Importance 0..=10.
+    pub importance: u8,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Normalize a single candidate's signals into a weighted score in `[0, 1]`.
+fn score_one(
+    s: &Signals,
+    w: &Weights,
+    now: chrono::DateTime<chrono::Utc>,
+) -> f32 {
+    // Vector similarity: cosine distance in [0, 2] -> similarity in [0, 1].
+    let vector_sim = match s.vector_distance {
+        Some(d) => 1.0 - (d / 2.0).clamp(0.0, 1.0),
+        None => 0.0,
+    };
+    // Keyword: reciprocal rank, 0 = best -> 1.0.
+    let keyword = match s.keyword_rank {
+        Some(r) => 1.0 / (1.0 + r as f32),
+        None => 0.0,
+    };
+    // Graph proximity: reciprocal hops, 0 hops -> 1.0.
+    let graph = match s.graph_hops {
+        Some(h) => 1.0 / (1.0 + h as f32),
+        None => 0.0,
+    };
+    // Importance normalized to [0, 1].
+    let importance = (s.importance as f32 / 10.0).clamp(0.0, 1.0);
+    // Recency: exponential decay over age in days. Future timestamps clamp to age 0.
+    let age_days = ((now - s.created_at).num_seconds() as f32 / 86_400.0).max(0.0);
+    let recency = (-age_days / HALF_LIFE).exp();
+
+    w.vector * vector_sim
+        + w.keyword * keyword
+        + w.graph * graph
+        + w.importance * importance
+        + w.recency * recency
+}
+
+/// Rank candidates by weighted, normalized signal score.
+///
+/// Pure and deterministic: returns `(id, score)` pairs sorted by score descending,
+/// truncated to `limit`. `slice::sort_by` is a stable sort, so equal scores preserve
+/// input order and output ordering is reproducible across runs. Missing signals
+/// contribute 0 (no penalty).
+pub fn rank(
+    signals: Vec<Signals>,
+    weights: Weights,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: usize,
+) -> Vec<(MemoryId, f32)> {
+    let mut scored: Vec<(MemoryId, f32)> = signals
+        .iter()
+        .map(|s| (s.id.clone(), score_one(s, &weights, now)))
+        .collect();
+    // Stable sort descending by score; partial_cmp is total here (scores are finite),
+    // and we fall back to Equal so a NaN (which cannot occur with finite inputs) does
+    // not panic, keeping the function panic-free on all paths.
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    scored.truncate(limit);
+    scored
+}
+```
+
+- [ ] **Step 4: Re-export from `lib.rs`.** Update `crates/rb-search/src/lib.rs` to re-export the new public items:
+
+```rust
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO, no async. Combines normalized keyword / vector / graph / importance /
+//! recency signals into a single weighted score (see `rank`).
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod rank;
+mod weights;
+
+pub use rank::{rank, Signals, HALF_LIFE};
+pub use weights::Weights;
+```
+
+- [ ] **Step 5: Run it — expect PASS.** Run: `cargo test -p rb-search rank -- --nocapture`
+  Expected: PASS (6 tests pass).
+
+- [ ] **Step 6: Lint + format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings`
+  Expected: no warnings, exit 0. Run: `cargo fmt --all`
+  Expected: no diff.
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-search/src/rank.rs crates/rb-search/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-search): add Signals, HALF_LIFE, and pure deterministic rank()"`
+  Expected: one commit created.
+
+---
+
+### Task 15: rb-search `merge.rs` — `build_signals()` candidate-merge helper
+
+**Files:**
+- Create: `crates/rb-search/src/merge.rs`
+- Modify: `crates/rb-search/src/lib.rs` (add `mod merge;` + re-export)
+- Test: inline `#[cfg(test)] mod tests` in `crates/rb-search/src/merge.rs`
+
+> `build_signals` is the pure glue that folds the three retrieval result sets (keyword `Vec<MemoryId>` in rank order, vector `Vec<(MemoryId, f32)>`, graph `Vec<MemoryId>` in hop order) plus a metadata lookup (`HashMap<MemoryId, (importance, created_at)>`) into the `Vec<Signals>` that `rank` consumes. A candidate may appear in any subset of the three paths; each path fills only its own field. Candidates missing from `meta` are dropped (they cannot be scored or fetched), which keeps the helper fail-closed.
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Create `crates/rb-search/src/merge.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use chrono::Utc;
+    use rb_types::MemoryId;
+    use std::collections::HashMap;
+
+    #[test]
+    fn merges_overlapping_paths_into_one_signal_per_id() {
+        let now = Utc::now();
+        let shared = MemoryId::new();
+        let kw_only = MemoryId::new();
+        let vec_only = MemoryId::new();
+        let graph_only = MemoryId::new();
+
+        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        for id in [&shared, &kw_only, &vec_only, &graph_only] {
+            meta.insert(id.clone(), (5, now));
+        }
+
+        let keyword = vec![shared.clone(), kw_only.clone()];
+        let vector = vec![(shared.clone(), 0.2), (vec_only.clone(), 0.9)];
+        let graph = vec![shared.clone(), graph_only.clone()];
+
+        let signals = build_signals(&keyword, &vector, &graph, &meta);
+        // one Signals per distinct id (4 total).
+        assert_eq!(signals.len(), 4);
+
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+
+        // shared appears in all three paths: keyword_rank 0 (first), vector dist 0.2, graph hops 0 (first).
+        let sh = by_id.get(&shared).unwrap();
+        assert_eq!(sh.keyword_rank, Some(0));
+        assert!((sh.vector_distance.unwrap() - 0.2).abs() < f32::EPSILON);
+        assert_eq!(sh.graph_hops, Some(0));
+
+        // kw_only: keyword_rank 1, no vector, no graph.
+        let k = by_id.get(&kw_only).unwrap();
+        assert_eq!(k.keyword_rank, Some(1));
+        assert!(k.vector_distance.is_none());
+        assert!(k.graph_hops.is_none());
+
+        // vec_only: only vector distance 0.9.
+        let v = by_id.get(&vec_only).unwrap();
+        assert!(v.keyword_rank.is_none());
+        assert!((v.vector_distance.unwrap() - 0.9).abs() < f32::EPSILON);
+        assert!(v.graph_hops.is_none());
+
+        // graph_only: graph hops 1 (second in graph order).
+        let g = by_id.get(&graph_only).unwrap();
+        assert!(g.keyword_rank.is_none());
+        assert!(g.vector_distance.is_none());
+        assert_eq!(g.graph_hops, Some(1));
+    }
+
+    #[test]
+    fn keyword_rank_and_graph_hops_follow_input_order() {
+        let now = Utc::now();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+        let mut meta = HashMap::new();
+        for id in [&a, &b, &c] {
+            meta.insert(id.clone(), (5, now));
+        }
+        let keyword = vec![a.clone(), b.clone(), c.clone()];
+        let graph = vec![c.clone(), b.clone(), a.clone()];
+        let signals = build_signals(&keyword, &[], &graph, &meta);
+        let by_id: HashMap<MemoryId, &Signals> =
+            signals.iter().map(|s| (s.id.clone(), s)).collect();
+        // keyword rank = index in keyword vec.
+        assert_eq!(by_id.get(&a).unwrap().keyword_rank, Some(0));
+        assert_eq!(by_id.get(&b).unwrap().keyword_rank, Some(1));
+        assert_eq!(by_id.get(&c).unwrap().keyword_rank, Some(2));
+        // graph hops = index in graph vec.
+        assert_eq!(by_id.get(&c).unwrap().graph_hops, Some(0));
+        assert_eq!(by_id.get(&b).unwrap().graph_hops, Some(1));
+        assert_eq!(by_id.get(&a).unwrap().graph_hops, Some(2));
+    }
+
+    #[test]
+    fn carries_importance_and_created_at_from_meta() {
+        let created = Utc::now();
+        let id = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(id.clone(), (8u8, created));
+        let signals = build_signals(&[id.clone()], &[], &[], &meta);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].importance, 8);
+        assert_eq!(signals[0].created_at, created);
+    }
+
+    #[test]
+    fn candidates_absent_from_meta_are_dropped() {
+        let now = Utc::now();
+        let known = MemoryId::new();
+        let unknown = MemoryId::new(); // appears in results but has no meta entry
+        let mut meta = HashMap::new();
+        meta.insert(known.clone(), (5, now));
+        let keyword = vec![known.clone(), unknown.clone()];
+        let signals = build_signals(&keyword, &[], &[], &meta);
+        // the unknown id is dropped (cannot be scored or fetched) -> fail closed.
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].id, known);
+    }
+
+    #[test]
+    fn output_feeds_rank_end_to_end() {
+        let now = Utc::now();
+        let strong = MemoryId::new();
+        let weak = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(strong.clone(), (9u8, now));
+        meta.insert(weak.clone(), (2u8, now));
+        let keyword = vec![strong.clone(), weak.clone()];
+        let vector = vec![(strong.clone(), 0.1), (weak.clone(), 1.7)];
+        let signals = build_signals(&keyword, &vector, &[], &meta);
+        let ranked = crate::rank::rank(signals, crate::weights::Weights::default(), now, 10);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].0, strong, "merge + rank place the strong doc first");
+    }
+}
+```
+
+  Add `mod merge;` (before `mod rank;`, alphabetical) in `crates/rb-search/src/lib.rs` (the `pub use` is added in Step 3).
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rb-search merge -- --nocapture`
+  Expected: FAIL to compile (`cannot find function 'build_signals' in this scope`), confirming the module is compiled and the helper is missing.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `crates/rb-search/src/merge.rs`:
+
+```rust
+use crate::rank::Signals;
+use rb_types::MemoryId;
+use std::collections::HashMap;
+
+/// Fold the three retrieval result sets into one `Signals` per distinct candidate.
+///
+/// - `keyword`: ids in rank order (index 0 = best keyword hit).
+/// - `vector`: `(id, cosine_distance)` pairs (smaller distance = closer).
+/// - `graph`: ids in hop order (index 0 = nearest in the graph walk).
+/// - `meta`: per-id `(importance, created_at)`, the source of truth for scoring/fetch.
+///
+/// A candidate may appear in any subset of the three paths; each path fills only its
+/// own field, leaving the rest `None` so `rank` contributes 0 for absent signals.
+/// Candidates with no `meta` entry are dropped (fail closed — they cannot be scored
+/// or later fetched). Output order follows first appearance across keyword, then
+/// vector, then graph, which `rank` re-sorts deterministically.
+pub fn build_signals(
+    keyword: &[MemoryId],
+    vector: &[(MemoryId, f32)],
+    graph: &[MemoryId],
+    meta: &HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)>,
+) -> Vec<Signals> {
+    // Preserve first-seen order with a parallel index map into `out`.
+    let mut index: HashMap<MemoryId, usize> = HashMap::new();
+    let mut out: Vec<Signals> = Vec::new();
+
+    // The closure captures only `meta` (by shared ref) and takes `index`/`out` as
+    // `&mut` parameters per call, so it does NOT need to be `mut` itself. Marking it
+    // `mut` would trip the `unused_mut` warning, which is denied under -D warnings.
+    let slot = |id: &MemoryId,
+                index: &mut HashMap<MemoryId, usize>,
+                out: &mut Vec<Signals>|
+     -> Option<usize> {
+        if let Some(&i) = index.get(id) {
+            return Some(i);
+        }
+        // Only materialize a candidate we have metadata for.
+        let (importance, created_at) = *meta.get(id)?;
+        let i = out.len();
+        out.push(Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: None,
+            graph_hops: None,
+            importance,
+            created_at,
+        });
+        index.insert(id.clone(), i);
+        Some(i)
+    };
+
+    for (rank_idx, id) in keyword.iter().enumerate() {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            out[i].keyword_rank = Some(rank_idx);
+        }
+    }
+    for (id, distance) in vector.iter() {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            out[i].vector_distance = Some(*distance);
+        }
+    }
+    for (hop_idx, id) in graph.iter().enumerate() {
+        if let Some(i) = slot(id, &mut index, &mut out) {
+            // hop index saturates into u8; graph depth is bounded well below 255.
+            out[i].graph_hops = Some(hop_idx.min(u8::MAX as usize) as u8);
+        }
+    }
+
+    out
+}
+```
+
+- [ ] **Step 4: Re-export from `lib.rs`.** Update `crates/rb-search/src/lib.rs` to its final form:
+
+```rust
+//! `rb_search`: pure, deterministic hybrid ranking for rusty-brain.
+//!
+//! No IO, no async. Combines normalized keyword / vector / graph / importance /
+//! recency signals into a single weighted score (see `rank`). `build_signals`
+//! folds the three retrieval result sets into the `Signals` that `rank` consumes.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod merge;
+mod rank;
+mod weights;
+
+pub use merge::build_signals;
+pub use rank::{rank, Signals, HALF_LIFE};
+pub use weights::Weights;
+```
+
+- [ ] **Step 5: Run it — expect PASS.** Run: `cargo test -p rb-search merge -- --nocapture`
+  Expected: PASS (5 tests pass).
+
+- [ ] **Step 6: Run the full crate suite + gates.** Run: `cargo test -p rb-search`
+  Expected: PASS (all 14 tests across `weights`, `rank`, `merge` pass). Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings`
+  Expected: `Finished` with no warnings (exit 0). Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-search/src/merge.rs crates/rb-search/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-search): add build_signals merge helper folding retrieval paths into Signals"`
+  Expected: one commit created; `cargo test -p rb-search` and workspace clippy both green.
+
+## Part I — rb-engine (trait-generic orchestration)
+
+### Task 16: rb-engine `backend.rs` — `MemoryBackend` async trait + in-test mock
+
+**Files:**
+- Modify: `crates/rb-engine/Cargo.toml` (ensure `tokio` dev-dependency present)
+- Create: `crates/rb-engine/src/backend.rs`
+- Modify: `crates/rb-engine/src/lib.rs` (add `mod backend;` + re-export)
+
+> The `rb-engine` crate skeleton (manifest + empty `lib.rs` with the test-only clippy allow) is created in the P1 setup task, mirroring how the P0 `rb-types`/`rb-store` skeletons were created. This task adds the first real module. The engine deliberately does NOT depend on `rb-store` — it is generic over the `MemoryBackend` trait so it stays pure policy and is unit-tested against an in-memory `HashMap` mock (no DB, no network).
+
+- [ ] **Step 1: Ensure `tokio` is a dev-dependency.** `#[tokio::test]` needs the tokio test runtime. Set `crates/rb-engine/Cargo.toml` to exactly this (adds the `[dev-dependencies]` block if the setup skeleton lacked it; leaves the runtime deps as the spine specifies):
+
+```toml
+[package]
+name = "rb-engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Single-request memory orchestration: heuristic enrichment, embed, hybrid recall ranking."
+
+[lib]
+name = "rb_engine"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-search = { path = "../rb-search" }
+rb-embed = { path = "../rb-embed" }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Write the failing test AND declare the module.** An undeclared `.rs` file is never compiled, so we declare `mod backend;` in `lib.rs` now and create `backend.rs` containing the trait-shaped test only. The build fails because `MemoryBackend` does not exist yet.
+
+  Create `crates/rb-engine/src/backend.rs` with ONLY the test module (it defines an in-memory mock that the trait must satisfy, then exercises every method). The mock's `keyword`/`vector` return ids in a **deterministic** order (created_at desc) so downstream recall ranking is reproducible:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Minimal in-memory backend used to unit-test the engine in isolation.
+    /// NOT backed by rb-store; just a HashMap behind a Mutex.
+    #[derive(Default)]
+    struct MockBackend {
+        notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+        embeddings: Mutex<HashMap<MemoryId, Vec<f32>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryBackend for MockBackend {
+        async fn write(
+            &self,
+            note: MemoryNote,
+            embedding: Option<Vec<f32>>,
+        ) -> rb_types::Result<()> {
+            if let Some(emb) = embedding {
+                self.embeddings.lock().unwrap().insert(note.id.clone(), emb);
+            }
+            self.notes.lock().unwrap().insert(note.id.clone(), note);
+            Ok(())
+        }
+        async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+            Ok(self.notes.lock().unwrap().get(&id).cloned())
+        }
+        async fn keyword(
+            &self,
+            _ns: Namespace,
+            _query: String,
+            _limit: usize,
+        ) -> rb_types::Result<Vec<MemoryId>> {
+            // Deterministic order (created_at desc) so keyword_rank is reproducible.
+            let mut notes: Vec<MemoryNote> =
+                self.notes.lock().unwrap().values().cloned().collect();
+            notes.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            Ok(notes.into_iter().map(|n| n.id).collect())
+        }
+        async fn vector(
+            &self,
+            _ns: Namespace,
+            _embedding: Vec<f32>,
+            _limit: usize,
+        ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+            let mut pairs: Vec<(MemoryId, MemoryNote)> = self
+                .embeddings
+                .lock()
+                .unwrap()
+                .keys()
+                .filter_map(|id| {
+                    self.notes
+                        .lock()
+                        .unwrap()
+                        .get(id)
+                        .cloned()
+                        .map(|n| (id.clone(), n))
+                })
+                .collect();
+            pairs.sort_by(|a, b| b.1.created_at.cmp(&a.1.created_at));
+            Ok(pairs.into_iter().map(|(id, _)| (id, 0.0)).collect())
+        }
+        async fn graph(
+            &self,
+            _id: MemoryId,
+            _depth: u8,
+        ) -> rb_types::Result<Vec<MemoryId>> {
+            Ok(Vec::new())
+        }
+        async fn list(
+            &self,
+            _ns: Namespace,
+            min_importance: Option<u8>,
+            limit: usize,
+        ) -> rb_types::Result<Vec<MemoryNote>> {
+            let mut v: Vec<MemoryNote> = self
+                .notes
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+                .cloned()
+                .collect();
+            v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            v.truncate(limit);
+            Ok(v)
+        }
+        async fn update(
+            &self,
+            id: MemoryId,
+            updates: MemoryUpdates,
+        ) -> rb_types::Result<()> {
+            let mut guard = self.notes.lock().unwrap();
+            let note = guard
+                .get_mut(&id)
+                .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+            if let Some(c) = updates.content {
+                note.content = c;
+            }
+            if let Some(s) = updates.summary {
+                note.summary = s;
+            }
+            Ok(())
+        }
+        async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+            let mut guard = self.notes.lock().unwrap();
+            let note = guard
+                .get_mut(&id)
+                .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+            note.archived_at = Some(chrono::Utc::now());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_backend_round_trips_write_and_get() {
+        let backend = MockBackend::default();
+        let note = MemoryNote::new(
+            Namespace::Global,
+            "hello world".to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        let id = note.id.clone();
+        backend
+            .write(note.clone(), Some(vec![0.1, 0.2, 0.3]))
+            .await
+            .unwrap();
+        let got = backend.get(id).await.unwrap().unwrap();
+        assert_eq!(got.content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn mock_backend_archive_sets_archived_at() {
+        let backend = MockBackend::default();
+        let note =
+            MemoryNote::new(Namespace::Global, "x".to_string(), MemoryType::Reference, 3);
+        let id = note.id.clone();
+        backend.write(note, None).await.unwrap();
+        backend.archive(id.clone()).await.unwrap();
+        assert!(backend.get(id).await.unwrap().unwrap().archived_at.is_some());
+    }
+}
+```
+
+  Set `crates/rb-engine/src/lib.rs` to declare the module (the `pub use` re-export is added in Step 4, once the trait exists):
+
+```rust
+//! `rb_engine`: single-request memory orchestration (policy only).
+//!
+//! Generic over a `MemoryBackend` (store access) and an
+//! `rb_embed::EmbeddingProvider`. P1 enrichment is heuristic only; LLM
+//! enrichment and semantic link generation are deferred to P2.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod backend;
+```
+
+- [ ] **Step 3: Run it — expect FAIL.** Run: `cargo test -p rb-engine backend` Expected: FAIL to compile (`cannot find trait 'MemoryBackend' in this scope`), confirming the mock `impl MemoryBackend for MockBackend` drives a real trait into existence rather than being silently skipped.
+
+- [ ] **Step 4: Add the trait above the test module.** Prepend to `crates/rb-engine/src/backend.rs`. NOTE: the parent-module `use` imports ONLY the types referenced by the trait signatures (`MemoryId`, `MemoryNote`, `MemoryUpdates`, `Namespace`). `MemoryType` is NOT used by the trait — it is imported separately inside the test module — so importing it here would be an `unused_imports` warning that fails `clippy -D warnings` in the lib (non-test) build:
+
+```rust
+use rb_types::{MemoryId, MemoryNote, MemoryUpdates, Namespace};
+
+/// Async store-access abstraction the engine is generic over. The daemon
+/// implements this on top of the synchronous `rb_store::Store` using a
+/// dedicated writer thread plus `spawn_blocking` readers; tests implement it
+/// over an in-memory map. The engine never touches a concrete store.
+#[async_trait::async_trait]
+pub trait MemoryBackend: Send + Sync {
+    async fn write(
+        &self,
+        note: MemoryNote,
+        embedding: Option<Vec<f32>>,
+    ) -> rb_types::Result<()>;
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>>;
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        query: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>>;
+    async fn vector(
+        &self,
+        ns: Namespace,
+        embedding: Vec<f32>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>>;
+    async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryId>>;
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>>;
+    async fn update(
+        &self,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()>;
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()>;
+}
+```
+
+  (verify against installed `async-trait` at execution; the `#[async_trait::async_trait]` attribute form is stable across 0.1.x but adjust if the macro path differs.)
+
+- [ ] **Step 5: Re-export the trait from `lib.rs`.** Set `crates/rb-engine/src/lib.rs` to:
+
+```rust
+//! `rb_engine`: single-request memory orchestration (policy only).
+//!
+//! Generic over a `MemoryBackend` (store access) and an
+//! `rb_embed::EmbeddingProvider`. P1 enrichment is heuristic only; LLM
+//! enrichment and semantic link generation are deferred to P2.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod backend;
+
+pub use backend::MemoryBackend;
+```
+
+- [ ] **Step 6: Run it — expect PASS.** Run: `cargo test -p rb-engine backend` Expected: PASS (2 tests pass).
+
+- [ ] **Step 7: Lint + format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 8: Commit.** Run: `git add crates/rb-engine/Cargo.toml crates/rb-engine/src/backend.rs crates/rb-engine/src/lib.rs && git commit -m "feat(rb-engine): add async MemoryBackend trait with in-memory mock test"`
+
+---
+
+### Task 17: rb-engine `enrich.rs` — heuristic summary + keyword derivation (pure, no IO)
+
+**Files:**
+- Create: `crates/rb-engine/src/enrich.rs`
+- Modify: `crates/rb-engine/src/lib.rs` (add `mod enrich;`)
+
+> P1 enrichment is HEURISTIC ONLY — no LLM. Two pure helpers: a summary default (first ~150 chars) and a simple keyword extractor (up to 5 tokens). Keeping them pure and separately tested lets `remember` stay tiny and lets the determinism be asserted without a backend or provider.
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Declare `mod enrich;` in `lib.rs` now and create `enrich.rs` with the test only; the build fails because the functions do not exist.
+
+  Create `crates/rb-engine/src/enrich.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn summary_of_short_content_is_unchanged_trimmed() {
+        assert_eq!(default_summary("  short body  "), "short body");
+    }
+
+    #[test]
+    fn summary_truncates_to_150_chars_on_char_boundary() {
+        let content = "x".repeat(400);
+        let s = default_summary(&content);
+        assert_eq!(s.chars().count(), 150);
+    }
+
+    #[test]
+    fn summary_truncation_never_splits_a_multibyte_char() {
+        // 200 'é' (2 bytes each in UTF-8); truncation must stay on a char boundary.
+        let content = "é".repeat(200);
+        let s = default_summary(&content);
+        assert_eq!(s.chars().count(), 150);
+        // Round-trips as valid UTF-8 (would panic on a bad boundary while building).
+        assert!(s.chars().all(|c| c == 'é'));
+    }
+
+    #[test]
+    fn keywords_lowercase_dedupe_and_cap_at_five() {
+        let kw = derive_keywords(
+            "SQLite WAL mode enables concurrent SQLITE readers and writers safely",
+        );
+        // length >= 4 (by char count), lowercased, order-preserving, deduped, max 5.
+        assert_eq!(kw, vec!["sqlite", "mode", "enables", "concurrent", "readers"]);
+    }
+
+    #[test]
+    fn keywords_skips_short_tokens_and_punctuation() {
+        let kw = derive_keywords("a an the to of, big-decision: keep!");
+        assert_eq!(kw, vec!["decision", "keep"]);
+    }
+
+    #[test]
+    fn keywords_empty_content_yields_empty() {
+        assert!(derive_keywords("   ").is_empty());
+    }
+
+    #[test]
+    fn keywords_length_guard_uses_char_count_not_bytes() {
+        // "café" is 5 bytes but 4 chars; "über" is 5 bytes but 4 chars.
+        // Both must be kept (>= 4 chars), proving the guard counts chars, not bytes.
+        let kw = derive_keywords("café über");
+        assert_eq!(kw, vec!["café", "über"]);
+    }
+}
+```
+
+  Add `mod enrich;` after `mod backend;` in `crates/rb-engine/src/lib.rs`.
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rb-engine enrich` Expected: FAIL to compile (`cannot find function 'default_summary'` / `derive_keywords`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `crates/rb-engine/src/enrich.rs`. The keyword length guard uses `chars().count()` (NOT byte length) so multibyte tokens are handled correctly:
+
+```rust
+/// Maximum characters retained in a heuristic summary.
+const SUMMARY_MAX_CHARS: usize = 150;
+/// Maximum number of derived keywords.
+const MAX_KEYWORDS: usize = 5;
+/// Minimum token length (in characters) kept as a keyword (drops stop-word-ish short tokens).
+const MIN_KEYWORD_LEN: usize = 4;
+
+/// Heuristic summary: trim, then keep the first `SUMMARY_MAX_CHARS` characters
+/// on a char boundary (never splitting a multi-byte UTF-8 sequence).
+pub(crate) fn default_summary(content: &str) -> String {
+    let trimmed = content.trim();
+    trimmed.chars().take(SUMMARY_MAX_CHARS).collect()
+}
+
+/// Heuristic keyword extraction: split on non-alphanumeric, lowercase, keep
+/// tokens of length >= `MIN_KEYWORD_LEN` characters, dedupe preserving
+/// first-seen order, and cap at `MAX_KEYWORDS`. Pure and deterministic.
+pub(crate) fn derive_keywords(content: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in content.split(|c: char| !c.is_alphanumeric()) {
+        if raw.chars().count() < MIN_KEYWORD_LEN {
+            continue;
+        }
+        let token = raw.to_lowercase();
+        if !out.iter().any(|existing| existing == &token) {
+            out.push(token);
+        }
+        if out.len() == MAX_KEYWORDS {
+            break;
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-engine enrich` Expected: PASS (7 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git add crates/rb-engine/src/enrich.rs crates/rb-engine/src/lib.rs && git commit -m "feat(rb-engine): add heuristic summary and keyword enrichment helpers"`
+
+---
+
+### Task 18: rb-engine `engine.rs` — `RememberInput` + `MemoryEngine::new` + `remember`
+
+**Files:**
+- Create: `crates/rb-engine/src/engine.rs`
+- Modify: `crates/rb-engine/src/lib.rs` (add `mod engine;` + re-exports)
+- Create: `crates/rb-engine/src/test_support.rs` (shared in-test mock backend, behind `#[cfg(test)]`)
+- Modify: `crates/rb-engine/src/lib.rs` (add `#[cfg(test)] mod test_support;`)
+
+> This task introduces the `MemoryEngine<B, P>` struct and the `remember` path. To avoid duplicating the mock across tasks, the in-test `MockBackend` (which also records what was written so `remember` can be asserted) lives in a shared `#[cfg(test)] mod test_support;`. The engine is tested with the offline `DeterministicProvider` so `remember` embeds without any network. The mock's `keyword`/`vector` return ids in a deterministic order (created_at desc) so recall ranking (Task 19) is reproducible across runs.
+
+- [ ] **Step 1: Write the shared test-support mock (test-only, no production code).** Create `crates/rb-engine/src/test_support.rs`. It is compiled only under `cfg(test)`, so it may use `unwrap` freely; the module-level allow keeps clippy quiet:
+
+```rust
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use crate::backend::MemoryBackend;
+use rb_types::{MemoryId, MemoryNote, MemoryUpdates, Namespace};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// In-memory `MemoryBackend` for engine unit tests. Records writes (note +
+/// embedding) so tests can assert what `remember` produced. Reads return the
+/// stored notes. Keyword/vector return ALL stored ids in a DETERMINISTIC order
+/// (created_at desc) so the ranker, not HashMap iteration order, decides
+/// result ordering; `graph` returns nothing (graph paths tested separately).
+#[derive(Default)]
+pub(crate) struct MockBackend {
+    pub notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+    pub embeddings: Mutex<HashMap<MemoryId, Vec<f32>>>,
+}
+
+impl MockBackend {
+    pub fn count(&self) -> usize {
+        self.notes.lock().unwrap().len()
+    }
+    pub fn embedding_of(&self, id: &MemoryId) -> Option<Vec<f32>> {
+        self.embeddings.lock().unwrap().get(id).cloned()
+    }
+    pub fn note_of(&self, id: &MemoryId) -> Option<MemoryNote> {
+        self.notes.lock().unwrap().get(id).cloned()
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryBackend for MockBackend {
+    async fn write(
+        &self,
+        note: MemoryNote,
+        embedding: Option<Vec<f32>>,
+    ) -> rb_types::Result<()> {
+        if let Some(emb) = embedding {
+            self.embeddings.lock().unwrap().insert(note.id.clone(), emb);
+        }
+        self.notes.lock().unwrap().insert(note.id.clone(), note);
+        Ok(())
+    }
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    }
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        _query: String,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(v.into_iter().map(|n| n.id).collect())
+    }
+    async fn vector(
+        &self,
+        ns: Namespace,
+        _embedding: Vec<f32>,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(v.into_iter().map(|n| (n.id, 0.0)).collect())
+    }
+    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+        Ok(Vec::new())
+    }
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+            .cloned()
+            .collect();
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+    async fn update(
+        &self,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        if let Some(c) = updates.content {
+            note.content = c;
+        }
+        if let Some(s) = updates.summary {
+            note.summary = s;
+        }
+        if let Some(i) = updates.importance {
+            note.importance = i;
+        }
+        if let Some(t) = updates.tags {
+            note.tags = t;
+        }
+        if let Some(ctx) = updates.context {
+            note.context = ctx;
+        }
+        Ok(())
+    }
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.archived_at = Some(chrono::Utc::now());
+        Ok(())
+    }
+}
+```
+
+  Add `#[cfg(test)] mod test_support;` after `mod enrich;` in `crates/rb-engine/src/lib.rs`.
+
+- [ ] **Step 2: Write the failing test AND declare the engine module.** Declare `mod engine;` in `lib.rs` and create `engine.rs` with the `remember` test only. It uses the offline `DeterministicProvider` (never hits the network) and the shared `MockBackend`. The build fails because `MemoryEngine`/`RememberInput` do not exist.
+
+  Create `crates/rb-engine/src/engine.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::test_support::MockBackend;
+    use rb_embed::DeterministicProvider;
+    use rb_types::{MemoryType, Namespace};
+
+    fn engine() -> MemoryEngine<MockBackend, DeterministicProvider> {
+        MemoryEngine::new(
+            MockBackend::default(),
+            DeterministicProvider::new(16),
+            Namespace::Project("rb".into()),
+        )
+    }
+
+    fn input(content: &str, importance: u8) -> RememberInput {
+        RememberInput {
+            content: content.to_string(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance,
+            keywords: Vec::new(),
+            tags: Vec::new(),
+            related_files: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn remember_stores_note_and_embedding() {
+        let eng = engine();
+        let id = eng.remember(input("single writer over sqlite wal", 7)).await.unwrap();
+        // exactly one note written, with an embedding of provider dim.
+        assert_eq!(eng.backend().count(), 1);
+        let emb = eng.backend().embedding_of(&id).unwrap();
+        assert_eq!(emb.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn remember_applies_heuristic_summary_and_keywords() {
+        let eng = engine();
+        let content = "concurrent readers never block the single dedicated writer thread";
+        let id = eng.remember(input(content, 6)).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        // summary defaults to the (trimmed) content since it's < 150 chars.
+        assert_eq!(note.summary, content);
+        // keywords derived (empty input) — non-empty, lowercased, capped at 5.
+        assert!(!note.keywords.is_empty());
+        assert!(note.keywords.len() <= 5);
+        assert!(note.keywords.iter().all(|k| k == &k.to_lowercase()));
+    }
+
+    #[tokio::test]
+    async fn remember_preserves_explicit_keywords_and_namespace() {
+        let eng = engine();
+        let mut inp = input("body text here", 5);
+        inp.keywords = vec!["explicit".to_string()];
+        inp.tags = vec!["t1".to_string()];
+        inp.context = Some("ctx".to_string());
+        let id = eng.remember(inp).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(note.keywords, vec!["explicit".to_string()]);
+        assert_eq!(note.tags, vec!["t1".to_string()]);
+        assert_eq!(note.context, "ctx");
+        // engine enforces its own namespace.
+        assert_eq!(note.namespace, Namespace::Project("rb".into()));
+    }
+
+    #[tokio::test]
+    async fn remember_sets_embedding_model_from_provider() {
+        let eng = engine();
+        let id = eng.remember(input("model id check", 5)).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(note.embedding_model, eng.embedder().model_id());
+    }
+
+    #[tokio::test]
+    async fn remember_is_deterministic_same_content_same_embedding() {
+        let eng = engine();
+        let id1 = eng.remember(input("identical content", 5)).await.unwrap();
+        let id2 = eng.remember(input("identical content", 5)).await.unwrap();
+        assert_ne!(id1, id2); // distinct notes
+        assert_eq!(
+            eng.backend().embedding_of(&id1),
+            eng.backend().embedding_of(&id2)
+        ); // deterministic provider => same vector
+    }
+}
+```
+
+  Add `mod engine;` after `#[cfg(test)] mod test_support;` in `crates/rb-engine/src/lib.rs`.
+
+- [ ] **Step 3: Run it — expect FAIL.** Run: `cargo test -p rb-engine engine::tests::remember` Expected: FAIL to compile (`cannot find type 'MemoryEngine'` / `RememberInput` / no method `backend`/`embedder`).
+
+- [ ] **Step 4: Add `RememberInput`, the struct, `new`, the test accessors, and `remember` above the test module.** Prepend to `crates/rb-engine/src/engine.rs`:
+
+```rust
+use crate::backend::MemoryBackend;
+use crate::enrich::{default_summary, derive_keywords};
+use rb_embed::EmbeddingProvider;
+use rb_search::Weights;
+use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
+
+/// Input to `remember`. Mirrors the proto `Request::Remember` payload.
+pub struct RememberInput {
+    pub content: String,
+    pub context: Option<String>,
+    pub memory_type: MemoryType,
+    pub importance: u8,
+    pub keywords: Vec<String>,
+    pub tags: Vec<String>,
+    pub related_files: Vec<String>,
+}
+
+/// Policy layer: orchestrates heuristic enrichment + embedding + ranking over a
+/// `MemoryBackend`. Generic so it is unit-tested without a DB or network.
+pub struct MemoryEngine<B: MemoryBackend, P: EmbeddingProvider> {
+    backend: B,
+    embedder: P,
+    weights: Weights,
+    namespace: Namespace,
+}
+
+impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
+    /// Construct an engine bound to a single namespace (set server-side from the
+    /// client handshake; clients cannot widen it).
+    pub fn new(backend: B, embedder: P, namespace: Namespace) -> Self {
+        Self {
+            backend,
+            embedder,
+            weights: Weights::default(),
+            namespace,
+        }
+    }
+
+    /// Borrow the backend (used by daemon/tests for introspection).
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Borrow the embedding provider.
+    pub fn embedder(&self) -> &P {
+        &self.embedder
+    }
+
+    /// Store a new memory: heuristic-enrich, embed the content, then write.
+    pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
+        let mut note = MemoryNote::new(
+            self.namespace.clone(),
+            input.content,
+            input.memory_type,
+            input.importance,
+        );
+        // Heuristic enrichment (no LLM in P1).
+        note.summary = default_summary(&note.content);
+        note.keywords = if input.keywords.is_empty() {
+            derive_keywords(&note.content)
+        } else {
+            input.keywords
+        };
+        note.tags = input.tags;
+        note.related_files = input.related_files;
+        if let Some(ctx) = input.context {
+            note.context = ctx;
+        }
+        note.embedding_model = self.embedder.model_id().to_string();
+
+        // Embed the content (single text in, single vector out).
+        let mut embeddings = self.embedder.embed(&[note.content.clone()]).await?;
+        let embedding = embeddings.pop();
+
+        let id = note.id.clone();
+        self.backend.write(note, embedding).await?;
+        Ok(id)
+    }
+}
+```
+
+  The `weights` field is read by `recall` (Task 19, same crate, committed before any release), but at THIS task's clippy gate `weights` is only written by `new()` and would trip `dead_code` ("field is never read"). Add a tiny accessor inside the `impl` block, right after `embedder`, so the field is read now:
+
+```rust
+    /// Borrow the ranking weights (used by `recall`).
+    pub fn weights(&self) -> Weights {
+        self.weights
+    }
+```
+
+  (verify against installed `async-trait`/`rb_embed` at execution; `self.embedder.embed(&[...])` must take a `&[String]` per the spine — `note.content.clone()` builds that single-element slice's owned String.)
+
+- [ ] **Step 5: Re-export from `lib.rs`.** Set the re-export block in `crates/rb-engine/src/lib.rs` so the crate root exposes the engine and input:
+
+```rust
+pub use backend::MemoryBackend;
+pub use engine::{MemoryEngine, RememberInput};
+```
+
+- [ ] **Step 6: Run it — expect PASS.** Run: `cargo test -p rb-engine engine::tests::remember` Expected: PASS (5 remember tests pass).
+
+- [ ] **Step 7: Lint + format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 8: Commit.** Run: `git add crates/rb-engine/src/engine.rs crates/rb-engine/src/test_support.rs crates/rb-engine/src/lib.rs && git commit -m "feat(rb-engine): add MemoryEngine, RememberInput, and remember path"`
+
+---
+
+### Task 19: rb-engine `recall` — embed query, hybrid candidates, rank, fetch, filter
+
+**Files:**
+- Modify: `crates/rb-engine/src/engine.rs` (add `recall` + candidate/meta helpers + tests)
+
+> `recall` embeds the query, gathers candidates from `backend.keyword` + `backend.vector` (+ a bounded 1-hop graph expansion of the top keyword hit), assembles a `meta` map and a note cache from the fetched notes, calls `rb_search::build_signals` + `rb_search::rank`, then returns `SearchResult { memory, score }` for the ranked ids — applying the type/tag filters. Fetching each candidate once (and caching it) means `rank` and the final result share the same notes with no second round-trip.
+
+> RANKING NOTE: `rb_search::build_signals` assigns `keyword_rank` by POSITION in the keyword vec, so two distinct candidates can never share the same keyword rank. With Default `Weights`, the keyword-rank delta between rank 0 and rank 1 (0.30·0.5 = 0.15 weighted) is strictly larger than the maximum importance delta (0.10·(9/10) ≈ 0.09 weighted). Therefore importance alone CANNOT override a one-position keyword-rank difference, and recall ordering between near-identical candidates is decided by keyword/vector position, NOT importance. Tests must not assert "higher importance ranks first" through `recall`; importance-driven ordering is verified via `list` (Task 20), which is deterministically ordered by recency.
+
+- [ ] **Step 1: Write the failing test.** Append a `recall` test module section to `crates/rb-engine/src/engine.rs`'s existing `#[cfg(test)] mod tests` block by adding these tests INSIDE it (place them after the `remember` tests, before the closing brace):
+
+```rust
+    async fn seed(eng: &MemoryEngine<MockBackend, DeterministicProvider>, content: &str, ty: MemoryType, imp: u8, tags: &[&str]) -> rb_types::MemoryId {
+        let mut inp = input(content, imp);
+        inp.memory_type = ty;
+        inp.tags = tags.iter().map(|t| t.to_string()).collect();
+        eng.remember(inp).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn recall_returns_results_for_seeded_memories() {
+        let eng = engine();
+        seed(&eng, "alpha topic about sqlite", MemoryType::Insight, 5, &[]).await;
+        seed(&eng, "beta topic about tokio", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("topic", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        // scores are finite and sorted descending.
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn recall_respects_limit() {
+        let eng = engine();
+        for i in 0..5 {
+            seed(&eng, &format!("doc number {i}"), MemoryType::Insight, 5, &[]).await;
+        }
+        let results = eng.recall("doc", 2, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn recall_type_filter_excludes_other_types() {
+        let eng = engine();
+        seed(&eng, "a bug fix note", MemoryType::BugFix, 5, &[]).await;
+        seed(&eng, "an insight note", MemoryType::Insight, 5, &[]).await;
+        let results = eng
+            .recall("note", 10, Some(MemoryType::BugFix), &[])
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].memory.memory_type, MemoryType::BugFix);
+    }
+
+    #[tokio::test]
+    async fn recall_tag_filter_requires_all_tags() {
+        let eng = engine();
+        seed(&eng, "tagged one", MemoryType::Insight, 5, &["x", "y"]).await;
+        seed(&eng, "tagged two", MemoryType::Insight, 5, &["x"]).await;
+        let results = eng
+            .recall("tagged", 10, None, &["x".to_string(), "y".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].memory.tags.contains(&"y".to_string()));
+    }
+
+    #[tokio::test]
+    async fn recall_ranks_all_candidates_with_finite_descending_scores() {
+        // NOTE: importance does NOT decide ordering between near-identical
+        // candidates (keyword-rank position dominates, see RANKING NOTE), so we
+        // assert the honest invariants: every candidate is returned, scores are
+        // finite, and the result is sorted descending. Importance-driven order
+        // is covered by the deterministic `list` test in Task 20.
+        let eng = engine();
+        let _low = seed(&eng, "ranking probe content", MemoryType::Insight, 2, &[]).await;
+        let _high = seed(&eng, "ranking probe content", MemoryType::Insight, 9, &[]).await;
+        let results = eng.recall("ranking probe", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn recall_empty_store_returns_empty() {
+        let eng = engine();
+        let results = eng.recall("anything", 10, None, &[]).await.unwrap();
+        assert!(results.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rb-engine engine::tests::recall` Expected: FAIL to compile (`no method named 'recall' found`).
+
+- [ ] **Step 3: Add `recall` and its private helpers to the `impl` block.** Insert these methods into the existing `impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P>` block in `crates/rb-engine/src/engine.rs`, after `remember`:
+
+```rust
+    /// Hybrid recall: embed the query, gather keyword + vector (+ 1-hop graph)
+    /// candidates scoped to the engine namespace, rank with `rb_search`, then
+    /// return ranked `SearchResult`s after applying type/tag filters.
+    pub async fn recall(
+        &self,
+        query: &str,
+        limit: usize,
+        type_filter: Option<MemoryType>,
+        tags: &[String],
+    ) -> rb_types::Result<Vec<rb_types::SearchResult>> {
+        use std::collections::HashMap;
+
+        // Over-fetch candidates so post-filtering still has enough to fill `limit`.
+        let candidate_limit = limit.saturating_mul(4).max(limit);
+
+        let mut query_emb = self.embedder.embed(&[query.to_string()]).await?;
+        let embedding = query_emb.pop().unwrap_or_default();
+
+        let keyword = self
+            .backend
+            .keyword(self.namespace.clone(), query.to_string(), candidate_limit)
+            .await?;
+        let vector = self
+            .backend
+            .vector(self.namespace.clone(), embedding, candidate_limit)
+            .await?;
+
+        // Bounded 1-hop graph expansion of the top keyword hit only.
+        let graph = match keyword.first() {
+            Some(top) => self.backend.graph(top.clone(), 1).await?,
+            None => Vec::new(),
+        };
+
+        // Collect the unique candidate id set across all three sources.
+        let mut order: Vec<MemoryId> = Vec::new();
+        let mut seen: std::collections::HashSet<MemoryId> = std::collections::HashSet::new();
+        for id in keyword
+            .iter()
+            .chain(vector.iter().map(|(id, _)| id))
+            .chain(graph.iter())
+        {
+            if seen.insert(id.clone()) {
+                order.push(id.clone());
+            }
+        }
+
+        // Fetch each candidate once; build the note cache + the rank meta map.
+        let mut notes: HashMap<MemoryId, MemoryNote> = HashMap::new();
+        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        for id in &order {
+            if let Some(note) = self.backend.get(id.clone()).await? {
+                meta.insert(id.clone(), (note.importance, note.created_at));
+                notes.insert(id.clone(), note);
+            }
+        }
+
+        let signals = rb_search::build_signals(&keyword, &vector, &graph, &meta);
+        let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
+
+        // Assemble results in ranked order, applying filters, truncating to limit.
+        let mut results: Vec<rb_types::SearchResult> = Vec::new();
+        for (id, score) in ranked {
+            let Some(note) = notes.get(&id) else { continue };
+            if let Some(ty) = type_filter {
+                if note.memory_type != ty {
+                    continue;
+                }
+            }
+            if !tags.iter().all(|t| note.tags.contains(t)) {
+                continue;
+            }
+            results.push(rb_types::SearchResult {
+                memory: note.clone(),
+                score,
+            });
+            if results.len() == limit {
+                break;
+            }
+        }
+        Ok(results)
+    }
+```
+
+  (verify against installed `rb_search` at execution: `build_signals(&keyword, &vector, &graph, &meta)` and `rank(signals, weights, now, limit)` signatures are taken from the P1 spine; adjust borrow/move shapes only if the implemented signatures differ.)
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-engine engine::tests::recall` Expected: PASS (6 recall tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git add crates/rb-engine/src/engine.rs && git commit -m "feat(rb-engine): add hybrid recall with embed, rank, and type/tag filters"`
+
+---
+
+### Task 20: rb-engine pass-throughs — `get`/`list`/`graph`/`update`/`delete` + `context`
+
+**Files:**
+- Modify: `crates/rb-engine/src/engine.rs` (add the remaining methods + tests)
+
+> The remaining operations are mostly thin pass-throughs to the backend, all scoped to the engine namespace. `delete` maps to soft archive (spec §12). `context` returns two lists: `recent` (list by recency, no importance floor) and `important` (importance >= 8). `graph` expands then fetches the connected notes. `list` is deterministically ordered by recency, so this is where importance-floor + ordering behavior is asserted (recall ordering is dominated by keyword/vector position — see Task 19 RANKING NOTE).
+
+- [ ] **Step 1: Write the failing test.** Add these tests INSIDE the existing `#[cfg(test)] mod tests` block in `crates/rb-engine/src/engine.rs` (after the recall tests, before the closing brace):
+
+```rust
+    #[tokio::test]
+    async fn get_returns_stored_note_or_none() {
+        let eng = engine();
+        let id = eng.remember(input("findable", 5)).await.unwrap();
+        assert!(eng.get(id.clone()).await.unwrap().is_some());
+        assert!(eng
+            .get(rb_types::MemoryId::new())
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn list_orders_by_recency_and_honors_min_importance() {
+        let eng = engine();
+        seed(&eng, "first", MemoryType::Insight, 3, &[]).await;
+        seed(&eng, "second", MemoryType::Insight, 9, &[]).await;
+        let all = eng.list(None, 10).await.unwrap();
+        assert_eq!(all.len(), 2);
+        // most recent first (second was inserted last).
+        assert_eq!(all[0].content, "second");
+        let important = eng.list(Some(8), 10).await.unwrap();
+        assert_eq!(important.len(), 1);
+        assert_eq!(important[0].importance, 9);
+    }
+
+    #[tokio::test]
+    async fn update_mutates_then_get_reflects_change() {
+        let eng = engine();
+        let id = eng.remember(input("old body", 5)).await.unwrap();
+        let updates = rb_types::MemoryUpdates {
+            content: Some("new body".to_string()),
+            importance: Some(9),
+            ..Default::default()
+        };
+        eng.update(id.clone(), updates).await.unwrap();
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert_eq!(note.content, "new body");
+        assert_eq!(note.importance, 9);
+    }
+
+    #[tokio::test]
+    async fn delete_soft_archives_the_note() {
+        let eng = engine();
+        let id = eng.remember(input("doomed", 5)).await.unwrap();
+        eng.delete(id.clone()).await.unwrap();
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert!(note.archived_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn graph_returns_connected_notes() {
+        // MockBackend.graph returns empty, so graph() yields no neighbors here;
+        // this asserts the pass-through shape and empty handling without a DB.
+        let eng = engine();
+        let id = eng.remember(input("anchor", 5)).await.unwrap();
+        let neighbors = eng.graph(id, 2).await.unwrap();
+        assert!(neighbors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn context_splits_recent_and_important() {
+        let eng = engine();
+        seed(&eng, "low importance recent", MemoryType::Insight, 2, &[]).await;
+        seed(&eng, "high importance note", MemoryType::Insight, 9, &[]).await;
+        let (recent, important, total) = eng.context().await.unwrap();
+        // recent includes both; important only the >= 8 one.
+        assert_eq!(recent.len(), 2);
+        assert_eq!(important.len(), 1);
+        assert_eq!(important[0].importance, 9);
+        assert_eq!(total, 2);
+    }
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rb-engine engine::tests` Expected: FAIL to compile (`no method named 'get'`/`'list'`/`'update'`/`'delete'`/`'graph'`/`'context'` found).
+
+- [ ] **Step 3: Add the pass-through methods to the `impl` block.** Insert these into the existing `impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P>` block in `crates/rb-engine/src/engine.rs`, after `recall`:
+
+```rust
+    /// Fetch a single memory by id (namespace scoping is enforced by the backend).
+    pub async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        self.backend.get(id).await
+    }
+
+    /// List memories in the engine namespace, most-recent first, optionally
+    /// filtered by a minimum importance.
+    pub async fn list(
+        &self,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        self.backend
+            .list(self.namespace.clone(), min_importance, limit)
+            .await
+    }
+
+    /// Expand the graph around `id` to `depth` hops and fetch the connected notes.
+    pub async fn graph(&self, id: MemoryId, depth: u8) -> rb_types::Result<Vec<MemoryNote>> {
+        let ids = self.backend.graph(id, depth).await?;
+        let mut notes = Vec::with_capacity(ids.len());
+        for nid in ids {
+            if let Some(note) = self.backend.get(nid).await? {
+                notes.push(note);
+            }
+        }
+        Ok(notes)
+    }
+
+    /// Apply a partial update to an existing memory.
+    pub async fn update(
+        &self,
+        id: MemoryId,
+        updates: rb_types::MemoryUpdates,
+    ) -> rb_types::Result<()> {
+        self.backend.update(id, updates).await
+    }
+
+    /// Soft-delete (archive) a memory. Spec §12: delete == soft archive.
+    pub async fn delete(&self, id: MemoryId) -> rb_types::Result<()> {
+        self.backend.archive(id).await
+    }
+
+    /// Project context payload: recent memories (by recency) plus important ones
+    /// (importance >= 8), with a total count of the recent window.
+    pub async fn context(
+        &self,
+    ) -> rb_types::Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)> {
+        const CONTEXT_LIMIT: usize = 50;
+        const IMPORTANT_FLOOR: u8 = 8;
+        let recent = self
+            .backend
+            .list(self.namespace.clone(), None, CONTEXT_LIMIT)
+            .await?;
+        let important = self
+            .backend
+            .list(self.namespace.clone(), Some(IMPORTANT_FLOOR), CONTEXT_LIMIT)
+            .await?;
+        let total = recent.len();
+        Ok((recent, important, total))
+    }
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-engine engine::tests` Expected: PASS (all engine tests — remember, recall, and these pass-throughs — pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git add crates/rb-engine/src/engine.rs && git commit -m "feat(rb-engine): add get/list/graph/update/delete pass-throughs and context"`
+
+---
+
+### Task 21: rb-engine `lib.rs` — finalize re-exports + public-API guard test + crate gate
+
+**Files:**
+- Modify: `crates/rb-engine/src/lib.rs` (finalize module list + flat re-exports)
+- Create: `crates/rb-engine/tests/public_api.rs` (integration test guarding the public surface end-to-end)
+
+> A `tests/` integration target compiles `rb-engine` as a downstream consumer would, so it proves the public re-exports are sufficient to drive a full remember→recall→context flow using only the offline `DeterministicProvider` and a consumer-defined in-memory backend (no DB, no network). This is the crate-level gate.
+
+- [ ] **Step 1: Finalize `lib.rs`.** Set `crates/rb-engine/src/lib.rs` to its final form (modules + flat re-exports; `MemoryBackend`, `MemoryEngine`, `RememberInput` are the public surface):
+
+```rust
+//! `rb_engine`: single-request memory orchestration (policy only).
+//!
+//! Generic over a [`MemoryBackend`] (store access) and an
+//! [`rb_embed::EmbeddingProvider`]. P1 enrichment is heuristic only; LLM
+//! enrichment and semantic link generation are deferred to P2.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod backend;
+mod enrich;
+mod engine;
+#[cfg(test)]
+mod test_support;
+
+pub use backend::MemoryBackend;
+pub use engine::{MemoryEngine, RememberInput};
+```
+
+- [ ] **Step 2: Write the public-API integration guard.** Create `crates/rb-engine/tests/public_api.rs`. It defines its OWN tiny backend (proving the trait is fully usable from outside the crate), wires it with `DeterministicProvider`, and exercises remember + recall + context through the public API. (`async-trait`, `chrono`, `rb-types`, and `rb-embed` are normal `[dependencies]` of rb-engine and are therefore visible as extern crates to integration targets; `tokio` is the dev-dependency added in Task 16. No Cargo.toml change is needed.)
+
+```rust
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_embed::DeterministicProvider;
+use rb_engine::{MemoryBackend, MemoryEngine, RememberInput};
+use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct VecBackend {
+    notes: Mutex<HashMap<MemoryId, MemoryNote>>,
+}
+
+#[async_trait::async_trait]
+impl MemoryBackend for VecBackend {
+    async fn write(
+        &self,
+        note: MemoryNote,
+        _embedding: Option<Vec<f32>>,
+    ) -> rb_types::Result<()> {
+        self.notes.lock().unwrap().insert(note.id.clone(), note);
+        Ok(())
+    }
+    async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        Ok(self.notes.lock().unwrap().get(&id).cloned())
+    }
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        _query: String,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .cloned()
+            .collect();
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(v.into_iter().map(|n| n.id).collect())
+    }
+    async fn vector(
+        &self,
+        _ns: Namespace,
+        _embedding: Vec<f32>,
+        _limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        Ok(Vec::new())
+    }
+    async fn graph(&self, _id: MemoryId, _depth: u8) -> rb_types::Result<Vec<MemoryId>> {
+        Ok(Vec::new())
+    }
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.namespace == ns)
+            .filter(|n| min_importance.map(|m| n.importance >= m).unwrap_or(true))
+            .cloned()
+            .collect();
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+    async fn update(
+        &self,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        if let Some(c) = updates.content {
+            note.content = c;
+        }
+        Ok(())
+    }
+    async fn archive(&self, id: MemoryId) -> rb_types::Result<()> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.archived_at = Some(chrono::Utc::now());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn full_flow_through_public_api() {
+    let engine = MemoryEngine::new(
+        VecBackend::default(),
+        DeterministicProvider::new(8),
+        Namespace::Project("rb".into()),
+    );
+
+    let id = engine
+        .remember(RememberInput {
+            content: "single writer over sqlite wal with concurrent readers".to_string(),
+            context: Some("architecture".to_string()),
+            memory_type: MemoryType::ArchitectureDecision,
+            importance: 9,
+            keywords: Vec::new(),
+            tags: vec!["concurrency".to_string()],
+            related_files: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    // get reflects the stored, enriched note.
+    let note = engine.get(id.clone()).await.unwrap().unwrap();
+    assert_eq!(note.memory_type, MemoryType::ArchitectureDecision);
+    assert!(!note.keywords.is_empty());
+    assert_eq!(note.context, "architecture");
+
+    // recall finds it.
+    let results = engine.recall("writer", 10, None, &[]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].memory.id, id);
+
+    // context surfaces it as both recent and important (importance 9 >= 8).
+    let (recent, important, total) = engine.context().await.unwrap();
+    assert_eq!(total, 1);
+    assert_eq!(recent.len(), 1);
+    assert_eq!(important.len(), 1);
+}
+```
+
+- [ ] **Step 3: Run the full crate test suite — expect PASS.** Run: `cargo test -p rb-engine` Expected: PASS — all unit tests (backend, enrich, engine) AND the `public_api` integration test pass. (If the integration target fails to resolve `async_trait`, add `async-trait = { workspace = true }` under `[dev-dependencies]` in `crates/rb-engine/Cargo.toml` and re-run — normally not required since it is a normal dependency. Verify against cargo at execution.)
+
+- [ ] **Step 4: Workspace gate — clippy with warnings denied.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` Expected: `Finished` with no warnings (exit 0). Proves the engine integrates cleanly with the rest of the workspace under the shared deny lints.
+
+- [ ] **Step 5: Workspace gate — format check.** Run: `cargo fmt --all --check` Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit.** Run: `git add crates/rb-engine/src/lib.rs crates/rb-engine/tests/public_api.rs && git commit -m "feat(rb-engine): finalize public API with end-to-end integration guard"`
+
+## Part J — rb-daemon (single-writer concurrent daemon)
+
+### Task 22: rb-daemon `change.rs` — `MemoryChanged` / `ChangeKind` broadcast event
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/change.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (add `mod change;` + re-export)
+
+These are the change-notification payloads the writer thread publishes on a `tokio::broadcast` channel after every successful commit (spec §8). They are pure data (serde round-trippable) so the deferred `subscribe` feature needs no new machinery. We build them first because every later task references `MemoryChanged`.
+
+- [ ] **Step 1: Write the failing test AND declare the module.** A `.rs` file not declared with `mod` is never compiled. Set `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` to declare the module (re-export added in Step 3):
+
+```rust
+//! `rb_daemon`: single-writer service over `rb_store`.
+//!
+//! One dedicated OS thread owns the write `SqliteStore` (rusqlite is `!Sync`,
+//! so the write connection never crosses threads); a bounded pool of read
+//! stores serves concurrent reads via `spawn_blocking`; a Unix-domain-socket
+//! listener frames `rb_proto` requests to a per-connection `MemoryEngine`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod change;
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/change.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryId, Namespace};
+
+    #[test]
+    fn change_kind_round_trips_all_variants() {
+        for kind in [ChangeKind::Created, ChangeKind::Updated, ChangeKind::Archived] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: ChangeKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn memory_changed_round_trips_and_clones() {
+        let evt = MemoryChanged {
+            id: MemoryId::new(),
+            namespace: Namespace::Project("rusty-brain".into()),
+            kind: ChangeKind::Created,
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        let back: MemoryChanged = serde_json::from_str(&json).unwrap();
+        assert_eq!(evt.id, back.id);
+        assert_eq!(evt.namespace, back.namespace);
+        assert_eq!(evt.kind, back.kind);
+        // Clone is required so broadcast subscribers each get an owned copy.
+        assert_eq!(evt.clone().kind, ChangeKind::Created);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.** Run: `cargo test -p rb-daemon change` Expected: FAIL to compile — `cannot find type 'MemoryChanged' in this scope` / `cannot find type 'ChangeKind'`. The module is compiled (declared in `lib.rs`) but the types do not exist yet, confirming the test drives new code.
+
+- [ ] **Step 3: Add the minimal implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/change.rs`:
+
+```rust
+use rb_types::{MemoryId, Namespace};
+use serde::{Deserialize, Serialize};
+
+/// What happened to a memory. Published after a successful commit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChangeKind {
+    Created,
+    Updated,
+    Archived,
+}
+
+/// Change-notification event broadcast on every successful write (spec §8).
+///
+/// Notification only — never coordination. Enables the deferred `subscribe`
+/// feature with no new machinery.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryChanged {
+    pub id: MemoryId,
+    pub namespace: Namespace,
+    pub kind: ChangeKind,
+}
+```
+
+  Add the re-export to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (after `mod change;`):
+
+```rust
+pub use change::{ChangeKind, MemoryChanged};
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-daemon change` Expected: PASS (2 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rb-daemon --all-targets --all-features -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-daemon/src/change.rs crates/rb-daemon/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-daemon): add MemoryChanged/ChangeKind broadcast events"`
+
+---
+
+### Task 23: rb-daemon `store_handle.rs` — dedicated writer thread + read pool + `MemoryBackend`
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/store_handle.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (add `mod store_handle;` + re-export)
+
+This is the core of the concurrency model (spec §8). `StoreHandle::start` spawns **one** dedicated `std::thread` that owns the write `SqliteStore` (rusqlite `Connection` is `Send` but `!Sync`, so the write store lives ONLY on that thread and is **never** wrapped in `Arc<Mutex>` or shared across tasks). Writes are sent as `WriteCommand`s over a bounded `tokio::sync::mpsc`, each carrying a `tokio::sync::oneshot::Sender` for the reply; on success the writer publishes a `MemoryChanged` on a `tokio::broadcast`. Reads acquire an `OwnedSemaphorePermit` in async context (bounded pool), then check out a `SqliteStore` from the pool inside `tokio::task::spawn_blocking`. `StoreHandle` implements `rb_engine::MemoryBackend` so the engine stays pure-policy.
+
+- [ ] **Step 1: Write the failing integration test AND declare the module.** Declare `mod store_handle;` in `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (re-export in Step 3). The test lives as an integration test so it exercises only the public surface and the async backend trait.
+
+  Set `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` to (keeping the prior `mod change;` + its re-export):
+
+```rust
+//! `rb_daemon`: single-writer service over `rb_store`.
+//!
+//! One dedicated OS thread owns the write `SqliteStore` (rusqlite is `!Sync`,
+//! so the write connection never crosses threads); a bounded pool of read
+//! stores serves concurrent reads via `spawn_blocking`; a Unix-domain-socket
+//! listener frames `rb_proto` requests to a per-connection `MemoryEngine`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+mod change;
+mod store_handle;
+
+pub use change::{ChangeKind, MemoryChanged};
+pub use store_handle::StoreHandle;
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/tests/store_handle.rs` with the complete contents below. It uses the async `MemoryBackend` trait directly against a tempdir DB. `DIM` matches the deterministic provider used elsewhere (8):
+
+```rust
+//! Integration tests for the StoreHandle concurrency core: writer thread,
+//! read pool, change broadcast, and the async MemoryBackend impl.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_daemon::{ChangeKind, StoreHandle};
+use rb_engine::MemoryBackend;
+use rb_types::{MemoryNote, MemoryType, MemoryUpdates, Namespace};
+
+const DIM: usize = 8;
+
+fn note(ns: &Namespace, body: &str) -> MemoryNote {
+    let mut n = MemoryNote::new(ns.clone(), body.to_string(), MemoryType::Insight, 5);
+    n.summary = body.chars().take(40).collect();
+    n.keywords = vec!["memory".to_string()];
+    n
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn write_then_read_round_trips_through_pool() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 4).unwrap();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "always one db one transaction");
+    let id = n.id.clone();
+    let emb = vec![0.1f32; DIM];
+
+    handle.write(n.clone(), Some(emb)).await.unwrap();
+
+    let got = handle.get(id.clone()).await.unwrap();
+    assert!(got.is_some(), "written memory must be retrievable");
+    assert_eq!(got.unwrap().content, "always one db one transaction");
+
+    let listed = handle.list(ns.clone(), None, 50).await.unwrap();
+    assert_eq!(listed.len(), 1, "list returns the one written memory");
+
+    let kw = handle.keyword(ns.clone(), "memory".to_string(), 50).await.unwrap();
+    assert_eq!(kw, vec![id.clone()], "keyword search finds it by keyword");
+
+    let vec_hits = handle.vector(ns, vec![0.1f32; DIM], 5).await.unwrap();
+    assert_eq!(vec_hits.len(), 1, "vector search returns the one embedded memory");
+    assert_eq!(vec_hits[0].0, id);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn write_publishes_change_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+    let mut rx = handle.subscribe();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "broadcast me");
+    let id = n.id.clone();
+    handle.write(n, Some(vec![0.2f32; DIM])).await.unwrap();
+
+    let evt = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("a change event must arrive within 2s")
+        .expect("broadcast channel must not be closed");
+    assert_eq!(evt.id, id);
+    assert_eq!(evt.namespace, ns);
+    assert_eq!(evt.kind, ChangeKind::Created);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_and_archive_emit_correct_kinds() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 2).unwrap();
+    let mut rx = handle.subscribe();
+
+    let ns = Namespace::Project("a".to_string());
+    let n = note(&ns, "evolve me");
+    let id = n.id.clone();
+    handle.write(n, Some(vec![0.3f32; DIM])).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Created);
+
+    let updates = MemoryUpdates { importance: Some(9), ..Default::default() };
+    handle.update(id.clone(), updates).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Updated);
+
+    handle.archive(id.clone()).await.unwrap();
+    assert_eq!(rx.recv().await.unwrap().kind, ChangeKind::Archived);
+
+    let got = handle.get(id).await.unwrap().unwrap();
+    assert_eq!(got.importance, 9, "update persisted");
+    assert!(got.archived_at.is_some(), "archive persisted (soft delete)");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn many_concurrent_writers_lose_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("rb.db");
+    let handle = StoreHandle::start(db, DIM, 4).unwrap();
+    let ns = Namespace::Project("a".to_string());
+
+    const N: usize = 200;
+    let mut tasks = Vec::with_capacity(N);
+    for i in 0..N {
+        let h = handle.clone();
+        let ns = ns.clone();
+        tasks.push(tokio::spawn(async move {
+            let n = note(&ns, &format!("concurrent note {i}"));
+            h.write(n, Some(vec![i as f32; DIM])).await
+            // `h` is dropped here when the task future completes, releasing this
+            // clone's writer Sender — required for shutdown to close the mpsc.
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap().unwrap();
+    }
+
+    let listed = handle.list(ns, None, N + 10).await.unwrap();
+    assert_eq!(listed.len(), N, "no writes lost under concurrency");
+
+    handle.shutdown().await;
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.** Run: `cargo test -p rb-daemon --test store_handle` Expected: FAIL to compile — `cannot find function 'start' in ... StoreHandle` / `the trait bound 'StoreHandle: MemoryBackend' is not satisfied`. This confirms the test drives the new implementation.
+
+- [ ] **Step 3: Implement `StoreHandle`, the writer thread, the read pool, and the `MemoryBackend` impl.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/store_handle.rs` with the complete contents below.
+
+  Key threading invariants honored exactly:
+  - The write `SqliteStore` is created **inside** the spawned `std::thread` and never leaves it — it is not `Arc`-wrapped, not `Mutex`-wrapped, not moved out. (`SqliteStore` is `Send` but `!Sync`; constructing it on the writer thread keeps it single-threaded.)
+  - Each `WriteCommand` carries its own `oneshot::Sender<Result<()>>`; the writer runs the sync op and replies, then (on `Ok`) broadcasts `MemoryChanged`.
+  - The writer loops until the `mpsc` closes (all `Sender`s dropped), then returns — graceful shutdown. (Callers must therefore ensure every `StoreHandle` clone is dropped before/at shutdown; the server in Task 25 drains its per-connection tasks before calling `shutdown`.)
+  - Reads acquire an `OwnedSemaphorePermit` **asynchronously** (never busy-waiting, never blocking a worker), then check out a `SqliteStore` from the bounded pool inside `spawn_blocking`, run the sync method, and return the store to the pool. The permit is held until the store is returned, so a held permit always implies an available store.
+
+```rust
+//! The single-writer store handle: one dedicated OS thread owns the write
+//! connection (rusqlite is `!Sync`, so it must never be shared); a bounded
+//! pool of read connections serves concurrent reads via `spawn_blocking`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rb_engine::MemoryBackend;
+use rb_store::{SqliteStore, Store};
+use rb_types::{Error, MemoryId, MemoryNote, MemoryUpdates, Namespace, Result};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex, Semaphore};
+
+use crate::change::{ChangeKind, MemoryChanged};
+
+/// Capacity of the broadcast channel: lagging subscribers drop oldest events
+/// (notification only, never coordination).
+const BROADCAST_CAPACITY: usize = 256;
+/// Bound on the write queue. Backpressure (spec §8): senders await capacity.
+const WRITE_QUEUE_CAPACITY: usize = 256;
+
+/// One write request handed to the dedicated writer thread. Each carries a
+/// `oneshot` reply channel; the writer also broadcasts a `MemoryChanged` on Ok.
+enum WriteCommand {
+    Insert {
+        note: Box<MemoryNote>,
+        embedding: Option<Vec<f32>>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    Update {
+        id: MemoryId,
+        updates: Box<MemoryUpdates>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    Archive {
+        id: MemoryId,
+        reply: oneshot::Sender<Result<()>>,
+    },
+}
+
+/// Cloneable handle to the single-writer store. Cloning shares the same writer
+/// thread, read pool, and broadcast channel.
+#[derive(Clone)]
+pub struct StoreHandle {
+    writer_tx: mpsc::Sender<WriteCommand>,
+    pool: Arc<ReadPool>,
+    events: broadcast::Sender<MemoryChanged>,
+    /// Joined on `shutdown`. `Mutex<Option<..>>` so a single clone can take it.
+    writer_join: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+}
+
+/// A bounded pool of read stores. The `Semaphore` bounds concurrency; the `Vec`
+/// holds the idle stores. Each read acquires one permit (async), pops one store
+/// (on a blocking thread), runs the sync op, and returns it. `permits` and
+/// `stores` are `Arc` so the owned permit and the locked Vec move cleanly into
+/// the blocking closure.
+struct ReadPool {
+    permits: Arc<Semaphore>,
+    stores: Arc<Mutex<Vec<SqliteStore>>>,
+}
+
+impl ReadPool {
+    fn open(db_path: &PathBuf, dim: usize, size: usize) -> Result<Self> {
+        let mut stores = Vec::with_capacity(size);
+        for _ in 0..size {
+            stores.push(SqliteStore::open(db_path, dim)?);
+        }
+        Ok(Self {
+            permits: Arc::new(Semaphore::new(size)),
+            stores: Arc::new(Mutex::new(stores)),
+        })
+    }
+}
+
+impl StoreHandle {
+    /// Start the writer thread and open the read pool. Returns immediately once
+    /// the writer's write store has opened successfully (errors surface here).
+    pub fn start(db_path: PathBuf, embedding_dim: usize, read_pool_size: usize) -> Result<Self> {
+        let pool = Arc::new(ReadPool::open(&db_path, embedding_dim, read_pool_size.max(1))?);
+        let (events, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (writer_tx, writer_rx) = mpsc::channel::<WriteCommand>(WRITE_QUEUE_CAPACITY);
+
+        // Channel for the writer thread to report whether its write store opened.
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<()>>();
+        let writer_events = events.clone();
+        let writer_path = db_path.clone();
+
+        let writer_join = std::thread::Builder::new()
+            .name("rb-writer".to_string())
+            .spawn(move || {
+                writer_loop(writer_path, embedding_dim, writer_rx, writer_events, ready_tx);
+            })
+            .map_err(|e| Error::Io(format!("spawn writer thread: {e}")))?;
+
+        // Block until the writer confirms the write store opened (or failed).
+        match ready_rx.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                let _ = writer_join.join();
+                return Err(e);
+            }
+            Err(_) => {
+                let _ = writer_join.join();
+                return Err(Error::Storage("writer thread exited before ready".to_string()));
+            }
+        }
+
+        Ok(Self {
+            writer_tx,
+            pool,
+            events,
+            writer_join: Arc::new(Mutex::new(Some(writer_join))),
+        })
+    }
+
+    /// Subscribe to change events. Each subscriber receives an owned copy.
+    pub fn subscribe(&self) -> broadcast::Receiver<MemoryChanged> {
+        self.events.subscribe()
+    }
+
+    /// Gracefully stop: drop this clone's write sender so the writer loop ends
+    /// once ALL clones are gone, then join the writer thread (which flushes its
+    /// WAL on connection close before exit).
+    ///
+    /// Callers MUST ensure no other live `StoreHandle` clone is holding a sender
+    /// (e.g. the server drains its per-connection tasks first); otherwise the
+    /// writer mpsc never closes and the join would block.
+    pub async fn shutdown(self) {
+        // Drop our sender + broadcast + pool so the writer's mpsc can close.
+        drop(self.writer_tx);
+        drop(self.events);
+        drop(self.pool);
+        // Take and join the writer thread on a blocking thread (join is sync).
+        let join = { self.writer_join.lock().await.take() };
+        if let Some(handle) = join {
+            let _ = tokio::task::spawn_blocking(move || handle.join()).await;
+        }
+    }
+
+    /// Send a write command and await the writer's reply.
+    async fn send_write(&self, cmd: WriteCommand, rx: oneshot::Receiver<Result<()>>) -> Result<()> {
+        self.writer_tx
+            .send(cmd)
+            .await
+            .map_err(|_| Error::Storage("writer thread unavailable".to_string()))?;
+        rx.await
+            .map_err(|_| Error::Storage("writer dropped reply".to_string()))?
+    }
+
+    /// Run a synchronous read against a checked-out store on a blocking thread.
+    ///
+    /// The semaphore permit is acquired in async context (no busy-wait, never
+    /// blocks a worker) and then MOVED into the blocking closure so it is held
+    /// for the whole read and released only after the store is returned.
+    async fn with_read<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&SqliteStore) -> Result<T> + Send + 'static,
+    {
+        let permits = Arc::clone(&self.pool.permits);
+        let stores = Arc::clone(&self.pool.stores);
+
+        // Acquire a permit asynchronously. A permit guarantees a store is in the
+        // pool (a permit is released only after its store is pushed back).
+        let permit = permits
+            .acquire_owned()
+            .await
+            .map_err(|_| Error::Storage("read pool closed".to_string()))?;
+
+        tokio::task::spawn_blocking(move || {
+            // Hold the permit for the full read (drops at closure end).
+            let _permit = permit;
+
+            // Check out a store. The permit invariant guarantees one is present.
+            let store = stores
+                .blocking_lock()
+                .pop()
+                .ok_or_else(|| Error::Storage("read pool exhausted (no store despite permit)".to_string()))?;
+
+            let result = f(&store);
+
+            // Always return the store to the pool, even on error.
+            stores.blocking_lock().push(store);
+            result
+        })
+        .await
+        .map_err(|e| Error::Storage(format!("read task panicked or cancelled: {e}")))?
+    }
+}
+
+/// The dedicated writer loop. Owns the write `SqliteStore` for its entire life;
+/// the store is created here and never escapes this thread (`!Sync`-safe).
+fn writer_loop(
+    db_path: PathBuf,
+    embedding_dim: usize,
+    mut rx: mpsc::Receiver<WriteCommand>,
+    events: broadcast::Sender<MemoryChanged>,
+    ready_tx: std::sync::mpsc::Sender<Result<()>>,
+) {
+    let store = match SqliteStore::open(&db_path, embedding_dim) {
+        Ok(s) => {
+            let _ = ready_tx.send(Ok(()));
+            s
+        }
+        Err(e) => {
+            let _ = ready_tx.send(Err(e));
+            return;
+        }
+    };
+
+    // Blocking receive loop: `blocking_recv` parks this OS thread (NOT a tokio
+    // worker) until a command arrives or all senders drop.
+    while let Some(cmd) = rx.blocking_recv() {
+        match cmd {
+            WriteCommand::Insert {
+                note,
+                embedding,
+                reply,
+            } => {
+                let ns = note.namespace.clone();
+                let id = note.id.clone();
+                let res = store.insert_memory(&note, embedding.as_deref());
+                let ok = res.is_ok();
+                let _ = reply.send(res);
+                if ok {
+                    let _ = events.send(MemoryChanged {
+                        id,
+                        namespace: ns,
+                        kind: ChangeKind::Created,
+                    });
+                }
+            }
+            WriteCommand::Update {
+                id,
+                updates,
+                reply,
+            } => {
+                let res = store.update_memory(&id, &updates);
+                let ok = res.is_ok();
+                // Look up the namespace for the event (we are already on the
+                // writer thread with the live connection; this read is cheap).
+                let ns = store.get_memory(&id).ok().flatten().map(|m| m.namespace);
+                let _ = reply.send(res);
+                if ok {
+                    if let Some(namespace) = ns {
+                        let _ = events.send(MemoryChanged {
+                            id,
+                            namespace,
+                            kind: ChangeKind::Updated,
+                        });
+                    }
+                }
+            }
+            WriteCommand::Archive { id, reply } => {
+                // Resolve namespace BEFORE archiving (still readable either way,
+                // but cheap and avoids surprises).
+                let ns = store.get_memory(&id).ok().flatten().map(|m| m.namespace);
+                let res = store.archive_memory(&id);
+                let ok = res.is_ok();
+                let _ = reply.send(res);
+                if ok {
+                    if let Some(namespace) = ns {
+                        let _ = events.send(MemoryChanged {
+                            id,
+                            namespace,
+                            kind: ChangeKind::Archived,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // mpsc closed (all senders dropped) -> graceful shutdown. Dropping the write
+    // `SqliteStore` closes its rusqlite connection, which flushes the WAL frames
+    // it produced; SQLite's default `wal_autocheckpoint` plus connection close
+    // provide durability. NOTE: P0's `SqliteStore` exposes no explicit
+    // checkpoint API (its `conn` is `pub(crate)` to rb-store), so we cannot
+    // issue `PRAGMA wal_checkpoint` here; a future rb-store explicit-checkpoint
+    // method should replace this drop-based flush.
+    drop(store);
+}
+
+#[async_trait]
+impl MemoryBackend for StoreHandle {
+    async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Insert {
+            note: Box::new(note),
+            embedding,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+
+    async fn get(&self, id: MemoryId) -> Result<Option<MemoryNote>> {
+        self.with_read(move |s| s.get_memory(&id)).await
+    }
+
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        query: String,
+        limit: usize,
+    ) -> Result<Vec<MemoryId>> {
+        self.with_read(move |s| s.keyword_search(&ns, &query, limit)).await
+    }
+
+    async fn vector(
+        &self,
+        ns: Namespace,
+        embedding: Vec<f32>,
+        limit: usize,
+    ) -> Result<Vec<(MemoryId, f32)>> {
+        self.with_read(move |s| s.vector_search(&ns, &embedding, limit)).await
+    }
+
+    async fn graph(&self, id: MemoryId, depth: u8) -> Result<Vec<MemoryId>> {
+        self.with_read(move |s| s.graph_neighbors(&id, depth)).await
+    }
+
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        self.with_read(move |s| s.list(&ns, min_importance, limit)).await
+    }
+
+    async fn update(&self, id: MemoryId, updates: MemoryUpdates) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Update {
+            id,
+            updates: Box::new(updates),
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+
+    async fn archive(&self, id: MemoryId) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Archive { id, reply };
+        self.send_write(cmd, rx).await
+    }
+}
+```
+
+  (verify against installed tokio at execution: `Semaphore::acquire_owned(self: Arc<Semaphore>) -> Result<OwnedSemaphorePermit, AcquireError>` and `tokio::sync::Mutex::blocking_lock` both exist in tokio 1.x; if the pinned tokio renames either, adjust. Do NOT call `Semaphore::acquire` on a non-`Arc` here — we need the `OwnedSemaphorePermit` to move it into `spawn_blocking`.)
+
+  Add `async-trait` to `crates/rb-daemon/Cargo.toml` `[dependencies]` if the setup cluster did not already (`async-trait = { workspace = true }`) — it is needed for the `#[async_trait]` impl. Also ensure `[dependencies]` includes `rb-store = { path = "../rb-store" }`, `rb-engine = { path = "../rb-engine" }`, `tokio = { workspace = true }`, and `[dev-dependencies]` includes `rb-engine = { path = "../rb-engine" }`, `tempfile = { workspace = true }`, and `tokio = { workspace = true }` (for `#[tokio::test]`).
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-daemon --test store_handle -- --nocapture` Expected: PASS — all four tests (`write_then_read_round_trips_through_pool`, `write_publishes_change_event`, `update_and_archive_emit_correct_kinds`, `many_concurrent_writers_lose_nothing`) report `ok`. If `many_concurrent_writers_lose_nothing` reports fewer than 200 rows, the writer is dropping commands — verify the `mpsc` capacity and that every `Insert` replies; if any test hangs, either the writer thread panicked before `ready_tx.send` (check `SqliteStore::open` dim matches) or a `StoreHandle` clone outlived `shutdown` (every spawned task must drop its clone before the final `handle.shutdown()`).
+
+- [ ] **Step 5: Stress for flakiness.** Run: `cargo test -p rb-daemon --test store_handle -- --nocapture` two more times. Expected: PASS every time (no lost writes, no panics). The single-writer serialization must make this deterministic.
+
+- [ ] **Step 6: Lint + format.** Run: `cargo clippy -p rb-daemon --all-targets --all-features -- -D warnings` Expected: no warnings (no `unwrap`/`expect`/`panic` outside tests; the writer thread never panics on the request path — it uses `let _ =` for best-effort replies/broadcasts). Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-daemon/src/store_handle.rs crates/rb-daemon/src/lib.rs crates/rb-daemon/tests/store_handle.rs crates/rb-daemon/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-daemon): add StoreHandle with dedicated writer thread, read pool, and MemoryBackend"`
+
+---
+
+### Task 24: rb-daemon `paths.rs` — default socket/db paths + shared embedder wrapper
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/paths.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/shared_embedder.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (add modules + re-exports)
+
+Two small support pieces the server and CLI both need: (1) `default_socket_path()` / `default_db_path()` derived via `directories`, honoring `$XDG_RUNTIME_DIR` for the socket (spec §14); (2) `SharedEmbedder`, an `Arc<dyn EmbeddingProvider>` newtype that itself implements `EmbeddingProvider`, so one embedder instance is shared across all per-connection `MemoryEngine`s without making `MemoryEngine` non-generic.
+
+- [ ] **Step 1: Write the failing tests AND declare the modules.** Add to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs`:
+
+```rust
+mod paths;
+mod shared_embedder;
+```
+
+  and the re-exports (after the existing `pub use`):
+
+```rust
+pub use paths::{default_db_path, default_socket_path};
+pub use shared_embedder::SharedEmbedder;
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/paths.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn socket_path_is_under_a_rusty_brain_dir_named_sock() {
+        let p = default_socket_path().unwrap();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("sock"));
+        assert!(
+            p.parent()
+                .and_then(|d| d.file_name())
+                .and_then(|s| s.to_str())
+                == Some("rusty-brain"),
+            "socket lives in a rusty-brain directory: {p:?}"
+        );
+    }
+
+    #[test]
+    fn db_path_ends_with_rusty_brain_db_file() {
+        let p = default_db_path().unwrap();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("memory.db"));
+    }
+
+    #[test]
+    fn xdg_runtime_dir_is_honored_for_socket() {
+        // NOTE: this test mutates process-global env. The sibling path tests
+        // only assert file_name == "sock" and parent == "rusty-brain", which
+        // hold for ANY base directory, so a parallel read of XDG_RUNTIME_DIR
+        // mid-mutation cannot break their assertions. We still restore the var.
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        let p = default_socket_path().unwrap();
+        assert!(
+            p.starts_with(dir.path()),
+            "socket must live under XDG_RUNTIME_DIR when set: {p:?}"
+        );
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+}
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/shared_embedder.rs` with ONLY the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_embed::{DeterministicProvider, EmbeddingProvider};
+
+    #[tokio::test]
+    async fn shared_embedder_delegates_dim_and_embed() {
+        let inner = DeterministicProvider::new(8);
+        let model = inner.model_id().to_string();
+        let shared = SharedEmbedder::new(inner);
+        assert_eq!(shared.dim(), 8);
+        assert_eq!(shared.model_id(), model);
+        let out = shared.embed(&["hello".to_string()]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].len(), 8);
+    }
+
+    #[tokio::test]
+    async fn cloning_shares_one_instance() {
+        let shared = SharedEmbedder::new(DeterministicProvider::new(8));
+        let clone = shared.clone();
+        // Both produce identical vectors for identical input (same instance).
+        let a = shared.embed(&["same".to_string()]).await.unwrap();
+        let b = clone.embed(&["same".to_string()]).await.unwrap();
+        assert_eq!(a, b);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.** Run: `cargo test -p rb-daemon paths` and `cargo test -p rb-daemon shared_embedder` Expected: both FAIL to compile — `cannot find function 'default_socket_path'` / `cannot find type 'SharedEmbedder'`. Confirms the tests drive the impl.
+
+- [ ] **Step 3: Implement `paths.rs`.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/paths.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use rb_types::{Error, Result};
+
+/// Default Unix-domain-socket path: `$XDG_RUNTIME_DIR/rusty-brain/sock` when the
+/// runtime dir is available, else the platform runtime dir from `directories`,
+/// else a fallback under the user's cache dir. The parent dir is created (0700)
+/// by the daemon, not here.
+pub fn default_socket_path() -> Result<PathBuf> {
+    if let Some(rt) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let rt = PathBuf::from(rt);
+        if !rt.as_os_str().is_empty() {
+            return Ok(rt.join("rusty-brain").join("sock"));
+        }
+    }
+    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
+        .ok_or_else(|| Error::Io("cannot determine a runtime directory".to_string()))?;
+    let base = dirs
+        .runtime_dir()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs.cache_dir().to_path_buf());
+    Ok(base.join("rusty-brain").join("sock"))
+}
+
+/// Default database path: `<data-dir>/rusty-brain/memory.db`.
+pub fn default_db_path() -> Result<PathBuf> {
+    let dirs = directories::ProjectDirs::from("dev", "rusty-brain", "rusty-brain")
+        .ok_or_else(|| Error::Io("cannot determine a data directory".to_string()))?;
+    Ok(dirs.data_dir().join("memory.db"))
+}
+```
+
+  (verify against installed `directories` v5 at execution: `ProjectDirs::from(qualifier, organization, application)` and `runtime_dir()->Option<&Path>`, `data_dir()->&Path`, `cache_dir()->&Path`. If v5 differs, adjust the accessor names.)
+
+- [ ] **Step 4: Implement `shared_embedder.rs`.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/shared_embedder.rs`:
+
+```rust
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rb_embed::EmbeddingProvider;
+use rb_types::Result;
+
+/// A reference-counted, cloneable embedding provider. Lets one embedder instance
+/// be shared across every per-connection `MemoryEngine` while keeping
+/// `MemoryEngine`'s `P: EmbeddingProvider` generic bound satisfied.
+#[derive(Clone)]
+pub struct SharedEmbedder {
+    inner: Arc<dyn EmbeddingProvider>,
+}
+
+impl SharedEmbedder {
+    /// Wrap any concrete provider.
+    pub fn new<P: EmbeddingProvider + 'static>(provider: P) -> Self {
+        Self {
+            inner: Arc::new(provider),
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for SharedEmbedder {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.inner.embed(texts).await
+    }
+}
+```
+
+  Ensure `crates/rb-daemon/Cargo.toml` `[dependencies]` includes `rb-embed = { path = "../rb-embed" }`, `async-trait = { workspace = true }`, and `directories = { workspace = true }`; and `[dev-dependencies]` includes `rb-embed = { path = "../rb-embed" }` (for the test) and `tempfile = { workspace = true }`.
+
+- [ ] **Step 5: Run it — expect PASS.** Run: `cargo test -p rb-daemon paths` then `cargo test -p rb-daemon shared_embedder` Expected: PASS (3 path tests, 2 embedder tests).
+
+- [ ] **Step 6: Lint + format.** Run: `cargo clippy -p rb-daemon --all-targets --all-features -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-daemon/src/paths.rs crates/rb-daemon/src/shared_embedder.rs crates/rb-daemon/src/lib.rs crates/rb-daemon/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-daemon): add default path helpers and SharedEmbedder wrapper"`
+
+---
+
+### Task 25: rb-daemon `server.rs` — UDS bind (0700 dir / 0600 socket), pidfile single-instance, per-connection dispatch, graceful shutdown
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/server.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/error_map.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs` (add modules + re-exports)
+
+The server: binds a `UnixListener` at `socket_path` inside a `0700` dir with the socket `chmod`'d `0600` (spec §14); writes a pidfile and enforces single-instance (a live socket means another daemon owns it → fail; a stale socket is reclaimed). The accept loop spawns a tokio task per connection (tracked in a `JoinSet`): read `Handshake` (reject on `contract_version` mismatch, capture namespace), send `HandshakeAck`, then loop reading `Request` frames and dispatching to a per-connection `MemoryEngine` whose namespace is fixed to the handshake namespace (server-side isolation: the client cannot widen scope). Each `rb_types::Error` maps to `Response::Error` with no internal leakage. Graceful shutdown stops accepting, **drains/aborts the per-connection tasks** (so their `StoreHandle` clones drop), `StoreHandle::shutdown` (writer-thread join), and removes the socket + pidfile.
+
+- [ ] **Step 1: Write the failing error-map test AND declare the module.** Add to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/lib.rs`:
+
+```rust
+mod error_map;
+mod server;
+```
+
+  and re-exports (after existing):
+
+```rust
+pub use server::{Daemon, DaemonConfig};
+```
+
+  Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/error_map.rs` with ONLY the test module (note the `clippy::panic` allow — the workspace denies `panic`, and this module calls `panic!`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use rb_proto::Response;
+    use rb_types::{Error, MemoryId};
+
+    #[test]
+    fn maps_each_error_to_stable_kind() {
+        let cases: Vec<(Error, &str)> = vec![
+            (Error::Storage("x".into()), "storage"),
+            (Error::Migration("x".into()), "migration"),
+            (Error::NotFound(MemoryId::new()), "not_found"),
+            (Error::InvalidNamespace("x".into()), "invalid_namespace"),
+            (Error::InvalidMemoryType("x".into()), "invalid_memory_type"),
+            (Error::InvalidLinkType("x".into()), "invalid_link_type"),
+            (Error::Serialization("x".into()), "serialization"),
+            (
+                Error::DimensionMismatch { expected: 1, got: 2 },
+                "dimension_mismatch",
+            ),
+            (Error::Io("x".into()), "io"),
+        ];
+        for (err, expected_kind) in cases {
+            match error_to_response(err) {
+                Response::Error { kind, message } => {
+                    assert_eq!(kind, expected_kind);
+                    assert!(!message.is_empty(), "message is populated");
+                }
+                other => panic!("expected Response::Error, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn message_does_not_leak_struct_internals() {
+        // The message is the Display string, never the Debug of the daemon.
+        let r = error_to_response(Error::Storage("disk full".into()));
+        if let Response::Error { message, .. } = r {
+            assert_eq!(message, "storage error: disk full");
+        } else {
+            panic!("expected error response");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect a compile failure.** Run: `cargo test -p rb-daemon error_map` Expected: FAIL to compile — `cannot find function 'error_to_response'`. Confirms the test drives the impl.
+
+- [ ] **Step 3: Implement `error_map.rs`.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/error_map.rs`:
+
+```rust
+use rb_proto::Response;
+use rb_types::Error;
+
+/// Map a domain `Error` to a wire `Response::Error` with a stable `kind` string
+/// and a human `message` (the `Display` form — no internal struct leakage).
+pub(crate) fn error_to_response(err: Error) -> Response {
+    let kind = match &err {
+        Error::Storage(_) => "storage",
+        Error::Migration(_) => "migration",
+        Error::NotFound(_) => "not_found",
+        Error::InvalidNamespace(_) => "invalid_namespace",
+        Error::InvalidMemoryType(_) => "invalid_memory_type",
+        Error::InvalidLinkType(_) => "invalid_link_type",
+        Error::Serialization(_) => "serialization",
+        Error::DimensionMismatch { .. } => "dimension_mismatch",
+        Error::Io(_) => "io",
+    };
+    Response::Error {
+        kind: kind.to_string(),
+        message: err.to_string(),
+    }
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rb-daemon error_map` Expected: PASS (2 tests).
+
+- [ ] **Step 5: Implement `server.rs` (Daemon + DaemonConfig + dispatch).** Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/src/server.rs` with the complete contents below. The dispatch builds one `MemoryEngine<StoreHandle, SharedEmbedder>` per connection, fixing the namespace to the handshake value (isolation enforced server-side). Client-supplied scope fields in `Recall`/`List`/`Graph` are ignored — every operation uses the connection namespace.
+
+```rust
+//! UDS server: single-instance bind, per-connection framed dispatch, graceful
+//! shutdown. Isolation is enforced server-side: every engine is pinned to the
+//! handshake namespace and the client cannot widen it.
+
+use std::future::Future;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use rb_embed::EmbeddingProvider;
+use rb_engine::{MemoryEngine, RememberInput};
+use rb_proto::{
+    read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+};
+use rb_types::{Error, Result};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinSet;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing::{info, warn};
+
+use crate::error_map::error_to_response;
+use crate::shared_embedder::SharedEmbedder;
+use crate::store_handle::StoreHandle;
+
+/// Static configuration for a daemon instance.
+pub struct DaemonConfig {
+    pub socket_path: PathBuf,
+    pub db_path: PathBuf,
+    pub read_pool_size: usize,
+}
+
+/// A bound, ready-to-run daemon: owns the listener, the store handle, the shared
+/// embedder, and the paths it must clean up on shutdown.
+pub struct Daemon {
+    listener: UnixListener,
+    store: StoreHandle,
+    embedder: SharedEmbedder,
+    socket_path: PathBuf,
+    pidfile_path: PathBuf,
+}
+
+impl Daemon {
+    /// Bind the daemon: start the `StoreHandle` (dim from the embedder), create
+    /// the socket dir `0700`, bind the UDS `0600`, and write a pidfile with the
+    /// single-instance guard. Fails closed if another live daemon owns the
+    /// socket; reclaims a stale socket.
+    pub async fn bind(config: DaemonConfig, embedder: SharedEmbedder) -> Result<Daemon> {
+        let dim = embedder.dim();
+
+        // 1. Ensure the data dir for the DB exists.
+        if let Some(parent) = config.db_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| Error::Io(format!("create db dir {}: {e}", parent.display())))?;
+        }
+
+        // 2. Single-instance: if a live daemon answers on the socket, refuse.
+        //    The authoritative guard is this live-socket probe plus the bind
+        //    below (a concurrent racer's bind fails with EADDRINUSE). The
+        //    pidfile written in step 6 is advisory for operators; a flock-based
+        //    pidfile lock is deferred (P1 is single-user).
+        if config.socket_path.exists() {
+            if probe_live(&config.socket_path).await {
+                return Err(Error::Io(format!(
+                    "another rusty-brain daemon is already listening at {}",
+                    config.socket_path.display()
+                )));
+            }
+            // Stale socket: reclaim it.
+            let _ = tokio::fs::remove_file(&config.socket_path).await;
+        }
+
+        // 3. Create the socket dir 0700.
+        let sock_dir = config
+            .socket_path
+            .parent()
+            .ok_or_else(|| Error::Io("socket path has no parent dir".to_string()))?
+            .to_path_buf();
+        tokio::fs::create_dir_all(&sock_dir)
+            .await
+            .map_err(|e| Error::Io(format!("create socket dir {}: {e}", sock_dir.display())))?;
+        tokio::fs::set_permissions(&sock_dir, std::fs::Permissions::from_mode(0o700))
+            .await
+            .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", sock_dir.display())))?;
+
+        // 4. Bind the listener, then chmod the socket 0600.
+        let listener = UnixListener::bind(&config.socket_path)
+            .map_err(|e| Error::Io(format!("bind {}: {e}", config.socket_path.display())))?;
+        tokio::fs::set_permissions(&config.socket_path, std::fs::Permissions::from_mode(0o600))
+            .await
+            .map_err(|e| {
+                Error::Io(format!("chmod 0600 {}: {e}", config.socket_path.display()))
+            })?;
+
+        // 5. Start the store handle (writer thread + read pool) on the DB.
+        let store = StoreHandle::start(config.db_path.clone(), dim, config.read_pool_size)?;
+
+        // 6. Write the (advisory) pidfile.
+        let pidfile_path = config.socket_path.with_extension("pid");
+        tokio::fs::write(&pidfile_path, std::process::id().to_string())
+            .await
+            .map_err(|e| Error::Io(format!("write pidfile: {e}")))?;
+
+        info!(socket = %config.socket_path.display(), "daemon bound");
+        Ok(Daemon {
+            listener,
+            store,
+            embedder,
+            socket_path: config.socket_path,
+            pidfile_path,
+        })
+    }
+
+    /// Run the accept loop until `shutdown` resolves, then drain connections and
+    /// clean up. Graceful shutdown order (spec §8): stop accepting -> abort and
+    /// join per-connection tasks (dropping their `StoreHandle` clones) ->
+    /// `StoreHandle::shutdown` (writer-thread join / WAL flush) -> remove socket
+    /// + pidfile.
+    pub async fn run(self, shutdown: impl Future<Output = ()>) -> Result<()> {
+        let Daemon {
+            listener,
+            store,
+            embedder,
+            socket_path,
+            pidfile_path,
+        } = self;
+        tokio::pin!(shutdown);
+
+        // Track per-connection tasks so shutdown can drain/abort them. Each task
+        // holds a `StoreHandle` clone (via its `MemoryEngine`); those clones MUST
+        // be dropped before `store.shutdown()`, or the writer mpsc never closes.
+        let mut conns: JoinSet<()> = JoinSet::new();
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => {
+                    info!("shutdown signal received; stopping accept loop");
+                    break;
+                }
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((stream, _addr)) => {
+                            let store = store.clone();
+                            let embedder = embedder.clone();
+                            conns.spawn(async move {
+                                if let Err(e) = handle_connection(stream, store, embedder).await {
+                                    warn!(error = %e, "connection ended with error");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "accept failed");
+                        }
+                    }
+                }
+                // Reap finished connection tasks so the JoinSet does not grow
+                // unbounded over the daemon's lifetime.
+                Some(_joined) = conns.join_next() => {}
+            }
+        }
+
+        // 1. Stop accepting (listener dropped here).
+        drop(listener);
+
+        // 2. Drain: abort all in-flight connection tasks and await them so their
+        //    `StoreHandle` clones (inside each task's `MemoryEngine`) are dropped.
+        //    Clients may hold connections open indefinitely, so abort rather than
+        //    wait forever.
+        conns.shutdown().await;
+
+        // 3. Now only this scope holds a `StoreHandle`; shutting it down closes
+        //    the writer mpsc and joins the writer thread (WAL flush on close).
+        store.shutdown().await;
+
+        // 4. Remove socket + pidfile.
+        drop(embedder);
+        let _ = tokio::fs::remove_file(&socket_path).await;
+        let _ = tokio::fs::remove_file(&pidfile_path).await;
+        info!("daemon shut down cleanly");
+        Ok(())
+    }
+}
+
+/// Probe whether a live daemon answers on `path` by completing a handshake.
+async fn probe_live(path: &std::path::Path) -> bool {
+    match UnixStream::connect(path).await {
+        Ok(stream) => {
+            let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+            let hs = Handshake {
+                contract_version: CONTRACT_VERSION,
+                namespace: rb_types::Namespace::Global,
+            };
+            if write_frame(&mut framed, &hs).await.is_err() {
+                return false;
+            }
+            // A live daemon replies with a HandshakeAck within a short window.
+            matches!(
+                tokio::time::timeout(
+                    std::time::Duration::from_millis(500),
+                    read_frame::<_, HandshakeAck>(&mut framed),
+                )
+                .await,
+                Ok(Ok(_))
+            )
+        }
+        Err(_) => false,
+    }
+}
+
+/// Handle one connection: handshake (verify contract, capture namespace), then
+/// loop request->engine->response. The engine is pinned to the handshake
+/// namespace; the client cannot read or write outside it.
+async fn handle_connection(
+    stream: UnixStream,
+    store: StoreHandle,
+    embedder: SharedEmbedder,
+) -> Result<()> {
+    let mut framed = Framed::new(stream, LengthDelimitedCodec::new());
+
+    // 1. Handshake.
+    let handshake: Handshake = match read_frame(&mut framed).await {
+        Ok(h) => h,
+        Err(e) => {
+            // Cannot even parse a handshake; nothing to reply to meaningfully.
+            return Err(e);
+        }
+    };
+    if handshake.contract_version != CONTRACT_VERSION {
+        let ack = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: false,
+            message: Some(format!(
+                "contract mismatch: server {CONTRACT_VERSION}, client {}",
+                handshake.contract_version
+            )),
+        };
+        write_frame(&mut framed, &ack).await?;
+        return Ok(());
+    }
+    let namespace = handshake.namespace.clone();
+    let ack = HandshakeAck {
+        contract_version: CONTRACT_VERSION,
+        ok: true,
+        message: None,
+    };
+    write_frame(&mut framed, &ack).await?;
+
+    // 2. Per-connection engine pinned to the handshake namespace.
+    let engine = MemoryEngine::new(store, embedder, namespace.clone());
+
+    // 3. Request loop. Reading via `read_frame` returns `Err` only on a hard
+    //    framing/socket error; a clean client disconnect surfaces as the
+    //    underlying codec stream ending, which `read_frame` maps to an Io error
+    //    we treat as end-of-connection.
+    loop {
+        let req: Request = match read_frame::<_, Request>(&mut framed).await {
+            Ok(r) => r,
+            // Client closed the connection (EOF) or framing ended: stop cleanly.
+            Err(_) => break,
+        };
+        let resp = dispatch(&engine, &namespace, req).await;
+        write_frame(&mut framed, &resp).await?;
+    }
+    Ok(())
+}
+
+/// Dispatch one request against the connection's engine. Isolation: scope fields
+/// in the request are IGNORED — every operation uses the connection namespace
+/// (pinned inside the engine).
+async fn dispatch<P: EmbeddingProvider>(
+    engine: &MemoryEngine<StoreHandle, P>,
+    _namespace: &rb_types::Namespace,
+    req: Request,
+) -> Response {
+    match req {
+        Request::Ping => Response::Pong {
+            contract_version: CONTRACT_VERSION,
+        },
+        Request::Remember {
+            content,
+            context,
+            memory_type,
+            importance,
+            keywords,
+            tags,
+            related_files,
+        } => {
+            let input = RememberInput {
+                content,
+                context,
+                memory_type,
+                importance,
+                keywords,
+                tags,
+                related_files,
+            };
+            match engine.remember(input).await {
+                Ok(id) => Response::Remembered { id },
+                Err(e) => error_to_response(e),
+            }
+        }
+        Request::Recall {
+            query,
+            scope: _,
+            memory_type,
+            tags,
+            limit,
+        } => match engine.recall(&query, limit, memory_type, &tags).await {
+            Ok(results) => Response::Recalled { results },
+            Err(e) => error_to_response(e),
+        },
+        Request::Get { id } => match engine.get(id).await {
+            Ok(memory) => Response::Got { memory },
+            Err(e) => error_to_response(e),
+        },
+        Request::List {
+            scope: _,
+            min_importance,
+            limit,
+        } => match engine.list(min_importance, limit).await {
+            Ok(memories) => Response::Listed { memories },
+            Err(e) => error_to_response(e),
+        },
+        Request::Graph { id, depth } => match engine.graph(id, depth).await {
+            Ok(memories) => Response::GraphResult { memories },
+            Err(e) => error_to_response(e),
+        },
+        Request::Update { id, updates } => match engine.update(id, updates).await {
+            Ok(()) => Response::Updated,
+            Err(e) => error_to_response(e),
+        },
+        Request::Delete { id } => match engine.delete(id).await {
+            Ok(()) => Response::Deleted,
+            Err(e) => error_to_response(e),
+        },
+        Request::Context => match engine.context().await {
+            Ok((recent, important, total)) => Response::ContextResult {
+                recent,
+                important,
+                total,
+            },
+            Err(e) => error_to_response(e),
+        },
+    }
+}
+```
+
+  NOTE on `engine.list` / `engine.graph` / `engine.context()` shapes: this dispatch assumes the rb-engine cluster exposes `list(min_importance: Option<u8>, limit: usize)`, `graph(id, depth) -> Vec<MemoryNote>`, and `context() -> Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)>` (matching `Response::ContextResult { recent, important, total }`), with the namespace pinned inside the engine. The spine states these are namespace-pinned pass-throughs; if the rb-engine cluster used slightly different arg orders or a single merged `context` Vec, adapt these arms to the engine's actual signatures (verify against rb-engine at execution; do NOT change the wire `Response` shapes).
+
+  NOTE on framing helpers: this calls `read_frame::<_, T>(&mut framed)` / `write_frame(&mut framed, &value)` against the rb-proto helpers. If rb-proto's helper signatures differ (e.g. take `&mut Framed<UnixStream, LengthDelimitedCodec>` explicitly, or return a different error type), adjust the calls to the actual form (verify against rb-proto at execution; keep the framing semantics — one serde value per length-delimited frame).
+
+  Add to `crates/rb-daemon/Cargo.toml` `[dependencies]` (if the setup cluster did not): `futures = { workspace = true }`, `tokio-util = { workspace = true }`, `tracing = { workspace = true }`, plus `rb-proto = { path = "../rb-proto" }`, `rb-engine = { path = "../rb-engine" }`, `rb-embed = { path = "../rb-embed" }`. (`serde_json` is no longer needed here since request decoding goes through `read_frame`; keep it only if other modules use it.)
+
+- [ ] **Step 6: Verify it compiles (full integration test arrives in Task 26).** Run: `cargo build -p rb-daemon` Expected: `Finished` (exit 0). The server wiring type-checks against `rb_proto`/`rb_engine`. If `read_frame`/`write_frame` signatures differ from `read_frame::<_, T>(&mut framed)` / `write_frame(&mut framed, &value)`, adjust the calls to the rb-proto helpers' actual form (verify against rb-proto at execution; keep the framing semantics).
+
+- [ ] **Step 7: Lint + format.** Run: `cargo clippy -p rb-daemon --all-targets --all-features -- -D warnings` Expected: no warnings. Run: `cargo fmt --all` Expected: no diff.
+
+- [ ] **Step 8: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-daemon/src/server.rs crates/rb-daemon/src/error_map.rs crates/rb-daemon/src/lib.rs crates/rb-daemon/Cargo.toml && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rb-daemon): add UDS server with single-instance guard, per-connection dispatch, and graceful shutdown"`
+
+---
+
+### Task 26: rb-daemon end-to-end integration tests — full client round-trip, concurrency, namespace isolation, single-instance
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/tests/daemon_e2e.rs`
+
+The capstone tests for the cluster. They bind a real `Daemon` on a temp socket, run it on a task with an oneshot-driven shutdown, connect a real `rb_proto::Client`, and exercise the full surface. The deterministic, offline `rb_embed::DeterministicProvider` is used (never real Voyage), so CI never touches the network. Three guarantees from spec §8/§15 are proven: (1) a full `remember→recall→get→list→graph→update→delete→context`+`ping` round-trip; (2) many concurrent clients with no lost writes and no errors; (3) namespace isolation — a client handshaked as `Project("a")` never sees `Project("b")` rows through the daemon.
+
+- [ ] **Step 1: Write the failing end-to-end test.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rb-daemon/tests/daemon_e2e.rs` with the complete contents below.
+
+```rust
+//! End-to-end daemon tests over a real Unix socket with the offline
+//! DeterministicProvider (no network). Proves the full round-trip, concurrency
+//! with no lost writes, namespace isolation, and single-instance guarding.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use rb_daemon::{Daemon, DaemonConfig, SharedEmbedder};
+use rb_embed::DeterministicProvider;
+use rb_proto::Client;
+use rb_types::{MemoryType, MemoryUpdates, Namespace};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+const DIM: usize = 8;
+
+/// A running daemon plus the means to shut it down and join its task.
+struct RunningDaemon {
+    socket: PathBuf,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+    _dir: tempfile::TempDir,
+}
+
+impl RunningDaemon {
+    async fn start(pool_size: usize) -> RunningDaemon {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("sock");
+        let db = dir.path().join("memory.db");
+        let cfg = DaemonConfig {
+            socket_path: socket.clone(),
+            db_path: db,
+            read_pool_size: pool_size,
+        };
+        let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+        let daemon = Daemon::bind(cfg, embedder).await.unwrap();
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let task = tokio::spawn(async move {
+            daemon
+                .run(async move {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        // Wait until the socket is connectable (bind completed before spawn, so
+        // this is effectively immediate, but poll to avoid races on slow CI).
+        for _ in 0..200 {
+            if tokio::net::UnixStream::connect(&socket).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        RunningDaemon {
+            socket,
+            shutdown: Some(tx),
+            task: Some(task),
+            _dir: dir,
+        }
+    }
+
+    async fn stop(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn full_round_trip_through_client() {
+    let daemon = RunningDaemon::start(4).await;
+    let ns = Namespace::Project("a".to_string());
+    let mut client = Client::connect(&daemon.socket, ns.clone()).await.unwrap();
+
+    // ping
+    client.ping().await.unwrap();
+
+    // remember
+    let id = client
+        .remember(
+            "rusty-brain uses one db and one transaction".to_string(),
+            Some("architecture".to_string()),
+            MemoryType::ArchitectureDecision,
+            8,
+            vec!["sqlite".to_string()],
+            vec!["design".to_string()],
+            vec!["src/store.rs".to_string()],
+        )
+        .await
+        .unwrap();
+
+    // get
+    let got = client.get(id.clone()).await.unwrap();
+    assert!(got.is_some());
+    let note = got.unwrap();
+    assert_eq!(note.content, "rusty-brain uses one db and one transaction");
+    assert_eq!(note.namespace, ns, "stored under the handshake namespace");
+
+    // recall: the stored doc and the query share FTS tokens (rusty-brain / db /
+    // transaction), so the KEYWORD signal surfaces it. (The DeterministicProvider
+    // hashes differing texts to dissimilar vectors, so the match here is driven
+    // by keyword search, not vector similarity.)
+    let results = client
+        .recall("rusty-brain db transaction".to_string(), 10, None, vec![])
+        .await
+        .unwrap();
+    assert!(
+        results.iter().any(|r| r.memory.id == id),
+        "recall must surface the remembered memory"
+    );
+
+    // list
+    let listed = client.list(None, 50).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, id);
+
+    // graph (no links yet -> neighborhood may be empty or contain only the node)
+    let graph = client.graph(id.clone(), 1).await.unwrap();
+    assert!(
+        graph.iter().all(|m| m.id != id) || graph.is_empty() || graph.iter().any(|m| m.id == id),
+        "graph returns a (possibly empty) neighborhood without error"
+    );
+
+    // update
+    let updates = MemoryUpdates {
+        importance: Some(10),
+        tags: Some(vec!["design".to_string(), "core".to_string()]),
+        ..Default::default()
+    };
+    client.update(id.clone(), updates).await.unwrap();
+    let after = client.get(id.clone()).await.unwrap().unwrap();
+    assert_eq!(after.importance, 10);
+
+    // context
+    let (recent, important, total) = client.context().await.unwrap();
+    assert!(total >= 1, "context total counts the active memory");
+    assert!(
+        recent.iter().chain(important.iter()).any(|m| m.id == id),
+        "context surfaces the high-importance memory"
+    );
+
+    // delete (soft archive) -> no longer listed
+    client.delete(id.clone()).await.unwrap();
+    let listed_after = client.list(None, 50).await.unwrap();
+    assert!(
+        listed_after.iter().all(|m| m.id != id),
+        "archived memory is not listed"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn many_concurrent_clients_no_lost_writes_no_errors() {
+    let daemon = RunningDaemon::start(4).await;
+    let ns = Namespace::Project("a".to_string());
+
+    const CLIENTS: usize = 16;
+    const PER_CLIENT: usize = 10;
+
+    let mut tasks = Vec::with_capacity(CLIENTS);
+    for c in 0..CLIENTS {
+        let socket = daemon.socket.clone();
+        let ns = ns.clone();
+        tasks.push(tokio::spawn(async move {
+            let mut client = Client::connect(&socket, ns).await.unwrap();
+            for i in 0..PER_CLIENT {
+                client
+                    .remember(
+                        format!("memory from client {c} item {i}"),
+                        None,
+                        MemoryType::Insight,
+                        5,
+                        vec!["concurrent".to_string()],
+                        vec![],
+                        vec![],
+                    )
+                    .await
+                    .unwrap();
+            }
+            // `client` (and its connection) is dropped here, closing the
+            // connection so the daemon's per-connection task can finish.
+        }));
+    }
+    for t in tasks {
+        t.await.unwrap();
+    }
+
+    // A fresh client must see EVERY write (no lost writes).
+    let mut verifier = Client::connect(&daemon.socket, ns).await.unwrap();
+    let listed = verifier.list(None, CLIENTS * PER_CLIENT + 10).await.unwrap();
+    assert_eq!(
+        listed.len(),
+        CLIENTS * PER_CLIENT,
+        "all {} writes must be present (no lost writes)",
+        CLIENTS * PER_CLIENT
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn namespace_isolation_enforced_server_side() {
+    let daemon = RunningDaemon::start(4).await;
+
+    // Client A writes under Project("a").
+    let ns_a = Namespace::Project("a".to_string());
+    let mut client_a = Client::connect(&daemon.socket, ns_a.clone()).await.unwrap();
+    let id_a = client_a
+        .remember(
+            "secret belonging to project a".to_string(),
+            None,
+            MemoryType::Insight,
+            7,
+            vec!["alpha".to_string()],
+            vec![],
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // Client B writes under Project("b").
+    let ns_b = Namespace::Project("b".to_string());
+    let mut client_b = Client::connect(&daemon.socket, ns_b.clone()).await.unwrap();
+    let id_b = client_b
+        .remember(
+            "secret belonging to project b".to_string(),
+            None,
+            MemoryType::Insight,
+            7,
+            vec!["beta".to_string()],
+            vec![],
+            vec![],
+        )
+        .await
+        .unwrap();
+
+    // B's list/recall must NOT reveal A's row, even if B asks broadly.
+    let b_list = client_b.list(None, 50).await.unwrap();
+    assert!(
+        b_list.iter().all(|m| m.id != id_a),
+        "namespace B must not see namespace A's memory via list"
+    );
+    assert!(
+        b_list.iter().any(|m| m.id == id_b),
+        "namespace B sees its own memory"
+    );
+
+    let b_recall = client_b
+        .recall("secret".to_string(), 50, None, vec![])
+        .await
+        .unwrap();
+    assert!(
+        b_recall.iter().all(|r| r.memory.id != id_a),
+        "namespace B must not recall namespace A's memory"
+    );
+
+    // And A cannot see B's row.
+    let a_list = client_a.list(None, 50).await.unwrap();
+    assert!(
+        a_list.iter().all(|m| m.id != id_b),
+        "namespace A must not see namespace B's memory"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn second_bind_on_live_socket_fails_closed() {
+    let daemon = RunningDaemon::start(2).await;
+
+    // A second bind on the SAME live socket must be refused (single-instance).
+    let dir2 = tempfile::tempdir().unwrap();
+    let cfg2 = DaemonConfig {
+        socket_path: daemon.socket.clone(),
+        db_path: dir2.path().join("memory.db"),
+        read_pool_size: 2,
+    };
+    let embedder = SharedEmbedder::new(DeterministicProvider::new(DIM));
+    let err = Daemon::bind(cfg2, embedder).await.unwrap_err();
+    assert!(
+        err.to_string().contains("already listening"),
+        "second bind on a live socket must fail closed: {err}"
+    );
+
+    daemon.stop().await;
+}
+```
+
+- [ ] **Step 2: Run it — expect PASS.** Run: `cargo test -p rb-daemon --test daemon_e2e -- --nocapture` Expected: PASS — `full_round_trip_through_client`, `many_concurrent_clients_no_lost_writes_no_errors`, `namespace_isolation_enforced_server_side`, and `second_bind_on_live_socket_fails_closed` all report `ok`. If `recall` finds nothing, the FTS keyword path is not matching shared tokens — confirm `rb-store::keyword_search` tokenizes content and `rb-search` ranks the keyword hit (the stored doc and the query share `rusty-brain`/`db`/`transaction`, so keyword match, not vector similarity, drives this). If `namespace_isolation_*` fails, the dispatch is honoring a client-supplied scope instead of pinning the handshake namespace — re-check Task 25's `dispatch` (scope fields are ignored; the engine's namespace is fixed).
+
+- [ ] **Step 3: Stress for flakiness.** Run: `cargo test -p rb-daemon --test daemon_e2e -- --nocapture` two more times. Expected: PASS every time. The concurrency test must always see exactly `CLIENTS * PER_CLIENT` rows; a single lost write or `SQLITE_BUSY` is a hard failure (the single writer thread serializes all writes, so this must hold).
+
+- [ ] **Step 4: Run the whole crate suite (no regressions).** Run: `cargo test -p rb-daemon` Expected: PASS — the unit tests (change, paths, shared_embedder, error_map), the `store_handle` integration tests, and these e2e tests all green.
+
+- [ ] **Step 5: Workspace-wide gates.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` Expected: no warnings (no `unwrap`/`expect`/`panic` outside `#[cfg(test)]`). Run: `cargo fmt --all --check` Expected: no diff, exit 0.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rb-daemon/tests/daemon_e2e.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "test(rb-daemon): end-to-end client round-trip, concurrency, namespace isolation, and single-instance gates"`
+
+## Part K — rusty-brain binary (CLI) & end-to-end tests
+
+### Task 27: bin crate wiring — `rusty-brain` Cargo.toml dev-deps, `main.rs`, and module skeleton
+
+The `crates/rusty-brain` skeleton (package `rusty-brain`, `[[bin]] name = "rusty-brain"`, lib name `rusty_brain`) was created in the P1 setup task with its runtime deps. This task adds the dev-dependencies the CLI tests need (`assert_cmd`, `predicates`, `tempfile`, `anyhow`), stands up the module layout (`cli`, `namespace_detect`, `paths`, `logging`, `output`, `run`), and wires a minimal `main.rs` that parses args and dispatches — so every later task plugs into a compiling crate. We split logic into a library (`lib.rs`) plus a thin `main.rs` so `assert_cmd` can drive the real binary while unit tests can call the library directly.
+
+**Files:**
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/Cargo.toml`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/cli.rs`
+
+- [ ] **Step 1: Add dev-dependencies to the bin manifest.** Modify `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/Cargo.toml` so the `[dependencies]` table (already present from setup) is followed by a `[dev-dependencies]` table and the `[lints]` table. Replace the whole file with exactly:
+
+```toml
+[package]
+name = "rusty-brain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain: shared agent memory daemon and CLI."
+
+[[bin]]
+name = "rusty-brain"
+path = "src/main.rs"
+
+[lib]
+name = "rusty_brain"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-proto = { path = "../rb-proto" }
+rb-daemon = { path = "../rb-daemon" }
+rb-embed = { path = "../rb-embed" }
+tokio = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+directories = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = { workspace = true }
+anyhow = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Write the clap CLI definition.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/cli.rs` with the full argument surface. Subcommand argument parsing for `--type` reuses `rb_types::MemoryType::parse` via a small `value_parser`. (`default_value = "insight"` is run through `parse_memory_type` at parse time; `MemoryType` needs no `Display` impl because we use a string default, not `default_value_t`.)
+
+```rust
+//! Command-line surface for the `rusty-brain` binary (clap derive).
+
+use clap::{Parser, Subcommand};
+use rb_types::MemoryType;
+
+/// Parse a `--type` value into a `MemoryType` using the canonical db strings.
+fn parse_memory_type(s: &str) -> Result<MemoryType, String> {
+    MemoryType::parse(s).map_err(|e| e.to_string())
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "rusty-brain",
+    about = "Shared semantic memory for AI agents (daemon + CLI).",
+    version
+)]
+pub struct Cli {
+    /// Emit machine-readable JSON instead of human text (where supported).
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Run the memory daemon in the foreground until Ctrl-C.
+    Serve,
+
+    /// Store a new memory.
+    Remember {
+        /// Memory content (the body to remember).
+        content: String,
+        /// Memory type (db string, e.g. `insight`, `bug_fix`).
+        #[arg(long = "type", default_value = "insight", value_parser = parse_memory_type)]
+        memory_type: MemoryType,
+        /// Importance 1-10.
+        #[arg(long, default_value_t = 5)]
+        importance: u8,
+        /// Optional context string.
+        #[arg(long)]
+        context: Option<String>,
+        /// Tags (repeatable: `--tags a --tags b`).
+        #[arg(long)]
+        tags: Vec<String>,
+    },
+
+    /// Recall memories matching a query.
+    Recall {
+        /// Free-text query.
+        query: String,
+        /// Maximum number of results.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+        /// Restrict to a memory type (db string).
+        #[arg(long = "type", value_parser = parse_memory_type)]
+        memory_type: Option<MemoryType>,
+        /// Filter by tags (repeatable).
+        #[arg(long)]
+        tags: Vec<String>,
+    },
+
+    /// Fetch a single memory by id.
+    Get {
+        /// Memory id (UUID).
+        id: String,
+    },
+
+    /// List memories in the current namespace.
+    List {
+        /// Maximum number of results.
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        /// Only memories with at least this importance.
+        #[arg(long)]
+        min_importance: Option<u8>,
+    },
+
+    /// Show memories connected to an id by graph links.
+    Graph {
+        /// Memory id (UUID).
+        id: String,
+        /// Traversal depth.
+        #[arg(long, default_value_t = 1)]
+        depth: u8,
+    },
+
+    /// Soft-delete (archive) a memory.
+    Delete {
+        /// Memory id (UUID).
+        id: String,
+    },
+
+    /// Show the project context payload (recent + important).
+    Context,
+
+    /// Ping the daemon and report its contract version.
+    Status,
+}
+```
+
+- [ ] **Step 3: Write a minimal `lib.rs` that re-exports the modules.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`. The later tasks add `namespace_detect`, `paths`, `logging`, `output`, `serve`, `client`, and `run`; declare only `cli` now so the crate compiles:
+
+```rust
+//! `rusty_brain` binary library: clap CLI, namespace detection, daemon/client glue.
+//!
+//! Logic lives here (testable directly); `main.rs` is a thin shell that parses
+//! args and dispatches. Later tasks add `paths`, `namespace_detect`, `logging`,
+//! `output`, `serve`, `client`, and `run`.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod cli;
+```
+
+- [ ] **Step 4: Write a minimal `main.rs` that parses args and exits cleanly.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs`. For now it only proves the CLI parses; real dispatch arrives in Task 34. Returning `std::process::ExitCode` keeps the no-`panic` lint satisfied:
+
+```rust
+//! `rusty-brain` binary entry point. Parses the CLI; dispatch is wired in Task 34.
+
+use clap::Parser;
+use rusty_brain::cli::Cli;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let _cli = Cli::parse();
+    ExitCode::SUCCESS
+}
+```
+
+- [ ] **Step 5: Verify the bin crate builds.** Run: `cargo build -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml`
+  Expected: `Compiling rusty-brain v0.0.1 ...` then `Finished` (exit 0).
+
+- [ ] **Step 6: Verify `--help` is generated.** Run: `cargo run -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- --help`
+  Expected: prints usage including the subcommands `serve`, `remember`, `recall`, `get`, `list`, `graph`, `delete`, `context`, `status` (exit 0).
+
+- [ ] **Step 7: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 8: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/Cargo.toml crates/rusty-brain/src/lib.rs crates/rusty-brain/src/main.rs crates/rusty-brain/src/cli.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add clap CLI surface and bin/lib skeleton"`
+  Expected: one commit created.
+
+---
+
+### Task 28: `paths` module — env-overridable socket/db paths
+
+Client and daemon must agree on where the socket and database live, and tests must be able to redirect both to a temp directory. This module wraps `rb_daemon::default_socket_path()` / `default_db_path()` and lets `RUSTY_BRAIN_SOCKET` / `RUSTY_BRAIN_DB` override them. The override is read from the process environment, so `assert_cmd` can set it per test.
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/paths.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod paths;` to `lib.rs` (after `pub mod cli;`), then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/paths.rs` with the test module only. The functions take an explicit `Option<String>` override so tests never mutate global process env (which is unsound across threads):
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn socket_path_prefers_override() {
+        let got = resolve_socket_path(Some("/tmp/rb-test.sock".to_string()));
+        assert_eq!(got, PathBuf::from("/tmp/rb-test.sock"));
+    }
+
+    #[test]
+    fn socket_path_falls_back_to_default_when_no_override() {
+        let got = resolve_socket_path(None);
+        // Cross-cluster coupling: this pins to rb-daemon's default socket file
+        // name (`sock`, per the spine `$XDG_RUNTIME_DIR/rusty-brain/sock`). If
+        // rb-daemon renames it, update this assertion.
+        assert_eq!(got.file_name().unwrap(), "sock");
+    }
+
+    #[test]
+    fn db_path_prefers_override() {
+        let got = resolve_db_path(Some("/tmp/rb-test.db".to_string()));
+        assert_eq!(got, PathBuf::from("/tmp/rb-test.db"));
+    }
+
+    #[test]
+    fn db_path_falls_back_to_default_when_no_override() {
+        let got = resolve_db_path(None);
+        // Cross-cluster coupling: pins to rb-daemon's default db extension `db`.
+        assert_eq!(got.extension().unwrap(), "db");
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml paths` Expected: FAIL to compile (`cannot find function 'resolve_socket_path'`), confirming the module is compiled and the impl is missing.
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/paths.rs`:
+
+```rust
+//! Socket / database path resolution with env-var overrides for tests.
+
+use std::path::PathBuf;
+
+/// Env var that overrides the daemon socket path.
+pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
+/// Env var that overrides the database path.
+pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
+
+/// Resolve the socket path: explicit override wins, else the daemon default.
+pub fn resolve_socket_path(override_value: Option<String>) -> PathBuf {
+    match override_value {
+        Some(p) => PathBuf::from(p),
+        None => rb_daemon::default_socket_path(),
+    }
+}
+
+/// Resolve the database path: explicit override wins, else the daemon default.
+pub fn resolve_db_path(override_value: Option<String>) -> PathBuf {
+    match override_value {
+        Some(p) => PathBuf::from(p),
+        None => rb_daemon::default_db_path(),
+    }
+}
+
+/// Read the socket path from the environment (override) or fall back to default.
+pub fn socket_path_from_env() -> PathBuf {
+    resolve_socket_path(std::env::var(SOCKET_ENV).ok())
+}
+
+/// Read the db path from the environment (override) or fall back to default.
+pub fn db_path_from_env() -> PathBuf {
+    resolve_db_path(std::env::var(DB_ENV).ok())
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml paths` Expected: PASS (4 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/paths.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add env-overridable socket/db path resolution"`
+  Expected: one commit created.
+
+---
+
+### Task 29: `namespace_detect` module — minimal git-root / cwd → `Namespace::Project`
+
+P1 namespace detection is deliberately minimal (full git/`CLAUDE.md` detection is P2): use the git repository root's directory name if inside a repo, else the current directory name, as `Namespace::Project(name)`; fall back to `Namespace::Global` only when no usable directory name exists. The detection is parameterized over a starting directory and a "git root finder" closure so it is fully unit-testable without touching the real cwd or shelling out to git.
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/namespace_detect.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod namespace_detect;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/namespace_detect.rs` with the test module only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::Namespace;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn uses_git_root_dirname_when_in_repo() {
+        let start = Path::new("/home/alice/code/rusty-brain/crates/rusty-brain");
+        let git_root = |_: &Path| -> Option<PathBuf> {
+            Some(PathBuf::from("/home/alice/code/rusty-brain"))
+        };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Project("rusty-brain".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_cwd_dirname_outside_repo() {
+        let start = Path::new("/home/alice/scratch/notes");
+        let git_root = |_: &Path| -> Option<PathBuf> { None };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Project("notes".to_string()));
+    }
+
+    #[test]
+    fn falls_back_to_global_for_root_dir() {
+        let start = Path::new("/");
+        let git_root = |_: &Path| -> Option<PathBuf> { None };
+        let ns = detect_namespace_with(start, git_root);
+        assert_eq!(ns, Namespace::Global);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml namespace_detect` Expected: FAIL to compile (`cannot find function 'detect_namespace_with'`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/namespace_detect.rs`:
+
+```rust
+//! Minimal namespace detection for P1: git-root or cwd directory name.
+//!
+//! Full git/`CLAUDE.md` resolution is deferred to P2. This is intentionally a
+//! single, predictable rule so behavior is obvious from the working directory.
+
+use rb_types::Namespace;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Detect the namespace for the real process, using the current directory and a
+/// `git rev-parse --show-toplevel` lookup. Never fails: degrades to `Global`.
+pub fn detect_namespace() -> Namespace {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    detect_namespace_with(&cwd, git_toplevel)
+}
+
+/// Core logic, parameterized for tests: pick the git-root dir name if a repo is
+/// found, else the start dir name, else `Global`.
+pub fn detect_namespace_with<F>(start: &Path, git_root: F) -> Namespace
+where
+    F: Fn(&Path) -> Option<PathBuf>,
+{
+    let base = git_root(start).unwrap_or_else(|| start.to_path_buf());
+    match base.file_name().and_then(|n| n.to_str()) {
+        Some(name) if !name.is_empty() => Namespace::Project(name.to_string()),
+        _ => Namespace::Global,
+    }
+}
+
+/// Find the git toplevel for `dir` by invoking git; `None` if not a repo.
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml namespace_detect` Expected: PASS (3 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/namespace_detect.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add minimal git-root/cwd namespace detection"`
+  Expected: one commit created.
+
+---
+
+### Task 30: `logging` module — tracing to stderr, results to stdout
+
+Logs must go to stderr so that `--json` and result lines on stdout stay machine-parseable. This installs a `tracing_subscriber` writing to stderr, honoring `RUST_LOG` (default `info`). It is idempotent-safe for tests (uses `try_init` so a second init in the same process is a no-op rather than a panic).
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/logging.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod logging;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/logging.rs` with the test module only. The subscriber is process-global, so whether THIS call wins the install race depends on test ordering across the binary; the only sound invariant is that the call returns a `bool` without panicking and that a second call is a no-op (still no panic):
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn init_logging_is_idempotent_and_never_panics() {
+        // The subscriber is global; another test may have installed it first, so
+        // we cannot assert a specific true/false for the first call. We CAN
+        // assert that calling it twice in a row never panics and that the second
+        // call reports "already initialized" (false), proving try-init semantics:
+        // once a subscriber is set, init_logging() must return false rather than
+        // panic.
+        let _ = init_logging();
+        let second = init_logging();
+        assert!(!second, "second init must be a no-op (try_init returns false)");
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml logging` Expected: FAIL to compile (`cannot find function 'init_logging'`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/logging.rs`:
+
+```rust
+//! tracing setup: human logs to stderr; stdout is reserved for results.
+
+use tracing_subscriber::EnvFilter;
+
+/// Initialize tracing to stderr, honoring `RUST_LOG` (default `info`).
+/// Returns `true` if this call installed the subscriber, `false` if one was
+/// already set (safe to call repeatedly in-process; used by tests).
+pub fn init_logging() -> bool {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init()
+        .is_ok()
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml logging` Expected: PASS (1 test passes).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/logging.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add stderr tracing init (results stay on stdout)"`
+  Expected: one commit created.
+
+---
+
+### Task 31: `output` module — human + `--json` rendering of results
+
+All client subcommands render either human-readable text (default) or JSON (`--json`) to stdout. These pure formatting functions take the proto/domain values and return strings, so they unit-test without any IO. JSON output reuses `serde_json` on the domain types (which already derive `Serialize` in P0).
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/output.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod output;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/output.rs` with the test module only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace, SearchResult};
+
+    fn note(content: &str, importance: u8) -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Project("p".into()),
+            content.to_string(),
+            MemoryType::Insight,
+            importance,
+        )
+    }
+
+    #[test]
+    fn human_recall_lists_score_and_summary() {
+        let mut n = note("one db one transaction", 8);
+        n.summary = "one db one transaction".to_string();
+        let results = vec![SearchResult { memory: n.clone(), score: 0.91 }];
+        let out = render_recall(&results, false);
+        assert!(out.contains("0.91"), "score shown: {out}");
+        assert!(out.contains("one db one transaction"), "summary shown: {out}");
+        assert!(out.contains(&n.id.to_string()), "id shown: {out}");
+    }
+
+    #[test]
+    fn json_recall_is_parseable_array() {
+        let n = note("body", 5);
+        let results = vec![SearchResult { memory: n, score: 0.5 }];
+        let out = render_recall(&results, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0]["score"].as_f64().unwrap(), 0.5);
+    }
+
+    #[test]
+    fn human_recall_empty_has_guidance() {
+        let out = render_recall(&[], false);
+        assert!(out.to_lowercase().contains("no memories"), "empty guidance: {out}");
+    }
+
+    #[test]
+    fn human_list_shows_each_note() {
+        let notes = vec![note("alpha", 7), note("beta", 3)];
+        let out = render_notes(&notes, false);
+        assert!(out.contains("alpha"));
+        assert!(out.contains("beta"));
+    }
+
+    #[test]
+    fn json_list_is_parseable_array() {
+        let notes = vec![note("alpha", 7)];
+        let out = render_notes(&notes, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed[0]["content"].as_str().unwrap(), "alpha");
+    }
+
+    #[test]
+    fn render_get_some_and_none() {
+        let n = note("body", 5);
+        let some = render_get(&Some(n.clone()), false);
+        assert!(some.contains("body"));
+        let none = render_get(&None, false);
+        assert!(none.to_lowercase().contains("not found"));
+        let json_none = render_get(&None, true);
+        assert_eq!(json_none.trim(), "null");
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml output` Expected: FAIL to compile (`cannot find function 'render_recall'`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/output.rs` (note: `Namespace`/`MemoryType` have no `Display`, so we use `as_db_string()` / `as_str()`):
+
+```rust
+//! Pure rendering of results to human text or JSON (stdout).
+
+use rb_types::{MemoryNote, SearchResult};
+
+/// Render recall hits. JSON: the raw `Vec<SearchResult>`. Human: one line per hit.
+pub fn render_recall(results: &[SearchResult], json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(results)
+            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+    }
+    if results.is_empty() {
+        return "No memories matched.".to_string();
+    }
+    let mut out = String::new();
+    for r in results {
+        let summary = if r.memory.summary.is_empty() {
+            r.memory.content.as_str()
+        } else {
+            r.memory.summary.as_str()
+        };
+        out.push_str(&format!(
+            "[{:.2}] {} ({}) {}\n",
+            r.score,
+            r.memory.id,
+            r.memory.memory_type.as_str(),
+            summary
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a list of notes (used by `list`, `graph`, and the `context` halves).
+pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(notes)
+            .unwrap_or_else(|e| format!("[] // json error: {e}"));
+    }
+    if notes.is_empty() {
+        return "No memories.".to_string();
+    }
+    let mut out = String::new();
+    for n in notes {
+        let summary = if n.summary.is_empty() {
+            n.content.as_str()
+        } else {
+            n.summary.as_str()
+        };
+        out.push_str(&format!(
+            "{} (imp {}, {}) {}\n",
+            n.id,
+            n.importance,
+            n.memory_type.as_str(),
+            summary
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a single fetched memory (or a not-found message).
+pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(memory)
+            .unwrap_or_else(|e| format!("null // json error: {e}"));
+    }
+    match memory {
+        Some(n) => format!(
+            "{}\nnamespace: {}\ntype: {}\nimportance: {}\n\n{}",
+            n.id,
+            n.namespace.as_db_string(),
+            n.memory_type.as_str(),
+            n.importance,
+            n.content
+        ),
+        None => "Memory not found.".to_string(),
+    }
+}
+
+/// Render a remembered id (json: an object `{ "id": "<uuid>" }`).
+pub fn render_remembered(id: &rb_types::MemoryId, json: bool) -> String {
+    if json {
+        format!("{{\"id\":\"{id}\"}}")
+    } else {
+        format!("Remembered {id}")
+    }
+}
+
+/// Render the `context` payload.
+pub fn render_context(
+    recent: &[MemoryNote],
+    important: &[MemoryNote],
+    total: usize,
+    json: bool,
+) -> String {
+    if json {
+        let value = serde_json::json!({
+            "recent": recent,
+            "important": important,
+            "total": total,
+        });
+        return serde_json::to_string_pretty(&value)
+            .unwrap_or_else(|e| format!("{{}} // json error: {e}"));
+    }
+    let mut out = format!("Context ({total} memories total)\n\nRecent:\n");
+    out.push_str(&render_notes(recent, false));
+    out.push_str("\n\nImportant:\n");
+    out.push_str(&render_notes(important, false));
+    out
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml output` Expected: PASS (6 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/output.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add human/JSON result rendering"`
+  Expected: one commit created.
+
+---
+
+### Task 32: `serve` command — `Daemon::bind` + `run` with Ctrl-C shutdown and provider selection
+
+`serve` builds a `DaemonConfig` from the resolved socket/db paths, picks an embedding provider (`VoyageProvider::from_env()` if `VOYAGE_API_KEY` is set, else `DeterministicProvider::new(512)` with a tracing warning), and runs the daemon until `tokio::signal::ctrl_c` fires. The provider-selection logic is factored into a pure function returning the chosen `ProviderKind` so it is unit-testable without binding a socket; the async `run_serve` wiring is exercised end-to-end in Task 35.
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/serve.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod serve;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/serve.rs` with the test module only. The test drives the pure selection helper, which takes the env value explicitly:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn selects_voyage_when_key_present() {
+        let sel = select_provider_kind(Some("vk-123".to_string()));
+        assert_eq!(sel, ProviderKind::Voyage);
+    }
+
+    #[test]
+    fn selects_deterministic_when_key_absent() {
+        let sel = select_provider_kind(None);
+        assert_eq!(sel, ProviderKind::Deterministic);
+    }
+
+    #[test]
+    fn selects_deterministic_when_key_empty() {
+        let sel = select_provider_kind(Some(String::new()));
+        assert_eq!(sel, ProviderKind::Deterministic);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml serve` Expected: FAIL to compile (`cannot find type 'ProviderKind'`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/serve.rs`. The two daemon-run branches are monomorphic over the concrete provider type, so a single generic `run_with_embedder` tail is instantiated per branch (the `Daemon` is generic over the embedder per the spine):
+
+```rust
+//! `serve` subcommand: bind the daemon and run until Ctrl-C.
+
+use rb_daemon::{Daemon, DaemonConfig};
+use rb_embed::{DeterministicProvider, EmbeddingProvider, VoyageProvider};
+use rb_types::Result;
+use std::path::PathBuf;
+
+/// Default embedding dimension for the offline provider and Voyage's default model.
+pub const DEFAULT_DIM: usize = 512;
+
+/// Which embedding provider `serve` will use.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ProviderKind {
+    Voyage,
+    Deterministic,
+}
+
+/// Pure selection: Voyage iff a non-empty API key is present, else Deterministic.
+pub fn select_provider_kind(api_key: Option<String>) -> ProviderKind {
+    match api_key {
+        Some(k) if !k.is_empty() => ProviderKind::Voyage,
+        _ => ProviderKind::Deterministic,
+    }
+}
+
+/// Run the daemon at the given paths until `shutdown` resolves.
+/// Picks the embedding provider from the environment (`VOYAGE_API_KEY`).
+pub async fn run_serve(
+    socket_path: PathBuf,
+    db_path: PathBuf,
+    read_pool_size: usize,
+    shutdown: impl std::future::Future<Output = ()>,
+) -> Result<()> {
+    let api_key = std::env::var("VOYAGE_API_KEY").ok();
+    match select_provider_kind(api_key) {
+        ProviderKind::Voyage => {
+            let embedder = VoyageProvider::from_env()?;
+            run_with_embedder(socket_path, db_path, read_pool_size, embedder, shutdown).await
+        }
+        ProviderKind::Deterministic => {
+            tracing::warn!(
+                "VOYAGE_API_KEY not set; using offline DeterministicProvider \
+                 (dim {DEFAULT_DIM}). Recall quality is reduced and embeddings \
+                 are not portable to a real model."
+            );
+            let embedder = DeterministicProvider::new(DEFAULT_DIM);
+            run_with_embedder(socket_path, db_path, read_pool_size, embedder, shutdown).await
+        }
+    }
+}
+
+/// Bind a daemon for a concrete embedder and run it to shutdown.
+async fn run_with_embedder<P>(
+    socket_path: PathBuf,
+    db_path: PathBuf,
+    read_pool_size: usize,
+    embedder: P,
+    shutdown: impl std::future::Future<Output = ()>,
+) -> Result<()>
+where
+    P: EmbeddingProvider + 'static,
+{
+    let config = DaemonConfig {
+        socket_path,
+        db_path,
+        read_pool_size,
+    };
+    let daemon = Daemon::bind(config, embedder).await?;
+    daemon.run(shutdown).await
+}
+```
+
+> Cross-cluster contract note (rb-daemon): the spine prints `Daemon::bind(config: DaemonConfig)`, but the spine's 3-field `DaemonConfig` (socket_path, db_path, read_pool_size) has no field for the embedder, while the spine's `Daemon` struct is documented to *hold* an embedder (it constructs `StoreHandle` with `dim = embedder.dim()` and gives each per-connection `MemoryEngine` an embedder). The only consistent way to inject it is `Daemon::bind(config, embedder)`. This cluster therefore requires rb-daemon's `bind` to take `(DaemonConfig, P: EmbeddingProvider + 'static)`. If the rb-daemon cluster instead threads the embedder through `DaemonConfig` or a builder, change this single call site accordingly — `select_provider_kind`, `ProviderKind`, and `DEFAULT_DIM` are unaffected. (verify against installed rb-daemon at execution; adjust if the API differs.)
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml serve` Expected: PASS (3 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/serve.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add serve command with provider selection and ctrl-c shutdown"`
+  Expected: one commit created.
+
+---
+
+### Task 33: `client` module — connect with daemon auto-start + backoff retry
+
+Client subcommands connect to the default socket. If the socket is absent (no daemon), they spawn `rusty-brain serve` as a detached child, then retry `Client::connect` with a short bounded backoff before giving up. The connect-with-retry logic is parameterized over a "connect attempt" closure and a "spawn" closure so the retry/backoff behavior is unit-tested deterministically without real sockets or processes.
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/client.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod client;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/client.rs` with the test module only. The generic retry helper is tested with async closures and a counter, simulating "fails until the daemon is up":
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn succeeds_on_first_try_without_spawning() {
+        let spawned = Arc::new(AtomicUsize::new(0));
+        let sp = Arc::clone(&spawned);
+        let spawn = move || {
+            sp.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let at = Arc::clone(&attempts);
+        let connect = move || {
+            at.fetch_add(1, Ordering::SeqCst);
+            async { Ok::<u32, rb_types::Error>(7) }
+        };
+        let v = connect_with_retry(connect, spawn, 5, std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+        assert_eq!(spawned.load(Ordering::SeqCst), 0, "no spawn when first connect works");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn spawns_then_retries_until_connected() {
+        let spawned = Arc::new(AtomicUsize::new(0));
+        let sp = Arc::clone(&spawned);
+        let spawn = move || {
+            sp.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let at = Arc::clone(&attempts);
+        // Fail the first two attempts, succeed on the third.
+        let connect = move || {
+            let n = at.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(rb_types::Error::Io("no socket".into()))
+                } else {
+                    Ok::<u32, rb_types::Error>(42)
+                }
+            }
+        };
+        let v = connect_with_retry(connect, spawn, 10, std::time::Duration::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(v, 42);
+        assert_eq!(spawned.load(Ordering::SeqCst), 1, "spawned exactly once after first failure");
+        assert!(attempts.load(Ordering::SeqCst) >= 3);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts() {
+        let spawn = || Ok(());
+        let connect = || async { Err::<u32, rb_types::Error>(rb_types::Error::Io("never".into())) };
+        let err = connect_with_retry(connect, spawn, 3, std::time::Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::Io(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml client` Expected: FAIL to compile (`cannot find function 'connect_with_retry'`).
+
+- [ ] **Step 3: Add the implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/client.rs`:
+
+```rust
+//! Client connection with daemon auto-start and bounded backoff retry.
+
+use rb_proto::Client;
+use rb_types::{Error, Namespace, Result};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Generic connect-with-retry: try `connect`; on the first failure run `spawn`
+/// (to start the daemon) once, then keep retrying up to `max_attempts`, sleeping
+/// `backoff` between attempts. Returns the last error if all attempts fail.
+pub async fn connect_with_retry<C, Fut, T, S>(
+    mut connect: C,
+    spawn: S,
+    max_attempts: usize,
+    backoff: Duration,
+) -> Result<T>
+where
+    C: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+    S: FnOnce() -> Result<()>,
+{
+    let mut spawn = Some(spawn);
+    let mut last_err: Option<Error> = None;
+    for attempt in 0..max_attempts.max(1) {
+        match connect().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last_err = Some(e);
+                // After the very first failure, start the daemon once.
+                if attempt == 0 {
+                    if let Some(s) = spawn.take() {
+                        s()?;
+                    }
+                }
+                if backoff > Duration::ZERO {
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| Error::Io("connect failed".into())))
+}
+
+/// Connect to the daemon at `socket_path` for `namespace`, auto-starting a
+/// detached `rusty-brain serve` child if the socket is not yet accepting.
+pub async fn connect_or_start(
+    socket_path: &Path,
+    namespace: Namespace,
+    self_exe: PathBuf,
+) -> Result<Client> {
+    let sock = socket_path.to_path_buf();
+    let ns = namespace.clone();
+    let connect = || {
+        let sock = sock.clone();
+        let ns = ns.clone();
+        async move { Client::connect(&sock, ns).await }
+    };
+    let spawn_sock = socket_path.to_path_buf();
+    let spawn = move || spawn_daemon(&self_exe, &spawn_sock);
+    connect_with_retry(connect, spawn, 50, Duration::from_millis(100)).await
+}
+
+/// Spawn `rusty-brain serve` as a detached child, passing the resolved
+/// `RUSTY_BRAIN_SOCKET` so child + client agree on the socket path.
+fn spawn_daemon(self_exe: &Path, socket_path: &Path) -> Result<()> {
+    let mut cmd = std::process::Command::new(self_exe);
+    cmd.arg("serve");
+    cmd.env(crate::paths::SOCKET_ENV, socket_path);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::null());
+    cmd.spawn().map(|_child| ()).map_err(|e| Error::Io(e.to_string()))
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml client` Expected: PASS (3 tests pass).
+
+- [ ] **Step 5: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 6: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/client.rs crates/rusty-brain/src/lib.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): add client connect with daemon auto-start and backoff"`
+  Expected: one commit created.
+
+---
+
+### Task 34: `run` dispatcher + `main.rs` wiring — async dispatch of every subcommand
+
+This wires the parsed `Cli` to behavior: `serve` calls `run_serve` with a Ctrl-C shutdown; every client subcommand resolves paths + namespace, connects (auto-starting the daemon), issues the matching typed `Client` request, renders output to stdout, and maps errors to a non-zero `ExitCode`. The dispatcher returns `anyhow::Result<()>`; `main.rs` runs it on a tokio runtime and converts the result into an `ExitCode` (no `panic`).
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/run.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/lib.rs`
+- Modify: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs`
+
+- [ ] **Step 1: Write the failing test AND declare the module.** Add `pub mod run;` to `lib.rs`, then create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/run.rs` with the test module only. The test covers the pure id-parsing helper (`parse_id`) the dispatcher uses for `get`/`graph`/`delete`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_id_accepts_valid_uuid() {
+        let id = rb_types::MemoryId::new();
+        let parsed = parse_id(&id.to_string()).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn parse_id_rejects_garbage_with_clear_error() {
+        let err = parse_id("not-a-uuid").unwrap_err();
+        let msg = err.to_string();
+        // rb_types::MemoryId::from_str returns Error::Storage with the message
+        // "invalid memory id 'not-a-uuid': ...", so both substrings are present.
+        assert!(msg.contains("not-a-uuid") || msg.to_lowercase().contains("invalid"), "{msg}");
+    }
+
+    #[test]
+    fn memory_id_from_str_is_what_parse_id_uses() {
+        // Guards that parse_id and MemoryId::from_str stay in agreement.
+        let id = rb_types::MemoryId::new();
+        let a = parse_id(&id.to_string()).unwrap();
+        let b = rb_types::MemoryId::from_str(&id.to_string()).unwrap();
+        assert_eq!(a, b);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml run::` Expected: FAIL to compile (`cannot find function 'parse_id'`). The `::` suffix scopes the filter to the `run` module.
+
+- [ ] **Step 3: Add the dispatcher implementation above the test module.** Prepend to `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/run.rs`. Note: `RememberInput` is an `rb-engine` type and the bin crate does NOT depend on rb-engine; the proto `Client::remember` wrapper takes the explicit `Request::Remember` fields (rb-proto has no rb-engine dependency). The `Serve` arm inside `run_client` is impossible (handled earlier) but is mapped to an error rather than `unreachable!`, keeping the binary panic-free under the workspace `panic = deny` lint:
+
+```rust
+//! Async dispatch from parsed `Cli` to daemon/client behavior.
+
+use crate::cli::{Cli, Command};
+use crate::namespace_detect::detect_namespace;
+use crate::{client, output, paths, serve};
+use anyhow::Context as _;
+use rb_types::MemoryId;
+use std::str::FromStr;
+
+/// Parse a CLI id argument into a `MemoryId`, surfacing a clear error.
+pub fn parse_id(s: &str) -> rb_types::Result<MemoryId> {
+    MemoryId::from_str(s)
+}
+
+/// Execute the parsed CLI. `serve` blocks until Ctrl-C; client commands connect
+/// (auto-starting the daemon), issue one request, print to stdout, and return.
+pub async fn run(cli: Cli) -> anyhow::Result<()> {
+    let socket_path = paths::socket_path_from_env();
+    let db_path = paths::db_path_from_env();
+
+    match cli.command {
+        Command::Serve => {
+            let shutdown = async {
+                let _ = tokio::signal::ctrl_c().await;
+            };
+            serve::run_serve(socket_path, db_path, 4, shutdown)
+                .await
+                .context("daemon failed")?;
+            Ok(())
+        }
+        other => run_client(other, cli.json, &socket_path).await,
+    }
+}
+
+/// Connect to the daemon and dispatch a single client request.
+async fn run_client(
+    command: Command,
+    json: bool,
+    socket_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let namespace = detect_namespace();
+    let self_exe = std::env::current_exe().context("locating own executable")?;
+    let mut client = client::connect_or_start(socket_path, namespace, self_exe)
+        .await
+        .context("connecting to daemon")?;
+
+    match command {
+        // `serve` is dispatched in `run` before we ever reach here; return an
+        // error instead of `unreachable!` to keep the binary panic-free.
+        Command::Serve => {
+            anyhow::bail!("internal: serve must be handled before run_client")
+        }
+        Command::Remember {
+            content,
+            memory_type,
+            importance,
+            context,
+            tags,
+        } => {
+            // rb-proto's typed wrapper takes the explicit Request::Remember
+            // fields (no rb-engine RememberInput; the bin/proto crates do not
+            // depend on rb-engine). P1 client sends empty keywords/related_files;
+            // heuristic enrichment happens server-side in the engine.
+            let id = client
+                .remember(
+                    content,
+                    context,
+                    memory_type,
+                    importance,
+                    Vec::new(), // keywords
+                    tags,
+                    Vec::new(), // related_files
+                )
+                .await
+                .context("remember failed")?;
+            println!("{}", output::render_remembered(&id, json));
+        }
+        Command::Recall {
+            query,
+            limit,
+            memory_type,
+            tags,
+        } => {
+            let results = client
+                .recall(&query, limit, memory_type, &tags)
+                .await
+                .context("recall failed")?;
+            println!("{}", output::render_recall(&results, json));
+        }
+        Command::Get { id } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let memory = client.get(id).await.context("get failed")?;
+            println!("{}", output::render_get(&memory, json));
+        }
+        Command::List {
+            limit,
+            min_importance,
+        } => {
+            let notes = client
+                .list(min_importance, limit)
+                .await
+                .context("list failed")?;
+            println!("{}", output::render_notes(&notes, json));
+        }
+        Command::Graph { id, depth } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let notes = client.graph(id, depth).await.context("graph failed")?;
+            println!("{}", output::render_notes(&notes, json));
+        }
+        Command::Delete { id } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            client.delete(id).await.context("delete failed")?;
+            println!("Deleted");
+        }
+        Command::Context => {
+            let (recent, important, total) =
+                client.context().await.context("context failed")?;
+            println!(
+                "{}",
+                output::render_context(&recent, &important, total, json)
+            );
+        }
+        Command::Status => {
+            let version = client.ping().await.context("status/ping failed")?;
+            if json {
+                println!("{{\"contract_version\":{version},\"ok\":true}}");
+            } else {
+                println!("ok (contract v{version})");
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+> Note: the typed `Client` wrappers follow the spine — `remember(content, context, memory_type, importance, keywords, tags, related_files)->MemoryId` (mirroring the `Request::Remember` fields; rb-proto has no rb-engine dependency so it cannot accept `rb_engine::RememberInput`), `recall(&str, usize, Option<MemoryType>, &[String])->Vec<SearchResult>`, `get(MemoryId)->Option<MemoryNote>`, `list(Option<u8>, usize)->Vec<MemoryNote>`, `graph(MemoryId, u8)->Vec<MemoryNote>`, `delete(MemoryId)`, `context()->(Vec<MemoryNote>, Vec<MemoryNote>, usize)`, `ping()->u32`. If the rb-proto cluster gives `remember` a different argument grouping (e.g. a proto-local `RememberArgs` struct mirroring those fields), adapt this single call site; the dispatch structure is unchanged. (verify against installed rb-proto at execution; adjust the wrapper call if it differs.)
+
+- [ ] **Step 4: Run it — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml run::` Expected: PASS (3 tests pass).
+
+- [ ] **Step 5: Rewrite `main.rs` to run the dispatcher on a tokio runtime and map errors to `ExitCode`.** Set `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/src/main.rs` to (the multi-threaded runtime is required so the daemon's `spawn_blocking` reads and dedicated writer thread have a worker pool):
+
+```rust
+//! `rusty-brain` binary entry point: init logging, parse, dispatch, map exit code.
+
+use clap::Parser;
+use rusty_brain::cli::Cli;
+use rusty_brain::logging::init_logging;
+use rusty_brain::run::run;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    init_logging();
+    let cli = Cli::parse();
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start tokio runtime: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match runtime.block_on(run(cli)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            // Print the full anyhow context chain to stderr; stdout stays clean.
+            eprintln!("error: {e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Verify the whole bin compiles and parses.** Run: `cargo build -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: `Finished` (exit 0). Run: `cargo run -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- recall --help` Expected: usage for `recall` including `--limit`, `--type`, `--tags` (exit 0).
+
+- [ ] **Step 7: Lint + format.** Run: `cargo clippy -p rusty-brain --all-targets --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff.
+
+- [ ] **Step 8: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/src/run.rs crates/rusty-brain/src/lib.rs crates/rusty-brain/src/main.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "feat(rusty-brain): wire async dispatcher and main exit-code handling"`
+  Expected: one commit created.
+
+---
+
+### Task 35: CLI surface tests (assert_cmd) + end-to-end remember→recall through the real binary
+
+This task locks the CLI behavior with `assert_cmd`: help/version, argument-validation exit codes, and a full end-to-end run that starts the **real** binary's daemon on a temp socket+DB (via `RUSTY_BRAIN_SOCKET`/`RUSTY_BRAIN_DB`), runs `remember` then `recall`, and asserts the recalled content appears. The end-to-end test force-clears `VOYAGE_API_KEY` so the offline `DeterministicProvider` is used — CI never touches a live API.
+
+**Files:**
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/tests/cli_surface.rs`
+- Create: `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/tests/end_to_end.rs`
+
+- [ ] **Step 1: Write the CLI-surface tests.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/tests/cli_surface.rs`. These exercise the parser surface only (no daemon), so they are fast and hermetic:
+
+```rust
+//! CLI surface tests: help, version, and argument-validation exit codes.
+//! These never start the daemon (parser-only paths).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn bin() -> Command {
+    Command::cargo_bin("rusty-brain").unwrap()
+}
+
+#[test]
+fn help_lists_all_subcommands() {
+    bin()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("serve"))
+        .stdout(predicate::str::contains("remember"))
+        .stdout(predicate::str::contains("recall"))
+        .stdout(predicate::str::contains("get"))
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("graph"))
+        .stdout(predicate::str::contains("delete"))
+        .stdout(predicate::str::contains("context"))
+        .stdout(predicate::str::contains("status"));
+}
+
+#[test]
+fn version_prints_a_version() {
+    bin()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rusty-brain"));
+}
+
+#[test]
+fn unknown_subcommand_fails_with_nonzero_exit() {
+    bin().arg("frobnicate").assert().failure();
+}
+
+#[test]
+fn remember_requires_content_argument() {
+    // Missing required positional `content` -> clap usage error, exit 2.
+    bin()
+        .arg("remember")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("content").or(predicate::str::contains("required")));
+}
+
+#[test]
+fn remember_rejects_invalid_memory_type() {
+    bin()
+        .args(["remember", "some content", "--type", "not_a_type"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid").or(predicate::str::contains("not_a_type")));
+}
+
+#[test]
+fn recall_help_shows_flags() {
+    bin()
+        .args(["recall", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--limit"))
+        .stdout(predicate::str::contains("--type"))
+        .stdout(predicate::str::contains("--tags"));
+}
+```
+
+- [ ] **Step 2: Run the surface tests — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml --test cli_surface` Expected: PASS (6 tests). `assert_cmd` builds the `rusty-brain` binary on first use. If `remember_rejects_invalid_memory_type` fails, confirm the `--type` `value_parser` in `cli.rs` returns the `MemoryType::parse` error string (Task 27), whose `Display` is `"invalid memory type: not_a_type"`.
+
+- [ ] **Step 3: Write the end-to-end test.** Create `/Users/bluby/repos/rusty-brain-p1/crates/rusty-brain/tests/end_to_end.rs`. It explicitly starts the daemon (`serve`) on temp paths, waits for the socket to appear, runs `remember` then `recall`, asserts the content is recalled, then shuts the daemon down. The spawned daemon child is owned directly by a `Reap` guard whose `Drop` kills and waits on it, so it is reaped even if an assertion below panics. `VOYAGE_API_KEY` is force-cleared so the offline provider is used and CI never hits the network:
+
+```rust
+//! End-to-end: start the real binary's daemon on a temp socket+DB, then run
+//! `remember` and `recall` through the built binary; assert the content returns.
+//! Uses the offline DeterministicProvider (VOYAGE_API_KEY is cleared), so CI
+//! never contacts a live embedding API.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::cargo::cargo_bin;
+use predicates::prelude::*;
+use predicates::Predicate;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Owns the spawned daemon process and reaps it on drop (kill + wait), even if a
+/// later assertion panics and unwinds the test.
+struct Reap(Child);
+impl Drop for Reap {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Block until `path` exists or the deadline passes. Returns true if it appeared.
+fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    path.exists()
+}
+
+#[test]
+fn remember_then_recall_round_trips_through_the_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+
+    // 1. Start the daemon in the background on the temp socket+DB, owned by the
+    //    reaper guard so it is always cleaned up.
+    let _reap = Reap(
+        Command::new(&exe)
+            .arg("serve")
+            .env("RUSTY_BRAIN_SOCKET", &socket)
+            .env("RUSTY_BRAIN_DB", &db)
+            .env_remove("VOYAGE_API_KEY") // force offline DeterministicProvider
+            .env("RUST_LOG", "warn")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn daemon"),
+    );
+
+    assert!(
+        wait_for_socket(&socket, Duration::from_secs(10)),
+        "daemon socket never appeared at {}",
+        socket.display()
+    );
+
+    // 2. remember
+    let remember = Command::new(&exe)
+        .args(["remember", "always use one database and one transaction"])
+        .args(["--type", "architecture_decision", "--importance", "9"])
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env_remove("VOYAGE_API_KEY")
+        .output()
+        .expect("run remember");
+    assert!(
+        remember.status.success(),
+        "remember failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&remember.stdout),
+        String::from_utf8_lossy(&remember.stderr)
+    );
+
+    // 3. recall — the stored content must come back.
+    let recall = Command::new(&exe)
+        .args(["recall", "one database transaction", "--limit", "10"])
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env_remove("VOYAGE_API_KEY")
+        .output()
+        .expect("run recall");
+    assert!(
+        recall.status.success(),
+        "recall failed: stderr={:?}",
+        String::from_utf8_lossy(&recall.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&recall.stdout);
+    let found = predicate::str::contains("one database and one transaction");
+    assert!(
+        found.eval(&stdout),
+        "recalled output did not contain the remembered content; got: {stdout}"
+    );
+}
+```
+
+- [ ] **Step 4: Run the end-to-end test — expect PASS.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml --test end_to_end -- --nocapture` Expected: PASS — `remember_then_recall_round_trips_through_the_binary ... ok`. If it hangs at `wait_for_socket`, the daemon failed to bind: re-run `serve` manually with `RUST_LOG=debug` and the same env to see the bind error on stderr. If `recall` returns empty, the DeterministicProvider must produce the same vector for identical text and `recall` must include the keyword candidate path (rb-engine cluster); the content token overlap ("one database … transaction") also drives the FTS keyword match.
+
+- [ ] **Step 5: Run the whole bin test suite together.** Run: `cargo test -p rusty-brain --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: PASS — unit tests (`paths`, `namespace_detect`, `logging`, `output`, `serve`, `client`, `run`) plus `cli_surface` and `end_to_end` integration tests all green.
+
+- [ ] **Step 6: Lint + format the workspace.** Run: `cargo clippy --workspace --all-targets --all-features --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml -- -D warnings` Expected: no warnings. Run: `cargo fmt --all --check --manifest-path /Users/bluby/repos/rusty-brain-p1/Cargo.toml` Expected: no diff (exit 0).
+
+- [ ] **Step 7: Commit.** Run: `git -C /Users/bluby/repos/rusty-brain-p1 add crates/rusty-brain/tests/cli_surface.rs crates/rusty-brain/tests/end_to_end.rs && git -C /Users/bluby/repos/rusty-brain-p1 commit -m "test(rusty-brain): CLI surface tests and end-to-end remember/recall through the binary"`
+  Expected: one commit created.
+
+
+---
+
+## After P1 — Roadmap & the P2 parallelism note
+
+### Parallelizing P2 with P1
+The seam is **`rb-proto`** (Part F of this plan): it depends only on `rb-types`, so once Part F is committed, P2's MCP adapter + namespace detection can be built in a SEPARATE worktree (e.g. `~/repos/rusty-brain-p2`, branch `feat/p2-mcp-surface`) against the frozen wire contract, in parallel with the rest of P1 (G–K). Caveat: if the proto contract changes mid-flight, the P2 adapter must re-sync. For a solo dev, sequential P1 → P2 is simpler; fork P2 only if you want throughput. (Subagent implementers cannot safely share one branch — parallel streams require separate worktrees.)
+
+### P2 — Agent surface
+- `mcp` subcommand: thin MCP stdio server (one tool per `rb_proto::Request`), translating MCP tool calls → `rb_proto::Client` requests; daemon auto-start.
+- Namespace detection: real git-root + `CLAUDE.md` frontmatter parsing → `Namespace` (replaces P1's minimal dirname heuristic).
+- Wire graph links into recall (semantic link generation); optional LLM enrichment (summary/keywords/type/links) as an opt-in replacement for P1's heuristic enrichment.
+- `ContractVersion` surfaced to MCP clients; MCP contract tests per tool.
+
+### P3 — Deferred (behind existing seams)
+- `subscribe` change-stream over the daemon's `tokio::broadcast` (cross-agent awareness).
+- Memory evolution (consolidation / link decay / importance recalibration) as opt-in daemon jobs.
+- `local` ONNX embedding feature in `rb-embed`.
+
+### P4 — Broader agent surface (deferred)
+- `rb-hooks` / `rb-install`: capture hooks + `install` for Claude Code / OpenCode / Copilot / Codex / Gemini — fail-open, `ContractVersion`-gated. Separate crates, never compiled into core.
+
+### Carry-forward follow-ups from P0/P1 review
+- `record_access` / `supersede` `Store` methods (recall-time access-count bump, supersession) — the columns already exist in the P0 schema.
+- Batch link-loading to remove the N+1 in `list`/`get` (P0 left a `// TODO(P1)` marker).
+
+
+---
+
+## Plan provenance
+
+Authored by a 6-cluster fan-out against a fixed async/threading interface spine; each cluster adversarially reviewed for placeholders, spine/type drift, Rust/async correctness (writer-thread `!Sync` model, reads via `spawn_blocking`, no live network in CI), and writing-plans format. Reviewer-confirmed fixes per cluster: proto-setup (5); embed (5); search (4); engine (5); daemon (8); bin (6). Tasks renumbered globally for sequential execution.


### PR DESCRIPTION
## Summary

Implements the P1 engine and daemon plan across the new workspace crates:

- Adds `rb-proto`, `rb-embed`, `rb-search`, `rb-engine`, `rb-daemon`, and the `rusty-brain` CLI.
- Wires the daemon around a dedicated single-writer store thread, read pool, server-side namespace isolation, change broadcasts, UDS transport, pidfile single-instance guard, and graceful shutdown.
- Adds deterministic offline embeddings for tests, Voyage provider support with wiremock coverage, hybrid ranking, engine orchestration, and CLI end-to-end coverage.
- Hardens daemon boundaries by validating handshake namespaces, rejecting invalid importance before embedding, requiring private socket directories, and bounding shared embedder concurrency.
- Keeps the CLI independent of `rb-engine` / `RememberInput` and removes unused direct dependencies.

## Validation

- `cargo test --workspace --all-targets --all-features --target-dir /private/tmp/rusty-brain-p1-target`
- `cargo clippy --workspace --all-targets --all-features --target-dir /private/tmp/rusty-brain-p1-target -- -D warnings`
- `cargo fmt --all --check`
- `cargo deny check`
- final spec and quality review pass with no blocking findings

`cargo deny check` exits 0; it still reports warning-level duplicate/wildcard/unmatched-license-allowance notices from the current policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Memory daemon service** – Added a persistent local daemon for storing and retrieving memories with namespace isolation for project-scoped organization.
* **Hybrid memory retrieval** – Implemented multi-method search combining keyword matching, semantic vector similarity, and graph-based connections.
* **Memory management** – Added CLI commands to remember, recall, list, update, and archive memories with configurable importance levels and tagging.
* **Embedding providers** – Integrated offline deterministic embeddings and Voyage AI for semantic search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->