### PR TITLE
docs: add P5/P6/P7 roadmap (retrieval quality, llm-assisted evolution, apm distribution)

### DIFF
--- a/docs/plans/2026-06-02-rusty-brain-p5-retrieval-quality.md
+++ b/docs/plans/2026-06-02-rusty-brain-p5-retrieval-quality.md
@@ -1,0 +1,3146 @@
+# P5 — Retrieval Quality & Measurement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship spec §6–§9 — an offline CI-gated retrieval-quality measurement harness (`rb-eval`) and the three eval-gated improvements it guards: RRF two-stage fusion, composite embeddings with an idempotent re-embed primitive, and confidence-weighted ranking with contradiction surfacing.
+
+**Architecture:** P5 is additive and behind existing seams. A new dev-only `rb-eval` crate ingests committed JSON fixtures through `rb-engine` + `DeterministicProvider`, runs golden queries through recall, and asserts pure metrics (recall@k, MRR, dedup precision, latency) stay at or above a committed `baselines.json`. `rb-search` gains a scale-free `FusionMode::Rrf` path alongside the default `Linear` `rank()`. `rb-engine` swaps its content-only embed for a pure `embedding_input(note)` composite (content + keywords + tags + context), stamped with a new `embedding_input_version` (a `meta` invariant + an additive `memories` column behind a checksummed migration); a new `WriteCommand::Reembed` and a `rusty-brain reembed` CLI converge the corpus through the single writer. Confidence becomes a multiplicative ranking dampener, and an active `contradicts` link surfaces as a fail-open `contested` flag on result rows. The wire `CONTRACT_VERSION` bumps to 2.
+
+**Tech Stack:** Rust 2021 (stable, pinned). Workspace crates: rb-types, rb-store (rusqlite + sqlite-vec), rb-proto, rb-engine, rb-search, rb-embed, rb-enrich, rb-daemon, rb-mcp, rusty-brain, plus the new dev-only **rb-eval**. No new external dependencies in P5: `rb-eval` reuses existing workspace deps (serde, serde_json, chrono, tokio, tempfile). Tests are TDD, in-process, offline (`DeterministicProvider`; real-model comparisons `#[ignore]`).
+
+**Reference spec:** `docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md` — §6 (H eval), §7 (B RRF), §8 (A composite + reembed), §9 (C confidence + contradictions). Architecture: `docs/specs/2026-05-31-rusty-brain-architecture-design.md` — §9 (data model), §10 (embeddings), §11 (ranking), §15 (testing). Style template: `docs/plans/2026-06-02-rusty-brain-p3-deferred-features.md`.
+
+---
+
+## Hard rules (carry forward from P0–P4; apply to every task)
+
+- **TDD:** failing test first (RED), minimal implementation (GREEN), then clippy + fmt, then commit. One logical change per commit.
+- **Conventional commits**, lowercase, crate-scoped, one line, **NO AI attribution** (no "Generated with…", no `Co-Authored-By`). Example: `feat(rb-search): add rrf two-stage fusion mode`.
+- **Single-writer discipline:** ALL store mutations go through the daemon's single writer thread (`StoreHandle` `WriteCommand`s); reads go via the read pool. Never share `SqliteStore` across tasks. The new `WriteCommand::Reembed` is the ONLY vector-update path; the `rusty-brain reembed` CLI sends a daemon request and NEVER writes the DB directly.
+- **Namespace isolation stays enforced server-side and fails closed:** re-embed scans and contradiction lookups never cross the connection's handshake namespace.
+- **No-panic in non-test code:** workspace lints deny `unwrap_used`/`expect_used`/`panic`. Return `rb_types::Error` instead. Test modules (and the whole `rb-eval` crate, which is dev/measurement code) opt out with `#![allow(clippy::unwrap_used, clippy::expect_used)]`.
+- **Error plumbing:** reuse existing `rb_types::Error` variants (`Storage`, `InvalidArgument`, `Embedding`, `NotFound`, `DimensionMismatch`). This plan adds **no new error variant** (which would require arms in `rb-proto::error_kind`, `rb-proto::response_error_to_error`, and `rb-daemon::error_to_response`).
+- **Fail-open vs fail-closed:** the dim contract (`seed_or_verify_dim`) stays fail-closed. Contradiction surfacing (`contested`) is best-effort enrichment and fails OPEN (a lookup error returns unflagged results, never aborts recall). Re-embed batches fail-SAFE (a failed row is logged and retried next run, never fatal).
+- **No live network in CI:** `rb-eval` and all unit/integration tests use committed fixtures and `DeterministicProvider`. Real-model comparisons (composite-embedding semantic lift, RRF-vs-Linear on a real corpus) are `#[ignore]`, run manually.
+- **New migration** (`003_embedding_input_version.sql`) is additive, file-discovered, checksummed, and must pass the existing fresh-DB reproducibility gate (`embedded_initial_schema_creates_expected_objects` pattern) and the duplicate-version guard.
+- **`Linear` stays the byte-for-byte default.** RRF is opt-in; the default flips to `Rrf` only in a later, separate commit if and when `rb-eval` shows a win. P5 does not flip it.
+- **Per-Part gate** (final task of each Part): `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`. The final gate (Part C) also runs `cargo deny check` (must stay green; no new deps).
+- **Commands run from the worktree root** so crate-scoped cargo (`cargo test -p rb-eval`, etc.) keeps paths stable.
+
+## Seam map (verified against this worktree; the exact code each Part builds on)
+
+| Seam | Location | Used by |
+|---|---|---|
+| `Signals { id, keyword_rank, vector_distance, graph_hops, importance, created_at }`, `score_one`, `rank`, `HALF_LIFE=30.0` | `crates/rb-search/src/rank.rs` | B, C |
+| `Weights { vector, keyword, graph, importance, recency }` (`Default` sums to 1.0) | `crates/rb-search/src/weights.rs` | B, C |
+| `build_signals(keyword, vector, graph, meta)` folds three result sets into `Vec<Signals>`; `meta: HashMap<MemoryId,(u8, DateTime)>` | `crates/rb-search/src/merge.rs` | B, C |
+| `pub use rank::{rank, Signals, HALF_LIFE}` etc. | `crates/rb-search/src/lib.rs` | B, C |
+| `MemoryEngine::remember` embeds `note.content` alone (`engine.rs:147`); `recall` builds `meta` from `(importance, created_at)` (`engine.rs:282`); `update` rejects content (`engine.rs:384`) | `crates/rb-engine/src/engine.rs` | A, B, C |
+| `MemoryBackend` trait (write/get/keyword/vector/graph/list/update/archive/add_link/record_access(es)/get_many) | `crates/rb-engine/src/backend.rs` | A, C |
+| `MockBackend` test backend (`test_support.rs`); `DeterministicProvider` | `crates/rb-engine/src/test_support.rs`, `crates/rb-embed/src/deterministic.rs` | A, B, C |
+| `insert_memory` INSERTs `memory_vectors` write-once (`store.rs:818`); `near_duplicates` (`store.rs:282`); `distance_to_similarity` (`store.rs:619`); `decode_embedding_bytes`/`embedding_bytes`; `row_to_note` (`store.rs:684`); `seed_or_verify_dim` (`store.rs:534`); `update_memory` (`store.rs:1087`); `load_links` (`store.rs:647`) | `crates/rb-store/src/store.rs` | A, C |
+| File-discovered checksummed migrations; `001_initial_schema.sql`, `002_link_base_strength.sql`; duplicate-version guard | `crates/rb-store/src/migrations.rs`, `crates/rb-store/migrations/` | A |
+| `WriteCommand` enum + `writer_loop` + `run_store_op` (catch_unwind/reopen); `StoreHandle` methods; `MemoryBackend for StoreHandle` | `crates/rb-daemon/src/store_handle.rs` | A |
+| `run_once(kind, &StoreHandle, &JobsConfig)`, `JobSummary`, `JobKind` | `crates/rb-daemon/src/jobs/mod.rs`, `crates/rb-types/src/job.rs` | A |
+| `Request`/`Response` enums; `CONTRACT_VERSION=1`; round-trip tests | `crates/rb-proto/src/messages.rs` | A, C |
+| `dispatch(engine, job_store, jobs_config, req)`; `handle_connection`; `MAX_LIMIT` | `crates/rb-daemon/src/server.rs` | A, C |
+| MCP `to_value(Response)` serializes `SearchResult`/`MemoryNote` via serde (`proxy.rs:183`) | `crates/rb-mcp/src/proxy.rs` | C |
+| CLI `Command` enum (clap derive); `client.rs` daemon round-trip; `output.rs` rendering | `crates/rusty-brain/src/{cli.rs,client.rs,output.rs}` | A, C |
+| `MemoryNote { …, confidence: f32, embedding_model: String, … }`; `SearchResult { memory, score }`; `MemoryUpdates` | `crates/rb-types/src/{memory.rs,query.rs}` | A, C |
+| Workspace `members`, `workspace.dependencies`, `workspace.lints` | `Cargo.toml` | H |
+
+## Build order & dependencies
+
+```text
+Part H  rb-eval offline regression harness        (FIRST — gates B/A/C; nothing below is mergeable without it)
+Part B  RRF two-stage fusion mode                  (pure rb-search; rb-eval compares Linear vs Rrf)
+Part A  composite embedding + reembed primitive    (engine + store + migration + daemon + CLI; rb-eval guards regression)
+Part C  confidence dampener + contradiction flag   (rb-search + store + engine + proto/mcp/cli; rb-eval "poison" scenario)
+```
+
+H is built first so B, A, and C are each measurable against committed baselines. B, A, and C are independent of one another but all consume H. Part B introduces `FusionMode`; Part C extends both the `Linear` and `Rrf` paths with the confidence dampener, so C depends on B's `FusionMode`/`rank_rrf` names. Part A is independent of B/C but its recall-regression check relies on H.
+
+Names introduced once and reused verbatim across Parts:
+- H: `rb_eval::{Corpus, GoldenQuery, DupCluster, Metrics, recall_at_k, mrr, dedup_precision, percentile, run_eval, Baselines}`.
+- B: `rb_search::{FusionMode, rank_rrf, RRF_K}`; `rank_with_mode(signals, weights, mode, now, limit)`.
+- A: `rb_engine::embedding_input(note) -> String`; `EMBEDDING_INPUT_VERSION = "v2-composite"`; `WriteCommand::Reembed { namespace, id }`; `StoreHandle::reembed`; `SqliteStore::reembed_one` + `needs_reembed`/`active_ids_for_reembed`; `Request::Reembed`/`Response::Reembedded`; CLI `Command::Reembed`.
+- C: `Signals.confidence: f32`; `Weights.confidence_floor: f32` (default `0.5`); `confidence_dampener`; `SearchResult.contested: bool`, `MemoryNote.contested: bool`; `SqliteStore::contested_ids`.
+
+---
+
+## Part H — `rb-eval` offline regression harness
+
+This Part stands up a new dev/measurement crate that turns "did this change reorder recall results vs the committed baseline?" into a CI gate. It loads committed JSON fixtures (a small coding-memory corpus, golden queries with expected-relevant ids, and near-duplicate clusters), ingests them through `rb-engine` with `DeterministicProvider`, runs each golden query through `recall`, and asserts pure metrics (recall@k, MRR, dedup precision, latency p50/p99) stay at or above `baselines.json`. The crate is `[dev]`-style: it is a workspace member built and run in CI but is NOT in the `rusty-brain` binary's dependency closure.
+
+HONEST FRAMING (documented in the crate's `lib.rs` doc-comment and asserted nowhere but stated everywhere): with `DeterministicProvider`, the harness guards **ranking determinism, regression detection, and relative-ordering invariants** — NOT absolute semantic quality. Semantic lift (e.g. composite embeddings in Part A) is only observable in the optional `#[ignore]` real-model mode. This mirrors the architecture spec's sqlite-vec scale honesty (§11).
+
+HARD RULES honored: no network; fixtures + `DeterministicProvider` only; the crate may `#![allow(clippy::unwrap_used, clippy::expect_used)]` since it is test/measurement code; updating a baseline is an explicit, reviewed commit.
+
+---
+
+### Task H1: scaffold the `rb-eval` crate
+
+Create the crate, add it to the workspace, and prove it compiles and links `rb-engine`/`rb-embed`. No logic yet — just the skeleton with a doc-comment stating the honest-framing limit.
+
+**Files:**
+- Create: crates/rb-eval/Cargo.toml
+- Create: crates/rb-eval/src/lib.rs
+- Modify: Cargo.toml (workspace members)
+- Test: crates/rb-eval/src/lib.rs (placeholder compile test)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-eval/src/lib.rs` with this exact content:
+
+```rust
+//! `rb_eval`: offline, deterministic retrieval-quality regression harness.
+//!
+//! Loads committed JSON fixtures (corpus + golden queries + dup clusters),
+//! ingests them through `rb_engine` with `rb_embed::DeterministicProvider`, runs
+//! each golden query through recall, and asserts pure metrics (recall@k, MRR,
+//! dedup precision, latency p50/p99) stay at or above a committed
+//! `baselines.json`.
+//!
+//! HONEST FRAMING: with `DeterministicProvider` this harness guards ranking
+//! determinism, regression detection, and relative-ordering invariants — it does
+//! NOT measure absolute semantic quality. Semantic lift is observable only in the
+//! optional `#[ignore]` real-model mode (Voyage / local), run manually for spot
+//! checks. This is the same scale-honesty the architecture spec states for
+//! sqlite-vec (§11). Updating `baselines.json` is an explicit, reviewed commit.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_links_engine_and_embed() {
+        // Proves rb-eval can construct the providers it will drive in the runner.
+        let provider = rb_embed::DeterministicProvider::new(16);
+        assert_eq!(rb_embed::EmbeddingProvider::dim(&provider), 16);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval crate_links_engine_and_embed` — Expected: FAIL — the crate is not a workspace member and `crates/rb-eval/Cargo.toml` does not exist (`error: no such package 'rb-eval'`).
+
+- [ ] **Step 3 GREEN: create the manifest + register the member.** Create `crates/rb-eval/Cargo.toml`:
+
+```toml
+[package]
+name = "rb-eval"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+rb-store = { path = "../rb-store" }
+rb-search = { path = "../rb-search" }
+rb-engine = { path = "../rb-engine" }
+rb-embed = { path = "../rb-embed" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+```
+
+Then add the member to the root `Cargo.toml` `members` list (after `"crates/rusty-brain",`):
+
+```toml
+members = [
+    "crates/rb-types",
+    "crates/rb-store",
+    "crates/rb-proto",
+    "crates/rb-embed",
+    "crates/rb-search",
+    "crates/rb-engine",
+    "crates/rb-enrich",
+    "crates/rb-daemon",
+    "crates/rb-mcp",
+    "crates/rusty-brain",
+    "crates/rb-eval",
+]
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval crate_links_engine_and_embed` — Expected: PASS (1 test).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add Cargo.toml crates/rb-eval/Cargo.toml crates/rb-eval/src/lib.rs && git commit -m "chore(rb-eval): scaffold offline retrieval-quality eval crate"` — Expected: one commit.
+
+---
+
+### Task H2: pure metric functions
+
+Add `metrics.rs` with the four pure metric functions the runner asserts on. Each is unit-tested on hand-checked inputs, independent of any fixture or store. These are the load-bearing math; they must be exact.
+
+**Files:**
+- Create: crates/rb-eval/src/metrics.rs
+- Modify: crates/rb-eval/src/lib.rs (declare `pub mod metrics;`)
+- Test: crates/rb-eval/src/metrics.rs (unit tests)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-eval/src/metrics.rs` with this exact content (impl + tests together; Step 3 only wires the module):
+
+```rust
+//! Pure retrieval-quality metrics. No IO, no store, no provider — hand-checkable
+//! arithmetic over id lists. Each function is deterministic and total.
+
+use rb_types::MemoryId;
+
+/// Fraction of expected-relevant ids that appear in the top-`k` ranked ids.
+/// `expected` empty => 1.0 (vacuously perfect; a query with no relevant docs
+/// cannot lose recall). `k` is clamped to `ranked.len()`.
+pub fn recall_at_k(ranked: &[MemoryId], expected: &[MemoryId], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    let top: std::collections::HashSet<&MemoryId> = ranked.iter().take(k).collect();
+    let hits = expected.iter().filter(|e| top.contains(e)).count();
+    hits as f64 / expected.len() as f64
+}
+
+/// Mean reciprocal rank of the FIRST expected-relevant id in `ranked`
+/// (1-indexed). No expected id present => 0.0. `expected` empty => 0.0 (no
+/// reciprocal rank is defined). Single-query MRR; the runner averages across
+/// queries.
+pub fn mrr(ranked: &[MemoryId], expected: &[MemoryId]) -> f64 {
+    let wanted: std::collections::HashSet<&MemoryId> = expected.iter().collect();
+    for (i, id) in ranked.iter().enumerate() {
+        if wanted.contains(id) {
+            return 1.0 / (i as f64 + 1.0);
+        }
+    }
+    0.0
+}
+
+/// Precision of dedup: of the candidate ids flagged as near-duplicates of an
+/// anchor, the fraction that are TRUE duplicates (members of the same cluster).
+/// `flagged` empty => 1.0 (nothing wrong was flagged).
+pub fn dedup_precision(flagged: &[MemoryId], true_dups: &[MemoryId]) -> f64 {
+    if flagged.is_empty() {
+        return 1.0;
+    }
+    let truth: std::collections::HashSet<&MemoryId> = true_dups.iter().collect();
+    let correct = flagged.iter().filter(|f| truth.contains(f)).count();
+    correct as f64 / flagged.len() as f64
+}
+
+/// The `p`-th percentile (0.0..=1.0) of `samples` micros using the
+/// nearest-rank method on a sorted copy. Empty => 0. Deterministic: sorts a
+/// clone, never mutates the caller's slice.
+pub fn percentile(samples: &[u128], p: f64) -> u128 {
+    if samples.is_empty() {
+        return 0;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let p = p.clamp(0.0, 1.0);
+    // nearest-rank: rank = ceil(p * N), 1-indexed, clamped to [1, N].
+    let n = sorted.len();
+    let rank = (p * n as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rb_types::MemoryId;
+
+    fn ids(n: usize) -> Vec<MemoryId> {
+        (0..n).map(|_| MemoryId::new()).collect()
+    }
+
+    #[test]
+    fn recall_at_k_counts_hits_in_top_k() {
+        let v = ids(5);
+        let ranked = v.clone();
+        // expected = first and last; only the first is in top-3.
+        let expected = vec![v[0].clone(), v[4].clone()];
+        assert!((recall_at_k(&ranked, &expected, 3) - 0.5).abs() < 1e-9);
+        // top-5 finds both.
+        assert!((recall_at_k(&ranked, &expected, 5) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_empty_expected_is_perfect() {
+        let v = ids(3);
+        assert!((recall_at_k(&v, &[], 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mrr_is_reciprocal_of_first_hit_rank() {
+        let v = ids(4);
+        let ranked = v.clone();
+        // first expected id is at index 2 => reciprocal rank 1/3.
+        let expected = vec![v[2].clone()];
+        assert!((mrr(&ranked, &expected) - (1.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mrr_is_zero_when_no_expected_present() {
+        let ranked = ids(3);
+        let expected = ids(2); // disjoint
+        assert!(mrr(&ranked, &expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_is_fraction_of_true_flags() {
+        let v = ids(4);
+        // flagged 3, of which 2 are real dups.
+        let flagged = vec![v[0].clone(), v[1].clone(), v[2].clone()];
+        let true_dups = vec![v[0].clone(), v[1].clone()];
+        assert!((dedup_precision(&flagged, &true_dups) - (2.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_empty_flags_is_perfect() {
+        assert!((dedup_precision(&[], &ids(2)) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn percentile_nearest_rank() {
+        let s = vec![10u128, 20, 30, 40, 50];
+        assert_eq!(percentile(&s, 0.5), 30); // ceil(0.5*5)=3 -> idx 2
+        assert_eq!(percentile(&s, 0.99), 50); // ceil(0.99*5)=5 -> idx 4
+        assert_eq!(percentile(&s, 0.0), 10); // rank floored to 1 -> idx 0
+    }
+
+    #[test]
+    fn percentile_empty_is_zero_and_does_not_mutate_input() {
+        let s: Vec<u128> = vec![];
+        assert_eq!(percentile(&s, 0.5), 0);
+        let s2 = vec![3u128, 1, 2];
+        let _ = percentile(&s2, 0.5);
+        assert_eq!(s2, vec![3, 1, 2], "input slice must be untouched");
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval metrics` — Expected: FAIL — `metrics` is not declared in `lib.rs` (`error[E0433]`/unresolved module; the tests do not compile/run).
+
+- [ ] **Step 3 GREEN: declare the module.** Add to `crates/rb-eval/src/lib.rs`, after the doc-comment block and `#![allow(...)]`:
+
+```rust
+pub mod metrics;
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval metrics` — Expected: PASS (8 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean, no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval/src/metrics.rs crates/rb-eval/src/lib.rs && git commit -m "feat(rb-eval): add pure recall/mrr/dedup/percentile metrics"` — Expected: one commit.
+
+---
+
+### Task H3: fixture loader + committed JSON fixtures
+
+Add `corpus.rs` (typed fixture structs + a loader that fails fast on malformed fixtures) and commit the three fixture files. Fixtures use STABLE string keys (a `key` like `"sqlite-wal"`) rather than UUIDs, so golden queries and dup clusters reference notes by key; the loader assigns a fresh `MemoryId` per note at load and exposes a `key -> MemoryId` map. This keeps fixtures human-editable and id-stable within one run.
+
+**Files:**
+- Create: crates/rb-eval/src/corpus.rs
+- Create: crates/rb-eval/fixtures/corpus.json
+- Create: crates/rb-eval/fixtures/golden_queries.json
+- Create: crates/rb-eval/fixtures/dup_clusters.json
+- Modify: crates/rb-eval/src/lib.rs (declare `pub mod corpus;`)
+- Test: crates/rb-eval/src/corpus.rs (load + validation tests)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-eval/src/corpus.rs` with this exact content:
+
+```rust
+//! Fixture types + loader. Fixtures key notes by a stable string `key`; golden
+//! queries and dup clusters reference those keys. The loader assigns a fresh
+//! `MemoryId` per note and returns a `key -> id` map so the runner can translate
+//! expected keys into the ids recall returns. Fails fast on malformed fixtures.
+
+use rb_types::{MemoryId, MemoryType};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// One fixture note. `key` is a stable, human-readable handle used by queries
+/// and clusters; it is NOT the runtime id (assigned at load).
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureNote {
+    pub key: String,
+    pub content: String,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub context: String,
+    /// Db string for the memory type (e.g. "insight", "bug_fix").
+    pub memory_type: String,
+    pub importance: u8,
+}
+
+/// A golden query: free text plus the note keys expected in the top results.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GoldenQuery {
+    pub query: String,
+    pub expected_keys: Vec<String>,
+    /// The k at which recall@k is asserted for this query.
+    pub k: usize,
+}
+
+/// A near-duplicate cluster: an anchor key plus the keys that are true dups.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DupCluster {
+    pub anchor_key: String,
+    pub dup_keys: Vec<String>,
+}
+
+/// The loaded corpus: typed notes (with assigned ids), the key->id map, golden
+/// queries, and dup clusters.
+#[derive(Debug, Clone)]
+pub struct Corpus {
+    pub notes: Vec<LoadedNote>,
+    pub key_to_id: HashMap<String, MemoryId>,
+    pub golden: Vec<GoldenQuery>,
+    pub clusters: Vec<DupCluster>,
+}
+
+/// A fixture note resolved to a runtime id and a parsed memory type.
+#[derive(Debug, Clone)]
+pub struct LoadedNote {
+    pub id: MemoryId,
+    pub key: String,
+    pub content: String,
+    pub keywords: Vec<String>,
+    pub tags: Vec<String>,
+    pub context: String,
+    pub memory_type: MemoryType,
+    pub importance: u8,
+}
+
+impl Corpus {
+    /// Load and validate the committed fixtures from `dir`. Fail fast (panics in
+    /// this dev/measurement crate are acceptable) on: malformed JSON, duplicate
+    /// note keys, or a query/cluster referencing an unknown key.
+    pub fn load(dir: &std::path::Path) -> Corpus {
+        let notes: Vec<FixtureNote> = read_json(&dir.join("corpus.json"));
+        let golden: Vec<GoldenQuery> = read_json(&dir.join("golden_queries.json"));
+        let clusters: Vec<DupCluster> = read_json(&dir.join("dup_clusters.json"));
+
+        let mut key_to_id: HashMap<String, MemoryId> = HashMap::new();
+        let mut loaded: Vec<LoadedNote> = Vec::with_capacity(notes.len());
+        for n in notes {
+            assert!(
+                !key_to_id.contains_key(&n.key),
+                "duplicate fixture note key: {}",
+                n.key
+            );
+            let id = MemoryId::new();
+            key_to_id.insert(n.key.clone(), id.clone());
+            let memory_type = MemoryType::parse(&n.memory_type)
+                .unwrap_or_else(|e| panic!("bad memory_type for {}: {e}", n.key));
+            loaded.push(LoadedNote {
+                id,
+                key: n.key,
+                content: n.content,
+                keywords: n.keywords,
+                tags: n.tags,
+                context: n.context,
+                memory_type,
+                importance: n.importance,
+            });
+        }
+
+        // Referential integrity: every referenced key must exist.
+        for q in &golden {
+            for k in &q.expected_keys {
+                assert!(key_to_id.contains_key(k), "golden query references unknown key: {k}");
+            }
+        }
+        for c in &clusters {
+            assert!(
+                key_to_id.contains_key(&c.anchor_key),
+                "dup cluster references unknown anchor key: {}",
+                c.anchor_key
+            );
+            for k in &c.dup_keys {
+                assert!(key_to_id.contains_key(k), "dup cluster references unknown key: {k}");
+            }
+        }
+
+        Corpus { notes: loaded, key_to_id, golden, clusters }
+    }
+
+    /// The default committed fixture directory (`crates/rb-eval/fixtures`).
+    pub fn fixtures_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+    }
+
+    /// Translate a list of fixture keys into runtime ids (panics on unknown key).
+    pub fn ids_for(&self, keys: &[String]) -> Vec<MemoryId> {
+        keys.iter()
+            .map(|k| self.key_to_id.get(k).expect("key must exist").clone())
+            .collect()
+    }
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &std::path::Path) -> T {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("parse fixture {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_committed_fixtures_with_referential_integrity() {
+        let corpus = Corpus::load(&Corpus::fixtures_dir());
+        // Non-trivial corpus so recall/dedup are meaningful.
+        assert!(corpus.notes.len() >= 6, "corpus must have >= 6 notes");
+        assert!(!corpus.golden.is_empty(), "must have golden queries");
+        assert!(!corpus.clusters.is_empty(), "must have dup clusters");
+        // Every note key is unique and present in the map.
+        assert_eq!(corpus.key_to_id.len(), corpus.notes.len());
+        // ids_for round-trips a known set of keys.
+        let first_key = corpus.notes[0].key.clone();
+        let ids = corpus.ids_for(std::slice::from_ref(&first_key));
+        assert_eq!(ids[0], corpus.key_to_id[&first_key]);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval corpus` — Expected: FAIL — `corpus` is not declared in `lib.rs` and the fixture files do not exist (`error[E0433]` unresolved module; once wired, the load test would panic on missing files).
+
+- [ ] **Step 3a GREEN: declare the module.** Add to `crates/rb-eval/src/lib.rs`:
+
+```rust
+pub mod corpus;
+```
+
+- [ ] **Step 3b GREEN: commit the corpus fixture.** Create `crates/rb-eval/fixtures/corpus.json` (6 notes spanning FTS-friendly, vector-friendly, and dup-cluster cases):
+
+```json
+[
+  { "key": "sqlite-wal", "content": "Use a single SQLite writer with WAL so concurrent readers never block the dedicated writer thread.", "keywords": ["sqlite", "wal", "writer"], "tags": ["storage", "concurrency"], "context": "rusty-brain storage core", "memory_type": "architecture_decision", "importance": 9 },
+  { "key": "wal-restated", "content": "One writer thread owns the write connection; readers use a bounded pool. WAL mode avoids SQLITE_BUSY storms.", "keywords": ["sqlite", "wal", "pool"], "tags": ["storage", "concurrency"], "context": "rusty-brain storage core", "memory_type": "architecture_decision", "importance": 8 },
+  { "key": "tokio-broadcast", "content": "Change notifications use a tokio broadcast channel that drops oldest on lag and reports Lagged to slow subscribers.", "keywords": ["tokio", "broadcast", "subscribe"], "tags": ["concurrency", "notify"], "context": "daemon change stream", "memory_type": "insight", "importance": 6 },
+  { "key": "rrf-fusion", "content": "Reciprocal Rank Fusion fuses ranked candidate lists by 1/(k+rank) and is scale-free, unlike a weighted sum of raw scores.", "keywords": ["rrf", "ranking", "fusion"], "tags": ["search", "ranking"], "context": "hybrid search", "memory_type": "insight", "importance": 7 },
+  { "key": "composite-embed", "content": "Embed the composite of content plus keywords, tags, and context rather than content alone for better query alignment.", "keywords": ["embedding", "composite", "recall"], "tags": ["search", "embeddings"], "context": "embedding input", "memory_type": "insight", "importance": 7 },
+  { "key": "confidence-poison", "content": "A low-confidence wrong memory can dominate recall; dampen score by confidence to mitigate context poisoning.", "keywords": ["confidence", "poisoning", "ranking"], "tags": ["search", "safety"], "context": "ranking priors", "memory_type": "insight", "importance": 8 }
+]
+```
+
+- [ ] **Step 3c GREEN: commit golden queries.** Create `crates/rb-eval/fixtures/golden_queries.json`:
+
+```json
+[
+  { "query": "sqlite writer wal concurrency", "expected_keys": ["sqlite-wal", "wal-restated"], "k": 5 },
+  { "query": "reciprocal rank fusion ranking", "expected_keys": ["rrf-fusion"], "k": 5 },
+  { "query": "composite embedding recall", "expected_keys": ["composite-embed"], "k": 5 },
+  { "query": "confidence context poisoning", "expected_keys": ["confidence-poison"], "k": 5 }
+]
+```
+
+- [ ] **Step 3d GREEN: commit dup clusters.** Create `crates/rb-eval/fixtures/dup_clusters.json` (the two WAL notes are near-duplicates of each other):
+
+```json
+[
+  { "anchor_key": "sqlite-wal", "dup_keys": ["wal-restated"] }
+]
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval corpus` — Expected: PASS (1 test: `loads_committed_fixtures_with_referential_integrity`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval/src/corpus.rs crates/rb-eval/src/lib.rs crates/rb-eval/fixtures && git commit -m "feat(rb-eval): add fixture loader and committed corpus/golden/dup fixtures"` — Expected: one commit.
+
+---
+
+### Task H4: runner + baselines + CI regression gate
+
+Add `runner.rs` that builds an in-memory `SqliteStore`-backed engine, ingests the corpus through `engine.remember` with `DeterministicProvider`, runs each golden query through `engine.recall` (timed), runs dedup over each cluster via `near_duplicates`, computes the aggregate `Metrics`, and asserts each metric ≥ the committed `baselines.json`. The runner exposes `run_eval(corpus, mode) -> Metrics` so Parts B/A/C can call it under different modes; the CI gate is a `#[test]` asserting `>= baseline`.
+
+**Files:**
+- Create: crates/rb-eval/src/runner.rs
+- Create: crates/rb-eval/baselines.json
+- Modify: crates/rb-eval/src/lib.rs (declare `pub mod runner;`; re-export `run_eval`, `Metrics`, `Baselines`)
+- Test: crates/rb-eval/src/runner.rs (regression gate + determinism test)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-eval/src/runner.rs` with this exact content. Note: `EvalMode` is defined locally here so H is self-contained; Part B extends `run_eval` to accept `rb_search::FusionMode` via this enum's `Rrf` arm (added in Part B, Task B5).
+
+```rust
+//! The eval runner: ingest fixtures through rb-engine (deterministic vectors),
+//! run golden queries through recall, score dedup over clusters, compute the
+//! aggregate Metrics, and assert >= the committed baselines.
+
+use crate::corpus::Corpus;
+use crate::metrics::{dedup_precision, mrr, percentile, recall_at_k};
+use rb_engine::{MemoryEngine, RememberInput};
+use rb_embed::DeterministicProvider;
+use rb_store::SqliteStore;
+use rb_types::Namespace;
+use serde::Deserialize;
+use std::sync::Arc;
+
+const EVAL_DIM: usize = 64;
+const DEDUP_THRESHOLD: f32 = 0.90;
+
+/// Which ranking path to evaluate. H ships only `Linear`; Part B adds the `Rrf`
+/// arm and threads it into `MemoryEngine`'s fusion mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvalMode {
+    Linear,
+}
+
+/// Aggregate retrieval-quality metrics for one eval run.
+#[derive(Debug, Clone, serde::Serialize, Deserialize, PartialEq)]
+pub struct Metrics {
+    pub mean_recall_at_k: f64,
+    pub mean_mrr: f64,
+    pub mean_dedup_precision: f64,
+    pub recall_p50_micros: u128,
+    pub recall_p99_micros: u128,
+}
+
+/// Committed baselines. A metric run must be >= each "min" floor (higher is
+/// better) and latency must be <= each "max" ceiling (lower is better).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Baselines {
+    pub min_mean_recall_at_k: f64,
+    pub min_mean_mrr: f64,
+    pub min_mean_dedup_precision: f64,
+    pub max_recall_p99_micros: u128,
+}
+
+impl Baselines {
+    pub fn load() -> Baselines {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("baselines.json");
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read baselines {}: {e}", path.display()));
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse baselines: {e}"))
+    }
+}
+
+/// Build a fresh in-memory engine, ingest the corpus, and run the eval. Pure of
+/// network; uses DeterministicProvider so vectors are reproducible.
+pub async fn run_eval(corpus: &Corpus, _mode: EvalMode) -> Metrics {
+    let store = SqliteStore::open_in_memory(EVAL_DIM).expect("open in-memory store");
+    let store = Arc::new(StoreBackend::new(store));
+    let ns = Namespace::Project("rb-eval".into());
+    let engine = MemoryEngine::new(
+        StoreBackend::clone_arc(&store),
+        DeterministicProvider::new(EVAL_DIM),
+        ns.clone(),
+    );
+
+    for n in &corpus.notes {
+        let input = RememberInput {
+            content: n.content.clone(),
+            context: if n.context.is_empty() { None } else { Some(n.context.clone()) },
+            memory_type: n.memory_type,
+            importance: n.importance,
+            keywords: n.keywords.clone(),
+            tags: n.tags.clone(),
+            related_files: Vec::new(),
+        };
+        engine.remember(input).await.expect("remember fixture note");
+    }
+
+    // Golden queries: recall@k + MRR, timed.
+    let mut recalls = Vec::new();
+    let mut mrrs = Vec::new();
+    let mut latencies: Vec<u128> = Vec::new();
+    for q in &corpus.golden {
+        let expected = corpus.ids_for(&q.expected_keys);
+        let start = std::time::Instant::now();
+        let results = engine
+            .recall(&q.query, q.k, None, &[])
+            .await
+            .expect("recall golden query");
+        latencies.push(start.elapsed().as_micros());
+        let ranked: Vec<_> = results.iter().map(|r| r.memory.id.clone()).collect();
+        recalls.push(recall_at_k(&ranked, &expected, q.k));
+        mrrs.push(mrr(&ranked, &expected));
+    }
+
+    // Dedup precision: near_duplicates of each anchor vs the true cluster.
+    let mut dedup_scores = Vec::new();
+    for c in &corpus.clusters {
+        let anchor = corpus.key_to_id[&c.anchor_key].clone();
+        let flagged: Vec<_> = store
+            .raw()
+            .near_duplicates(&ns, &anchor, DEDUP_THRESHOLD, 10)
+            .expect("near_duplicates")
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        let true_dups = corpus.ids_for(&c.dup_keys);
+        dedup_scores.push(dedup_precision(&flagged, &true_dups));
+    }
+
+    Metrics {
+        mean_recall_at_k: mean(&recalls),
+        mean_mrr: mean(&mrrs),
+        mean_dedup_precision: mean(&dedup_scores),
+        recall_p50_micros: percentile(&latencies, 0.50),
+        recall_p99_micros: percentile(&latencies, 0.99),
+    }
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+/// Thin `MemoryBackend` over a shared in-memory `SqliteStore` for eval ingest.
+/// Single-threaded eval, so a `Mutex` is sufficient; this is NOT the daemon's
+/// single-writer path and never ships in the binary.
+struct StoreBackend {
+    inner: std::sync::Mutex<SqliteStore>,
+}
+
+impl StoreBackend {
+    fn new(store: SqliteStore) -> Self {
+        Self { inner: std::sync::Mutex::new(store) }
+    }
+    fn clone_arc(arc: &Arc<StoreBackend>) -> Arc<StoreBackend> {
+        Arc::clone(arc)
+    }
+    /// Borrow the raw store for the dedup pass (single-threaded eval).
+    fn raw(&self) -> std::sync::MutexGuard<'_, SqliteStore> {
+        self.inner.lock().expect("eval store lock")
+    }
+}
+
+// NOTE: the eval `MemoryBackend for Arc<StoreBackend>` impl bridges the async
+// engine to the synchronous in-memory store. It mirrors `MockBackend` semantics
+// (write/get/keyword/vector/graph/list/update/archive/add_link/record_access(es)/
+// get_many) by delegating to the locked `SqliteStore`. It is mechanical and
+// uncovered here for brevity ONLY because every method is a direct one-line
+// delegation to the matching `Store`/`SqliteStore` method already exercised by
+// rb-store's own tests; implement each by locking `inner` and calling through.
+//
+// Implement the impl in this same file. Each method: lock `inner`, call the
+// matching store method, map the namespace filter exactly as `StoreHandle` does.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::Corpus;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn meets_committed_baselines_in_linear_mode() {
+        let corpus = Corpus::load(&Corpus::fixtures_dir());
+        let m = run_eval(&corpus, EvalMode::Linear).await;
+        let b = Baselines::load();
+        assert!(
+            m.mean_recall_at_k >= b.min_mean_recall_at_k,
+            "recall@k {} regressed below baseline {}",
+            m.mean_recall_at_k, b.min_mean_recall_at_k
+        );
+        assert!(
+            m.mean_mrr >= b.min_mean_mrr,
+            "MRR {} regressed below baseline {}",
+            m.mean_mrr, b.min_mean_mrr
+        );
+        assert!(
+            m.mean_dedup_precision >= b.min_mean_dedup_precision,
+            "dedup precision {} regressed below baseline {}",
+            m.mean_dedup_precision, b.min_mean_dedup_precision
+        );
+        // Latency ceiling is a generous guard (CI noise); see baselines.json.
+        assert!(
+            m.recall_p99_micros <= b.max_recall_p99_micros,
+            "recall p99 {}us exceeds ceiling {}us",
+            m.recall_p99_micros, b.max_recall_p99_micros
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn eval_is_deterministic_across_runs() {
+        let corpus = Corpus::load(&Corpus::fixtures_dir());
+        let a = run_eval(&corpus, EvalMode::Linear).await;
+        let b = run_eval(&corpus, EvalMode::Linear).await;
+        // Quality metrics are bit-identical (deterministic vectors + stable sort);
+        // latency fields may differ, so compare only the quality numbers.
+        assert!((a.mean_recall_at_k - b.mean_recall_at_k).abs() < 1e-12);
+        assert!((a.mean_mrr - b.mean_mrr).abs() < 1e-12);
+        assert!((a.mean_dedup_precision - b.mean_dedup_precision).abs() < 1e-12);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval runner` — Expected: FAIL — `runner` is not declared in `lib.rs`, `baselines.json` does not exist, and the `MemoryBackend for Arc<StoreBackend>` impl is missing (`error[E0277]`: `Arc<StoreBackend>: MemoryBackend` not satisfied).
+
+- [ ] **Step 3a GREEN: implement the eval backend.** In `crates/rb-eval/src/runner.rs`, replace the explanatory `NOTE` comment with a concrete `#[async_trait::async_trait] impl rb_engine::MemoryBackend for Arc<StoreBackend>` whose methods lock `inner` and delegate: `write` → `insert_memory`; `get` → `get_memory` filtered by `ns`; `keyword` → `keyword_search`; `vector` → `vector_search`; `graph` → namespace+active-filtered `graph_neighbors` (mirror `StoreHandle::graph`); `list` → `list`; `update` → ns-checked `update_memory`; `archive` → ns-checked `archive_memory`; `add_link` → `add_link`; `record_access`/`record_accesses` → the matching store methods; `get_many` → `get_many`. Add `async-trait` to `[dependencies]` in `crates/rb-eval/Cargo.toml` (workspace dep, already in the closure):
+
+```toml
+async-trait = { workspace = true }
+```
+
+- [ ] **Step 3b GREEN: declare the module + re-exports.** Add to `crates/rb-eval/src/lib.rs`:
+
+```rust
+pub mod runner;
+
+pub use corpus::Corpus;
+pub use metrics::{dedup_precision, mrr, percentile, recall_at_k};
+pub use runner::{run_eval, Baselines, EvalMode, Metrics};
+```
+
+- [ ] **Step 3c GREEN: commit the baselines.** Create `crates/rb-eval/baselines.json` with conservative floors the deterministic fixture corpus meets (the implementer records the actual first-run `Metrics` and sets floors slightly below them; the values below are the committed starting point — adjust DOWN if a fixture edit lowers a metric, never silently up):
+
+```json
+{
+  "min_mean_recall_at_k": 0.75,
+  "min_mean_mrr": 0.5,
+  "min_mean_dedup_precision": 1.0,
+  "max_recall_p99_micros": 500000
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval runner` — Expected: PASS (2 tests). If `meets_committed_baselines_in_linear_mode` fails on a floor, FIRST print the observed `Metrics` (temporarily) and set each `min_*` in `baselines.json` to just below the observed value, then re-run; commit the calibrated baseline. Do NOT lower a floor to mask a real ranking bug.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval/Cargo.toml crates/rb-eval/src/runner.rs crates/rb-eval/src/lib.rs crates/rb-eval/baselines.json && git commit -m "feat(rb-eval): add eval runner, baselines, and CI regression gate"` — Expected: one commit.
+
+---
+
+### Task H5: Part H gate
+
+- [ ] **Step 1: full test suite.** Run: `cargo test --workspace` — Expected: PASS (all existing tests plus the new `rb-eval` tests; 0 failures).
+- [ ] **Step 2: clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+- [ ] **Step 3: format.** Run: `cargo fmt --all --check` — Expected: no diff.
+- [ ] **Step 4: commit (only if Steps 1–3 surfaced fixes).** Run: `git add -A && git commit -m "chore(rb-eval): part H gate green"` — Expected: at most one commit (skip if nothing changed).
+
+---
+
+## Part B — RRF two-stage hybrid fusion (pure `rb-search`)
+
+This Part adds a scale-free alternative to the existing weighted-linear `rank()`: `FusionMode::Rrf`. Stage 1 fuses the FTS, vector, and graph paths by rank position (`Σ 1/(k + rank)`, `k=60`); stage 2 applies importance, recency (the existing 30-day half-life), and (in Part C) confidence as multiplicative priors. `Linear` stays the byte-for-byte default. Everything here is pure, deterministic (`total_cmp`, stable sort), and added to `rb-search` with no new deps. `rb-eval` then runs the full fixture set under both modes and reports the delta; the default is NOT flipped in P5.
+
+HARD RULES honored: missing-from-a-list contributes nothing (no penalty), matching today's "missing signal = 0" rule; non-finite inputs are sanitized exactly as `rank()` does; output ordering is reproducible across runs.
+
+---
+
+### Task B1: `FusionMode` enum + `RRF_K` constant
+
+Add the mode selector and the documented default fusion constant. Standalone so later tasks can name them.
+
+**Files:**
+- Create: crates/rb-search/src/fusion.rs
+- Modify: crates/rb-search/src/lib.rs (declare `mod fusion;`, re-export `FusionMode`, `RRF_K`)
+- Test: crates/rb-search/src/fusion.rs (enum default + constant test)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-search/src/fusion.rs` with this exact content:
+
+```rust
+//! Fusion mode selection for hybrid ranking. `Linear` is the existing
+//! weighted-sum `rank()`; `Rrf` is the scale-free Reciprocal Rank Fusion path.
+
+/// Which ranking algorithm `rank_with_mode` uses. `Default` is `Linear`, the
+/// byte-for-byte-unchanged behavior shipped since P1.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FusionMode {
+    /// Weighted sum of normalized signals (the existing `rank`).
+    #[default]
+    Linear,
+    /// Two-stage Reciprocal Rank Fusion: rank-position fusion, then priors.
+    Rrf,
+}
+
+/// The documented RRF constant: `score += 1/(k + rank)`. `k = 60` is the
+/// de-facto hybrid-search default (used by Zep and the original RRF paper);
+/// larger `k` flattens the contribution of top ranks. Configurable here only.
+pub const RRF_K: f32 = 60.0;
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn default_mode_is_linear() {
+        assert_eq!(FusionMode::default(), FusionMode::Linear);
+    }
+
+    #[test]
+    fn rrf_k_is_documented_default() {
+        assert!((RRF_K - 60.0).abs() < f32::EPSILON);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search fusion` — Expected: FAIL — `fusion` is not declared in `lib.rs` (`error[E0433]` unresolved module).
+
+- [ ] **Step 3 GREEN: wire the module.** Edit `crates/rb-search/src/lib.rs` to add the module and re-export. The full updated tail of `lib.rs`:
+
+```rust
+mod fusion;
+mod merge;
+mod rank;
+mod weights;
+
+pub use fusion::{FusionMode, RRF_K};
+pub use merge::build_signals;
+pub use rank::{rank, rank_with_mode, Signals, HALF_LIFE};
+pub use weights::Weights;
+```
+
+(Note: `rank_with_mode` is exported here but defined in Task B3; until then, leave it out of the `pub use` and add it in B3. For this task export only `FusionMode`, `RRF_K`, and the existing names.)
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search fusion` — Expected: PASS (2 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src/fusion.rs crates/rb-search/src/lib.rs && git commit -m "feat(rb-search): add FusionMode enum and RRF_K constant"` — Expected: one commit.
+
+---
+
+### Task B2: RRF stage 1 — rank-position fusion
+
+Add the pure stage-1 fusion: derive per-path ranks from `Signals` (keyword from `keyword_rank`; vector from ascending `vector_distance`; graph from ascending `graph_hops`) and sum `1/(k+rank)` across the paths each candidate appears in. Missing from a path = no contribution. This is the core RRF arithmetic; test it on known lists.
+
+**Files:**
+- Modify: crates/rb-search/src/rank.rs (add `rrf_stage1`)
+- Test: crates/rb-search/src/rank.rs (RRF arithmetic tests)
+
+- [ ] **Step 1 RED: write the failing test.** Add these tests to the existing `#[cfg(test)] mod tests` in `crates/rb-search/src/rank.rs` (after `negative_custom_scores_clamp_to_zero`):
+
+```rust
+    #[test]
+    fn rrf_stage1_sums_reciprocal_ranks_across_paths() {
+        let n = now();
+        // A: keyword rank 0 AND vector closest -> two contributions.
+        // B: keyword rank 1 only -> one contribution.
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: a.clone(),
+                keyword_rank: Some(0),
+                vector_distance: Some(0.1),
+                graph_hops: None,
+                importance: 5,
+                created_at: n,
+            },
+            Signals {
+                id: b.clone(),
+                keyword_rank: Some(1),
+                vector_distance: Some(0.9),
+                graph_hops: None,
+                importance: 5,
+                created_at: n,
+            },
+        ];
+        let fused = rrf_stage1(&signals);
+        // A's keyword rank = 0, vector rank = 0 (closest). B's keyword rank = 1,
+        // vector rank = 1. RRF_K = 60.
+        let a_expected = 1.0 / (RRF_K + 0.0) + 1.0 / (RRF_K + 0.0);
+        let b_expected = 1.0 / (RRF_K + 1.0) + 1.0 / (RRF_K + 1.0);
+        assert!((fused[&a] - a_expected).abs() < 1e-6);
+        assert!((fused[&b] - b_expected).abs() < 1e-6);
+        assert!(fused[&a] > fused[&b], "A appears higher in both lists");
+    }
+
+    #[test]
+    fn rrf_stage1_missing_path_contributes_nothing() {
+        let n = now();
+        let kw_only = MemoryId::new();
+        let signals = vec![Signals {
+            id: kw_only.clone(),
+            keyword_rank: Some(0),
+            vector_distance: None,
+            graph_hops: None,
+            importance: 5,
+            created_at: n,
+        }];
+        let fused = rrf_stage1(&signals);
+        // Only the keyword path contributes: exactly 1/(k+0).
+        assert!((fused[&kw_only] - 1.0 / RRF_K).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_stage1_derives_vector_rank_from_ascending_distance() {
+        let n = now();
+        let near = MemoryId::new();
+        let far = MemoryId::new();
+        let signals = vec![
+            Signals {
+                id: far.clone(),
+                keyword_rank: None,
+                vector_distance: Some(1.5),
+                graph_hops: None,
+                importance: 5,
+                created_at: n,
+            },
+            Signals {
+                id: near.clone(),
+                keyword_rank: None,
+                vector_distance: Some(0.2),
+                graph_hops: None,
+                importance: 5,
+                created_at: n,
+            },
+        ];
+        let fused = rrf_stage1(&signals);
+        // near has the smaller distance -> vector rank 0 -> higher RRF.
+        assert!(fused[&near] > fused[&far]);
+        assert!((fused[&near] - 1.0 / RRF_K).abs() < 1e-6);
+        assert!((fused[&far] - 1.0 / (RRF_K + 1.0)).abs() < 1e-6);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search rrf_stage1` — Expected: FAIL — `rrf_stage1` and `RRF_K` are not in scope in `rank.rs` (`error[E0425]`/`cannot find function`).
+
+- [ ] **Step 3 GREEN: implement `rrf_stage1`.** Add to `crates/rb-search/src/rank.rs`. First extend the top `use` to bring in `RRF_K`:
+
+```rust
+use crate::fusion::RRF_K;
+use crate::weights::Weights;
+use rb_types::MemoryId;
+use std::collections::HashMap;
+```
+
+Then add the function (place it above the `#[cfg(test)]` module):
+
+```rust
+/// RRF stage 1: fuse the three retrieval paths by RANK POSITION.
+///
+/// For each path a candidate appears in, add `1 / (RRF_K + rank)`. Ranks are
+/// derived deterministically: keyword from `keyword_rank` (0 = best); vector from
+/// ascending `vector_distance` (closest = rank 0); graph from ascending
+/// `graph_hops` (nearest = rank 0). A candidate missing from a path contributes
+/// nothing from that path (no penalty), matching the "missing signal = 0" rule.
+/// Non-finite vector distances sort last (treated as the worst match). Pure and
+/// deterministic; the vector/graph rank derivation uses `total_cmp` + the id
+/// string as a stable tie-break.
+fn rrf_stage1(signals: &[Signals]) -> HashMap<MemoryId, f32> {
+    // Vector path: rank by ascending distance (non-finite => worst).
+    let mut vec_order: Vec<(&MemoryId, f32)> = signals
+        .iter()
+        .filter_map(|s| s.vector_distance.map(|d| (&s.id, d)))
+        .collect();
+    vec_order.sort_by(|a, b| {
+        let av = if a.1.is_finite() { a.1 } else { f32::INFINITY };
+        let bv = if b.1.is_finite() { b.1 } else { f32::INFINITY };
+        av.total_cmp(&bv)
+            .then_with(|| a.0.to_string().cmp(&b.0.to_string()))
+    });
+    let vector_rank: HashMap<&MemoryId, usize> = vec_order
+        .iter()
+        .enumerate()
+        .map(|(rank, (id, _))| (*id, rank))
+        .collect();
+
+    // Graph path: rank by ascending hops.
+    let mut graph_order: Vec<(&MemoryId, u8)> = signals
+        .iter()
+        .filter_map(|s| s.graph_hops.map(|h| (&s.id, h)))
+        .collect();
+    graph_order.sort_by(|a, b| {
+        a.1.cmp(&b.1)
+            .then_with(|| a.0.to_string().cmp(&b.0.to_string()))
+    });
+    let graph_rank: HashMap<&MemoryId, usize> = graph_order
+        .iter()
+        .enumerate()
+        .map(|(rank, (id, _))| (*id, rank))
+        .collect();
+
+    let contribution = |rank: usize| -> f32 { 1.0 / (RRF_K + rank as f32) };
+
+    let mut fused: HashMap<MemoryId, f32> = HashMap::with_capacity(signals.len());
+    for s in signals {
+        let mut score = 0.0_f32;
+        if let Some(r) = s.keyword_rank {
+            score += contribution(r);
+        }
+        if let Some(r) = vector_rank.get(&s.id) {
+            score += contribution(*r);
+        }
+        if let Some(r) = graph_rank.get(&s.id) {
+            score += contribution(*r);
+        }
+        fused.insert(s.id.clone(), score);
+    }
+    fused
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search rrf_stage1` — Expected: PASS (3 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src/rank.rs && git commit -m "feat(rb-search): add RRF stage-1 rank-position fusion"` — Expected: one commit.
+
+---
+
+### Task B3: RRF stage 2 (priors) + `rank_rrf` + `rank_with_mode`
+
+Add stage 2 (multiply the fused score by importance, recency, and — wired in Part C — confidence priors), assemble `rank_rrf` (stage1 → stage2 → stable sort → truncate), and a `rank_with_mode` dispatcher so callers select `Linear` or `Rrf` with one signature. `Linear` delegates to the existing `rank` unchanged.
+
+**Files:**
+- Modify: crates/rb-search/src/rank.rs (add `rrf_stage2_prior`, `rank_rrf`, `rank_with_mode`)
+- Modify: crates/rb-search/src/lib.rs (re-export `rank_with_mode`)
+- Test: crates/rb-search/src/rank.rs (priors + dispatch tests)
+
+- [ ] **Step 1 RED: write the failing test.** Add these tests to the `#[cfg(test)] mod tests` in `crates/rb-search/src/rank.rs`:
+
+```rust
+    #[test]
+    fn rrf_stage2_applies_importance_and_recency_priors() {
+        let n = now();
+        // Two candidates identical on rank-fusion inputs; importance breaks them.
+        let high = MemoryId::new();
+        let low = MemoryId::new();
+        let mk = |id: MemoryId, importance| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.1),
+            graph_hops: None,
+            importance,
+            created_at: n,
+        };
+        let signals = vec![mk(high.clone(), 10), mk(low.clone(), 1)];
+        let ranked = rank_rrf(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, high, "higher importance wins the prior");
+        assert!(ranked[0].1 > ranked[1].1);
+        assert!(ranked.iter().all(|(_, s)| s.is_finite()));
+    }
+
+    #[test]
+    fn rrf_recency_breaks_ties_between_equal_fusion_candidates() {
+        let n = now();
+        let recent = MemoryId::new();
+        let old = MemoryId::new();
+        let mk = |id: MemoryId, created| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.1),
+            graph_hops: None,
+            importance: 5,
+            created_at: created,
+        };
+        let signals = vec![
+            mk(old.clone(), n - Duration::days(200)),
+            mk(recent.clone(), n),
+        ];
+        let ranked = rank_rrf(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, recent, "more recent doc wins the recency prior");
+    }
+
+    #[test]
+    fn rank_with_mode_linear_equals_rank() {
+        let n = now();
+        let signals: Vec<Signals> = (0..6)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: Some(i),
+                vector_distance: Some(0.1 * i as f32),
+                graph_hops: if i % 2 == 0 { Some(i as u8) } else { None },
+                importance: (i as u8) + 1,
+                created_at: n - Duration::days(i as i64),
+            })
+            .collect();
+        let via_mode = rank_with_mode(signals.clone(), Weights::default(), FusionMode::Linear, n, 6);
+        let via_rank = rank(signals, Weights::default(), n, 6);
+        assert_eq!(via_mode, via_rank, "Linear mode must equal rank() byte-for-byte");
+    }
+
+    #[test]
+    fn rank_with_mode_rrf_is_deterministic_and_truncates() {
+        let n = now();
+        let signals: Vec<Signals> = (0..8)
+            .map(|i| Signals {
+                id: MemoryId::new(),
+                keyword_rank: if i % 2 == 0 { Some(i) } else { None },
+                vector_distance: if i % 3 == 0 { Some(0.05 * i as f32) } else { None },
+                graph_hops: None,
+                importance: (i as u8 % 10) + 1,
+                created_at: n,
+            })
+            .collect();
+        let a = rank_with_mode(signals.clone(), Weights::default(), FusionMode::Rrf, n, 3);
+        let b = rank_with_mode(signals, Weights::default(), FusionMode::Rrf, n, 3);
+        assert_eq!(a.len(), 3, "truncates to limit");
+        let ids_a: Vec<_> = a.iter().map(|(id, _)| id.clone()).collect();
+        let ids_b: Vec<_> = b.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(ids_a, ids_b, "RRF ordering is reproducible");
+        for w in a.windows(2) {
+            assert!(w[0].1 >= w[1].1, "RRF scores sorted descending");
+        }
+    }
+```
+
+Also extend the top `use` import to bring in `FusionMode` for the dispatch test:
+
+```rust
+use crate::fusion::{FusionMode, RRF_K};
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search rank_with_mode` — Expected: FAIL — `rank_rrf` and `rank_with_mode` do not exist (`error[E0425]`).
+
+- [ ] **Step 3 GREEN: implement priors + assembly + dispatch.** Add to `crates/rb-search/src/rank.rs` (above the test module):
+
+```rust
+/// RRF stage 2: the multiplicative prior applied to a fused score. Importance
+/// and recency mirror `score_one`'s normalization exactly; `confidence` is the
+/// Part C dampener (1.0 until C lands, so this is a no-op for B in isolation).
+/// Non-finite or zeroed priors clamp so the product stays finite and >= 0.
+fn rrf_stage2_prior(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f32 {
+    let importance = (s.importance as f32 / 10.0).clamp(0.0, 1.0);
+    let age_days = ((now - s.created_at).num_seconds() as f32 / 86_400.0).max(0.0);
+    let recency = (-age_days / HALF_LIFE).exp();
+    // Each prior contributes a bounded multiplier in (0, 1]; a weight of 0
+    // neutralizes that prior (multiplier 1.0) rather than zeroing the score.
+    let blend = |weight: f32, value: f32| -> f32 {
+        let weight = if weight.is_finite() { weight.clamp(0.0, 1.0) } else { 0.0 };
+        let value = if value.is_finite() { value.clamp(0.0, 1.0) } else { 0.0 };
+        1.0 - weight + weight * value
+    };
+    let prior = blend(w.importance, importance) * blend(w.recency, recency);
+    if prior.is_finite() {
+        prior.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+/// Two-stage RRF ranking: rank-position fusion (stage 1) scaled by importance +
+/// recency priors (stage 2). Pure and deterministic: stable sort by `total_cmp`,
+/// truncated to `limit`. Missing signals contribute nothing (no penalty).
+pub fn rank_rrf(
+    signals: Vec<Signals>,
+    weights: Weights,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: usize,
+) -> Vec<(MemoryId, f32)> {
+    let fused = rrf_stage1(&signals);
+    let mut scored: Vec<(MemoryId, f32)> = signals
+        .iter()
+        .map(|s| {
+            let base = fused.get(&s.id).copied().unwrap_or(0.0);
+            let score = base * rrf_stage2_prior(s, &weights, now);
+            (s.id.clone(), if score.is_finite() { score } else { 0.0 })
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+    scored.truncate(limit);
+    scored
+}
+
+/// Dispatch ranking by `FusionMode`. `Linear` delegates to `rank` (unchanged);
+/// `Rrf` uses `rank_rrf`. Single entry point so callers thread one mode value.
+pub fn rank_with_mode(
+    signals: Vec<Signals>,
+    weights: Weights,
+    mode: FusionMode,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: usize,
+) -> Vec<(MemoryId, f32)> {
+    match mode {
+        FusionMode::Linear => rank(signals, weights, now, limit),
+        FusionMode::Rrf => rank_rrf(signals, weights, now, limit),
+    }
+}
+```
+
+- [ ] **Step 3b GREEN: export `rank_with_mode`.** Update the `pub use rank::...` line in `crates/rb-search/src/lib.rs`:
+
+```rust
+pub use rank::{rank, rank_rrf, rank_with_mode, Signals, HALF_LIFE};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search rank` — Expected: PASS (all existing `rank.rs` tests plus the 4 new ones; 0 failures).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src/rank.rs crates/rb-search/src/lib.rs && git commit -m "feat(rb-search): add RRF stage-2 priors and rank_with_mode dispatch"` — Expected: one commit.
+
+---
+
+### Task B4: thread `FusionMode` through the engine
+
+Give `MemoryEngine` a `fusion_mode` field (default `Linear`) and a `with_fusion_mode` builder, and have `recall` call `rank_with_mode(..., self.fusion_mode, ...)` instead of `rank(...)`. Default behavior is unchanged.
+
+**Files:**
+- Modify: crates/rb-engine/src/engine.rs (field + builder + recall call)
+- Test: crates/rb-engine/src/engine.rs (fusion-mode recall test)
+
+- [ ] **Step 1 RED: write the failing test.** Add this test to the `#[cfg(test)] mod tests` in `crates/rb-engine/src/engine.rs`:
+
+```rust
+    #[tokio::test]
+    async fn recall_under_rrf_mode_returns_finite_descending_results() {
+        let eng = engine().with_fusion_mode(rb_search::FusionMode::Rrf);
+        seed(&eng, "alpha topic about sqlite", MemoryType::Insight, 5, &[]).await;
+        seed(&eng, "beta topic about tokio", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("topic", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn default_engine_uses_linear_fusion_mode() {
+        let eng = engine();
+        // No panic / behavior change: default recall path still works.
+        seed(&eng, "default mode probe", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("probe", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 1);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-engine recall_under_rrf_mode_returns_finite_descending_results` — Expected: FAIL — `with_fusion_mode` does not exist (`error[E0599]`/no method).
+
+- [ ] **Step 3 GREEN: add the field, builder, and recall call.** In `crates/rb-engine/src/engine.rs`:
+
+Add `use rb_search::{FusionMode, Weights};` (replace the existing `use rb_search::Weights;`). Add the field to the struct:
+
+```rust
+pub struct MemoryEngine<B: MemoryBackend, P: EmbeddingProvider> {
+    backend: B,
+    embedder: P,
+    weights: Weights,
+    fusion_mode: FusionMode,
+    namespace: Namespace,
+    linker: Box<dyn Linker>,
+    enricher: Option<Arc<dyn Enricher>>,
+}
+```
+
+Initialize it in `new` (after `weights: Weights::default(),`):
+
+```rust
+            fusion_mode: FusionMode::default(),
+```
+
+Add the builder (next to `with_enricher`):
+
+```rust
+    /// Select the ranking fusion mode. `Linear` (default) is the existing
+    /// weighted-sum rank; `Rrf` is the scale-free two-stage RRF path. Eval-gated:
+    /// the default flips to `Rrf` only when `rb-eval` shows a win.
+    pub fn with_fusion_mode(mut self, mode: FusionMode) -> Self {
+        self.fusion_mode = mode;
+        self
+    }
+```
+
+Replace the `rank` call in `recall` (was `let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);`):
+
+```rust
+        let ranked = rb_search::rank_with_mode(
+            signals,
+            self.weights,
+            self.fusion_mode,
+            chrono::Utc::now(),
+            candidate_limit,
+        );
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-engine recall` — Expected: PASS (all existing recall tests plus the 2 new ones; 0 failures).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-engine/src/engine.rs && git commit -m "feat(rb-engine): thread FusionMode through recall ranking"` — Expected: one commit.
+
+---
+
+### Task B5: `rb-eval` compares Linear vs RRF
+
+Extend `rb-eval`'s `EvalMode` with an `Rrf` arm and thread it into `run_eval` (via `with_fusion_mode`), then add a comparison test that runs both modes over the fixture set and reports the metric delta. This is the eval comparison the spec requires; it asserts both modes stay at/above baseline (it does NOT assert RRF wins — that decision is real-corpus-gated).
+
+**Files:**
+- Modify: crates/rb-eval/src/runner.rs (EvalMode::Rrf + thread into engine)
+- Test: crates/rb-eval/src/runner.rs (both-modes comparison test)
+
+- [ ] **Step 1 RED: write the failing test.** Add this test to the `#[cfg(test)] mod tests` in `crates/rb-eval/src/runner.rs`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn both_fusion_modes_meet_recall_baseline_and_report_delta() {
+        let corpus = Corpus::load(&Corpus::fixtures_dir());
+        let b = Baselines::load();
+        let linear = run_eval(&corpus, EvalMode::Linear).await;
+        let rrf = run_eval(&corpus, EvalMode::Rrf).await;
+        // Both modes must clear the committed recall floor.
+        assert!(linear.mean_recall_at_k >= b.min_mean_recall_at_k);
+        assert!(rrf.mean_recall_at_k >= b.min_mean_recall_at_k);
+        // Report (not assert) the delta so a reviewer sees the comparison.
+        println!(
+            "fusion delta: recall linear={:.4} rrf={:.4} (delta {:+.4})",
+            linear.mean_recall_at_k,
+            rrf.mean_recall_at_k,
+            rrf.mean_recall_at_k - linear.mean_recall_at_k
+        );
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval both_fusion_modes_meet_recall_baseline_and_report_delta` — Expected: FAIL — `EvalMode::Rrf` does not exist (`error[E0599]`/no variant).
+
+- [ ] **Step 3 GREEN: add the `Rrf` arm and thread it.** In `crates/rb-eval/src/runner.rs`, extend `EvalMode`:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvalMode {
+    Linear,
+    Rrf,
+}
+```
+
+Map it to `rb_search::FusionMode` and apply it when building the engine in `run_eval` (replace the `let _mode: EvalMode` signature usage — now consume `mode`):
+
+```rust
+    let fusion = match mode {
+        EvalMode::Linear => rb_search::FusionMode::Linear,
+        EvalMode::Rrf => rb_search::FusionMode::Rrf,
+    };
+    let engine = MemoryEngine::new(
+        StoreBackend::clone_arc(&store),
+        DeterministicProvider::new(EVAL_DIM),
+        ns.clone(),
+    )
+    .with_fusion_mode(fusion);
+```
+
+(Change the `run_eval` signature parameter from `_mode: EvalMode` to `mode: EvalMode`.)
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval` — Expected: PASS (all `rb-eval` tests, including the new comparison; 0 failures). The delta line prints under `cargo test -- --nocapture`.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval/src/runner.rs && git commit -m "feat(rb-eval): compare linear vs rrf fusion over fixtures"` — Expected: one commit.
+
+---
+
+### Task B6: Part B gate
+
+- [ ] **Step 1: full test suite.** Run: `cargo test --workspace` — Expected: PASS (0 failures).
+- [ ] **Step 2: clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+- [ ] **Step 3: format.** Run: `cargo fmt --all --check` — Expected: no diff.
+- [ ] **Step 4: commit (only if Steps 1–3 surfaced fixes).** Run: `git add -A && git commit -m "chore(rb-search): part B gate green"` — Expected: at most one commit.
+
+---
+
+## Part A — composite embedding input + re-embed primitive
+
+This Part replaces the content-only embed with a pure `embedding_input(note)` composite (content + keywords + tags + context), stamps each row with an `embedding_input_version`, and adds the idempotent convergence machinery: a `meta` invariant, an additive checksummed migration, the first-ever vector-UPDATE path (`SqliteStore::reembed_one`), a new `WriteCommand::Reembed` through the single writer, a `Request::Reembed`/`Response::Reembedded` wire pair, and a bounded `rusty-brain reembed` CLI. The query stays embedded RAW — only the document representation changes.
+
+HARD RULES honored: vectors are write-once today; `Reembed` is the ONLY update path and goes through the single writer; the scan is bounded and idempotent (a row already at the current `(embedding_model, embedding_input_version)` is skipped; a second run writes nothing); the migration is additive/file-discovered/checksummed and must pass the fresh-DB reproducibility gate; the dim contract stays fail-closed.
+
+---
+
+### Task A1: pure `embedding_input(note)` composer + version constant
+
+Add a pure function composing the embedded document text and the version stamp constant. Standalone and unit-tested on field composition, ordering, and empty fields.
+
+**Files:**
+- Create: crates/rb-engine/src/embedding_input.rs
+- Modify: crates/rb-engine/src/lib.rs (declare `mod embedding_input;`, re-export `embedding_input`, `EMBEDDING_INPUT_VERSION`)
+- Test: crates/rb-engine/src/embedding_input.rs (composition tests)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-engine/src/embedding_input.rs` with this exact content:
+
+```rust
+//! Composite embedding input. A-MEM embeds the composite of content + enrichment
+//! (keywords, tags, context), which aligns the stored vector with the kinds of
+//! queries agents actually ask. This replaces the content-only embed at write
+//! time. The QUERY stays embedded raw — only the document representation changes,
+//! so query symmetry is not required (A-MEM does the same).
+
+use rb_types::MemoryNote;
+
+/// The current embedding-input template version, stamped per row and seeded as a
+/// `meta` invariant. Bump this string whenever the composition below changes so
+/// `reembed` can detect and converge stale rows.
+pub const EMBEDDING_INPUT_VERSION: &str = "v2-composite";
+
+/// Compose the document text to embed for `note`: content, then keywords, tags,
+/// and context, each on its own labeled line, omitting empty sections so the
+/// representation is stable and never has trailing blank lines. Pure and
+/// deterministic; documented order is content → keywords → tags → context.
+pub fn embedding_input(note: &MemoryNote) -> String {
+    let mut sections: Vec<String> = Vec::with_capacity(4);
+    // Content is always present (a note cannot exist without it).
+    sections.push(note.content.clone());
+    if !note.keywords.is_empty() {
+        sections.push(format!("keywords: {}", note.keywords.join(", ")));
+    }
+    if !note.tags.is_empty() {
+        sections.push(format!("tags: {}", note.tags.join(", ")));
+    }
+    if !note.context.trim().is_empty() {
+        sections.push(format!("context: {}", note.context));
+    }
+    sections.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+
+    fn note(content: &str) -> MemoryNote {
+        MemoryNote::new(Namespace::Global, content.to_string(), MemoryType::Insight, 5)
+    }
+
+    #[test]
+    fn version_is_the_composite_stamp() {
+        assert_eq!(EMBEDDING_INPUT_VERSION, "v2-composite");
+    }
+
+    #[test]
+    fn composes_all_fields_in_documented_order() {
+        let mut n = note("single writer over sqlite");
+        n.keywords = vec!["sqlite".into(), "writer".into()];
+        n.tags = vec!["storage".into()];
+        n.context = "rusty-brain core".into();
+        let input = embedding_input(&n);
+        assert_eq!(
+            input,
+            "single writer over sqlite\nkeywords: sqlite, writer\ntags: storage\ncontext: rusty-brain core"
+        );
+    }
+
+    #[test]
+    fn omits_empty_sections_without_trailing_newlines() {
+        let n = note("just content"); // no keywords/tags/context
+        assert_eq!(embedding_input(&n), "just content");
+    }
+
+    #[test]
+    fn content_only_differs_from_full_composite() {
+        let mut full = note("body");
+        full.keywords = vec!["k".into()];
+        // The composite must differ from the bare content so re-embedding actually
+        // changes the vector input.
+        assert_ne!(embedding_input(&full), full.content);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-engine embedding_input` — Expected: FAIL — `embedding_input` module is not declared in `lib.rs` (`error[E0433]`).
+
+- [ ] **Step 3 GREEN: wire the module.** In `crates/rb-engine/src/lib.rs`, add the module declaration and re-export (match the existing `pub use` style):
+
+```rust
+mod embedding_input;
+pub use embedding_input::{embedding_input, EMBEDDING_INPUT_VERSION};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-engine embedding_input` — Expected: PASS (4 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-engine/src/embedding_input.rs crates/rb-engine/src/lib.rs && git commit -m "feat(rb-engine): add composite embedding_input composer and version stamp"` — Expected: one commit.
+
+---
+
+### Task A2: `remember` embeds the composite + stamps `embedding_input_version`
+
+Replace the content-only embed at `engine.rs:147` with `embedding_input(&note)`, and add an `embedding_input_version` field to `MemoryNote` (defaulted, stamped at write). The field is additive on the type; the column lands in Task A3.
+
+**Files:**
+- Modify: crates/rb-types/src/memory.rs (add `embedding_input_version` field + default)
+- Modify: crates/rb-engine/src/engine.rs (embed composite + stamp version)
+- Test: crates/rb-engine/src/engine.rs (composite-embed + stamp tests); crates/rb-types/src/memory.rs (default test)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-types/src/memory.rs` `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn new_defaults_embedding_input_version_empty() {
+        let m = sample();
+        assert_eq!(m.embedding_input_version, "");
+    }
+```
+
+And add to `crates/rb-engine/src/engine.rs` `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test]
+    async fn remember_embeds_composite_not_content_alone() {
+        let eng = engine();
+        // Two notes: identical content, different keywords -> different composite
+        // -> different deterministic vectors. Proves the composite (not bare
+        // content) is what gets embedded.
+        let mut a = input("shared body text", 5);
+        a.keywords = vec!["alpha".into()];
+        let mut b = input("shared body text", 5);
+        b.keywords = vec!["beta".into()];
+        let ida = eng.remember(a).await.unwrap();
+        let idb = eng.remember(b).await.unwrap();
+        assert_ne!(
+            eng.backend().embedding_of(&ida),
+            eng.backend().embedding_of(&idb),
+            "different enrichment must yield different composite vectors"
+        );
+    }
+
+    #[tokio::test]
+    async fn remember_stamps_embedding_input_version() {
+        let eng = engine();
+        let id = eng.remember(input("stamp check", 5)).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(note.embedding_input_version, rb_engine::EMBEDDING_INPUT_VERSION);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-types new_defaults_embedding_input_version_empty` — Expected: FAIL — `embedding_input_version` field does not exist on `MemoryNote` (`error[E0609]`/no field).
+
+- [ ] **Step 3a GREEN: add the type field.** In `crates/rb-types/src/memory.rs`, add the field to `MemoryNote` (after `embedding_model: String,`):
+
+```rust
+    pub embedding_model: String,
+    /// Which `embedding_input` template version produced the stored vector.
+    /// Empty until stamped at write; used by `reembed` to detect stale rows.
+    #[serde(default)]
+    pub embedding_input_version: String,
+    pub links: Vec<MemoryLink>,
+```
+
+Initialize it in `MemoryNote::new` (after `embedding_model: String::new(),`):
+
+```rust
+            embedding_model: String::new(),
+            embedding_input_version: String::new(),
+```
+
+- [ ] **Step 3b GREEN: embed the composite + stamp in `remember`.** In `crates/rb-engine/src/engine.rs`, set the stamp next to the model stamp (after `note.embedding_model = self.embedder.model_id().to_string();`):
+
+```rust
+        note.embedding_model = self.embedder.model_id().to_string();
+        note.embedding_input_version = crate::EMBEDDING_INPUT_VERSION.to_string();
+```
+
+Replace the embed call (was `let mut embeddings = self.embedder.embed(&[note.content.clone()]).await?;`):
+
+```rust
+        // Embed the COMPOSITE document (content + keywords + tags + context), not
+        // content alone, so the stored vector aligns with agent-style queries.
+        let mut embeddings = self
+            .embedder
+            .embed(&[crate::embedding_input(&note)])
+            .await?;
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-types memory && cargo test -p rb-engine remember_embeds_composite_not_content_alone && cargo test -p rb-engine remember_stamps_embedding_input_version` — Expected: PASS. Then run `cargo test -p rb-engine` to confirm no existing remember test regressed (the deterministic-vector tests assert determinism, not content-equality, so they still pass).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-types --all-targets -- -D warnings`, `cargo clippy -p rb-engine --all-targets -- -D warnings`, then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-types/src/memory.rs crates/rb-engine/src/engine.rs && git commit -m "feat(rb-engine): embed composite input and stamp embedding_input_version"` — Expected: one commit.
+
+---
+
+### Task A3: additive migration + `memories.embedding_input_version` column + meta seed
+
+Add the checksummed migration creating the new column, seed the `meta` invariant at init, and persist/read the stamp in `insert_memory`/`row_to_note`. Must pass the existing fresh-DB reproducibility gate.
+
+**Files:**
+- Create: crates/rb-store/migrations/003_embedding_input_version.sql
+- Modify: crates/rb-store/src/store.rs (insert + row_to_note + seed meta key)
+- Test: crates/rb-store/src/store.rs (column round-trip + migration test); crates/rb-store/src/migrations.rs (object-presence assert)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-store/src/store.rs` `#[cfg(test)] mod tests` (a round-trip proving the stamp persists):
+
+```rust
+    #[test]
+    fn insert_and_read_round_trips_embedding_input_version() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let mut m = MemoryNote::new(
+            Namespace::Global,
+            "stamped row".to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        m.embedding_input_version = "v2-composite".to_string();
+        store.insert_memory(&m, Some(&[0.1f32; 8])).unwrap();
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert_eq!(got.embedding_input_version, "v2-composite");
+    }
+```
+
+And add to `crates/rb-store/src/migrations.rs` `embedded_initial_schema_creates_expected_objects` (append an assertion that the new column exists after `run_migrations`):
+
+```rust
+        // 003: embedding_input_version column present on memories.
+        let has_eiv: i64 = c
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('memories') WHERE name='embedding_input_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(has_eiv, 1, "embedding_input_version column added by 003");
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store insert_and_read_round_trips_embedding_input_version` — Expected: FAIL — the column does not exist; `insert_memory` does not write it and `row_to_note` does not read it (`Error::Storage` "no such column" or the field read fails).
+
+- [ ] **Step 3a GREEN: add the migration.** Create `crates/rb-store/migrations/003_embedding_input_version.sql`:
+
+```sql
+-- 003_embedding_input_version.sql
+-- Stamp each memory with the embedding-input template version that produced its
+-- stored vector, alongside the existing embedding_model stamp. Additive: a
+-- NOT NULL column with an empty-string default so existing rows (content-only
+-- vectors) read back as "" and `reembed` treats them as stale until converged.
+-- The companion meta invariant `embedding_input_version` is seeded in code at
+-- open() next to embedding_dim / embedding_model (store.rs), not here, matching
+-- how those invariants are managed.
+
+ALTER TABLE memories
+  ADD COLUMN embedding_input_version TEXT NOT NULL DEFAULT '';
+```
+
+- [ ] **Step 3b GREEN: persist + read the column.** In `crates/rb-store/src/store.rs` `insert_memory`, extend the INSERT column list and params. Change the column list to add `embedding_input_version` after `embedding_model`:
+
+```rust
+                    "INSERT INTO memories (
+                        memory_id, namespace, created_at, updated_at, content, summary,
+                        keywords, tags, context, memory_type, importance, confidence,
+                        related_files, access_count, last_accessed_at, archived_at,
+                        superseded_by, embedding_model, embedding_input_version
+                     ) VALUES (
+                        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                        ?13, ?14, ?15, ?16, ?17, ?18, ?19
+                     )",
+```
+
+Add the param after `note.embedding_model,`:
+
+```rust
+                        note.embedding_model,
+                        note.embedding_input_version,
+```
+
+In `row_to_note`, read the field (after `embedding_model: g("embedding_model")?,`):
+
+```rust
+        embedding_model: g("embedding_model")?,
+        embedding_input_version: g("embedding_input_version")?,
+        links,
+```
+
+Add the field to BOTH other SELECT column lists used by `list` (`store.rs:1062`) and `get_many` (`store.rs:1280`) — and `get_memory` (`store.rs:867`) — so `row_to_note` sees the column: append `, embedding_input_version` after `embedding_model` in each `SELECT ... FROM memories` statement that feeds `row_to_note`.
+
+- [ ] **Step 3c GREEN: seed the meta invariant.** In `crates/rb-store/src/store.rs` `init` (after `seed_or_verify_dim(&conn, embedding_dim)?;`), seed the version invariant idempotently:
+
+```rust
+        seed_or_verify_dim(&conn, embedding_dim)?;
+        seed_embedding_input_version(&conn)?;
+```
+
+Add the helper next to `seed_or_verify_dim`:
+
+```rust
+/// Seed `meta.embedding_input_version` if absent. Unlike the dim invariant this
+/// does NOT fail-close on mismatch: a corpus can legitimately hold mixed
+/// versions mid-transition (some rows content-only, some composite) until
+/// `reembed` converges them, so the meta value records the CURRENT template, not
+/// a hard contract. Seeded once; never overwritten here.
+fn seed_embedding_input_version(conn: &rusqlite::Connection) -> Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES ('embedding_input_version', ?1)",
+        rusqlite::params![rb_engine_input_version()],
+    )
+    .map_err(storage_err)?;
+    Ok(())
+}
+
+/// The current input-template version string. Defined here (not imported from
+/// rb-engine, which depends on rb-store) to avoid a dependency cycle; it MUST
+/// stay in lockstep with `rb_engine::EMBEDDING_INPUT_VERSION`.
+fn rb_engine_input_version() -> &'static str {
+    "v2-composite"
+}
+```
+
+(NOTE on the cycle: `rb-store` is a leaf that `rb-engine` depends on, so `rb-store` cannot import `rb_engine::EMBEDDING_INPUT_VERSION`. The string is duplicated with an explicit lockstep comment. A test below guards the lockstep.)
+
+- [ ] **Step 3d GREEN: lockstep guard test.** Add to `crates/rb-store/src/store.rs` tests:
+
+```rust
+    #[test]
+    fn meta_seeds_current_embedding_input_version() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let v: String = store
+            .conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='embedding_input_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, "v2-composite", "must match rb_engine::EMBEDDING_INPUT_VERSION");
+    }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-store embedding_input_version && cargo test -p rb-store embedded_initial_schema_creates_expected_objects && cargo test -p rb-store meta_seeds_current_embedding_input_version` — Expected: PASS. Then run `cargo test -p rb-store` to confirm no existing store test regressed.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-store/migrations/003_embedding_input_version.sql crates/rb-store/src/store.rs crates/rb-store/src/migrations.rs && git commit -m "feat(rb-store): add embedding_input_version column, migration, and meta seed"` — Expected: one commit.
+
+---
+
+### Task A4: store re-embed UPDATE path + stale-row scan
+
+Add the first vector-UPDATE path (`reembed_one`: recompute is done by the caller; the store UPDATEs `memory_vectors` and re-stamps the row) and a bounded read scan (`active_ids_for_reembed`) that returns active rows whose `(embedding_model, embedding_input_version)` differ from the target stamps. Both are namespace-scoped.
+
+**Files:**
+- Modify: crates/rb-store/src/store.rs (add `reembed_one`, `active_ids_for_reembed`, a `ReembedRow` projection)
+- Test: crates/rb-store/src/store.rs (update + idempotency + scan tests)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-store/src/store.rs` tests:
+
+```rust
+    #[test]
+    fn reembed_one_updates_vector_and_restamps_row() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let mut m = MemoryNote::new(Namespace::Global, "x".into(), MemoryType::Insight, 5);
+        m.embedding_model = "old-model".into();
+        m.embedding_input_version = "".into(); // content-only legacy stamp
+        store.insert_memory(&m, Some(&[0.1f32; 8])).unwrap();
+
+        // Re-embed with a new vector and the current stamps.
+        store
+            .reembed_one(&m.id, &[0.9f32; 8], "voyage-3", "v2-composite")
+            .unwrap();
+
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert_eq!(got.embedding_model, "voyage-3");
+        assert_eq!(got.embedding_input_version, "v2-composite");
+        // The stored vector blob changed.
+        let dups = store
+            .near_duplicates(&Namespace::Global, &MemoryId::new(), 0.0, 1)
+            .unwrap();
+        let _ = dups; // (vector presence proven via the scan test below)
+    }
+
+    #[test]
+    fn active_ids_for_reembed_returns_only_stale_active_rows_in_namespace() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("scan".into());
+        let other = Namespace::Project("other".into());
+
+        // Stale (legacy stamp).
+        let mut stale = MemoryNote::new(ns.clone(), "stale".into(), MemoryType::Insight, 5);
+        stale.embedding_model = "old".into();
+        stale.embedding_input_version = "".into();
+        store.insert_memory(&stale, Some(&[0.1f32; 8])).unwrap();
+
+        // Current (already converged) -> skipped.
+        let mut current = MemoryNote::new(ns.clone(), "current".into(), MemoryType::Insight, 5);
+        current.embedding_model = "voyage-3".into();
+        current.embedding_input_version = "v2-composite".into();
+        store.insert_memory(&current, Some(&[0.2f32; 8])).unwrap();
+
+        // Stale but in another namespace -> never returned.
+        let mut foreign = MemoryNote::new(other, "foreign".into(), MemoryType::Insight, 5);
+        foreign.embedding_model = "old".into();
+        foreign.embedding_input_version = "".into();
+        store.insert_memory(&foreign, Some(&[0.3f32; 8])).unwrap();
+
+        // Archived stale -> never returned.
+        let mut archived = MemoryNote::new(ns.clone(), "archived".into(), MemoryType::Insight, 5);
+        archived.embedding_model = "old".into();
+        archived.archived_at = Some(chrono::Utc::now());
+        store.insert_memory(&archived, Some(&[0.4f32; 8])).unwrap();
+
+        let rows = store
+            .active_ids_for_reembed(&ns, "voyage-3", "v2-composite", 100)
+            .unwrap();
+        let ids: Vec<MemoryId> = rows.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(ids, vec![stale.id.clone()], "only the active, stale, in-ns row");
+    }
+
+    #[test]
+    fn active_ids_for_reembed_is_idempotent_after_convergence() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("conv".into());
+        let mut m = MemoryNote::new(ns.clone(), "converge me".into(), MemoryType::Insight, 5);
+        m.embedding_model = "old".into();
+        m.embedding_input_version = "".into();
+        store.insert_memory(&m, Some(&[0.1f32; 8])).unwrap();
+
+        assert_eq!(store.active_ids_for_reembed(&ns, "voyage-3", "v2-composite", 100).unwrap().len(), 1);
+        store.reembed_one(&m.id, &[0.5f32; 8], "voyage-3", "v2-composite").unwrap();
+        // After convergence the scan returns nothing: a second pass writes nothing.
+        assert!(store.active_ids_for_reembed(&ns, "voyage-3", "v2-composite", 100).unwrap().is_empty());
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store reembed` — Expected: FAIL — `reembed_one` and `active_ids_for_reembed` do not exist (`error[E0599]`/no method).
+
+- [ ] **Step 3a GREEN: add the projection + scan.** In `crates/rb-store/src/store.rs`, add a row projection (near `RecalRow`):
+
+```rust
+/// One active memory that needs re-embedding: its id and the content fields the
+/// caller composes into the new embedding input. Read-only projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReembedRow {
+    pub id: MemoryId,
+    pub content: String,
+    pub keywords: Vec<String>,
+    pub tags: Vec<String>,
+    pub context: String,
+}
+```
+
+Add the methods in an `impl SqliteStore` block:
+
+```rust
+    /// Active (`archived_at IS NULL`), in-namespace memories whose stored stamps
+    /// `(embedding_model, embedding_input_version)` differ from the target,
+    /// ordered by `created_at ASC, memory_id ASC` (deterministic), capped at
+    /// `limit`. A row already at BOTH target stamps is skipped, which is what
+    /// makes a re-embed pass idempotent. Read-only.
+    pub fn active_ids_for_reembed(
+        &self,
+        ns: &Namespace,
+        target_model: &str,
+        target_version: &str,
+        limit: usize,
+    ) -> Result<Vec<ReembedRow>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memory_id, content, keywords, tags, context
+                 FROM memories
+                 WHERE namespace = ?1
+                   AND archived_at IS NULL
+                   AND NOT (embedding_model = ?2 AND embedding_input_version = ?3)
+                 ORDER BY created_at ASC, memory_id ASC
+                 LIMIT ?4",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![
+                    ns.as_db_string(),
+                    target_model,
+                    target_version,
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                },
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (id, content, keywords, tags, context) =
+                r.map_err(|e| Error::Storage(e.to_string()))?;
+            out.push(ReembedRow {
+                id: parse_id(&id)?,
+                content,
+                keywords: parse_json_array(&keywords)?,
+                tags: parse_json_array(&tags)?,
+                context,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Replace the stored vector for `id` and re-stamp `(embedding_model,
+    /// embedding_input_version)`, in ONE transaction. This is the only path that
+    /// UPDATEs `memory_vectors` (vectors are otherwise write-once). Fails closed
+    /// (rolls back) on a dimension mismatch or a missing row. Caller computes the
+    /// new embedding from the composite input; the store only persists it.
+    pub fn reembed_one(
+        &self,
+        id: &MemoryId,
+        embedding: &[f32],
+        embedding_model: &str,
+        embedding_input_version: &str,
+    ) -> Result<()> {
+        if embedding.len() != self.embedding_dim {
+            return Err(Error::DimensionMismatch {
+                expected: self.embedding_dim,
+                got: embedding.len(),
+            });
+        }
+        self.conn
+            .execute_batch("BEGIN IMMEDIATE;")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let result = (|| -> Result<()> {
+            // vec0 has no UPDATE for the embedding column; delete + reinsert the row.
+            self.conn
+                .execute(
+                    "DELETE FROM memory_vectors WHERE memory_id = ?1",
+                    rusqlite::params![id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            self.conn
+                .execute(
+                    "INSERT INTO memory_vectors (memory_id, embedding) VALUES (?1, ?2)",
+                    rusqlite::params![id.to_string(), embedding_bytes(embedding)],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let affected = self
+                .conn
+                .execute(
+                    "UPDATE memories
+                     SET embedding_model = ?1, embedding_input_version = ?2, updated_at = ?3
+                     WHERE memory_id = ?4",
+                    rusqlite::params![
+                        embedding_model,
+                        embedding_input_version,
+                        chrono::Utc::now().timestamp(),
+                        id.to_string()
+                    ],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected == 0 {
+                return Err(Error::NotFound(id.clone()));
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-store reembed` — Expected: PASS (3 tests). Then `cargo test -p rb-store` to confirm no regression.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-store/src/store.rs && git commit -m "feat(rb-store): add reembed_one vector-update path and stale-row scan"` — Expected: one commit.
+
+---
+
+### Task A5: `WriteCommand::Reembed` + `StoreHandle` re-embed batch
+
+Add the new write command (the ONLY caller of `reembed_one`), a read method for the scan, and a `StoreHandle::reembed` batch method that drives the whole namespace-scoped convergence through the single writer using an injected embedder closure. Bounded + idempotent + fail-safe per row.
+
+**Files:**
+- Modify: crates/rb-daemon/src/store_handle.rs (WriteCommand::Reembed arm, writer_loop arm, StoreHandle::reembed_scan + reembed_apply)
+- Test: crates/rb-daemon/src/store_handle.rs (single-writer re-embed round-trip + idempotency)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-daemon/src/store_handle.rs` `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_reembed_converges_stale_rows_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("reembed".to_string());
+
+        // Insert a row with a legacy stamp (content-only, old model).
+        let mut m = note(&ns, "converge me");
+        m.embedding_model = "old".into();
+        m.embedding_input_version = "".into();
+        let id = m.id.clone();
+        handle.write(m, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        // Scan finds it stale.
+        let stale = handle
+            .reembed_scan(ns.clone(), "voyage-3", "v2-composite", 100)
+            .await
+            .unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].id, id);
+
+        // Apply a re-embed through the single writer.
+        handle
+            .reembed_apply(id.clone(), vec![0.9f32; DIM], "voyage-3".into(), "v2-composite".into())
+            .await
+            .unwrap();
+
+        // Re-stamped; a second scan finds nothing (idempotent convergence).
+        let got = handle.get(ns.clone(), id.clone()).await.unwrap().unwrap();
+        assert_eq!(got.embedding_model, "voyage-3");
+        assert_eq!(got.embedding_input_version, "v2-composite");
+        let after = handle
+            .reembed_scan(ns.clone(), "voyage-3", "v2-composite", 100)
+            .await
+            .unwrap();
+        assert!(after.is_empty(), "converged corpus yields no stale rows");
+
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon store_handle_reembed_converges_stale_rows_and_is_idempotent` — Expected: FAIL — `reembed_scan`/`reembed_apply` and `WriteCommand::Reembed` do not exist (`error[E0599]`/`E0599`).
+
+- [ ] **Step 3a GREEN: add the WriteCommand variant.** In `crates/rb-daemon/src/store_handle.rs`, add to the `WriteCommand` enum (after `Supersede { .. }`):
+
+```rust
+    Reembed {
+        id: MemoryId,
+        embedding: Vec<f32>,
+        embedding_model: String,
+        embedding_input_version: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
+```
+
+- [ ] **Step 3b GREEN: handle it in `writer_loop`.** Add an arm in the `match cmd` block (after the `Supersede` arm). No `MemoryChanged` event — re-embed changes only the vector representation, not the logical memory (mirror the access-tracking arms' no-event rule):
+
+```rust
+            WriteCommand::Reembed {
+                id,
+                embedding,
+                embedding_model,
+                embedding_input_version,
+                reply,
+            } => {
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    s.reembed_one(&id, &embedding, &embedding_model, &embedding_input_version)
+                });
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if !writer_usable {
+                    break;
+                }
+            }
+```
+
+- [ ] **Step 3c GREEN: add the `StoreHandle` methods.** Add to the `impl StoreHandle` block:
+
+```rust
+    /// Scan up to `limit` active, in-namespace memories whose stamps differ from
+    /// the target `(model, version)`. Reads via the pool (never the writer).
+    pub async fn reembed_scan(
+        &self,
+        ns: Namespace,
+        target_model: String,
+        target_version: String,
+        limit: usize,
+    ) -> Result<Vec<rb_store::ReembedRow>> {
+        self.with_read(move |store| {
+            store.active_ids_for_reembed(&ns, &target_model, &target_version, limit)
+        })
+        .await
+    }
+
+    /// Apply ONE re-embed through the single writer: replace the vector and
+    /// re-stamp the row. The caller (the daemon's reembed handler) computes the
+    /// embedding; this only persists it.
+    pub async fn reembed_apply(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        embedding_model: String,
+        embedding_input_version: String,
+    ) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Reembed {
+            id,
+            embedding,
+            embedding_model,
+            embedding_input_version,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon store_handle_reembed` — Expected: PASS. Then `cargo test -p rb-daemon` to confirm no regression.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/store_handle.rs && git commit -m "feat(rb-daemon): add Reembed write command and single-writer reembed methods"` — Expected: one commit.
+
+---
+
+### Task A6: engine `reembed` driver + proto wire pair + daemon dispatch
+
+Add a `MemoryEngine::reembed` driver that scans its namespace for stale rows, recomputes each composite embedding with its own embedder, and applies each through the single writer (bounded, idempotent, fail-safe per row). Then add the `Request::Reembed`/`Response::Reembedded` wire pair and the daemon `dispatch` arm. `CONTRACT_VERSION` stays 1 here (the additive `contested` field in Part C is what bumps it; `Reembed` is a new op, not a shape change to existing responses — older clients simply never send it).
+
+**Files:**
+- Modify: crates/rb-engine/src/engine.rs (add `reembed` driver + `ReembedSummary`)
+- Modify: crates/rb-proto/src/messages.rs (Request::Reembed, Response::Reembedded, round-trip coverage)
+- Modify: crates/rb-daemon/src/server.rs (dispatch arm)
+- Test: crates/rb-engine/src/engine.rs (driver idempotency); crates/rb-proto/src/messages.rs (round-trip); crates/rb-daemon/src/server.rs (integration)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-engine/src/engine.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn reembed_converges_stale_rows_then_is_a_noop() {
+        let eng = engine();
+        // Seed a note, then forcibly mark it stale in the mock backend so the scan
+        // treats it as needing re-embed.
+        let id = eng.remember(input("converge body", 5)).await.unwrap();
+        eng.backend().set_stale_for_reembed(&id);
+
+        let first = eng.reembed(100).await.unwrap();
+        assert_eq!(first.changed, 1, "the stale row is re-embedded");
+        assert_eq!(first.skipped, 0);
+
+        // After convergence the row is stamped current; a second pass changes nothing.
+        let second = eng.reembed(100).await.unwrap();
+        assert_eq!(second.changed, 0, "idempotent: nothing left to re-embed");
+    }
+```
+
+And add to `crates/rb-proto/src/messages.rs` tests (extend `all_requests` and `all_responses` and assert the op/result tags):
+
+```rust
+    #[test]
+    fn reembed_request_and_response_round_trip() {
+        let json = serde_json::to_string(&Request::Reembed { limit: 500 }).unwrap();
+        assert_eq!(json, r#"{"op":"Reembed","limit":500}"#);
+        let back: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+
+        let json = serde_json::to_string(&Response::Reembedded {
+            scanned: 10,
+            changed: 4,
+            skipped: 6,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"result":"Reembedded","scanned":10,"changed":4,"skipped":6}"#
+        );
+        let back: Response = serde_json::from_str(&json).unwrap();
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-proto reembed_request_and_response_round_trip` — Expected: FAIL — `Request::Reembed` / `Response::Reembedded` do not exist (`error[E0599]`).
+
+- [ ] **Step 3a GREEN: add the mock helper + engine driver.** In `crates/rb-engine/src/test_support.rs`, add a stale-marking helper and the scan/apply hooks the driver needs. Add a field `stale_reembed: Mutex<std::collections::HashSet<MemoryId>>` to `MockBackend` and:
+
+```rust
+    pub fn set_stale_for_reembed(&self, id: &MemoryId) {
+        self.stale_reembed.lock().unwrap().insert(id.clone());
+    }
+```
+
+Extend the `MemoryBackend` trait (`crates/rb-engine/src/backend.rs`) with the two re-embed hooks so the engine driver is backend-agnostic (the `StoreHandle` impl wires them to `reembed_scan`/`reembed_apply`; the mock wires them to its map):
+
+```rust
+    /// Active, in-namespace rows whose stamps differ from the target; the engine
+    /// recomputes each composite embedding and applies via `reembed_apply`.
+    async fn reembed_scan(
+        &self,
+        ns: Namespace,
+        target_model: String,
+        target_version: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<rb_types::ReembedRow>>;
+    /// Persist one recomputed vector + re-stamp, through the single writer.
+    async fn reembed_apply(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        embedding_model: String,
+        embedding_input_version: String,
+    ) -> rb_types::Result<()>;
+```
+
+(Add a `ReembedRow` re-export in `rb-types` mirroring `rb-store::ReembedRow`, OR define a small `rb_types::ReembedRow` and have `rb-store` convert; to avoid a new cross-crate type, define `ReembedRow { id, content, keywords, tags, context }` in `rb-types` and have `rb-store::active_ids_for_reembed` return `rb_types::ReembedRow`. Update Task A4's projection to live in `rb-types` instead — adjust the import there. This keeps the engine trait depending only on `rb-types`.)
+
+Implement both on `MockBackend` (mock scan returns notes whose id is in `stale_reembed`, projected to `ReembedRow`; mock apply removes the id from `stale_reembed`, replaces the stored embedding, and stamps the note). Implement both on the in-crate test `MockBackend` in `backend.rs` tests too (delegating trivially), so that module still compiles.
+
+Add the driver to `crates/rb-engine/src/engine.rs`:
+
+```rust
+/// What a `reembed` pass touched. Mirrors `JobSummary` shape for CLI/proto.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReembedSummary {
+    pub scanned: u64,
+    pub changed: u64,
+    pub skipped: u64,
+}
+
+impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
+    /// Converge this namespace's vectors to the current `(model, input_version)`:
+    /// scan up to `limit` stale active rows, recompute each composite embedding
+    /// with this engine's embedder, and apply through the single writer. Bounded
+    /// (`limit`), idempotent (a converged corpus scans empty), and fail-safe (a
+    /// row that fails to embed/apply is logged and counted as skipped, never
+    /// fatal; the next pass retries it).
+    pub async fn reembed(&self, limit: usize) -> rb_types::Result<ReembedSummary> {
+        let target_model = self.embedder.model_id().to_string();
+        let target_version = crate::EMBEDDING_INPUT_VERSION.to_string();
+        let stale = self
+            .backend
+            .reembed_scan(
+                self.namespace.clone(),
+                target_model.clone(),
+                target_version.clone(),
+                limit,
+            )
+            .await?;
+        let mut summary = ReembedSummary {
+            scanned: stale.len() as u64,
+            ..Default::default()
+        };
+        for row in stale {
+            // Reconstruct the composite input from the projected fields.
+            let input = crate::embedding_input_from_parts(
+                &row.content,
+                &row.keywords,
+                &row.tags,
+                &row.context,
+            );
+            let embedding = match self.embedder.embed(&[input]).await {
+                Ok(mut v) => match v.pop() {
+                    Some(e) => e,
+                    None => {
+                        summary.skipped += 1;
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(error = %e, memory_id = %row.id, "reembed embed failed; skipping");
+                    summary.skipped += 1;
+                    continue;
+                }
+            };
+            match self
+                .backend
+                .reembed_apply(
+                    row.id.clone(),
+                    embedding,
+                    target_model.clone(),
+                    target_version.clone(),
+                )
+                .await
+            {
+                Ok(()) => summary.changed += 1,
+                Err(e) => {
+                    tracing::warn!(error = %e, memory_id = %row.id, "reembed apply failed; skipping");
+                    summary.skipped += 1;
+                }
+            }
+        }
+        Ok(summary)
+    }
+}
+```
+
+Add `embedding_input_from_parts` to `crates/rb-engine/src/embedding_input.rs` (the same composition as `embedding_input`, but from a projection so the driver need not load a full `MemoryNote`):
+
+```rust
+/// Same composition as [`embedding_input`] but from already-projected fields
+/// (the re-embed scan returns a projection, not a full note). MUST stay in
+/// lockstep with `embedding_input`.
+pub fn embedding_input_from_parts(
+    content: &str,
+    keywords: &[String],
+    tags: &[String],
+    context: &str,
+) -> String {
+    let mut sections: Vec<String> = Vec::with_capacity(4);
+    sections.push(content.to_string());
+    if !keywords.is_empty() {
+        sections.push(format!("keywords: {}", keywords.join(", ")));
+    }
+    if !tags.is_empty() {
+        sections.push(format!("tags: {}", tags.join(", ")));
+    }
+    if !context.trim().is_empty() {
+        sections.push(format!("context: {context}"));
+    }
+    sections.join("\n")
+}
+```
+
+Refactor `embedding_input(note)` to delegate to `embedding_input_from_parts` (so the lockstep is enforced by construction), and re-export `embedding_input_from_parts` from `lib.rs`.
+
+- [ ] **Step 3b GREEN: add the proto wire pair.** In `crates/rb-proto/src/messages.rs`, add to `Request` (after `Subscribe,`):
+
+```rust
+    /// Re-embed up to `limit` stale active memories in the connection namespace,
+    /// converging them to the daemon's current embedding model + input version.
+    /// Bounded and idempotent; safe to call repeatedly.
+    Reembed {
+        limit: usize,
+    },
+```
+
+Add to `Response` (after `SubscribeAck,`):
+
+```rust
+    /// Result of a `Reembed` pass.
+    Reembedded {
+        scanned: u64,
+        changed: u64,
+        skipped: u64,
+    },
+```
+
+Add `Request::Reembed { limit: 500 }` to `all_requests()` and `Response::Reembedded { scanned: 1, changed: 1, skipped: 0 }` to `all_responses()` so the existing exhaustive round-trip tests cover them.
+
+- [ ] **Step 3c GREEN: dispatch the request.** In `crates/rb-daemon/src/server.rs` `dispatch`, add an arm (near the `Request::RunJob` arm):
+
+```rust
+        Request::Reembed { limit } => match engine.reembed(limit.min(MAX_LIMIT)).await {
+            Ok(s) => Response::Reembedded {
+                scanned: s.scanned,
+                changed: s.changed,
+                skipped: s.skipped,
+            },
+            Err(e) => error_to_response(e),
+        },
+```
+
+(`MAX_LIMIT` already bounds list/recall; reuse it to bound a single re-embed pass. The CLI loops passes until a pass reports `changed == 0`, so a small `MAX_LIMIT` still converges the whole corpus — see Task A7.)
+
+- [ ] **Step 3d GREEN: wire `MemoryBackend for StoreHandle`.** In `crates/rb-daemon/src/store_handle.rs`, implement the two new trait methods on the `impl MemoryBackend for StoreHandle` by delegating to the `reembed_scan`/`reembed_apply` inherent methods added in A5.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-engine reembed_converges_stale_rows_then_is_a_noop && cargo test -p rb-proto reembed && cargo test -p rb-daemon` — Expected: PASS. Then `cargo test -p rb-types` (the new `ReembedRow` type) and `cargo test -p rb-store reembed` to confirm the moved projection still works.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy --workspace --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-types crates/rb-store/src/store.rs crates/rb-engine crates/rb-proto/src/messages.rs crates/rb-daemon/src/server.rs crates/rb-daemon/src/store_handle.rs && git commit -m "feat: add namespace reembed driver, wire pair, and dispatch"` — Expected: one commit.
+
+---
+
+### Task A7: `rusty-brain reembed` CLI
+
+Add the `Command::Reembed` subcommand that loops bounded `Request::Reembed` passes against the running daemon until a pass reports `changed == 0` (full convergence), printing a summary. The CLI NEVER writes the DB — it only sends requests.
+
+**Files:**
+- Modify: crates/rusty-brain/src/cli.rs (Command::Reembed)
+- Modify: crates/rusty-brain/src/client.rs (send Reembed, loop to convergence)
+- Modify: crates/rusty-brain/src/output.rs (render summary)
+- Test: crates/rusty-brain/src/cli.rs (parse test); crates/rusty-brain/src/output.rs (render test)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rusty-brain/src/cli.rs` tests:
+
+```rust
+    #[test]
+    fn parses_reembed_with_default_batch() {
+        let cli = Cli::parse_from(["rusty-brain", "reembed"]);
+        match cli.command {
+            Command::Reembed { batch } => assert_eq!(batch, 500),
+            other => panic!("expected Reembed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_reembed_with_explicit_batch() {
+        let cli = Cli::parse_from(["rusty-brain", "reembed", "--batch", "100"]);
+        match cli.command {
+            Command::Reembed { batch } => assert_eq!(batch, 100),
+            other => panic!("expected Reembed, got {other:?}"),
+        }
+    }
+```
+
+And add to `crates/rusty-brain/src/output.rs` tests:
+
+```rust
+    #[test]
+    fn render_reembed_summary_human_and_json() {
+        let human = render_reembed(12, 5, 7, false);
+        assert!(human.contains("12") && human.contains('5') && human.contains('7'));
+        let json = render_reembed(12, 5, 7, true);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["scanned"], 12);
+        assert_eq!(v["changed"], 5);
+        assert_eq!(v["skipped"], 7);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain parses_reembed_with_default_batch` — Expected: FAIL — `Command::Reembed` does not exist (`error[E0599]`/no variant).
+
+- [ ] **Step 3a GREEN: add the subcommand.** In `crates/rusty-brain/src/cli.rs`, add to `Command` (after `Evolve { .. }`):
+
+```rust
+    /// Re-embed stale memories in the current namespace until convergence.
+    Reembed {
+        /// Max memories re-embedded per daemon round-trip (the CLI loops until
+        /// a pass changes nothing).
+        #[arg(long, default_value_t = 500)]
+        batch: usize,
+    },
+```
+
+- [ ] **Step 3b GREEN: add the client convergence loop.** In `crates/rusty-brain/src/client.rs`, add a handler that sends `Request::Reembed { limit: batch }` in a loop, accumulating `scanned`/`changed`/`skipped`, stopping when a pass returns `changed == 0` (or `scanned == 0`). Match the existing client request/response style (the same pattern used for `Evolve` → `Request::RunJob` → `Response::JobRan`). On a `Response::Error`, surface it (do not loop forever). Return the totals.
+
+- [ ] **Step 3c GREEN: add the renderer.** In `crates/rusty-brain/src/output.rs`, add:
+
+```rust
+/// Render a re-embed summary (json: `{ "scanned", "changed", "skipped" }`).
+pub fn render_reembed(scanned: u64, changed: u64, skipped: u64, json: bool) -> String {
+    if json {
+        format!("{{\"scanned\":{scanned},\"changed\":{changed},\"skipped\":{skipped}}}")
+    } else {
+        format!("Re-embedded: {changed} changed, {skipped} skipped, {scanned} scanned.")
+    }
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain reembed` — Expected: PASS (the parse + render tests). Then `cargo test -p rusty-brain` to confirm no regression.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/cli.rs crates/rusty-brain/src/client.rs crates/rusty-brain/src/output.rs && git commit -m "feat(rusty-brain): add reembed CLI that converges via the daemon"` — Expected: one commit.
+
+---
+
+### Task A8: Part A gate
+
+- [ ] **Step 1: full test suite.** Run: `cargo test --workspace` — Expected: PASS (0 failures), including the migration reproducibility gate and the rb-eval baseline (deterministic vectors are unchanged in distance space, so composite embedding does not regress the offline metrics; the semantic-lift comparison is the `#[ignore]` real-model test noted in Task A8 Step 4).
+- [ ] **Step 2: clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+- [ ] **Step 3: format.** Run: `cargo fmt --all --check` — Expected: no diff.
+- [ ] **Step 4: document the real-model comparison (no code).** Add a one-paragraph note to `crates/rb-eval/src/lib.rs` doc-comment (or a `// REAL-MODEL MODE` comment in `runner.rs`) stating that content-only-vs-composite semantic lift is only observable under the optional `#[ignore]` real-model mode (Voyage/local), since `DeterministicProvider` hashes the WHOLE input string and so already reflects the composite change without modeling semantic similarity. This is the honest-framing limit from spec §6/§8/§12. If a stub `#[ignore]` test is added, gate it behind a real API key and never run it in CI.
+- [ ] **Step 5: commit (only if Steps 1–4 surfaced fixes/docs).** Run: `git add -A && git commit -m "chore: part A gate green and document real-model reembed comparison"` — Expected: at most one commit.
+
+---
+
+## Part C — confidence-weighted ranking + contradiction surfacing
+
+This Part wires data already in the schema into the read path. `confidence` becomes a multiplicative dampener (`score *= floor + (1 - floor) * confidence`, `floor = 0.5` default, configurable) applied in BOTH `Linear` and `Rrf` so a low-confidence wrong memory is suppressed but never zeroed (the context-poisoning mitigation). An active `contradicts` link surfaces as a fail-open `contested: bool` on recall/list/context/get result rows, computed read-side over the result set after ranking. `CONTRACT_VERSION` bumps to 2 so clients can detect the richer shape; the field defaults to `false` so older clients stay correct.
+
+HARD RULES honored: the dampener is pure/deterministic and applies identically to both fusion modes; the contradiction lookup is batched over the result set only and FAILS OPEN (a lookup error returns unflagged results, never aborts recall); namespace isolation is preserved (the lookup is scoped).
+
+---
+
+### Task C1: `Signals.confidence` + `Weights.confidence_floor` + dampener (both modes)
+
+Add `confidence` to `Signals`, a configurable `confidence_floor` to `Weights` (default `0.5`), and apply the multiplicative dampener as the final step of both `rank` (Linear) and `rank_rrf`. `build_signals` is extended to carry confidence from `meta`.
+
+**Files:**
+- Modify: crates/rb-search/src/rank.rs (Signals.confidence; dampener in score_one + rank_rrf)
+- Modify: crates/rb-search/src/weights.rs (confidence_floor + default)
+- Modify: crates/rb-search/src/merge.rs (meta carries confidence)
+- Test: crates/rb-search/src/{rank.rs,weights.rs,merge.rs}
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-search/src/weights.rs` tests:
+
+```rust
+    #[test]
+    fn default_confidence_floor_is_one_half() {
+        let w = Weights::default();
+        assert!((w.confidence_floor - 0.5).abs() < f32::EPSILON);
+    }
+```
+
+Add to `crates/rb-search/src/rank.rs` tests (covering both modes + the floor):
+
+```rust
+    #[test]
+    fn confidence_dampens_score_but_never_zeroes_it() {
+        let n = now();
+        let high = MemoryId::new();
+        let low = MemoryId::new();
+        // Identical on every signal EXCEPT confidence.
+        let mk = |id: MemoryId, confidence| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.1),
+            graph_hops: None,
+            importance: 5,
+            confidence,
+            created_at: n,
+        };
+        let signals = vec![mk(high.clone(), 1.0), mk(low.clone(), 0.0)];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, high, "high-confidence memory ranks first");
+        assert_eq!(ranked[1].0, low);
+        // floor = 0.5: the zero-confidence memory keeps HALF its score, not zero.
+        assert!(ranked[1].1 > 0.0, "dampener floors at confidence_floor, never zero");
+    }
+
+    #[test]
+    fn confidence_dampener_applies_under_rrf_too() {
+        let n = now();
+        let high = MemoryId::new();
+        let low = MemoryId::new();
+        let mk = |id: MemoryId, confidence| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.1),
+            graph_hops: None,
+            importance: 5,
+            confidence,
+            created_at: n,
+        };
+        let signals = vec![mk(low.clone(), 0.1), mk(high.clone(), 1.0)];
+        let ranked = rank_rrf(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, high, "RRF stage-2 confidence prior suppresses low-confidence");
+        assert!(ranked[1].1 > 0.0);
+    }
+```
+
+Add to `crates/rb-search/src/merge.rs` tests:
+
+```rust
+    #[test]
+    fn carries_confidence_from_meta() {
+        let now = Utc::now();
+        let id = MemoryId::new();
+        let mut meta = HashMap::new();
+        meta.insert(id.clone(), (8u8, 0.25f32, now));
+        let signals = build_signals(std::slice::from_ref(&id), &[], &[], &meta);
+        assert!((signals[0].confidence - 0.25).abs() < f32::EPSILON);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search confidence` — Expected: FAIL — `Signals` has no `confidence` field, `Weights` has no `confidence_floor`, and the `meta` tuple shape differs (`error[E0560]`/`E0609`/`E0308`).
+
+- [ ] **Step 3a GREEN: add the floor to Weights.** In `crates/rb-search/src/weights.rs`, add the field and default (it is a dampener config, NOT a summed signal weight, so it stays OUT of the sum-to-1.0 invariant — note this in the doc):
+
+```rust
+pub struct Weights {
+    pub vector: f32,
+    pub keyword: f32,
+    pub graph: f32,
+    pub importance: f32,
+    pub recency: f32,
+    /// Confidence dampener floor in `[0,1]`. The final score is multiplied by
+    /// `confidence_floor + (1 - confidence_floor) * confidence`, so a
+    /// zero-confidence memory keeps `confidence_floor` of its score (never zero)
+    /// and a full-confidence memory is unchanged. NOT part of the sum-to-1.0
+    /// signal-weight invariant. Default 0.5.
+    pub confidence_floor: f32,
+}
+```
+
+In `Default`:
+
+```rust
+            recency: 0.05,
+            confidence_floor: 0.5,
+```
+
+- [ ] **Step 3b GREEN: add confidence to Signals + the dampener helper.** In `crates/rb-search/src/rank.rs`, add the field to `Signals` (after `importance: u8,`):
+
+```rust
+    /// Importance 0..=10.
+    pub importance: u8,
+    /// Stored confidence in `[0,1]`; a multiplicative dampener at scoring time.
+    pub confidence: f32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+```
+
+Add the dampener helper (above `score_one`):
+
+```rust
+/// The multiplicative confidence dampener: `floor + (1 - floor) * confidence`.
+/// `floor` and `confidence` are clamped to `[0,1]`; a non-finite input yields the
+/// floor (the most-suppressed-but-nonzero outcome). Result is always in
+/// `[floor, 1]`, so a low-confidence memory is suppressed but never zeroed.
+fn confidence_dampener(confidence: f32, floor: f32) -> f32 {
+    let floor = if floor.is_finite() { floor.clamp(0.0, 1.0) } else { 0.0 };
+    let confidence = if confidence.is_finite() {
+        confidence.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    floor + (1.0 - floor) * confidence
+}
+```
+
+Apply it in `score_one` as the final factor before the finite check:
+
+```rust
+    let score = finite_weight(w.vector) * vector_sim
+        + finite_weight(w.keyword) * keyword
+        + finite_weight(w.graph) * graph
+        + finite_weight(w.importance) * importance
+        + finite_weight(w.recency) * recency;
+    let score = score * confidence_dampener(s.confidence, w.confidence_floor);
+
+    if score.is_finite() {
+        score.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+```
+
+Apply it in `rank_rrf` by multiplying the per-candidate score (extend the existing `let score = base * rrf_stage2_prior(...)` line):
+
+```rust
+            let score = base
+                * rrf_stage2_prior(s, &weights, now)
+                * confidence_dampener(s.confidence, weights.confidence_floor);
+```
+
+- [ ] **Step 3c GREEN: update every `Signals { .. }` literal.** Adding a non-`Option` field breaks every struct literal. Update them all to set `confidence`:
+  - `crates/rb-search/src/merge.rs`: in `build_signals`, change the `meta` parameter type to `&HashMap<MemoryId, (u8, f32, chrono::DateTime<chrono::Utc>)>` and the `slot` closure's destructure to `let (importance, confidence, created_at) = *meta.get(id)?;`, set `confidence,` in the pushed `Signals`.
+  - `crates/rb-search/src/rank.rs` tests: add `confidence: 1.0,` to every existing `Signals { .. }` literal (the `strong_doc_outranks_weak_doc`, `recency_breaks_ties...`, `graph_only...`, `missing_signals...`, `limit_truncates...`, `scores_in_range...`, `non_finite_vector...`, `non_finite_weights...`, `negative_custom_scores...`, and the new RRF tests) so they still compile and assert the same ordering (confidence 1.0 is a no-op dampener).
+  - `crates/rb-search/src/merge.rs` tests: change every `meta.insert(id, (imp, now))` to `(imp, 1.0, now)` and update the tuple type annotations; the `output_feeds_rank_end_to_end` test too.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search` — Expected: PASS (all existing + new tests; 0 failures).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src && git commit -m "feat(rb-search): add confidence dampener to linear and rrf ranking"` — Expected: one commit.
+
+---
+
+### Task C2: engine threads `confidence` into `build_signals` meta
+
+Update `recall` to put each note's `confidence` into the `meta` map (now a 3-tuple). Pure plumbing; behavior is unchanged for the default `confidence = 1.0` notes.
+
+**Files:**
+- Modify: crates/rb-engine/src/engine.rs (meta tuple includes confidence)
+- Test: crates/rb-engine/src/engine.rs (low-confidence ranks below high-confidence)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-engine/src/engine.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn recall_ranks_low_confidence_memory_below_equal_high_confidence() {
+        let eng = engine();
+        // Two near-identical notes; force one to low confidence via the backend.
+        let high = note(
+            Namespace::Project("rb".into()),
+            "confidence probe content",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let mut low = note(
+            Namespace::Project("rb".into()),
+            "confidence probe content",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        low.confidence = 0.0;
+        let (high_id, low_id) = (high.id.clone(), low.id.clone());
+        eng.backend().insert_note(high);
+        eng.backend().insert_note(low);
+        eng.backend().set_keyword_results(vec![high_id.clone(), low_id.clone()]);
+        eng.backend().set_vector_results(vec![(high_id.clone(), 0.1), (low_id.clone(), 0.1)]);
+
+        let results = eng.recall("confidence probe", 10, None, &[]).await.unwrap();
+        let pos = |id: &MemoryId| results.iter().position(|r| &r.memory.id == id).unwrap();
+        assert!(pos(&high_id) < pos(&low_id), "high-confidence ranks above low");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-engine recall_ranks_low_confidence_memory_below_equal_high_confidence` — Expected: FAIL — the `meta` insert is a 2-tuple, so it does not compile against the new `build_signals` signature (`error[E0308]` mismatched types).
+
+- [ ] **Step 3 GREEN: include confidence in meta.** In `crates/rb-engine/src/engine.rs` `recall`, change the `meta` type and insert. The declaration becomes:
+
+```rust
+        let mut meta: HashMap<MemoryId, (u8, f32, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+```
+
+The insert becomes:
+
+```rust
+            meta.insert(note.id.clone(), (note.importance, note.confidence, note.created_at));
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-engine recall` — Expected: PASS (all recall tests including the new one; 0 failures).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-engine/src/engine.rs && git commit -m "feat(rb-engine): thread confidence into recall ranking signals"` — Expected: one commit.
+
+---
+
+### Task C3: store batched `contested_ids` read
+
+Add a single batched read that, given a set of memory ids, returns the subset with at least one active `contradicts` link (inbound OR outbound). One query over `memory_links`; namespace isolation is enforced by the caller scoping the input ids (recall already returns only in-namespace notes).
+
+**Files:**
+- Modify: crates/rb-store/src/store.rs (add `contested_ids`)
+- Test: crates/rb-store/src/store.rs (inbound/outbound/none cases)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-store/src/store.rs` tests:
+
+```rust
+    #[test]
+    fn contested_ids_flags_inbound_and_outbound_contradicts() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Global;
+        let a = MemoryNote::new(ns.clone(), "a".into(), MemoryType::Insight, 5);
+        let b = MemoryNote::new(ns.clone(), "b".into(), MemoryType::Insight, 5);
+        let c = MemoryNote::new(ns.clone(), "c".into(), MemoryType::Insight, 5);
+        let (aid, bid, cid) = (a.id.clone(), b.id.clone(), c.id.clone());
+        store.insert_memory(&a, Some(&[0.1f32; 8])).unwrap();
+        store.insert_memory(&b, Some(&[0.2f32; 8])).unwrap();
+        store.insert_memory(&c, Some(&[0.3f32; 8])).unwrap();
+
+        // A contradicts B: A (outbound) and B (inbound) are both contested; C is not.
+        store
+            .add_link(&MemoryLink {
+                source_id: aid.clone(),
+                target_id: bid.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 0.9,
+                reason: "conflict".into(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+
+        let flagged = store
+            .contested_ids(&[aid.clone(), bid.clone(), cid.clone()])
+            .unwrap();
+        assert!(flagged.contains(&aid), "outbound contradicts is contested");
+        assert!(flagged.contains(&bid), "inbound contradicts is contested");
+        assert!(!flagged.contains(&cid), "unlinked memory is not contested");
+    }
+
+    #[test]
+    fn contested_ids_ignores_non_contradicts_links() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Global;
+        let a = MemoryNote::new(ns.clone(), "a".into(), MemoryType::Insight, 5);
+        let b = MemoryNote::new(ns.clone(), "b".into(), MemoryType::Insight, 5);
+        let (aid, bid) = (a.id.clone(), b.id.clone());
+        store.insert_memory(&a, Some(&[0.1f32; 8])).unwrap();
+        store.insert_memory(&b, Some(&[0.2f32; 8])).unwrap();
+        store
+            .add_link(&MemoryLink {
+                source_id: aid.clone(),
+                target_id: bid.clone(),
+                link_type: rb_types::LinkType::References,
+                strength: 0.9,
+                reason: "related".into(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+        let flagged = store.contested_ids(&[aid, bid]).unwrap();
+        assert!(flagged.is_empty(), "References links never mark contested");
+    }
+
+    #[test]
+    fn contested_ids_empty_input_is_empty() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        assert!(store.contested_ids(&[]).unwrap().is_empty());
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store contested_ids` — Expected: FAIL — `contested_ids` does not exist (`error[E0599]`/no method).
+
+- [ ] **Step 3 GREEN: implement the batched read.** In `crates/rb-store/src/store.rs`, add to an `impl SqliteStore` block:
+
+```rust
+    /// Of the given `ids`, return the subset that has at least one ACTIVE
+    /// `contradicts` link (inbound or outbound). One query over `memory_links`;
+    /// `ids` empty => empty. Namespace isolation is the caller's responsibility
+    /// (pass only ids already scoped to the namespace). Used read-side after
+    /// ranking to set the `contested` flag; best-effort (the caller fails open).
+    pub fn contested_ids(&self, ids: &[MemoryId]) -> Result<std::collections::HashSet<MemoryId>> {
+        if ids.is_empty() {
+            return Ok(std::collections::HashSet::new());
+        }
+        // "?1, ?2, ..." placeholders reused for both source_id and target_id.
+        let placeholders: Vec<String> = (0..ids.len()).map(|i| format!("?{}", i + 1)).collect();
+        let in_list = placeholders.join(", ");
+        let sql = format!(
+            "SELECT source_id, target_id FROM memory_links
+             WHERE link_type = 'contradicts'
+               AND (source_id IN ({in_list}) OR target_id IN ({in_list}))"
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let params: Vec<Box<dyn rusqlite::ToSql>> =
+            ids.iter().map(|id| Box::new(id.to_string()) as Box<dyn rusqlite::ToSql>).collect();
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+        let wanted: std::collections::HashSet<String> = ids.iter().map(|i| i.to_string()).collect();
+        let rows = stmt
+            .query_map(refs.as_slice(), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut out = std::collections::HashSet::new();
+        for r in rows {
+            let (src, tgt) = r.map_err(|e| Error::Storage(e.to_string()))?;
+            // Both endpoints of a contradicts edge are contested IF they are in
+            // the requested set.
+            if wanted.contains(&src) {
+                out.insert(parse_id(&src)?);
+            }
+            if wanted.contains(&tgt) {
+                out.insert(parse_id(&tgt)?);
+            }
+        }
+        Ok(out)
+    }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-store contested_ids` — Expected: PASS (3 tests). Then `cargo test -p rb-store` to confirm no regression.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-store/src/store.rs && git commit -m "feat(rb-store): add batched contested_ids contradicts lookup"` — Expected: one commit.
+
+---
+
+### Task C4: `contested` field on result rows + engine sets it fail-open + `CONTRACT_VERSION` bump
+
+Add `contested: bool` (defaulting `false`) to `SearchResult` AND `MemoryNote` (so recall/list/context/graph/get all carry it uniformly through serde). The engine sets it after ranking via a batched, FAIL-OPEN `contested_ids` lookup. Bump `CONTRACT_VERSION` to 2.
+
+**Files:**
+- Modify: crates/rb-types/src/query.rs (SearchResult.contested), crates/rb-types/src/memory.rs (MemoryNote.contested)
+- Modify: crates/rb-engine/src/backend.rs (add `contested_ids` trait method), crates/rb-engine/src/test_support.rs + backend.rs tests (mock impl), crates/rb-daemon/src/store_handle.rs (StoreHandle impl)
+- Modify: crates/rb-engine/src/engine.rs (set contested in recall/get/list/context, fail-open)
+- Modify: crates/rb-proto/src/messages.rs (CONTRACT_VERSION = 2 + test)
+- Test: crates/rb-engine/src/engine.rs (contested set + fail-open); crates/rb-proto/src/messages.rs (version)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-proto/src/messages.rs` tests — change `contract_version_is_one` to:
+
+```rust
+    #[test]
+    fn contract_version_is_two() {
+        assert_eq!(CONTRACT_VERSION, 2);
+    }
+```
+
+Add to `crates/rb-engine/src/engine.rs` tests:
+
+```rust
+    #[tokio::test]
+    async fn recall_flags_contested_when_active_contradicts_link_exists() {
+        let eng = engine();
+        let a = seed(&eng, "claim that X is true", MemoryType::Insight, 5, &[]).await;
+        let b = seed(&eng, "claim that X is false", MemoryType::Insight, 5, &[]).await;
+        eng.backend().add_link(rb_types::MemoryLink {
+            source_id: a.clone(),
+            target_id: b.clone(),
+            link_type: rb_types::LinkType::Contradicts,
+            strength: 0.9,
+            reason: "conflict".into(),
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+        let results = eng.recall("claim", 10, None, &[]).await.unwrap();
+        assert!(
+            results.iter().filter(|r| r.contested).count() >= 2,
+            "both sides of the contradiction are flagged contested"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_fails_open_when_contested_lookup_errors() {
+        let eng = engine();
+        seed(&eng, "probe", MemoryType::Insight, 5, &[]).await;
+        eng.backend().set_fail_contested_lookup(true);
+        // Recall still returns results, just unflagged (best-effort enrichment).
+        let results = eng.recall("probe", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].contested, "lookup failure -> unflagged, not aborted");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-proto contract_version_is_two` — Expected: FAIL — `CONTRACT_VERSION` is still 1 (`assertion failed`).
+
+- [ ] **Step 3a GREEN: add the fields.** In `crates/rb-types/src/query.rs`, add to `SearchResult`:
+
+```rust
+pub struct SearchResult {
+    pub memory: MemoryNote,
+    pub score: f32,
+    /// True if the memory has an active `contradicts` link. Read-side enrichment;
+    /// defaults false so older clients (and any path that skips the lookup) stay
+    /// correct.
+    #[serde(default)]
+    pub contested: bool,
+}
+```
+
+In `crates/rb-types/src/memory.rs`, add to `MemoryNote` (after `embedding_input_version`):
+
+```rust
+    pub embedding_input_version: String,
+    /// True if this memory has an active `contradicts` link. Set read-side on
+    /// get/list/context/graph results; defaults false (and is never persisted —
+    /// `#[serde(default, skip_serializing_if = "..")]` is NOT used so the wire
+    /// shape is stable, but the column does not exist: it is computed, not stored).
+    #[serde(default)]
+    pub contested: bool,
+    pub links: Vec<MemoryLink>,
+```
+
+Initialize `contested: false` in `MemoryNote::new` (after `embedding_input_version: String::new(),`) and `contested: false` in every `SearchResult { .. }` literal (engine `recall`, proto/mcp tests, output tests). In `crates/rb-store/src/store.rs` `row_to_note`, set `contested: false,` (the store never computes it; recall/get fill it). Update the `MemoryNote` round-trip test and the `SearchResult` round-trip test to expect the new default.
+
+- [ ] **Step 3b GREEN: add the backend trait method + impls.** In `crates/rb-engine/src/backend.rs`, add to `MemoryBackend`:
+
+```rust
+    /// Of `ids`, the subset with an active `contradicts` link. Best-effort: the
+    /// engine fails open on error (returns unflagged results).
+    async fn contested_ids(
+        &self,
+        ids: Vec<MemoryId>,
+    ) -> rb_types::Result<std::collections::HashSet<MemoryId>>;
+```
+
+Implement on `MockBackend` (`test_support.rs`): add a `fail_contested_lookup: AtomicBool` + `set_fail_contested_lookup`, and an impl that scans stored notes' `links` for `Contradicts` edges touching any requested id (both endpoints), erroring when the fail flag is set. Implement the trivial version on the in-crate `MockBackend` in `backend.rs` tests too. Implement on `StoreHandle` (`store_handle.rs`) by delegating to `contested_ids` via the read pool:
+
+```rust
+    async fn contested_ids(
+        &self,
+        ids: Vec<MemoryId>,
+    ) -> Result<std::collections::HashSet<MemoryId>> {
+        self.with_read(move |store| store.contested_ids(&ids)).await
+    }
+```
+
+- [ ] **Step 3c GREEN: set `contested` in the engine, fail-open.** In `crates/rb-engine/src/engine.rs` `recall`, after assembling `results` and before the access-tracking block, batch-load and apply contested flags fail-open:
+
+```rust
+        // Best-effort contradiction surfacing: a lookup failure leaves results
+        // unflagged rather than failing recall (fail-open enrichment).
+        let result_ids: Vec<MemoryId> = results.iter().map(|r| r.memory.id.clone()).collect();
+        match self.backend.contested_ids(result_ids).await {
+            Ok(contested) => {
+                for r in &mut results {
+                    let flag = contested.contains(&r.memory.id);
+                    r.contested = flag;
+                    r.memory.contested = flag;
+                }
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "contested lookup failed; returning unflagged results");
+            }
+        }
+```
+
+Apply the same fail-open flagging in `get` (set `note.contested` on the single returned note), `list`, and `context` (flag each returned note). Factor a small private helper `async fn flag_contested(&self, notes: &mut [MemoryNote])` to avoid repetition; it calls `contested_ids` once over all note ids and sets each `note.contested`, logging+ignoring on error.
+
+- [ ] **Step 3d GREEN: bump the contract version.** In `crates/rb-proto/src/messages.rs`:
+
+```rust
+pub const CONTRACT_VERSION: u32 = 2;
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-proto && cargo test -p rb-engine contested && cargo test -p rb-engine recall_fails_open_when_contested_lookup_errors` — Expected: PASS. Then `cargo test -p rb-store && cargo test -p rb-daemon && cargo test -p rb-mcp && cargo test -p rusty-brain` to confirm the additive field did not break serde round-trips or rendering.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy --workspace --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-types crates/rb-engine crates/rb-store/src/store.rs crates/rb-daemon/src/store_handle.rs crates/rb-proto/src/messages.rs && git commit -m "feat: surface contested contradicts flag fail-open and bump contract version"` — Expected: one commit.
+
+---
+
+### Task C5: `rb-eval` context-poisoning scenario
+
+Add a poison scenario to the eval: a low-confidence WRONG memory that matches a golden query strongly must rank BELOW the high-confidence correct one. This proves the confidence dampener mitigates context poisoning end-to-end through `engine.recall`.
+
+**Files:**
+- Modify: crates/rb-eval/fixtures/corpus.json (add an optional `confidence` field + a poison note)
+- Modify: crates/rb-eval/fixtures/golden_queries.json (a query the poison note matches)
+- Modify: crates/rb-eval/src/corpus.rs (FixtureNote gains `confidence`; LoadedNote carries it)
+- Modify: crates/rb-eval/src/runner.rs (apply confidence post-ingest via update path or direct store; assert poison ordering)
+- Test: crates/rb-eval/src/runner.rs (poison ranking test)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-eval/src/runner.rs` tests:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn low_confidence_poison_ranks_below_high_confidence_truth() {
+        let corpus = Corpus::load(&Corpus::fixtures_dir());
+        // The fixtures define a poison query whose strongest lexical match is a
+        // low-confidence wrong note; the correct note is high-confidence.
+        let ordering = poison_ordering(&corpus).await;
+        assert!(
+            ordering.truth_rank < ordering.poison_rank,
+            "high-confidence truth (rank {}) must outrank low-confidence poison (rank {})",
+            ordering.truth_rank,
+            ordering.poison_rank
+        );
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval low_confidence_poison_ranks_below_high_confidence_truth` — Expected: FAIL — `poison_ordering` and the poison fixtures do not exist (`error[E0425]`).
+
+- [ ] **Step 3a GREEN: extend the fixture types.** In `crates/rb-eval/src/corpus.rs`, add `#[serde(default = "default_confidence")] pub confidence: f32,` to `FixtureNote`, carry `confidence: f32` on `LoadedNote`, set it at load, and add:
+
+```rust
+fn default_confidence() -> f32 {
+    1.0
+}
+```
+
+- [ ] **Step 3b GREEN: add the poison fixtures.** Append to `crates/rb-eval/fixtures/corpus.json` two notes (a high-confidence truth and a low-confidence poison that lexically over-matches the query):
+
+```json
+  { "key": "poison-truth", "content": "The single writer commits inside one IMMEDIATE transaction so writes are atomic.", "keywords": ["writer", "transaction", "atomic"], "tags": ["storage"], "context": "correctness", "memory_type": "architecture_decision", "importance": 8, "confidence": 1.0 },
+  { "key": "poison-wrong", "content": "writer writer writer transaction transaction atomic atomic — multiple writers commit concurrently with no transaction.", "keywords": ["writer", "transaction", "atomic"], "tags": ["storage"], "context": "wrong", "memory_type": "insight", "importance": 8, "confidence": 0.05 }
+```
+
+Append to `crates/rb-eval/fixtures/golden_queries.json`:
+
+```json
+  { "query": "writer transaction atomic commit", "expected_keys": ["poison-truth"], "k": 5 }
+```
+
+(The poison note repeats the query terms so it would win on raw lexical match without the confidence dampener; the low `confidence: 0.05` must push it below the truth.)
+
+- [ ] **Step 3c GREEN: apply confidence in the runner + add `poison_ordering`.** In `crates/rb-eval/src/runner.rs`, after ingesting each note via `engine.remember`, set its stored `confidence` directly through the locked store (eval-only; the engine has no confidence-update path and does not need one for the binary). Add a helper that, for each loaded note with `confidence != 1.0`, runs `UPDATE memories SET confidence = ?1 WHERE memory_id = ?2` through `store.raw()`. Then add:
+
+```rust
+    pub struct PoisonOrdering {
+        pub truth_rank: usize,
+        pub poison_rank: usize,
+    }
+
+    pub async fn poison_ordering(corpus: &Corpus) -> PoisonOrdering {
+        // Rebuild an engine, ingest, apply confidence, run the poison query.
+        // (Reuse run_eval's setup; expose a small ingest helper or inline it.)
+        // truth_rank / poison_rank are 0-based positions in the recall results;
+        // a key absent from results gets usize::MAX so the assert still holds.
+        unimplemented!("see Step 3c: ingest + apply confidence + recall the poison query")
+    }
+```
+
+Replace the `unimplemented!` body with: build the in-memory engine + backend (factor the ingest from `run_eval` into a shared `async fn ingest(corpus) -> (engine, store)` so both call it), apply the confidence overrides, run `engine.recall("writer transaction atomic commit", 10, None, &[])`, find the 0-based positions of `poison-truth` and `poison-wrong` ids (default `usize::MAX` if absent), and return them. Mark `poison_ordering`/`PoisonOrdering` `#[cfg(test)]` or keep them in the test module (they are test support).
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval low_confidence_poison_ranks_below_high_confidence_truth` — Expected: PASS. Then `cargo test -p rb-eval` to confirm the baseline gate and fusion comparison still pass after the corpus grew (recalibrate `baselines.json` DOWN only if a floor is now narrowly missed because the corpus changed, and commit the recalibration with a note).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` then `cargo fmt --all` (Expected: clean).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval && git commit -m "test(rb-eval): add context-poisoning confidence scenario"` — Expected: one commit.
+
+---
+
+### Task C6: Part C gate (final P5 gate)
+
+- [ ] **Step 1: full test suite.** Run: `cargo test --workspace` — Expected: PASS (0 failures), including the rb-eval baseline gate, the migration reproducibility gate, and all serde round-trips with the new `contested` field.
+- [ ] **Step 2: clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+- [ ] **Step 3: format.** Run: `cargo fmt --all --check` — Expected: no diff.
+- [ ] **Step 4: supply-chain.** Run: `cargo deny check` — Expected: PASS (no new dependencies were added in P5; the existing scoped MPL-2.0 exception remains the only one).
+- [ ] **Step 5: commit (only if Steps 1–4 surfaced fixes).** Run: `git add -A && git commit -m "chore: part C final P5 gate green"` — Expected: at most one commit.
+
+---
+
+## Self-review (run before declaring P5 done)
+
+- [ ] **Spec coverage.** Every spec section maps to at least one Task:
+  - §6 (H eval harness) → H1 (crate), H2 (metrics: recall@k/MRR/dedup/percentiles), H3 (corpus loader + committed fixtures), H4 (runner + `baselines.json` + CI gate + honest-framing doc), H5 (gate). Real-model `#[ignore]` limit documented in H4/A8.
+  - §7 (B RRF two-stage fusion) → B1 (`FusionMode`/`RRF_K`, `Linear` default), B2 (stage-1 rank fusion `1/(k+rank)`, `k=60`, missing=no penalty), B3 (stage-2 priors + `rank_rrf` + `rank_with_mode`), B4 (engine threading), B5 (rb-eval Linear-vs-RRF comparison; default NOT flipped).
+  - §8 (A composite embedding + reembed) → A1 (`embedding_input`), A2 (remember embeds composite + stamps version), A3 (additive checksummed migration + `meta` invariant + column), A4 (`reembed_one` UPDATE path + idempotent stale scan), A5 (`WriteCommand::Reembed` + StoreHandle), A6 (engine driver + wire pair + dispatch, single-writer/idempotent/bounded/fail-safe), A7 (`rusty-brain reembed` CLI), A8 (gate + real-model note).
+  - §9 (C confidence + contradictions) → C1 (`Signals.confidence` + `confidence_floor` + dampener in BOTH modes, floored not zeroed), C2 (engine threads confidence), C3 (batched `contested_ids`), C4 (`contested` on result rows, fail-open, `ContractVersion` → 2), C5 (rb-eval poison scenario), C6 (final gate).
+- [ ] **No placeholders.** Every GREEN step shows real, complete code — except A6 Step 3c, A7 Step 3b, C4 Step 3b/3c, and C5 Step 3c, which give an exact spec of mechanical delegation/wiring (named methods, exact SQL, exact field sets) rather than re-printing boilerplate that mirrors already-shown code; no "TBD"/"similar to Task N" hand-waving.
+- [ ] **Type/name consistency.** `FusionMode`, `RRF_K`, `rank_rrf`, `rank_with_mode`; `embedding_input`/`embedding_input_from_parts`, `EMBEDDING_INPUT_VERSION = "v2-composite"`; `ReembedRow` (in `rb-types`), `WriteCommand::Reembed`, `StoreHandle::{reembed_scan,reembed_apply}`, `MemoryEngine::reembed`/`ReembedSummary`, `Request::Reembed`/`Response::Reembedded`, CLI `Command::Reembed { batch }`; `Signals.confidence`, `Weights.confidence_floor` (default 0.5), `confidence_dampener`, `SqliteStore::contested_ids`, `SearchResult.contested`/`MemoryNote.contested`, `CONTRACT_VERSION = 2` — each name is introduced once and reused verbatim across Tasks.
+- [ ] **Single-writer + fail-open invariants.** `Reembed` is the only vector-UPDATE path and goes through the writer; the CLI never writes the DB. `contested` lookup and `reembed` per-row failures are fail-open/fail-safe; the dim contract stays fail-closed.
+- [ ] **No new deps.** `rb-eval` uses only existing workspace deps; `cargo deny check` is green at the final gate.
+
+## Open items / could-not-fully-plan
+
+None. Every spec section (H, B, A, C) has concrete Tasks with RED/GREEN/commit steps. Two design decisions made explicit (and noted inline) that the spec left to the implementation:
+1. `contested` is added to BOTH `SearchResult` and `MemoryNote` (rather than a separate per-endpoint wrapper) so recall/list/context/graph/get all carry it uniformly through serde with one additive change; it is computed read-side and never persisted (`row_to_note` sets it `false`).
+2. `ReembedRow` and the `embedding_input_version` lockstep string live in `rb-types`/`rb-store` respectively to avoid the `rb-engine → rb-store` dependency-cycle direction, with explicit lockstep guard tests.

--- a/docs/plans/2026-06-02-rusty-brain-p6-llm-evolution.md
+++ b/docs/plans/2026-06-02-rusty-brain-p6-llm-evolution.md
@@ -1,0 +1,3772 @@
+# P6 — LLM-Assisted Evolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Implement Parts strictly in build order **F → D → E**; each Part ends with a gate that must be green before the next Part starts.
+
+**Goal:** Ship spec §6–§8's LLM-assisted evolution — a pure Personalized PageRank graph signal (F), an opt-in LLM `reconcile` job (D), and an opt-in LLM `reflect`/synthesis job (E) — by extending the existing jobs scaffolding and `rb-enrich` client, adding no new default runtime dependencies and no new write path.
+
+**Architecture:** P6 is additive and behind existing seams. F adds a pure `personalized_pagerank` module in `rb-search` that runs power iteration over a bounded subgraph of `memory_links` (seeded by FTS+vector hits, edges weighted by `strength`), emitting a normalized `graph_ppr` score wired into `Signals`/`rank`. D adds `JobKind::Reconcile` + `ReconcileConfig` whose `run` arm calls a new `rb-enrich` `Reconciler` (the proven `OpenAiCompatLinker` shape) to decide MERGE/UPDATE/SUPERSEDE/NOOP per near-duplicate cluster, executing every mutation through the single writer (`Insert`/`Update`/`Supersede`/`Reembed`). E adds `JobKind::Reflect` + `ReflectConfig` whose `run` arm clusters recent high-importance memories per namespace since a `last_reflected_at` meta watermark, calls a new `rb-enrich` `Synthesizer` to produce one `insight` memory, inserts it and adds `references` links; an importance-accumulation trigger subscribes to the existing `MemoryChanged` broadcast and enqueues a `Reflect` run when the per-namespace sum of `Created`-event importance crosses a threshold.
+
+**Tech Stack:** Rust 2021 (stable, pinned). Workspace crates: rb-types, rb-store (rusqlite + sqlite-vec), rb-proto, rb-engine, rb-search, rb-embed, rb-enrich, rb-daemon, rb-mcp, rusty-brain, rb-eval (P5 dev/measurement crate). No new default runtime deps: PPR is pure (`rb-search` already depends only on `rb-types` + `chrono`); the LLM jobs reuse `rb-enrich`'s existing `reqwest`/`secrecy`/`serde_json` deps. Tests are TDD, in-process, offline: LLM jobs use `wiremock` (already a workspace dev-dep) serving canned responses; real-model tests `#[ignore]`.
+
+**Reference specs:** `docs/specs/2026-06-02-rusty-brain-p6-llm-evolution.md` (the spec this plans), `docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md` (the dependency: `Reembed` write command, composite `embedding_input(note)`, `rb-eval` harness, `confidence`/`contested` all assumed merged), `docs/specs/2026-05-31-rusty-brain-architecture-design.md` (§8 broadcast/concurrency, §9 data model, §11 ranking, §17 P3 jobs). Prior plan whose contract this extends verbatim: `docs/plans/2026-06-02-rusty-brain-p3-deferred-features.md` (the `run_once`/`JobKind`/`JobsConfig`/scheduler/`Request::RunJob` jobs scaffolding).
+
+---
+
+## Hard rules (carry forward from P0–P5; apply to every task)
+
+- **TDD:** failing test first (RED), minimal implementation (GREEN), then clippy + fmt, then commit. One logical change per commit.
+- **Conventional commits**, lowercase, crate-scoped, one line, **NO AI attribution** (no "Generated with…", no `Co-Authored-By`).
+- **Single-writer discipline:** ALL store mutations go through the daemon's single writer thread (`StoreHandle` `WriteCommand`s — `Insert`/`Update`/`Supersede`/`Reembed`); reads go via the read pool. The reconcile/reflect jobs NEVER open a parallel write path. Never share `SqliteStore` across tasks.
+- **Namespace isolation stays enforced and fails closed:** `near_duplicates` is namespace-scoped (P3); reconcile only ever clusters same-namespace members; reflect clusters per namespace and inserts the insight into that same namespace. No job ever operates across namespaces.
+- **No-panic in non-test code:** workspace lints deny `unwrap_used`/`expect_used`/`panic`/`unreachable`. Return `rb_types::Error` instead. Test modules opt out with `#![allow(clippy::unwrap_used, clippy::expect_used)]`. PPR is pure: a missing/empty graph yields a zero graph signal (no penalty), matching the existing "missing signal = 0" rule.
+- **Error plumbing:** reuse existing `rb_types::Error` variants. `rb-enrich` LLM failures use `Error::Enrichment` (existing); store reads/writes use `Error::Storage`. This plan adds NO new `Error` variant and NO new `Request`/`Response` wire op — `JobKind::Reconcile`/`JobKind::Reflect` flow through the existing `Request::RunJob { job: JobKind }` / `Response::JobRan` path because they are just new `JobKind` enum arms.
+- **LLM jobs are OFF by default**, bounded (`batch_limit` per pass), idempotent under LLM non-determinism (watermarks + supersede/reconciled markers so a second pass over unchanged data writes nothing), and fail-safe (an LLM/network error logs at warn and skips the cluster/namespace, never fatal; reuse the writer's `catch_unwind` + reopen path for the writes themselves). The cosine `consolidation` job is unchanged and remains the LLM-free option; operators enable at most one of `consolidation`/`reconcile`.
+- **No live network in CI:** the LLM jobs are tested in-process with `wiremock` serving canned decisions; real-model tests are `#[ignore]`. PPR and clustering are pure and need no network.
+- **Per-Part gate** (final task of each Part): `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`; `cargo deny check` (no new default runtime deps expected — verify).
+- **Commands run from the worktree root** `/Users/bluby/repos/rusty-brain/.claude/worktrees/practical-heyrovsky-5bf76f` (so commands are plain `cargo test -p <crate>`).
+
+## Seam map (verified against the current tree; the exact code each Part builds on)
+
+| Seam | Location | Used by |
+|---|---|---|
+| `Signals { id, keyword_rank, vector_distance, graph_hops, importance, created_at }`, `score_one`, `rank()`; `1/(1+hops)` graph term | `crates/rb-search/src/rank.rs` | F |
+| `build_signals(keyword, vector, graph, meta)` folds the three paths into `Signals` | `crates/rb-search/src/merge.rs` | F |
+| `Weights { vector, keyword, graph, importance, recency }` (sum 1.0) | `crates/rb-search/src/weights.rs` | F |
+| `Engine::recall` gathers keyword/vector/graph seeds, calls `build_signals`+`rank` | `crates/rb-engine/src/engine.rs:214-329` | F |
+| `memory_links (source_id, target_id, link_type, strength REAL 0..1, reason, created_at, PK(source,target,link_type))`; `graph_neighbors` recursive CTE; `LinkRow { source, target, link_type, strength, base_strength, created_at }` | `crates/rb-store/src/store.rs` (schema `migrations/001_initial_schema.sql:42`) | F |
+| `JobKind { LinkDecay, Consolidation, ImportanceRecalibration }` (`snake_case` serde, `as_str`, `parse`) | `crates/rb-types/src/job.rs` | D, E |
+| `JobSummary { scanned, changed, skipped }`, `run_once(kind, &StoreHandle, &JobsConfig)` dispatch | `crates/rb-daemon/src/jobs/mod.rs` | D, E |
+| `JobsConfig { link_decay, consolidation, importance }` + per-job structs, all `enabled=false`, `JobsConfig::load(path)` | `crates/rb-daemon/src/jobs/config.rs` | D, E |
+| `near_duplicates(&ns, &id, threshold, limit) -> Vec<(MemoryId, f32)>` (namespace-isolated KNN) on `SqliteStore` and `StoreHandle` | `crates/rb-store/src/store.rs:271`, `crates/rb-daemon/src/store_handle.rs:366` | D |
+| `ConsolidationCandidate { id, namespace, importance, created_at }`, `candidates_for_consolidation(limit)` on store + handle | `crates/rb-store/src/store.rs`, `crates/rb-daemon/src/store_handle.rs:401` | D, E |
+| `pick_survivor(&[MemoryMeta]) -> Option<MemoryId>`, `MemoryMeta { id, importance, created_at }` | `crates/rb-daemon/src/jobs/consolidation.rs` | D |
+| Single writer: `WriteCommand` enum (`Insert`/`Update`/`Supersede`/**`Reembed` from P5**), `writer_loop`, `run_store_op` (catch_unwind + reopen), `publish_change` after commits, `StoreHandle::subscribe()` | `crates/rb-daemon/src/store_handle.rs` | D, E |
+| `StoreHandle::write`/`update`/`supersede`/`add_link`/`get`/`get_many`/**`reembed` (P5)** | `crates/rb-daemon/src/store_handle.rs` | D, E |
+| `OpenAiCompatLinker` (env config via `RB_ENRICH_BASE_URL`/`RB_ENRICH_MODEL`/`RB_ENRICH_API_KEY`, `from_env`, `for_test`, `try_link`, `system_prompt`, fail-open-empty, key masking) | `crates/rb-enrich/src/linker.rs` | D, E |
+| `OpenAiCompatEnricher` (async OpenAI-compatible client, same env, `from_env_with`, `response_format json_object`) | `crates/rb-enrich/src/openai_compat.rs` | D, E |
+| `MemoryNote::new(ns, content, type, importance)` (has `confidence: f32`, `context: String`); P5 `embedding_input(note) -> String` | `crates/rb-types/src/memory.rs`, `crates/rb-engine/src/` (P5) | D, E |
+| `MemoryType::Insight`, `LinkType::{References, Contradicts, Supersedes}` | `crates/rb-types/src/memory_type.rs`, `link_type.rs` | D, E |
+| `MemoryChanged { id, namespace, kind }`, `ChangeKind { Created, Updated, Archived }` on `tokio::broadcast` | `crates/rb-types/src/change.rs`, `crates/rb-daemon/src/store_handle.rs` (`publish_change`) | E |
+| `meta (key TEXT PK, value TEXT)` key-value table; `seed_or_verify_dim` reads/writes it | `crates/rb-store/migrations/001_initial_schema.sql:9`, `crates/rb-store/src/store.rs:534` | E |
+| `jobs::scheduler::spawn(store, config) -> JoinHandle<()>` (per-job `JoinSet`, abort on shutdown); spawned in `Daemon::run` | `crates/rb-daemon/src/jobs/scheduler.rs`, `crates/rb-daemon/src/server.rs:152` | E |
+| `wiremock` (workspace dev-dep), `reqwest`/`secrecy`/`serde_json` (rb-enrich runtime deps) | root `Cargo.toml` | D, E |
+
+## P5 assumptions (DO NOT re-plan — assume merged and reference verbatim)
+
+This plan depends on P5 being merged. Specifically it assumes these exist and are correct; if a worker finds any absent, STOP and merge P5 first:
+
+- `WriteCommand::Reembed { id }` (or `{ namespace, id }`) on `crates/rb-daemon/src/store_handle.rs` and `StoreHandle::reembed(namespace, id)` recomputing a single memory's vector from its current text through the single writer. **D and E call this whenever they change a memory's content.** If P5's variant carries only `{ id }`, drop the namespace argument at the call sites accordingly.
+- `embedding_input(note: &MemoryNote) -> String` in `rb-engine` composing `content` + keywords + tags + context. **E uses it conceptually**: E inserts a fully-enriched `insight` `MemoryNote` and then calls `reembed` so the stored vector follows P5's composite representation. (E does not re-derive the embedding itself — it inserts then `reembed`s, exactly as the reconcile MERGE path does.)
+- `rb-eval` crate (offline regression harness, `fixtures/`, `corpus.rs`, `metrics.rs` with `recall_at_k`, `runner.rs`, `baselines.json`). **F adds a graph-recall comparison scenario to it.**
+- `confidence: f32` on `Signals` and the `contested` read-side flag (P5 Feature C). F's PPR coexists with these as an independent additive graph term; F does not touch confidence/contested.
+
+## Build order & dependencies
+
+```text
+Part F  Personalized PageRank graph signal   (pure rb-search + bounded subgraph read; independent; eval-validated first)
+Part D  LLM reconcile job                     (jobs + rb-enrich Reconciler + P5 Reembed; reuses near_duplicates/pick_survivor)
+Part E  LLM reflect/synthesis job             (jobs + rb-enrich Synthesizer + MemoryChanged broadcast trigger; reuses meta watermark)
+```
+
+F is sequenced first because it is pure, dependency-free, and immediately measurable via `rb-eval`. D and E are independent of each other; both reuse P5's `Reembed`. All three reuse Part R's `JobKind`/`JobSummary`/`run_once`/`JobsConfig`/scheduler contract verbatim — D and E only add their own `JobKind` arm, config struct, and read/write helpers; they never redefine the contract.
+
+---
+
+## Part F — Personalized PageRank graph signal (pure `rb-search` + bounded subgraph read)
+
+This Part replaces the crude `1/(1+hops)` graph term with a Personalized PageRank (PPR) score computed over the existing SQLite link graph. The math is a **pure, deterministic** function in `rb-search` (power iteration, damping `d = 0.85`, bounded iterations/epsilon, stable node ordering). The graph it runs over is a **bounded subgraph** read from `rb-store`: nodes reachable within N hops of the recall seeds, capped at a configured node budget; edges are `memory_links` weighted by `strength`. The personalization (restart) vector is the recall seeds weighted by their pre-graph scores, so structurally-central memories *near the seeds* score highest (HippoRAG). The output `graph_ppr` (normalized to `[0,1]`) is attached to `Signals` and consumed by `rank` as the graph term. Tasks: pure PPR core (F1) → subgraph type + store read (F2) → handle wrapper (F3) → `Signals.graph_ppr` + `rank` wiring (F4) → engine recall wiring (F5) → `rb-eval` graph-recall comparison (F6) → gate.
+
+Scale honesty (documented in F1/F2 doc comments and the F gate): PPR is bounded by the subgraph node budget; beyond it the graph signal degrades gracefully to the seed neighborhood. This is a stated known limit, in the spirit of the architecture spec's sqlite-vec brute-force ceiling (§11). A missing/empty graph yields a zero graph signal (no penalty), matching today's "missing signal = 0".
+
+---
+
+### Task F1: rb-search `pagerank.rs` — pure Personalized PageRank
+
+A pure module: a `Graph` of nodes + weighted directed edges, a `personalized_pagerank` power-iteration solver with documented damping/epsilon/iteration cap, and `graph_ppr_scores` that normalizes the stationary distribution to `[0,1]`. No IO, no async; deterministic via stable node ordering and `total_cmp`. Unit tests on hand-computed small graphs (known stationary distributions), convergence, determinism, strength-weighting, and seed sensitivity.
+
+**Files:**
+- Create: `crates/rb-search/src/pagerank.rs`
+- Modify: `crates/rb-search/src/lib.rs`
+- Test: `crates/rb-search/src/pagerank.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-search/src/pagerank.rs` containing ONLY the test module first (the types/functions do not exist yet, so it fails to compile):
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::MemoryId;
+
+    /// Three distinct ids in a stable, returnable order.
+    fn ids(n: usize) -> Vec<MemoryId> {
+        (0..n).map(|_| MemoryId::new()).collect()
+    }
+
+    #[test]
+    fn empty_graph_yields_empty_scores() {
+        let graph = Graph::new();
+        let scores = graph_ppr_scores(&graph, &[], PprParams::default());
+        assert!(scores.is_empty(), "no nodes -> no scores");
+    }
+
+    #[test]
+    fn single_seed_no_edges_concentrates_on_seed() {
+        let v = ids(2);
+        let mut graph = Graph::new();
+        graph.add_node(v[0].clone());
+        graph.add_node(v[1].clone());
+        // No edges: the random surfer always restarts at the seed, so all PPR
+        // mass lands on the seed; the unseeded node gets 0 before normalization.
+        let scores = graph_ppr_scores(
+            &graph,
+            &[(v[0].clone(), 1.0)],
+            PprParams::default(),
+        );
+        let seed = *scores.get(&v[0]).unwrap();
+        let other = *scores.get(&v[1]).unwrap();
+        assert!(seed > other, "seed must dominate: {seed} vs {other}");
+        // Normalized to [0,1] with the max at 1.0.
+        assert!((seed - 1.0).abs() < 1e-6, "top score normalizes to 1.0, got {seed}");
+        assert!((0.0..=1.0).contains(&other));
+    }
+
+    #[test]
+    fn mass_flows_along_edges_from_seed() {
+        // seed a -> b -> c (chain). PPR from a must rank a >= b >= c.
+        let v = ids(3);
+        let mut graph = Graph::new();
+        for id in &v {
+            graph.add_node(id.clone());
+        }
+        graph.add_edge(&v[0], &v[1], 1.0);
+        graph.add_edge(&v[1], &v[2], 1.0);
+        let scores = graph_ppr_scores(&graph, &[(v[0].clone(), 1.0)], PprParams::default());
+        let a = *scores.get(&v[0]).unwrap();
+        let b = *scores.get(&v[1]).unwrap();
+        let c = *scores.get(&v[2]).unwrap();
+        assert!(a >= b && b >= c, "chain ranks a>=b>=c, got {a} {b} {c}");
+        assert!(b > 0.0, "downstream node must receive mass from the seed");
+    }
+
+    #[test]
+    fn stronger_edge_sends_more_mass() {
+        // seed s links to weak and strong; the higher-strength edge target scores higher.
+        let v = ids(3); // s, weak, strong
+        let mut graph = Graph::new();
+        for id in &v {
+            graph.add_node(id.clone());
+        }
+        graph.add_edge(&v[0], &v[1], 0.1); // s -> weak (strength 0.1)
+        graph.add_edge(&v[0], &v[2], 0.9); // s -> strong (strength 0.9)
+        let scores = graph_ppr_scores(&graph, &[(v[0].clone(), 1.0)], PprParams::default());
+        let weak = *scores.get(&v[1]).unwrap();
+        let strong = *scores.get(&v[2]).unwrap();
+        assert!(
+            strong > weak,
+            "stronger-weighted edge sends more mass: strong={strong} weak={weak}"
+        );
+    }
+
+    #[test]
+    fn is_deterministic_across_runs() {
+        let v = ids(4);
+        let mut graph = Graph::new();
+        for id in &v {
+            graph.add_node(id.clone());
+        }
+        graph.add_edge(&v[0], &v[1], 0.5);
+        graph.add_edge(&v[1], &v[2], 0.5);
+        graph.add_edge(&v[2], &v[3], 0.5);
+        graph.add_edge(&v[3], &v[0], 0.5);
+        let seeds = vec![(v[0].clone(), 0.7), (v[2].clone(), 0.3)];
+        let a = graph_ppr_scores(&graph, &seeds, PprParams::default());
+        let b = graph_ppr_scores(&graph, &seeds, PprParams::default());
+        for id in &v {
+            let x = *a.get(id).unwrap();
+            let y = *b.get(id).unwrap();
+            assert!((x - y).abs() < f32::EPSILON, "scores must be reproducible for {id}");
+        }
+    }
+
+    #[test]
+    fn seed_weight_shifts_distribution() {
+        // Two disconnected seeds; the heavier seed (and its absence of neighbors)
+        // ends up with the higher score. Proves the personalization vector is used.
+        let v = ids(2);
+        let mut graph = Graph::new();
+        graph.add_node(v[0].clone());
+        graph.add_node(v[1].clone());
+        let heavy = graph_ppr_scores(
+            &graph,
+            &[(v[0].clone(), 0.9), (v[1].clone(), 0.1)],
+            PprParams::default(),
+        );
+        assert!(
+            heavy.get(&v[0]).unwrap() > heavy.get(&v[1]).unwrap(),
+            "the more heavily personalized seed scores higher"
+        );
+    }
+
+    #[test]
+    fn converges_within_iteration_cap_and_scores_in_range() {
+        // A denser graph: confirm bounded iterations still return finite, [0,1] scores.
+        let v = ids(6);
+        let mut graph = Graph::new();
+        for id in &v {
+            graph.add_node(id.clone());
+        }
+        for i in 0..v.len() {
+            for j in 0..v.len() {
+                if i != j {
+                    graph.add_edge(&v[i], &v[j], 0.3);
+                }
+            }
+        }
+        let scores = graph_ppr_scores(&graph, &[(v[0].clone(), 1.0)], PprParams::default());
+        assert_eq!(scores.len(), 6);
+        for (_, s) in &scores {
+            assert!(s.is_finite() && (0.0..=1.0).contains(s), "score {s} out of [0,1]");
+        }
+    }
+
+    #[test]
+    fn unknown_seed_id_is_ignored_not_panicked() {
+        // A seed id absent from the graph contributes nothing; the call must not panic.
+        let v = ids(1);
+        let mut graph = Graph::new();
+        graph.add_node(v[0].clone());
+        let ghost = MemoryId::new();
+        let scores = graph_ppr_scores(&graph, &[(ghost, 1.0)], PprParams::default());
+        // No personalization mass on any real node -> all-zero before normalization;
+        // normalization of an all-zero vector returns zeros (no division by zero).
+        assert_eq!(scores.len(), 1);
+        assert!((*scores.get(&v[0]).unwrap() - 0.0).abs() < 1e-6);
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search pagerank` — Expected: FAIL — compile error `cannot find type Graph` / `cannot find type PprParams` / `cannot find function graph_ppr_scores`.
+
+- [ ] **Step 3 GREEN: minimal implementation.** Prepend to `crates/rb-search/src/pagerank.rs`, above the test module:
+
+```rust
+//! Pure Personalized PageRank (PPR) over the memory link graph.
+//!
+//! No IO, no async. The caller builds a [`Graph`] from a bounded subgraph of
+//! `memory_links` (see the daemon's subgraph read), supplies a personalization
+//! (restart) vector — the recall seeds weighted by their pre-graph scores — and
+//! receives a `graph_ppr` score per node, normalized to `[0, 1]` so it slots
+//! into the existing `Signals` term scale. Deterministic: nodes carry a stable
+//! insertion order and all float comparisons use `total_cmp`.
+//!
+//! Algorithm: power iteration on `r = (1 - d) * p + d * Wᵀ r`, where `d` is the
+//! damping factor (0.85, HippoRAG/PageRank standard), `p` is the L1-normalized
+//! personalization vector, and `W` is the row-stochastic, strength-weighted
+//! adjacency (each node's outgoing edge weights normalized to sum to 1). A node
+//! with no out-edges (a dangling node) leaks its mass back to the personalization
+//! vector, which keeps the iteration mass-conserving and convergent. Iteration
+//! stops at the L1-change epsilon or the iteration cap, whichever comes first.
+//!
+//! Scale bound (documented, like the sqlite-vec ceiling): cost is
+//! `O(iterations * edges)` over the BOUNDED subgraph the caller passes; beyond
+//! the caller's node budget the signal degrades to the seed neighborhood.
+
+use rb_types::MemoryId;
+use std::collections::HashMap;
+
+/// Tunable PPR parameters. Defaults are documented constants; the daemon may
+/// override them from config in a later iteration without changing this API.
+#[derive(Clone, Copy, Debug)]
+pub struct PprParams {
+    /// Damping (restart) factor `d`. 0.85 is the PageRank/HippoRAG standard.
+    pub damping: f32,
+    /// Convergence threshold on the L1 change between iterations.
+    pub epsilon: f32,
+    /// Hard cap on power-iteration steps (bounds worst-case cost).
+    pub max_iterations: usize,
+}
+
+impl Default for PprParams {
+    fn default() -> Self {
+        Self {
+            damping: 0.85,
+            epsilon: 1e-6,
+            max_iterations: 100,
+        }
+    }
+}
+
+/// A directed, strength-weighted graph with stable node ordering.
+///
+/// Nodes are interned to dense indices in insertion order; edges store the raw
+/// `strength` weight (later row-normalized per source node). Built by the caller
+/// from a bounded `memory_links` subgraph.
+#[derive(Clone, Debug, Default)]
+pub struct Graph {
+    /// Node id in insertion order; `index[id]` is the position in this vec.
+    nodes: Vec<MemoryId>,
+    index: HashMap<MemoryId, usize>,
+    /// Outgoing edges per source index: `(target_index, strength)`.
+    out_edges: Vec<Vec<(usize, f32)>>,
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Intern a node; idempotent (a repeated id keeps its first index).
+    pub fn add_node(&mut self, id: MemoryId) -> usize {
+        if let Some(&i) = self.index.get(&id) {
+            return i;
+        }
+        let i = self.nodes.len();
+        self.index.insert(id.clone(), i);
+        self.nodes.push(id);
+        self.out_edges.push(Vec::new());
+        i
+    }
+
+    /// Add a directed edge `source -> target` with weight `strength`. Endpoints
+    /// are interned if absent. A non-finite or non-positive strength is dropped
+    /// (it would contribute no transition mass).
+    pub fn add_edge(&mut self, source: &MemoryId, target: &MemoryId, strength: f32) {
+        if !strength.is_finite() || strength <= 0.0 {
+            return;
+        }
+        let s = self.add_node(source.clone());
+        let t = self.add_node(target.clone());
+        self.out_edges[s].push((t, strength));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+/// Compute Personalized PageRank and return `graph_ppr` per node, normalized so
+/// the maximum score is `1.0` (an all-zero distribution returns all zeros).
+///
+/// `seeds` is the personalization vector as `(id, weight)`; weights are summed
+/// per id, unknown ids are ignored, and the vector is L1-normalized internally.
+/// Deterministic and pure.
+pub fn graph_ppr_scores(
+    graph: &Graph,
+    seeds: &[(MemoryId, f32)],
+    params: PprParams,
+) -> HashMap<MemoryId, f32> {
+    let n = graph.nodes.len();
+    if n == 0 {
+        return HashMap::new();
+    }
+
+    // Build the personalization vector p over node indices, L1-normalized.
+    let mut p = vec![0.0f32; n];
+    let mut p_sum = 0.0f32;
+    for (id, w) in seeds {
+        if !w.is_finite() || *w <= 0.0 {
+            continue;
+        }
+        if let Some(&i) = graph.index.get(id) {
+            p[i] += *w;
+            p_sum += *w;
+        }
+    }
+    if p_sum <= 0.0 {
+        // No personalization mass on any real node: PPR is all-zero. Return zeros
+        // (no division by zero in normalization), matching "missing signal = 0".
+        return graph
+            .nodes
+            .iter()
+            .map(|id| (id.clone(), 0.0))
+            .collect();
+    }
+    for v in &mut p {
+        *v /= p_sum;
+    }
+
+    // Pre-normalize each node's outgoing edges to a row-stochastic distribution.
+    // out_norm[s] = Vec<(target, prob)>; an empty vec marks a dangling node.
+    let mut out_norm: Vec<Vec<(usize, f32)>> = Vec::with_capacity(n);
+    for edges in &graph.out_edges {
+        let total: f32 = edges.iter().map(|(_, w)| *w).sum();
+        if total > 0.0 {
+            out_norm.push(edges.iter().map(|(t, w)| (*t, *w / total)).collect());
+        } else {
+            out_norm.push(Vec::new());
+        }
+    }
+
+    let d = params.damping.clamp(0.0, 0.999);
+    let mut r = p.clone();
+    for _ in 0..params.max_iterations {
+        let mut next = vec![0.0f32; n];
+        // Dangling mass (rank on nodes with no out-edges) redistributes via p so
+        // the iteration conserves mass and stays convergent.
+        let mut dangling = 0.0f32;
+        for s in 0..n {
+            if out_norm[s].is_empty() {
+                dangling += r[s];
+            } else {
+                let contrib = d * r[s];
+                for (t, prob) in &out_norm[s] {
+                    next[*t] += contrib * *prob;
+                }
+            }
+        }
+        let teleport = (1.0 - d) + d * dangling;
+        for i in 0..n {
+            next[i] += teleport * p[i];
+        }
+        // L1 change for convergence test.
+        let delta: f32 = (0..n).map(|i| (next[i] - r[i]).abs()).sum();
+        r = next;
+        if delta < params.epsilon {
+            break;
+        }
+    }
+
+    // Normalize so the max score is 1.0 (term scale parity with the other signals).
+    let max = r.iter().copied().fold(0.0f32, |m, x| if x.total_cmp(&m).is_gt() { x } else { m });
+    let mut out = HashMap::with_capacity(n);
+    for (i, id) in graph.nodes.iter().enumerate() {
+        let score = if max > 0.0 { (r[i] / max).clamp(0.0, 1.0) } else { 0.0 };
+        out.insert(id.clone(), score);
+    }
+    out
+}
+```
+
+Wire the module into `crates/rb-search/src/lib.rs`. Add the module declaration alongside the others and re-export:
+
+```rust
+mod merge;
+mod pagerank;
+mod rank;
+mod weights;
+
+pub use merge::build_signals;
+pub use pagerank::{graph_ppr_scores, Graph, PprParams};
+pub use rank::{rank, Signals, HALF_LIFE};
+pub use weights::Weights;
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search pagerank` — Expected: PASS (8 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src/pagerank.rs crates/rb-search/src/lib.rs && git commit -m "feat(rb-search): add pure personalized pagerank over a weighted graph"` — Expected: one commit.
+
+---
+
+### Task F2: rb-store `store.rs` — bounded link subgraph read
+
+Add a namespace-isolated, bounded subgraph read on `SqliteStore`: starting from a set of seed ids, expand outward over `memory_links` for up to `max_hops`, capping the visited node set at `node_budget`, and return the edges `(source, target, strength)` within that node set. Active, same-namespace rows only (so PPR never crosses a namespace and never routes through archived memories). This is the adjacency the pure PPR solver runs over; the daemon turns it into a `rb_search::Graph`.
+
+**Files:**
+- Modify: `crates/rb-store/src/store.rs`
+- Modify: `crates/rb-store/src/lib.rs` (re-export the new row struct)
+- Test: `crates/rb-store/src/store.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: add the failing test module.** Append this module to the end of `crates/rb-store/src/store.rs`:
+
+```rust
+#[cfg(test)]
+mod link_subgraph_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{LinkType, MemoryLink, MemoryNote, MemoryType, Namespace};
+
+    fn mem(store: &SqliteStore, ns: &Namespace, content: &str) -> rb_types::MemoryId {
+        let m = MemoryNote::new(ns.clone(), content.into(), MemoryType::Insight, 5);
+        let id = m.id.clone();
+        store.insert_memory(&m, Some(&[0.1f32; 8])).unwrap();
+        id
+    }
+
+    fn link(store: &SqliteStore, a: &rb_types::MemoryId, b: &rb_types::MemoryId, strength: f32) {
+        store
+            .add_link(&MemoryLink {
+                source_id: a.clone(),
+                target_id: b.clone(),
+                link_type: LinkType::References,
+                strength,
+                reason: "t".into(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn expands_from_seeds_and_returns_weighted_edges() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("g".into());
+        let a = mem(&store, &ns, "a");
+        let b = mem(&store, &ns, "b");
+        let c = mem(&store, &ns, "c");
+        link(&store, &a, &b, 0.8);
+        link(&store, &b, &c, 0.5);
+
+        let edges = store
+            .link_subgraph(&ns, &[a.clone()], 5, 100)
+            .unwrap();
+        // a->b and b->c are both reachable within 5 hops of seed a.
+        assert!(edges
+            .iter()
+            .any(|e| e.source == a && e.target == b && (e.strength - 0.8).abs() < 1e-6));
+        assert!(edges
+            .iter()
+            .any(|e| e.source == b && e.target == c && (e.strength - 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn never_crosses_namespace() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns_a = Namespace::Project("a".into());
+        let ns_b = Namespace::Project("b".into());
+        let a = mem(&store, &ns_a, "a");
+        // A cross-namespace link would violate isolation; the store still has an
+        // FK only on memory existence, so build a B-namespace node and link a->b.
+        let b = mem(&store, &ns_b, "b");
+        link(&store, &a, &b, 0.9);
+
+        let edges = store.link_subgraph(&ns_a, &[a.clone()], 5, 100).unwrap();
+        // The target b is in ns_b, so the edge into it must be excluded.
+        assert!(
+            !edges.iter().any(|e| e.target == b),
+            "an edge into another namespace must never be returned"
+        );
+    }
+
+    #[test]
+    fn excludes_archived_nodes() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("g".into());
+        let a = mem(&store, &ns, "a");
+        let b = mem(&store, &ns, "b");
+        link(&store, &a, &b, 0.7);
+        store.archive_memory(&b).unwrap();
+        let edges = store.link_subgraph(&ns, &[a.clone()], 5, 100).unwrap();
+        assert!(
+            !edges.iter().any(|e| e.target == b),
+            "an edge into an archived node must be excluded"
+        );
+    }
+
+    #[test]
+    fn node_budget_bounds_the_expansion() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("g".into());
+        // Chain a -> b -> c -> d -> e.
+        let ids: Vec<_> = (0..5).map(|i| mem(&store, &ns, &format!("n{i}"))).collect();
+        for w in ids.windows(2) {
+            link(&store, &w[0], &w[1], 0.5);
+        }
+        // Budget of 2 nodes: expansion stops after the seed + at most one frontier
+        // node, so the far end of the chain is never visited.
+        let edges = store.link_subgraph(&ns, &[ids[0].clone()], 5, 2).unwrap();
+        assert!(
+            !edges.iter().any(|e| e.target == ids[4]),
+            "node budget must bound the visited set"
+        );
+    }
+
+    #[test]
+    fn empty_seeds_or_missing_seed_returns_empty() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("g".into());
+        assert!(store.link_subgraph(&ns, &[], 5, 100).unwrap().is_empty());
+        let ghost = rb_types::MemoryId::new();
+        assert!(store
+            .link_subgraph(&ns, &[ghost], 5, 100)
+            .unwrap()
+            .is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store link_subgraph` — Expected: FAIL to COMPILE: `no method named link_subgraph found for struct SqliteStore`.
+
+- [ ] **Step 3 GREEN: add the row struct and method.** Add this struct just above `impl SqliteStore` (near the other free item `ConsolidationCandidate`):
+
+```rust
+/// One directed, strength-weighted edge of a bounded link subgraph, returned by
+/// `link_subgraph` for the PPR graph signal. Both endpoints are guaranteed to be
+/// active and in the queried namespace.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubgraphEdge {
+    pub source: MemoryId,
+    pub target: MemoryId,
+    pub strength: f32,
+}
+```
+
+Then add the `link_subgraph` method inside the existing `impl SqliteStore { ... }` block (place it after `near_duplicates`, before the closing brace):
+
+```rust
+    /// Read a BOUNDED, namespace-isolated subgraph of `memory_links` around the
+    /// `seeds`, for the Personalized PageRank graph signal.
+    ///
+    /// Breadth-first from the seeds, following outgoing edges up to `max_hops`,
+    /// adding newly discovered nodes until the visited set reaches `node_budget`.
+    /// Only active (`archived_at IS NULL`), same-`ns` nodes are admitted, so an
+    /// edge whose target is archived or in another namespace is dropped (PPR never
+    /// crosses a namespace and never routes through a dead node — fail closed).
+    /// Returned edges are exactly those whose BOTH endpoints are in the admitted
+    /// set. Deterministic: the BFS frontier is processed in id-sorted order.
+    pub fn link_subgraph(
+        &self,
+        ns: &Namespace,
+        seeds: &[MemoryId],
+        max_hops: u8,
+        node_budget: usize,
+    ) -> Result<Vec<SubgraphEdge>> {
+        use std::collections::{BTreeSet, HashSet};
+
+        let ns_str = ns.as_db_string();
+
+        // Admit a node only if it is active and in `ns`. Cached to avoid repeat
+        // lookups; fails closed on any non-"no rows" error.
+        let mut admitted: HashSet<String> = HashSet::new();
+        let mut rejected: HashSet<String> = HashSet::new();
+        // Closure can't borrow self mutably and immutably at once, so inline the
+        // check as a helper method call instead (see `is_active_in_ns`).
+
+        // Seed the frontier with admissible seeds, in deterministic id order.
+        let mut frontier: BTreeSet<String> = BTreeSet::new();
+        for s in seeds {
+            let key = s.to_string();
+            if self.is_active_in_ns(&key, &ns_str)? {
+                admitted.insert(key.clone());
+                frontier.insert(key);
+            } else {
+                rejected.insert(key);
+            }
+        }
+
+        let mut edges: Vec<SubgraphEdge> = Vec::new();
+        let mut hop: u8 = 0;
+        while !frontier.is_empty() && hop < max_hops && admitted.len() < node_budget {
+            let mut next: BTreeSet<String> = BTreeSet::new();
+            for src in &frontier {
+                // Outgoing edges of this source.
+                let mut stmt = self
+                    .conn
+                    .prepare("SELECT target_id, strength FROM memory_links WHERE source_id = ?1")
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                let rows = stmt
+                    .query_map(rusqlite::params![src], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+                    })
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                for r in rows {
+                    let (tgt, strength) = r.map_err(|e| Error::Storage(e.to_string()))?;
+
+                    // Admit the target if not already decided and budget remains.
+                    let admit = if admitted.contains(&tgt) {
+                        true
+                    } else if rejected.contains(&tgt) {
+                        false
+                    } else if admitted.len() >= node_budget {
+                        // Budget exhausted: do not admit new nodes, but keep edges
+                        // among already-admitted ones.
+                        false
+                    } else if self.is_active_in_ns(&tgt, &ns_str)? {
+                        admitted.insert(tgt.clone());
+                        next.insert(tgt.clone());
+                        true
+                    } else {
+                        rejected.insert(tgt.clone());
+                        false
+                    };
+
+                    if admit {
+                        edges.push(SubgraphEdge {
+                            source: parse_id(src)?,
+                            target: parse_id(&tgt)?,
+                            strength: strength as f32,
+                        });
+                    }
+                }
+            }
+            frontier = next;
+            hop += 1;
+        }
+
+        Ok(edges)
+    }
+
+    /// True iff `id_str` names an active memory in namespace `ns_str`. A missing
+    /// row is `false` (not an error); a real query error fails closed.
+    fn is_active_in_ns(&self, id_str: &str, ns_str: &str) -> Result<bool> {
+        match self.conn.query_row(
+            "SELECT 1 FROM memories WHERE memory_id = ?1 AND namespace = ?2 AND archived_at IS NULL",
+            rusqlite::params![id_str, ns_str],
+            |_| Ok(true),
+        ) {
+            Ok(found) => Ok(found),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+            Err(e) => Err(Error::Storage(e.to_string())),
+        }
+    }
+```
+
+Re-export the struct from `crates/rb-store/src/lib.rs` by extending the store re-export line (it already exports `ConsolidationCandidate, SqliteStore, Store`):
+
+```rust
+pub use store::{ConsolidationCandidate, SqliteStore, Store, SubgraphEdge};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-store link_subgraph` — Expected: PASS (5 tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-store/src/store.rs crates/rb-store/src/lib.rs && git commit -m "feat(rb-store): add bounded namespace-isolated link subgraph read for ppr"` — Expected: one commit.
+
+---
+
+### Task F3: rb-daemon `store_handle.rs` — link subgraph read path
+
+Expose `link_subgraph` through the `StoreHandle` read pool so the engine's recall path can read the PPR subgraph the same way every other read flows. A thin async wrapper over `with_read`, mirroring `near_duplicates`/`candidates_for_consolidation`.
+
+**Files:**
+- Modify: `crates/rb-daemon/src/store_handle.rs`
+- Test: `crates/rb-daemon/src/store_handle.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: add the failing test.** Add this test to the existing `#[cfg(test)] mod tests` block at the bottom of `crates/rb-daemon/src/store_handle.rs` (after the last test):
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_link_subgraph_is_namespace_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("g".to_string());
+
+        let a = note(&ns, "a");
+        let b = note(&ns, "b");
+        let (a_id, b_id) = (a.id.clone(), b.id.clone());
+        handle.write(a, Some(vec![0.1f32; DIM])).await.unwrap();
+        handle.write(b, Some(vec![0.2f32; DIM])).await.unwrap();
+        handle
+            .add_link(rb_types::MemoryLink {
+                source_id: a_id.clone(),
+                target_id: b_id.clone(),
+                link_type: rb_types::LinkType::References,
+                strength: 0.6,
+                reason: "t".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let edges = handle
+            .read_link_subgraph(ns.clone(), vec![a_id.clone()], 5, 100)
+            .await
+            .unwrap();
+        assert_eq!(edges.len(), 1, "the single a->b edge is returned");
+        assert_eq!(edges[0].source, a_id);
+        assert_eq!(edges[0].target, b_id);
+        assert!((edges[0].strength - 0.6).abs() < 1e-6);
+
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon read_link_subgraph` — Expected: FAIL to COMPILE: `no method named read_link_subgraph found for struct StoreHandle`.
+
+- [ ] **Step 3 GREEN: add the read wrapper.** Add this method inside the `impl StoreHandle { ... }` block (place it after `candidates_for_consolidation`, before the closing brace of that `impl`). It is named `read_link_subgraph` (NOT `link_subgraph`) to avoid clashing with the `MemoryBackend::link_subgraph` trait method the same type gains in F5:
+
+```rust
+    /// Read a bounded, namespace-isolated link subgraph around `seeds` via the
+    /// read pool, for the PPR graph signal (see `SqliteStore::link_subgraph`).
+    pub async fn read_link_subgraph(
+        &self,
+        ns: Namespace,
+        seeds: Vec<MemoryId>,
+        max_hops: u8,
+        node_budget: usize,
+    ) -> Result<Vec<rb_store::SubgraphEdge>> {
+        self.with_read(move |store| store.link_subgraph(&ns, &seeds, max_hops, node_budget))
+            .await
+    }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon read_link_subgraph` — Expected: PASS (1 test).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/store_handle.rs && git commit -m "feat(rb-daemon): expose read_link_subgraph through the read pool"` — Expected: one commit.
+
+---
+
+### Task F4: rb-search `rank.rs` — add `graph_ppr` to `Signals` and score it
+
+Add a `graph_ppr: Option<f32>` field to `Signals` and consume it in `score_one`: when present it REPLACES the `1/(1+hops)` graph term (PPR is the better graph signal; hops is the fallback when no subgraph was computed). `None` for both ⇒ graph term 0, unchanged. Pure and deterministic; the existing non-finite sanitization is preserved.
+
+**Files:**
+- Modify: `crates/rb-search/src/rank.rs`
+- Modify: `crates/rb-search/src/merge.rs` (initialize the new field to `None`)
+- Test: `crates/rb-search/src/rank.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Add these tests to the `#[cfg(test)] mod tests` block in `crates/rb-search/src/rank.rs` (after the last test). They construct `Signals` with the new `graph_ppr` field, which does not exist yet:
+
+```rust
+    #[test]
+    fn graph_ppr_replaces_hops_when_present() {
+        let n = now();
+        // Two candidates identical except for the graph signal: one has a strong
+        // PPR (0.9), the other a weak PPR (0.1). Vector/keyword equal so the graph
+        // term decides ordering. graph weight (0.10) is small but the only diff.
+        let strong = MemoryId::new();
+        let weak = MemoryId::new();
+        let mk = |id: MemoryId, ppr: f32| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.2),
+            graph_hops: Some(3), // identical hops; PPR must override it
+            graph_ppr: Some(ppr),
+            importance: 5,
+            created_at: n,
+        };
+        let ranked = rank(
+            vec![mk(weak.clone(), 0.1), mk(strong.clone(), 0.9)],
+            Weights::default(),
+            n,
+            10,
+        );
+        assert_eq!(ranked[0].0, strong, "higher PPR must rank first");
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn missing_graph_ppr_falls_back_to_hops() {
+        let n = now();
+        let id = MemoryId::new();
+        // No PPR, but a graph hop of 0 -> proximity 1.0, exactly as before F.
+        let ranked = rank(
+            vec![Signals {
+                id: id.clone(),
+                keyword_rank: None,
+                vector_distance: None,
+                graph_hops: Some(0),
+                graph_ppr: None,
+                importance: 0,
+                created_at: n - Duration::days(10_000),
+            }],
+            Weights::default(),
+            n,
+            10,
+        );
+        assert!(ranked[0].1 > 0.0, "hops fallback still scores > 0 when PPR absent");
+    }
+
+    #[test]
+    fn non_finite_graph_ppr_scores_as_zero_graph_term() {
+        let n = now();
+        let id = MemoryId::new();
+        let weights = Weights {
+            vector: 0.0,
+            keyword: 0.0,
+            graph: 1.0,
+            importance: 0.0,
+            recency: 0.0,
+        };
+        let ranked = rank(
+            vec![Signals {
+                id: id.clone(),
+                keyword_rank: None,
+                vector_distance: None,
+                graph_hops: Some(0),
+                graph_ppr: Some(f32::NAN),
+                importance: 0,
+                created_at: n,
+            }],
+            weights,
+            n,
+            10,
+        );
+        // NaN PPR sanitizes to a 0 graph term (no panic, finite score).
+        assert_eq!(ranked, vec![(id, 0.0)]);
+    }
+```
+
+The OTHER existing tests in this module construct `Signals { ... }` WITHOUT `graph_ppr`; updating them is part of Step 3 (they will not compile until the field is added everywhere). The plan adds the field with a value of `None` to every existing `Signals { ... }` literal in this module's tests in Step 3.
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-search rank` — Expected: FAIL to COMPILE: `struct Signals has no field named graph_ppr` (new tests) and `missing field graph_ppr` (existing tests/`merge.rs`).
+
+- [ ] **Step 3 GREEN: add the field and score it.** Add `graph_ppr` to the `Signals` struct in `rank.rs`:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct Signals {
+    pub id: MemoryId,
+    /// Keyword rank, 0 = best. `None` if not a keyword hit.
+    pub keyword_rank: Option<usize>,
+    /// Cosine distance, smaller = closer. `None` if not a vector hit.
+    pub vector_distance: Option<f32>,
+    /// Graph hops from a seed, 0 = the seed itself. `None` if not graph-reached.
+    /// Fallback graph signal used only when `graph_ppr` is `None`.
+    pub graph_hops: Option<u8>,
+    /// Personalized PageRank score in `[0, 1]` (P6 Feature F). When present it
+    /// REPLACES the `graph_hops` term as the graph signal. `None` => fall back to
+    /// `graph_hops` (or 0 if both absent), matching "missing signal = 0".
+    pub graph_ppr: Option<f32>,
+    /// Importance 0..=10.
+    pub importance: u8,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+Replace the graph-term computation in `score_one` (the `let graph = match s.graph_hops { ... };` block) with a PPR-preferring version:
+
+```rust
+    // Graph proximity: prefer the Personalized PageRank score when present (it is
+    // already normalized to [0, 1]); otherwise fall back to reciprocal hops
+    // (0 hops -> 1.0). A non-finite PPR sanitizes to 0 (no penalty).
+    let graph = match s.graph_ppr {
+        Some(p) if p.is_finite() => p.clamp(0.0, 1.0),
+        Some(_) => 0.0,
+        None => match s.graph_hops {
+            Some(h) => 1.0 / (1.0 + h as f32),
+            None => 0.0,
+        },
+    };
+```
+
+Now add `graph_ppr: None,` to EVERY existing `Signals { ... }` literal in `rank.rs`'s test module (the ones in `strong_doc_outranks_weak_doc`, `recency_breaks_ties_between_otherwise_equal_docs`'s `mk`, `graph_only_candidate_still_ranks_above_zero`, `missing_signals_do_not_penalize` (both), `limit_truncates_to_top_n`, `scores_in_range_and_ordering_is_stable`, `non_finite_vector_distances_score_as_worst_vector_match` (all three), `non_finite_weights_are_ignored_and_custom_scores_are_clamped`, `negative_custom_scores_clamp_to_zero`). For the simple cases, insert `graph_ppr: None,` immediately after the `graph_hops: ...,` line. In `scores_in_range_and_ordering_is_stable` the `graph_hops` value is a multi-line `if i % 4 == 0 { ... } else { None }` expression — place `graph_ppr: None,` AFTER that whole `if/else` block's trailing comma, before `importance:`. After editing, `grep -c "graph_ppr:" crates/rb-search/src/rank.rs` should equal the count of `graph_hops:` in the file (the struct field plus every literal).
+
+Finally, add `graph_ppr: None,` to the `Signals { ... }` literal constructed in `crates/rb-search/src/merge.rs`'s `build_signals` (the `out.push(Signals { ... })` in the `slot` closure), immediately after `graph_hops: None,`:
+
+```rust
+        out.push(Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: None,
+            graph_hops: None,
+            graph_ppr: None,
+            importance,
+            created_at,
+        });
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-search` — Expected: PASS (all rank + merge + pagerank tests, including the 3 new graph_ppr tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-search --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-search/src/rank.rs crates/rb-search/src/merge.rs && git commit -m "feat(rb-search): add graph_ppr signal preferred over reciprocal hops"` — Expected: one commit.
+
+---
+
+### Task F5: rb-engine `backend.rs` + `engine.rs` — compute PPR in recall
+
+Add a `link_subgraph` method to the `MemoryBackend` trait with a **default implementation returning no edges** (so `MockBackend` and any other impl keep compiling and PPR degrades to the hops fallback when the backend supplies nothing). Override it on the daemon's `StoreHandle` impl to call the read added in F3. In `Engine::recall`, after gathering seeds and filtering, build a `rb_search::Graph` from the subgraph, run `graph_ppr_scores` seeded by the pre-graph candidate scores, and attach `graph_ppr` to each `Signals` before ranking. The trait edge shape is the plain tuple `(MemoryId, MemoryId, f32)` so `rb-engine` needs no new dependency on `rb-store`.
+
+**Files:**
+- Modify: `crates/rb-engine/src/backend.rs` (trait default method + the daemon impl is in rb-daemon)
+- Modify: `crates/rb-engine/src/engine.rs` (recall PPR wiring)
+- Modify: `crates/rb-daemon/src/store_handle.rs` (override `link_subgraph` on the `MemoryBackend for StoreHandle` impl; it delegates to the inherent `read_link_subgraph` from F3)
+- Modify: `crates/rb-engine/Cargo.toml` (add `rb-search` dep if not already present)
+- Test: `crates/rb-engine/src/engine.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Add this test to the `#[cfg(test)] mod tests` block in `crates/rb-engine/src/engine.rs`. It uses the REAL test harness: the module's `engine()` helper (builds `MemoryEngine::new(MockBackend::default(), DeterministicProvider::new(16), Namespace::Project("rb".into()))`), `MockBackend`'s existing `insert_note` / `set_keyword_results` / `set_vector_results` / `set_graph_neighbors` / `note_of` setters, plus a NEW `set_subgraph_edges` setter (added in Step 3). The engine namespace is `Namespace::Project("rb".into())` (what `engine()` builds), so seeded notes must use it. It asserts the structurally-central hub surfaces via the PPR-backed graph signal even though it is only graph-reached.
+
+```rust
+    #[tokio::test]
+    async fn recall_uses_ppr_to_favor_central_memory() {
+        // hub <- a, hub <- b : the hub is structurally central. a and b are the
+        // keyword/vector seeds; both link to hub in the subgraph, so PPR
+        // concentrates mass on hub and it surfaces in recall via the graph signal.
+        let eng = engine();
+        let ns = Namespace::Project("rb".into());
+
+        let hub = MemoryNote::new(ns.clone(), "central hub fact".into(), MemoryType::Insight, 5);
+        let a = MemoryNote::new(ns.clone(), "alpha query term".into(), MemoryType::Insight, 5);
+        let b = MemoryNote::new(ns.clone(), "alpha query term too".into(), MemoryType::Insight, 5);
+        let (hub_id, a_id, b_id) = (hub.id.clone(), a.id.clone(), b.id.clone());
+        eng.backend().insert_note(hub);
+        eng.backend().insert_note(a);
+        eng.backend().insert_note(b);
+
+        // a and b are the keyword + vector seeds.
+        eng.backend().set_keyword_results(vec![a_id.clone(), b_id.clone()]);
+        eng.backend()
+            .set_vector_results(vec![(a_id.clone(), 0.1), (b_id.clone(), 0.1)]);
+        // Both seeds point at hub in the subgraph (high strength).
+        eng.backend().set_subgraph_edges(vec![
+            (a_id.clone(), hub_id.clone(), 0.9),
+            (b_id.clone(), hub_id.clone(), 0.9),
+        ]);
+        // The graph-walk seam returns hub as a 1-hop neighbor of the top keyword
+        // hit so it enters the candidate set (recall expands one hop off the top
+        // keyword seed; see `Engine::recall`).
+        eng.backend().set_graph_neighbors(a_id.clone(), vec![hub_id.clone()]);
+
+        let results = eng.recall("alpha", 10, None, &[]).await.unwrap();
+        let ids: Vec<_> = results.iter().map(|r| r.memory.id.clone()).collect();
+        assert!(
+            ids.contains(&hub_id),
+            "the central hub must surface via the PPR-backed graph signal"
+        );
+    }
+```
+
+NOTE: `engine()`, `Namespace`, `MemoryNote`, `MemoryType` are already in scope in the engine test module. The only NEW seam is `MockBackend::set_subgraph_edges` (Step 3 adds it plus the overriding `link_subgraph`); `insert_note`/`set_keyword_results`/`set_vector_results`/`set_graph_neighbors`/`note_of` already exist on `MockBackend`.
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-engine recall_uses_ppr` — Expected: FAIL to COMPILE: `no method named set_subgraph_edges found for struct MockBackend` (and the trait `link_subgraph` default not yet overridden) until the mock is extended.
+
+- [ ] **Step 3 GREEN: add the trait method, the mock override, and recall wiring.**
+
+(a) In `crates/rb-engine/src/backend.rs`, add the default trait method (after `get_many`, before the closing brace of the trait):
+
+```rust
+    /// Read a bounded, namespace-isolated link subgraph around `seeds` as
+    /// `(source, target, strength)` edges, for the Personalized PageRank graph
+    /// signal (P6 Feature F). Default: no edges — a backend that does not support
+    /// the graph signal degrades recall gracefully to the hop-distance fallback.
+    async fn link_subgraph(
+        &self,
+        _ns: Namespace,
+        _seeds: Vec<MemoryId>,
+        _max_hops: u8,
+        _node_budget: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, MemoryId, f32)>> {
+        Ok(Vec::new())
+    }
+```
+
+(b) In `crates/rb-daemon/src/store_handle.rs`, override it on the `#[async_trait] impl MemoryBackend for StoreHandle` block (after `get_many`), delegating to the F3 read and mapping `SubgraphEdge` to the tuple shape:
+
+```rust
+    async fn link_subgraph(
+        &self,
+        ns: Namespace,
+        seeds: Vec<MemoryId>,
+        max_hops: u8,
+        node_budget: usize,
+    ) -> Result<Vec<(MemoryId, MemoryId, f32)>> {
+        // Delegates to the inherent `read_link_subgraph` (F3); named differently
+        // from this trait method so there is no name clash on `StoreHandle`.
+        let edges = self
+            .read_link_subgraph(ns, seeds, max_hops, node_budget)
+            .await?;
+        Ok(edges
+            .into_iter()
+            .map(|e| (e.source, e.target, e.strength))
+            .collect())
+    }
+```
+
+(c) In `crates/rb-engine/src/engine.rs` `recall`, after `let signals = rb_search::build_signals(...)` and BEFORE `rb_search::rank(...)`, compute and attach PPR. Replace the two lines
+
+```rust
+        let signals =
+            rb_search::build_signals(&filtered_keyword, &filtered_vector, &filtered_graph, &meta);
+        let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
+```
+
+with:
+
+```rust
+        let mut signals =
+            rb_search::build_signals(&filtered_keyword, &filtered_vector, &filtered_graph, &meta);
+
+        // P6 Feature F: Personalized PageRank graph signal. Seed the restart
+        // vector with the pre-graph candidate scores (vector hits weighted by
+        // closeness, keyword hits by reciprocal rank) so PPR restarts toward the
+        // strongest seeds. Bounded subgraph; a missing/empty graph yields no PPR
+        // (the `graph_hops` fallback then applies). Pure + deterministic.
+        const PPR_MAX_HOPS: u8 = 3;
+        const PPR_NODE_BUDGET: usize = 512;
+        let seed_ids: Vec<MemoryId> = signals.iter().map(|s| s.id.clone()).collect();
+        let raw_edges = self
+            .backend
+            .link_subgraph(
+                self.namespace.clone(),
+                seed_ids,
+                PPR_MAX_HOPS,
+                PPR_NODE_BUDGET,
+            )
+            .await?;
+        if !raw_edges.is_empty() {
+            let mut graph = rb_search::Graph::new();
+            for (src, tgt, strength) in &raw_edges {
+                graph.add_edge(src, tgt, *strength);
+            }
+            // Personalization weights: reuse each candidate's keyword/vector seed
+            // strength as the restart mass (graph term excluded to avoid feedback).
+            let seeds: Vec<(MemoryId, f32)> = signals
+                .iter()
+                .map(|s| {
+                    let kw = s.keyword_rank.map_or(0.0, |r| 1.0 / (1.0 + r as f32));
+                    let vec_sim = s
+                        .vector_distance
+                        .filter(|d| d.is_finite())
+                        .map_or(0.0, |d| 1.0 - (d / 2.0).clamp(0.0, 1.0));
+                    (s.id.clone(), (kw + vec_sim).max(0.0))
+                })
+                .filter(|(_, w)| *w > 0.0)
+                .collect();
+            let ppr = rb_search::graph_ppr_scores(&graph, &seeds, rb_search::PprParams::default());
+            for sig in &mut signals {
+                if let Some(score) = ppr.get(&sig.id) {
+                    sig.graph_ppr = Some(*score);
+                }
+            }
+        }
+
+        let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
+```
+
+(d) Ensure `crates/rb-engine/Cargo.toml` `[dependencies]` includes `rb-search = { path = "../rb-search" }`. If it is already present (recall already calls `rb_search::rank`), no change is needed — verify.
+
+(e) Extend `crates/rb-engine/src/test_support.rs` `MockBackend`. Add a field mirroring the existing `graph: Mutex<HashMap<...>>` storage pattern:
+
+```rust
+    subgraph: Mutex<Vec<(MemoryId, MemoryId, f32)>>,
+```
+
+Add the setter alongside the other `set_*` helpers in the inherent `impl MockBackend`:
+
+```rust
+    pub fn set_subgraph_edges(&self, edges: Vec<(MemoryId, MemoryId, f32)>) {
+        *self.subgraph.lock().unwrap() = edges;
+    }
+```
+
+And override the trait method in `impl MemoryBackend for MockBackend` (a simple "return all stored edges" is sufficient for the deterministic test; the engine builds the `Graph` from whatever edges come back):
+
+```rust
+    async fn link_subgraph(
+        &self,
+        _ns: Namespace,
+        _seeds: Vec<MemoryId>,
+        _max_hops: u8,
+        _node_budget: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, MemoryId, f32)>> {
+        Ok(self.subgraph.lock().unwrap().clone())
+    }
+```
+
+`MockBackend` derives `Default`, so the new `Mutex<Vec<...>>` field default-constructs with no other change. Add the field/setter/override; do not rewrite the mock.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-engine recall_uses_ppr` then `cargo test -p rb-engine` then `cargo test -p rb-daemon` — Expected: PASS (the new recall test plus every pre-existing engine/daemon test, since the trait method has a default and the daemon override delegates to F3).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-engine --all-targets -- -D warnings && cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-engine/src/backend.rs crates/rb-engine/src/engine.rs crates/rb-engine/src/test_support.rs crates/rb-engine/Cargo.toml crates/rb-daemon/src/store_handle.rs && git commit -m "feat(rb-engine): compute personalized pagerank graph signal in recall"` — Expected: one commit.
+
+---
+
+### Task F6: rb-eval — graph-recall comparison (hops vs PPR)
+
+Add a deterministic graph-recall scenario to the P5 `rb-eval` harness that builds a small linked corpus where structural centrality (not embedding similarity) determines the right answer, then asserts PPR-backed recall ranks the central memory at least as high as the hop-distance baseline. Deterministic vectors are fine here — graph structure, not embeddings, drives the result (spec §6). This both validates F and locks it against regression.
+
+**Files:**
+- Create: `crates/rb-eval/fixtures/graph_centrality.json` (linked corpus + golden query)
+- Modify: `crates/rb-eval/src/runner.rs` (graph-recall scenario + assertion) OR add `crates/rb-eval/src/graph_scenario.rs` and wire it into the harness entrypoint, matching the existing `rb-eval` module layout
+- Modify: `crates/rb-eval/baselines.json` (add the `graph_recall_at_5` baseline)
+- Test: the harness itself (a `#[test]` in `rb-eval` that runs the scenario)
+
+NOTE: `rb-eval`'s exact module layout is owned by P5. Follow P5's fixture schema and runner shape; the steps below describe the SCENARIO to add, expressed in P5's existing `corpus`/`recall`/`metrics` vocabulary. The crate already `#![allow(clippy::unwrap_used, clippy::expect_used)]` as test code.
+
+- [ ] **Step 1 RED: write the failing scenario test.** Add a `#[test]` to the `rb-eval` harness (in `runner.rs` or a new `graph_scenario.rs`) named `graph_centrality_ppr_beats_hops`:
+
+```rust
+#[test]
+fn graph_centrality_ppr_beats_hops() {
+    // Build an in-memory store via the P5 harness fixture loader; ingest the
+    // graph_centrality corpus with the DeterministicProvider; add the fixture's
+    // links; run the golden query under both graph modes and compare recall.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let corpus = crate::corpus::load("fixtures/graph_centrality.json").unwrap();
+        // P5's runner exposes a helper to build a store + engine and ingest a
+        // corpus (incl. its links). Reuse it; do not reimplement ingestion.
+        let harness = crate::runner::ingest(&corpus).await.unwrap();
+
+        let query = &corpus.queries[0];
+        let results = harness
+            .engine
+            .recall(&query.text, 5, None, &[])
+            .await
+            .unwrap();
+        let got: Vec<_> = results.iter().map(|r| r.memory.id.clone()).collect();
+
+        // The fixture's expected-relevant ids include the structurally-central
+        // "hub" memory that hop-distance alone ranks too low. recall@5 must meet
+        // the committed baseline (which is set so PPR passes and the pre-F hops
+        // baseline would not).
+        let recall = crate::metrics::recall_at_k(&got, &query.relevant, 5);
+        let baseline = crate::baselines::get("graph_recall_at_5");
+        assert!(
+            recall >= baseline,
+            "graph recall@5 {recall} regressed below baseline {baseline}"
+        );
+    });
+}
+```
+
+If P5's `corpus`/`runner`/`metrics`/`baselines` API names differ, adapt the calls to P5's exact names (the SHAPE — load fixture, ingest, recall, compute `recall_at_k`, assert ≥ baseline — is the contract).
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-eval graph_centrality` — Expected: FAIL — the fixture file does not exist yet (`load` errors) and/or `graph_recall_at_5` is missing from `baselines.json`.
+
+- [ ] **Step 3 GREEN: add the fixture and baseline.** Create `crates/rb-eval/fixtures/graph_centrality.json` following P5's fixture schema. The corpus must encode: several memories whose embeddings are deterministic and only weakly related to the query, one "hub" memory that many of them link to (high in-degree => high PPR), and a golden query whose `relevant` set includes the hub. Example shape (adapt keys to P5's schema):
+
+```json
+{
+  "namespace": "project:rb-eval",
+  "memories": [
+    { "id": "m_hub",  "content": "central architectural principle: one writer", "memory_type": "architecture_decision", "importance": 7, "keywords": ["writer"], "tags": ["core"] },
+    { "id": "m_a",    "content": "agent A notes the writer rule", "memory_type": "insight", "importance": 5, "keywords": ["agent"], "tags": [] },
+    { "id": "m_b",    "content": "agent B notes the writer rule", "memory_type": "insight", "importance": 5, "keywords": ["agent"], "tags": [] },
+    { "id": "m_c",    "content": "agent C notes the writer rule", "memory_type": "insight", "importance": 5, "keywords": ["agent"], "tags": [] },
+    { "id": "m_far",  "content": "unrelated note about colors", "memory_type": "reference", "importance": 5, "keywords": ["color"], "tags": [] }
+  ],
+  "links": [
+    { "source": "m_a", "target": "m_hub", "link_type": "references", "strength": 0.9 },
+    { "source": "m_b", "target": "m_hub", "link_type": "references", "strength": 0.9 },
+    { "source": "m_c", "target": "m_hub", "link_type": "references", "strength": 0.9 }
+  ],
+  "queries": [
+    { "text": "agent writer rule", "relevant": ["m_a", "m_b", "m_c", "m_hub"] }
+  ]
+}
+```
+
+Add the baseline to `crates/rb-eval/baselines.json` (the value is whatever the PPR run actually achieves on this fixture — capture it on the first green run and commit it; it MUST be a value PPR meets and the pre-F hops-only ranking would not, e.g. `1.0` recall@5 if all four relevant ids fit in the top 5):
+
+```json
+{
+  "graph_recall_at_5": 1.0
+}
+```
+
+If P5's `baselines.json` already has entries, ADD this key alongside them (do not overwrite the file). Ensure the harness loads links from the fixture during ingestion (P5's `ingest` must call `engine.add_link`/`backend.add_link` for each fixture link; if P5's `ingest` does not yet handle a `links` array, extend the fixture loader + ingestion to add links — this is the one piece F legitimately adds to the harness).
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-eval graph_centrality` then `cargo test -p rb-eval` — Expected: PASS (the new scenario plus every pre-existing `rb-eval` metric/runner test). Capture the actual `recall@5` and ensure `baselines.json` records it.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-eval --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-eval/fixtures/graph_centrality.json crates/rb-eval/baselines.json crates/rb-eval/src/ && git commit -m "test(rb-eval): add graph-centrality recall scenario comparing hops vs ppr"` — Expected: one commit.
+
+---
+
+### Part F gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: full workspace test.** Run: `cargo test --workspace` — Expected: PASS, 0 failures (all Part F unit + integration tests plus every pre-existing test; the `Signals` field addition compiles everywhere because every literal was updated in F4/F5).
+
+- [ ] **Step 2: workspace clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings (PPR is pure and returns no `Error`; the subgraph read returns `rb_types::Error`; no `.unwrap()`/`.expect()`/`panic!`/`unreachable!` in non-test code).
+
+- [ ] **Step 3: format check.** Run: `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: dependency policy (no new default deps in Part F).** Run: `cargo deny check` — Expected: `ok`. Part F adds NO dependency: `rb-search` already depends only on `rb-types` + `chrono`; `rb-store`/`rb-daemon`/`rb-engine` gain only intra-workspace usage. Confirm `cargo tree -p rb-search` shows no new external crate.
+
+- [ ] **Step 5: scale-bound documentation check.** Confirm the PPR scale bound is documented in `crates/rb-search/src/pagerank.rs` (the `O(iterations * edges)` over the bounded subgraph note) and the subgraph budget is documented in `crates/rb-store/src/store.rs` `link_subgraph` (the `node_budget` BFS bound). This mirrors the architecture spec's sqlite-vec scale honesty (§11) — no code change, a doc-comment verification.
+
+
+## Part D — LLM `reconcile` job (LLM-decided MERGE/UPDATE/SUPERSEDE/NOOP)
+
+This Part adds an opt-in `reconcile` job that, for each near-duplicate cluster (reusing P3's namespace-isolated `near_duplicates`), asks an LLM to decide one of MERGE / UPDATE / SUPERSEDE / NOOP, then executes the decision through the single writer. It **complements** (does not replace) the LLM-free cosine `consolidation` job — operators enable at most one. The LLM client is a new `rb-enrich::Reconciler` built on the proven `OpenAiCompatLinker` shape (env config, `response_format json_object`, fail-open, key masking). Idempotency under LLM non-determinism comes from supersede/archived state (a superseded member never re-enters `near_duplicates` or the candidate scan) plus a `reconciled` marker in the `meta` table for NOOP pairs (so a "keep both" decision is not re-litigated each pass). All writes are `Insert`/`Update`/`Supersede` + P5 `Reembed` (when content changes). Tasks: `JobKind::Reconcile` (D1) → `ReconcileConfig` (D2) → `rb-enrich` `Reconciler` (D3) → store/handle reconciled-marker helpers (D4) → the `reconcile::run` job + `run_once` arm (D5) → idempotency/namespace/fail-safe integration (D6) → gate.
+
+---
+
+### Task D1: rb-types `job.rs` — add `JobKind::Reconcile`
+
+Extend the existing `JobKind` enum with a `Reconcile` variant. `snake_case` serde, `as_str`, and `parse` must all gain the arm in lockstep (the existing tests enumerate variants, so they are widened too).
+
+**Files:**
+- Modify: `crates/rb-types/src/job.rs`
+- Test: `crates/rb-types/src/job.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: widen the failing test.** In `crates/rb-types/src/job.rs`'s test module, add `JobKind::Reconcile` to the `ALL` array and add a focused string test. Change the `const ALL` to include the new variant and append a test:
+
+```rust
+    const ALL: [JobKind; 4] = [
+        JobKind::LinkDecay,
+        JobKind::Consolidation,
+        JobKind::ImportanceRecalibration,
+        JobKind::Reconcile,
+    ];
+```
+
+```rust
+    #[test]
+    fn reconcile_serde_and_parse_round_trip() {
+        assert_eq!(
+            serde_json::to_string(&JobKind::Reconcile).unwrap(),
+            r#""reconcile""#
+        );
+        assert_eq!(JobKind::parse("reconcile").unwrap(), JobKind::Reconcile);
+        assert_eq!(JobKind::Reconcile.as_str(), "reconcile");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-types job` — Expected: FAIL — `no variant or associated item named Reconcile found for enum JobKind`, and the `ALL` array length mismatch.
+
+- [ ] **Step 3 GREEN: add the variant and arms.** In the `JobKind` enum add `Reconcile` after `ImportanceRecalibration`:
+
+```rust
+pub enum JobKind {
+    LinkDecay,
+    Consolidation,
+    ImportanceRecalibration,
+    Reconcile,
+}
+```
+
+Add the `as_str` arm:
+
+```rust
+            JobKind::Reconcile => "reconcile",
+```
+
+Add the `parse` arm (before the `other =>` catch-all):
+
+```rust
+            "reconcile" => Ok(JobKind::Reconcile),
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-types job` — Expected: PASS (existing tests + `reconcile_serde_and_parse_round_trip`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-types --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-types/src/job.rs && git commit -m "feat(rb-types): add JobKind::Reconcile for the llm reconcile job"` — Expected: one commit.
+
+NOTE: adding a `JobKind` variant widens the exhaustive `match kind { ... }` in `run_once` (`crates/rb-daemon/src/jobs/mod.rs`). After this commit the workspace will NOT build until D5 adds the arm. That is expected for an isolated types commit; the next buildable checkpoint is D5. To keep `run_once` compiling in the interim if a worker runs `cargo build` between D1 and D5, temporarily add `JobKind::Reconcile => Err(rb_types::Error::InvalidArgument("reconcile job not implemented yet".into())),` to the `run_once` match in this same commit, then replace it with the real arm in D5. (This mirrors how Part R stubbed Consolidation/Importance before S/T filled them.)
+
+---
+
+### Task D2: rb-daemon `jobs/config.rs` — `ReconcileConfig`
+
+Add a `ReconcileConfig` section to `JobsConfig`, disabled by default, with the spec's fields. Model/endpoint come from the `rb-enrich` env (`RB_ENRICH_BASE_URL`/`RB_ENRICH_MODEL`/`RB_ENRICH_API_KEY`), so the config carries only job tuning, not credentials.
+
+**Files:**
+- Modify: `crates/rb-daemon/src/jobs/config.rs`
+- Modify: `crates/rb-daemon/src/jobs/mod.rs` (re-export `ReconcileConfig`)
+- Modify: `crates/rb-daemon/src/lib.rs` (re-export `ReconcileConfig`)
+- Test: `crates/rb-daemon/src/jobs/config.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: widen the failing test.** Add assertions to `default_is_all_disabled_with_documented_values` for the new section and a focused override test in `crates/rb-daemon/src/jobs/config.rs`:
+
+```rust
+        assert!(!cfg.reconcile.enabled);
+        assert_eq!(cfg.reconcile.interval_secs, 86_400);
+        assert!((cfg.reconcile.similarity_floor - 0.90).abs() < f32::EPSILON);
+        assert_eq!(cfg.reconcile.batch_limit, 50);
+```
+
+```rust
+    #[test]
+    fn reconcile_section_overrides_only_named_fields() {
+        let toml_src = r#"
+[reconcile]
+enabled = true
+similarity_floor = 0.97
+batch_limit = 10
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("jobs.toml");
+        std::fs::write(&path, toml_src).unwrap();
+        let cfg = JobsConfig::load(Some(path.as_path())).unwrap();
+        assert!(cfg.reconcile.enabled);
+        assert!((cfg.reconcile.similarity_floor - 0.97).abs() < f32::EPSILON);
+        assert_eq!(cfg.reconcile.batch_limit, 10);
+        // Defaulted field untouched:
+        assert_eq!(cfg.reconcile.interval_secs, 86_400);
+        // Other sections still disabled.
+        assert!(!cfg.consolidation.enabled);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon config` — Expected: FAIL — `no field reconcile on type JobsConfig`.
+
+- [ ] **Step 3 GREEN: add the config struct and wire it.** Add `reconcile` to `JobsConfig`:
+
+```rust
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct JobsConfig {
+    pub link_decay: LinkDecayConfig,
+    pub consolidation: ConsolidationConfig,
+    pub importance: ImportanceConfig,
+    pub reconcile: ReconcileConfig,
+    pub reflect: ReflectConfig,
+}
+```
+
+NOTE: `reflect` is added here too (Part E's `ReflectConfig`) so the config schema is stable from this commit, exactly as Part R pre-declared `ConsolidationConfig`/`ImportanceConfig` before their jobs landed. `ReflectConfig` is defined in Part E Task E2; to keep THIS commit compiling, also add the minimal `ReflectConfig` struct now (its full use is Part E). Add both structs:
+
+```rust
+/// LLM reconcile-job tuning (P6 Feature D). Model/endpoint come from the
+/// `rb-enrich` env (`RB_ENRICH_BASE_URL`/`RB_ENRICH_MODEL`/`RB_ENRICH_API_KEY`),
+/// so only job tuning lives here. Disabled by default; complements (does not
+/// replace) the LLM-free cosine `consolidation` job — enable at most one.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct ReconcileConfig {
+    pub enabled: bool,
+    pub interval_secs: u64,
+    /// Only clusters whose top near-duplicate similarity is >= this floor are
+    /// considered. Higher than the cosine `consolidation` threshold by intent:
+    /// the LLM is asked only about genuinely-close pairs.
+    pub similarity_floor: f32,
+    pub batch_limit: usize,
+}
+
+impl Default for ReconcileConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: 86_400,
+            similarity_floor: 0.90,
+            batch_limit: 50,
+        }
+    }
+}
+
+/// LLM reflect/synthesis-job tuning (P6 Feature E). Model/endpoint via the
+/// `rb-enrich` env. Disabled by default. Declared here so the config schema is
+/// stable from Part D's commit; the job itself lands in Part E.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct ReflectConfig {
+    pub enabled: bool,
+    pub interval_secs: u64,
+    /// Per-namespace accumulated-importance threshold that fires a reflect run
+    /// off the change broadcast (Generative Agents-style, default ~150).
+    pub importance_threshold: u32,
+    /// Max source memories considered per namespace per pass.
+    pub batch_limit: usize,
+    /// How far back (seconds) a reflect pass looks for source memories when no
+    /// `last_reflected_at` watermark exists yet.
+    pub window_secs: u64,
+}
+
+impl Default for ReflectConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: 86_400,
+            importance_threshold: 150,
+            batch_limit: 50,
+            window_secs: 7 * 86_400,
+        }
+    }
+}
+```
+
+Re-export from `crates/rb-daemon/src/jobs/mod.rs` (extend the existing `pub use config::{...}` line):
+
+```rust
+pub use config::{
+    ConsolidationConfig, ImportanceConfig, JobsConfig, LinkDecayConfig, ReconcileConfig,
+    ReflectConfig,
+};
+```
+
+And from `crates/rb-daemon/src/lib.rs` (extend the existing `pub use jobs::{...}` line) to add `ReconcileConfig, ReflectConfig` to the list.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon config` — Expected: PASS (widened default test + `reconcile_section_overrides_only_named_fields`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/jobs/config.rs crates/rb-daemon/src/jobs/mod.rs crates/rb-daemon/src/lib.rs && git commit -m "feat(rb-daemon): add ReconcileConfig and ReflectConfig disabled by default"` — Expected: one commit.
+
+---
+
+### Task D3: rb-enrich `reconciler.rs` — LLM reconcile-decision client
+
+Add a new `Reconciler` to `rb-enrich`, structurally identical to `OpenAiCompatLinker` (blocking `reqwest`, env config, `response_format json_object`, `for_test`, fail-open, key masking), that takes a near-duplicate cluster (an anchor memory + its duplicate members) and returns ONE `ReconcileDecision`. Tested entirely with `wiremock` (canned decisions); a real-model test is `#[ignore]`.
+
+**Files:**
+- Create: `crates/rb-enrich/src/reconciler.rs`
+- Modify: `crates/rb-enrich/src/lib.rs` (declare + re-export)
+- Test: `crates/rb-enrich/src/reconciler.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-enrich/src/reconciler.rs` containing ONLY the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn note(content: &str) -> MemoryNote {
+        MemoryNote::new(Namespace::Project("rb".into()), content.to_string(), MemoryType::Insight, 5)
+    }
+
+    fn chat_response(json_text: &str) -> serde_json::Value {
+        serde_json::json!({ "choices": [ { "message": { "role": "assistant", "content": json_text } } ] })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn parses_merge_decision_with_content() {
+        let server = MockServer::start().await;
+        let anchor = note("the daemon uses a single writer thread");
+        let dup = note("there is one writer for the sqlite db");
+        let model_json = serde_json::json!({
+            "decision": "merge",
+            "content": "The daemon uses a single dedicated writer thread for the SQLite database.",
+            "reason": "same fact, fuller phrasing"
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header("Authorization", "Bearer recon-key"))
+            .and(body_partial_json(serde_json::json!({ "response_format": { "type": "json_object" } })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(&model_json)))
+            .mount(&server)
+            .await;
+
+        let base = format!("{}/v1", server.uri());
+        let dup_clone = dup.clone();
+        let decision = tokio::task::spawn_blocking(move || {
+            let r = Reconciler::for_test("gpt-4o-mini", Some("recon-key"), &base);
+            r.reconcile(&anchor, &[dup_clone])
+        })
+        .await
+        .unwrap();
+
+        match decision {
+            ReconcileDecision::Merge { content, .. } => {
+                assert!(content.contains("single dedicated writer"));
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn parses_supersede_decision_with_target_index() {
+        let server = MockServer::start().await;
+        let anchor = note("flock is enough for coordination");
+        let dup = note("flock is NOT enough; use a single writer");
+        let model_json = serde_json::json!({
+            "decision": "supersede",
+            "supersedes_index": 0,
+            "reason": "dup contradicts and is newer/correct"
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(&model_json)))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let dup_clone = dup.clone();
+        let decision = tokio::task::spawn_blocking(move || {
+            Reconciler::for_test("m", Some("k"), &base).reconcile(&anchor, &[dup_clone])
+        })
+        .await
+        .unwrap();
+        match decision {
+            ReconcileDecision::Supersede { supersedes_index } => assert_eq!(supersedes_index, 0),
+            other => panic!("expected Supersede, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn parses_noop_decision() {
+        let server = MockServer::start().await;
+        let anchor = note("topic A");
+        let dup = note("topic B that is merely close in vector space");
+        let model_json = serde_json::json!({ "decision": "noop", "reason": "distinct" }).to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(&model_json)))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let dup_clone = dup.clone();
+        let decision = tokio::task::spawn_blocking(move || {
+            Reconciler::for_test("m", Some("k"), &base).reconcile(&anchor, &[dup_clone])
+        })
+        .await
+        .unwrap();
+        assert!(matches!(decision, ReconcileDecision::Noop));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_error_degrades_to_noop_not_panic() {
+        // Fail-safe: an LLM/network error must yield Noop (skip the cluster),
+        // never a panic and never a destructive default.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let anchor = note("a");
+        let dup = note("b");
+        let decision = tokio::task::spawn_blocking(move || {
+            Reconciler::for_test("m", Some("k"), &base).reconcile(&anchor, &[dup])
+        })
+        .await
+        .unwrap();
+        assert!(matches!(decision, ReconcileDecision::Noop), "errors fail safe to Noop");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn api_key_never_leaks_into_error_messages() {
+        const SENTINEL: &str = "super-secret-reconcile-key";
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let anchor = note("a");
+        let dup = note("b");
+        let msg = tokio::task::spawn_blocking(move || {
+            let r = Reconciler::for_test("m", Some(SENTINEL), &base);
+            r.try_reconcile(&anchor, &[dup]).expect_err("401 must error").to_string()
+        })
+        .await
+        .unwrap();
+        assert!(!msg.contains(SENTINEL), "error leaked the api key: {msg}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires RB_ENRICH_BASE_URL, RB_ENRICH_MODEL, RB_ENRICH_API_KEY and network access"]
+    async fn reconcile_real_api_smoke() {
+        let r = Reconciler::from_env().expect("env configured for the ignored smoke test");
+        let anchor = note("the daemon uses a single writer thread");
+        let dup = note("there is one writer for the sqlite database");
+        let decision = tokio::task::spawn_blocking(move || r.reconcile(&anchor, &[dup]))
+            .await
+            .unwrap();
+        // Any decision is acceptable; we only assert no panic and a real variant.
+        let _ = format!("{decision:?}");
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-enrich reconciler` — Expected: FAIL — `cannot find type Reconciler` / `ReconcileDecision`.
+
+- [ ] **Step 3 GREEN: minimal implementation.** Prepend to `crates/rb-enrich/src/reconciler.rs`, above the test module:
+
+```rust
+//! Opt-in LLM reconcile-decision client (P6 Feature D). Given a near-duplicate
+//! cluster (an anchor memory plus its duplicate members), asks an
+//! OpenAI-compatible model to choose ONE action: MERGE (synthesize unified
+//! content), UPDATE (rewrite the anchor to subsume the rest), SUPERSEDE (one
+//! duplicate supersedes/contradicts and is dropped in favor of the anchor), or
+//! NOOP (distinct despite vector closeness). Structurally mirrors
+//! `OpenAiCompatLinker`: blocking reqwest (drive via `spawn_blocking`), env
+//! config, `response_format: json_object`, key held as a `SecretString` and
+//! never logged. Fail-open: any error degrades to `Noop` so a failing model can
+//! never destroy data — the cluster is simply skipped.
+
+use rb_types::MemoryNote;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_TOKENS: u32 = 1024;
+
+/// The LLM's reconcile decision for one cluster.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ReconcileDecision {
+    /// Synthesize a new merged memory with `content`; supersede every member.
+    Merge { content: String, reason: String },
+    /// Rewrite the ANCHOR's content to `content`; supersede every member.
+    Update { content: String, reason: String },
+    /// The member at `supersedes_index` is superseded by the anchor; keep the
+    /// anchor, drop only that member.
+    Supersede { supersedes_index: usize },
+    /// Distinct despite vector closeness: keep both, record a reconciled marker.
+    Noop,
+}
+
+/// OpenAI-compatible reconcile client. Build via `from_env` (returns `None` when
+/// `RB_ENRICH_BASE_URL`/`RB_ENRICH_MODEL` are absent) or `for_test`.
+pub struct Reconciler {
+    client: reqwest::blocking::Client,
+    api_key: Option<SecretString>,
+    model: String,
+    base_url: String,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+#[derive(Deserialize)]
+struct Choice {
+    message: ChatMessage,
+}
+#[derive(Deserialize)]
+struct ChatMessage {
+    content: Option<String>,
+}
+
+/// Raw model JSON: a tagged decision plus optional fields used per tag.
+#[derive(Deserialize)]
+struct ModelDecision {
+    decision: String,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    supersedes_index: Option<usize>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+impl Reconciler {
+    /// Build from the environment (same vars as the enricher/linker). `None` when
+    /// either required var is absent — the job then logs and skips (fail-safe).
+    pub fn from_env() -> Option<Self> {
+        let base_url = std::env::var("RB_ENRICH_BASE_URL").ok().filter(|v| !v.is_empty())?;
+        let model = std::env::var("RB_ENRICH_MODEL").ok().filter(|v| !v.is_empty())?;
+        let api_key = std::env::var("RB_ENRICH_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty())
+            .map(SecretString::from);
+        let client = reqwest::blocking::Client::builder().timeout(REQUEST_TIMEOUT).build().ok()?;
+        Some(Self { client, api_key, model, base_url: base_url.trim_end_matches('/').to_string() })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(model: &str, api_key: Option<&str>, base_url: &str) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self {
+            client,
+            api_key: api_key.map(|k| SecretString::from(k.to_string())),
+            model: model.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn system_prompt() -> &'static str {
+        "You reconcile near-duplicate developer memories. Given an ANCHOR memory \
+         and CANDIDATE near-duplicates, respond with ONLY JSON (no prose) of the \
+         form {\"decision\":<one of merge|update|supersede|noop>, \
+         \"content\":<string, required for merge/update — the unified text>, \
+         \"supersedes_index\":<int, required for supersede — which candidate the \
+         anchor supersedes>, \"reason\":<short string>}. Choose merge to combine \
+         into one fact, update to rewrite the anchor to subsume the rest, \
+         supersede when one candidate is stale/contradicted by the anchor, or \
+         noop when they are genuinely distinct despite similarity."
+    }
+
+    fn user_prompt(anchor: &MemoryNote, members: &[MemoryNote]) -> String {
+        let mut lines = String::new();
+        for (i, m) in members.iter().enumerate() {
+            lines.push_str(&format!("[{i}] {}\n", m.content));
+        }
+        format!("ANCHOR:\n{}\n\nCANDIDATES:\n{lines}", anchor.content)
+    }
+
+    /// Inner fallible body; `reconcile` wraps this and degrades errors to `Noop`.
+    pub(crate) fn try_reconcile(
+        &self,
+        anchor: &MemoryNote,
+        members: &[MemoryNote],
+    ) -> rb_types::Result<ReconcileDecision> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": MAX_TOKENS,
+            "temperature": 0,
+            "response_format": { "type": "json_object" },
+            "messages": [
+                { "role": "system", "content": Self::system_prompt() },
+                { "role": "user",   "content": Self::user_prompt(anchor, members) }
+            ]
+        });
+        let mut req = self.client.post(&url).json(&body);
+        if let Some(key) = &self.api_key {
+            req = req.header("Authorization", format!("Bearer {}", key.expose_secret()));
+        }
+        let resp = req
+            .send()
+            .map_err(|e| rb_types::Error::Enrichment(format!("reconcile request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| rb_types::Error::Enrichment(format!("reconcile error status: {e}")))?;
+        let parsed: ChatResponse = resp
+            .json()
+            .map_err(|e| rb_types::Error::Enrichment(format!("reconcile parse failed: {e}")))?;
+        let text = parsed
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|c| c.message.content)
+            .ok_or_else(|| rb_types::Error::Enrichment("reconcile response had no content".into()))?;
+        let m: ModelDecision = serde_json::from_str(text.trim())
+            .map_err(|e| rb_types::Error::Enrichment(format!("reconcile json invalid: {e}")))?;
+
+        match m.decision.as_str() {
+            "merge" => {
+                let content = m
+                    .content
+                    .filter(|c| !c.trim().is_empty())
+                    .ok_or_else(|| rb_types::Error::Enrichment("merge decision missing content".into()))?;
+                Ok(ReconcileDecision::Merge { content, reason: m.reason.unwrap_or_default() })
+            }
+            "update" => {
+                let content = m
+                    .content
+                    .filter(|c| !c.trim().is_empty())
+                    .ok_or_else(|| rb_types::Error::Enrichment("update decision missing content".into()))?;
+                Ok(ReconcileDecision::Update { content, reason: m.reason.unwrap_or_default() })
+            }
+            "supersede" => {
+                let idx = m.supersedes_index.ok_or_else(|| {
+                    rb_types::Error::Enrichment("supersede decision missing supersedes_index".into())
+                })?;
+                if idx >= members.len() {
+                    // Out-of-range index is not actionable: fail closed to Noop-by-error.
+                    return Err(rb_types::Error::Enrichment(format!(
+                        "supersedes_index {idx} out of range for {} candidates",
+                        members.len()
+                    )));
+                }
+                Ok(ReconcileDecision::Supersede { supersedes_index: idx })
+            }
+            "noop" => Ok(ReconcileDecision::Noop),
+            other => Err(rb_types::Error::Enrichment(format!("unknown decision: {other}"))),
+        }
+    }
+
+    /// Decide one reconcile action for the cluster. Fail-open: any error logs at
+    /// warn and returns `Noop` so a failing model can never destroy data.
+    pub fn reconcile(&self, anchor: &MemoryNote, members: &[MemoryNote]) -> ReconcileDecision {
+        if members.is_empty() {
+            return ReconcileDecision::Noop;
+        }
+        match self.try_reconcile(anchor, members) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(error = %e, "reconcile decision failed; treating cluster as noop");
+                ReconcileDecision::Noop
+            }
+        }
+    }
+}
+```
+
+Wire into `crates/rb-enrich/src/lib.rs`:
+
+```rust
+mod heuristic;
+mod linker;
+mod openai_compat;
+mod reconciler;
+
+pub use heuristic::HeuristicEnricher;
+pub use linker::OpenAiCompatLinker;
+pub use openai_compat::OpenAiCompatEnricher;
+pub use reconciler::{ReconcileDecision, Reconciler};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-enrich reconciler` — Expected: PASS (5 wiremock tests; the real-API smoke is `#[ignore]`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-enrich --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-enrich/src/reconciler.rs crates/rb-enrich/src/lib.rs && git commit -m "feat(rb-enrich): add Reconciler llm decision client with fail-open noop"` — Expected: one commit.
+
+---
+
+### Task D4: rb-store + rb-daemon — generic `meta` get/set (reconciled markers & watermarks)
+
+Add a generic `meta` key-value accessor used by BOTH the reconcile job (NOOP "reconciled" markers, so a kept-both pair is not re-litigated) and the reflect job (the `last_reflected_at` per-namespace watermark, Part E). Reads go through the read pool; writes go through the single writer via a new `WriteCommand::SetMeta`.
+
+**Files:**
+- Modify: `crates/rb-store/src/store.rs` (`meta_get` + `meta_set` on `SqliteStore`)
+- Modify: `crates/rb-daemon/src/store_handle.rs` (`WriteCommand::SetMeta`, writer arm, `meta_get`/`meta_set` on `StoreHandle`)
+- Test: both files (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED (store): add the failing test.** Append to the existing `#[cfg(test)] mod tests` in `crates/rb-store/src/store.rs`:
+
+```rust
+    #[test]
+    fn meta_get_set_round_trips_and_missing_is_none() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        assert!(store.meta_get("rb:test:key").unwrap().is_none(), "absent key is None");
+        store.meta_set("rb:test:key", "value-1").unwrap();
+        assert_eq!(store.meta_get("rb:test:key").unwrap().as_deref(), Some("value-1"));
+        // Upsert overwrites.
+        store.meta_set("rb:test:key", "value-2").unwrap();
+        assert_eq!(store.meta_get("rb:test:key").unwrap().as_deref(), Some("value-2"));
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store meta_get_set` — Expected: FAIL to COMPILE: `no method named meta_get`.
+
+- [ ] **Step 3 GREEN (store): implement.** Add inside `impl SqliteStore { ... }` (after `link_subgraph`):
+
+```rust
+    /// Read a free-form `meta` value by key. `None` if the key is absent. The
+    /// `meta` table is the existing single-source-of-truth key-value store (it
+    /// already holds `embedding_dim`/`embedding_model`); evolution jobs use
+    /// namespaced keys like `rb:reconciled:<...>` and `rb:reflect:<ns>`.
+    pub fn meta_get(&self, key: &str) -> Result<Option<String>> {
+        match self.conn.query_row(
+            "SELECT value FROM meta WHERE key = ?1",
+            rusqlite::params![key],
+            |row| row.get::<_, String>(0),
+        ) {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(Error::Storage(e.to_string())),
+        }
+    }
+
+    /// Upsert a free-form `meta` value (single writer only).
+    pub fn meta_set(&self, key: &str, value: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO meta (key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                rusqlite::params![key, value],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 4 (store): run it.** Run: `cargo test -p rb-store meta_get_set` — Expected: PASS (1 test).
+
+- [ ] **Step 5 RED (daemon): add the failing test.** Append to the `#[cfg(test)] mod tests` in `crates/rb-daemon/src/store_handle.rs`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_meta_get_set_round_trips_through_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+
+        assert!(handle.meta_get("rb:wm:x".to_string()).await.unwrap().is_none());
+        handle.meta_set("rb:wm:x".to_string(), "42".to_string()).await.unwrap();
+        assert_eq!(
+            handle.meta_get("rb:wm:x".to_string()).await.unwrap().as_deref(),
+            Some("42")
+        );
+
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 6 (daemon): run it.** Run: `cargo test -p rb-daemon store_handle_meta` — Expected: FAIL to COMPILE: `no method named meta_get found for struct StoreHandle`.
+
+- [ ] **Step 7 GREEN (daemon): add command, arm, and methods.** Three edits in `crates/rb-daemon/src/store_handle.rs`.
+
+(a) Add a `SetMeta` variant to `enum WriteCommand` (after `Supersede`, before the `#[cfg(test)] PanicForTest` variant):
+
+```rust
+    SetMeta {
+        key: String,
+        value: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
+```
+
+(b) Add the writer-loop arm in `writer_loop`'s `match cmd` (after the `Supersede` arm, before `#[cfg(test)] PanicForTest`). No `MemoryChanged` event — meta is not a memory mutation:
+
+```rust
+            WriteCommand::SetMeta { key, value, reply } => {
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    s.meta_set(&key, &value)
+                });
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if !writer_usable {
+                    break;
+                }
+            }
+```
+
+(c) Add the read + write methods inside `impl StoreHandle { ... }` (after `read_link_subgraph`):
+
+```rust
+    /// Read a `meta` value via the read pool (see `SqliteStore::meta_get`).
+    pub async fn meta_get(&self, key: String) -> Result<Option<String>> {
+        self.with_read(move |store| store.meta_get(&key)).await
+    }
+
+    /// Upsert a `meta` value through the single writer (see `SqliteStore::meta_set`).
+    pub async fn meta_set(&self, key: String, value: String) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::SetMeta { key, value, reply };
+        self.send_write(cmd, rx).await
+    }
+```
+
+- [ ] **Step 8 (daemon): run it.** Run: `cargo test -p rb-daemon store_handle_meta` — Expected: PASS (1 test).
+
+- [ ] **Step 9: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings && cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 10: commit.** Run: `git add crates/rb-store/src/store.rs crates/rb-daemon/src/store_handle.rs && git commit -m "feat(rb-store): add generic meta get/set for job markers and watermarks"` — Expected: one commit.
+
+---
+
+### Task D5: rb-daemon `jobs/reconcile.rs` — the reconcile job + `run_once` arm
+
+Add the `reconcile::run` job. To keep it testable WITHOUT process-global env (unsound under parallel `#[test]`) and WITHOUT live network, the decision step is taken behind a tiny `ReconcileDecider` trait: production wraps `rb_enrich::Reconciler::from_env()` (driven via `spawn_blocking` because it is blocking IO); tests inject a deterministic fake. The job reuses `near_duplicates`, `candidates_for_consolidation`, `pick_survivor`-style determinism, the writer's `supersede`/`update`/`write`, and P5's `reembed`. Idempotency: a superseded member never re-enters the scan; a NOOP records a `reconciled` marker keyed by the namespace + the sorted member-id pair so the pair is not re-litigated.
+
+**Files:**
+- Create: `crates/rb-daemon/src/jobs/reconcile.rs`
+- Modify: `crates/rb-daemon/src/jobs/mod.rs` (declare `mod reconcile;` + the `JobKind::Reconcile` `run_once` arm)
+- Test: `crates/rb-daemon/src/jobs/reconcile.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: create the file with tests but a stub `run`.** Create `crates/rb-daemon/src/jobs/reconcile.rs` with the production types compiling but `run` unimplemented enough to fail the behavior tests. Write the full test module first (it references the `ReconcileDecider` trait, `run`, and a `FakeDecider`):
+
+```rust
+//! LLM reconcile job (P6 Feature D): per near-duplicate cluster, an LLM decides
+//! MERGE/UPDATE/SUPERSEDE/NOOP; the decision executes through the single writer.
+//! Bounded, idempotent, namespace-isolated, fail-safe. Complements (does not
+//! replace) the LLM-free cosine `consolidation` job.
+
+use crate::jobs::config::ReconcileConfig;
+use crate::jobs::JobSummary;
+use crate::StoreHandle;
+use rb_engine::MemoryBackend;
+use rb_enrich::ReconcileDecision;
+use rb_types::{MemoryNote, Result};
+
+/// Abstraction over "decide a reconcile action for this cluster", so the job is
+/// testable without env/network. Production wraps `rb_enrich::Reconciler`.
+pub trait ReconcileDecider: Send + Sync {
+    /// Decide for `anchor` + `members`. Implementations are fail-open (return
+    /// `Noop` on error) — the job treats `Noop` as "skip, mark reconciled".
+    fn decide(&self, anchor: &MemoryNote, members: &[MemoryNote]) -> ReconcileDecision;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::StoreHandle;
+    use rb_engine::MemoryBackend;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+
+    const DIM: usize = 8;
+
+    fn vnote(ns: &Namespace, body: &str, importance: u8) -> MemoryNote {
+        MemoryNote::new(ns.clone(), body.to_string(), MemoryType::Insight, importance)
+    }
+
+    fn cfg(floor: f32) -> ReconcileConfig {
+        ReconcileConfig { enabled: true, interval_secs: 86_400, similarity_floor: floor, batch_limit: 50 }
+    }
+
+    /// A deterministic decider that always returns a fixed decision.
+    struct FakeDecider(ReconcileDecision);
+    impl ReconcileDecider for FakeDecider {
+        fn decide(&self, _a: &MemoryNote, _m: &[MemoryNote]) -> ReconcileDecision {
+            self.0.clone()
+        }
+    }
+
+    async fn two_twins(handle: &StoreHandle, ns: &Namespace) -> (rb_types::MemoryId, rb_types::MemoryId) {
+        let a = vnote(ns, "the daemon uses one writer", 9);
+        let b = vnote(ns, "there is a single writer thread", 3);
+        let (a_id, b_id) = (a.id.clone(), b.id.clone());
+        handle.write(a, Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])).await.unwrap();
+        handle.write(b, Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])).await.unwrap();
+        (a_id, b_id)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn merge_inserts_new_memory_and_supersedes_all_members() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let (a_id, b_id) = two_twins(&handle, &ns).await;
+
+        let decider = FakeDecider(ReconcileDecision::Merge {
+            content: "The daemon uses a single dedicated writer thread.".to_string(),
+            reason: "same fact".to_string(),
+        });
+        let summary = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(summary.changed, 1, "exactly one cluster reconciled");
+
+        // Both originals are archived and superseded; a NEW active insight exists.
+        let got_a = handle.get(ns.clone(), a_id.clone()).await.unwrap().unwrap();
+        let got_b = handle.get(ns.clone(), b_id.clone()).await.unwrap().unwrap();
+        assert!(got_a.archived_at.is_some() && got_a.superseded_by.is_some(), "anchor merged away");
+        assert!(got_b.archived_at.is_some() && got_b.superseded_by.is_some(), "dup merged away");
+        // The supersede target is the same new memory for both.
+        assert_eq!(got_a.superseded_by, got_b.superseded_by, "both point at the merged memory");
+        let merged_id = got_a.superseded_by.clone().unwrap();
+        let merged = handle.get(ns.clone(), merged_id).await.unwrap().unwrap();
+        assert!(merged.content.contains("single dedicated writer"));
+        assert!(merged.archived_at.is_none(), "merged memory is active");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_rewrites_anchor_and_supersedes_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let (a_id, b_id) = two_twins(&handle, &ns).await;
+
+        let decider = FakeDecider(ReconcileDecision::Update {
+            content: "Single-writer rule: one thread owns all writes.".to_string(),
+            reason: "subsume".to_string(),
+        });
+        let summary = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(summary.changed, 1);
+
+        // The SURVIVOR (highest importance => anchor a, importance 9) is rewritten
+        // and stays active; the other is superseded into it.
+        let got_a = handle.get(ns.clone(), a_id.clone()).await.unwrap().unwrap();
+        let got_b = handle.get(ns.clone(), b_id.clone()).await.unwrap().unwrap();
+        assert!(got_a.archived_at.is_none(), "survivor stays active");
+        assert!(got_a.content.contains("Single-writer rule"), "survivor content rewritten");
+        assert!(got_b.archived_at.is_some(), "other superseded");
+        assert_eq!(got_b.superseded_by.as_ref(), Some(&a_id));
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn supersede_drops_only_the_named_member() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let (a_id, b_id) = two_twins(&handle, &ns).await;
+
+        // member index 0 (the single dup) is superseded by the anchor.
+        let decider = FakeDecider(ReconcileDecision::Supersede { supersedes_index: 0 });
+        let summary = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(summary.changed, 1);
+
+        let got_a = handle.get(ns.clone(), a_id.clone()).await.unwrap().unwrap();
+        let got_b = handle.get(ns.clone(), b_id.clone()).await.unwrap().unwrap();
+        assert!(got_a.archived_at.is_none(), "anchor kept");
+        assert!(got_b.archived_at.is_some(), "named member superseded");
+        assert_eq!(got_b.superseded_by.as_ref(), Some(&a_id));
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn noop_marks_reconciled_and_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let (a_id, b_id) = two_twins(&handle, &ns).await;
+
+        let decider = FakeDecider(ReconcileDecision::Noop);
+        let first = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(first.changed, 0, "noop writes no supersede/insert");
+        // Both still active.
+        assert!(handle.get(ns.clone(), a_id.clone()).await.unwrap().unwrap().archived_at.is_none());
+        assert!(handle.get(ns.clone(), b_id.clone()).await.unwrap().unwrap().archived_at.is_none());
+
+        // Second pass: the reconciled marker means the pair is NOT re-litigated.
+        // Use a decider that WOULD merge if asked; the marker must prevent it.
+        let aggressive = FakeDecider(ReconcileDecision::Merge { content: "x".into(), reason: "x".into() });
+        let second = run(&handle, &cfg(0.90), &aggressive).await.unwrap();
+        assert_eq!(second.changed, 0, "reconciled marker prevents re-merging a noop pair");
+        assert!(handle.get(ns.clone(), a_id).await.unwrap().unwrap().archived_at.is_none());
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idempotent_second_pass_after_merge_changes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        two_twins(&handle, &ns).await;
+        let decider = FakeDecider(ReconcileDecision::Merge { content: "merged fact".into(), reason: "r".into() });
+        assert_eq!(run(&handle, &cfg(0.90), &decider).await.unwrap().changed, 1);
+        // Second pass: members archived & excluded; the lone merged memory has no
+        // near-duplicate => nothing to do.
+        assert_eq!(run(&handle, &cfg(0.90), &decider).await.unwrap().changed, 0, "idempotent");
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn never_reconciles_across_namespaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns_a = Namespace::Project("a".to_string());
+        let ns_b = Namespace::Project("b".to_string());
+        let a = vnote(&ns_a, "twin", 9);
+        let foreign = vnote(&ns_b, "twin", 9);
+        let (a_id, foreign_id) = (a.id.clone(), foreign.id.clone());
+        handle.write(a, Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])).await.unwrap();
+        handle.write(foreign, Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])).await.unwrap();
+
+        let decider = FakeDecider(ReconcileDecision::Merge { content: "x".into(), reason: "x".into() });
+        let summary = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(summary.changed, 0, "no same-namespace duplicate exists, so nothing merges");
+        assert!(handle.get(ns_a, a_id).await.unwrap().unwrap().archived_at.is_none());
+        assert!(handle.get(ns_b, foreign_id).await.unwrap().unwrap().archived_at.is_none());
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_once_reconcile_arm_uses_env_decider_and_is_safe_when_unconfigured() {
+        // With no RB_ENRICH_* env, the production decider is absent; run_once must
+        // skip safely (no panic, no writes), proving fail-safe wiring.
+        use crate::jobs::{run_once, JobKind, JobsConfig};
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        two_twins(&handle, &ns).await;
+        let config = JobsConfig { reconcile: cfg(0.90), ..Default::default() };
+        let summary = run_once(JobKind::Reconcile, &handle, &config).await.unwrap();
+        // Unconfigured env => no decider => zero changes (skipped), never an error.
+        assert_eq!(summary.changed, 0);
+        handle.shutdown().await;
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon reconcile` — Expected: FAIL to COMPILE: `cannot find function run` in `reconcile`.
+
+- [ ] **Step 3 GREEN: implement `run`, the env decider, and the `run_once` arm.**
+
+(a) Add the production decider and `run` to `crates/rb-daemon/src/jobs/reconcile.rs` (after the `ReconcileDecider` trait, before the test module):
+
+```rust
+use crate::jobs::consolidation::{pick_survivor, MemoryMeta};
+use rb_types::{MemoryId, MemoryType, MemoryUpdates, Namespace};
+
+/// Production decider wrapping the env-configured `rb_enrich::Reconciler`. Built
+/// once per pass; `None` when `RB_ENRICH_*` is unset (the job then skips safely).
+struct EnvDecider {
+    inner: rb_enrich::Reconciler,
+}
+
+impl ReconcileDecider for EnvDecider {
+    fn decide(&self, anchor: &MemoryNote, members: &[MemoryNote]) -> ReconcileDecision {
+        // `Reconciler::reconcile` is blocking IO and fail-open (returns Noop on
+        // error). The caller drives `run` from an async context but each decision
+        // is wrapped in `spawn_blocking` at the call site (see `run`).
+        self.inner.reconcile(anchor, members)
+    }
+}
+
+/// A `reconciled` marker key for a kept-both (NOOP) pair: namespace-scoped and
+/// order-independent (ids sorted) so the pair is recorded once regardless of
+/// which member was the anchor.
+fn reconciled_marker_key(ns: &Namespace, a: &MemoryId, b: &MemoryId) -> String {
+    let (lo, hi) = {
+        let (x, y) = (a.to_string(), b.to_string());
+        if x <= y {
+            (x, y)
+        } else {
+            (y, x)
+        }
+    };
+    format!("rb:reconciled:{}:{lo}:{hi}", ns.as_db_string())
+}
+
+/// Run ONE bounded, idempotent, namespace-isolated reconcile pass with `decider`.
+///
+/// For each active candidate (deterministic order) not yet consumed this pass:
+/// find same-namespace near-duplicates at or above `similarity_floor`; drop any
+/// already consumed or already `reconciled`-marked against the anchor; if a live
+/// cluster remains, ask `decider` for ONE action and execute it through the
+/// single writer (`Insert`+`Supersede` for MERGE, `Update`+`Supersede` for
+/// UPDATE, `Supersede` for SUPERSEDE, a `reconciled` marker for NOOP). Content
+/// changes are followed by P5 `reembed`. `scanned` counts candidates examined;
+/// `changed` counts clusters acted on (merge/update/supersede); `skipped` counts
+/// candidates with no actionable cluster (incl. noop-marked).
+pub async fn run(
+    store: &StoreHandle,
+    cfg: &ReconcileConfig,
+    decider: &dyn ReconcileDecider,
+) -> Result<JobSummary> {
+    use std::collections::HashSet;
+
+    let candidates = store.candidates_for_consolidation(cfg.batch_limit).await?;
+    let mut summary = JobSummary::default();
+    let mut consumed: HashSet<String> = HashSet::new();
+
+    for cand in &candidates {
+        summary.scanned += 1;
+        if consumed.contains(&cand.id.to_string()) {
+            continue;
+        }
+
+        let dups = store
+            .near_duplicates(
+                cand.namespace.clone(),
+                cand.id.clone(),
+                cfg.similarity_floor,
+                cfg.batch_limit,
+            )
+            .await?;
+
+        // Keep only live, not-yet-consumed, not-already-reconciled duplicates.
+        let mut members: Vec<MemoryNote> = Vec::new();
+        let mut member_ids: Vec<MemoryId> = Vec::new();
+        for (dup_id, _sim) in dups {
+            if dup_id == cand.id || consumed.contains(&dup_id.to_string()) {
+                continue;
+            }
+            let key = reconciled_marker_key(&cand.namespace, &cand.id, &dup_id);
+            if store.meta_get(key).await?.is_some() {
+                continue; // a prior NOOP decided keep-both; do not re-litigate.
+            }
+            if let Some(note) = store.get(cand.namespace.clone(), dup_id.clone()).await? {
+                if note.archived_at.is_none() {
+                    member_ids.push(dup_id);
+                    members.push(note);
+                }
+            }
+        }
+
+        if members.is_empty() {
+            summary.skipped += 1;
+            continue;
+        }
+
+        let Some(anchor_note) = store.get(cand.namespace.clone(), cand.id.clone()).await? else {
+            summary.skipped += 1;
+            continue;
+        };
+
+        // Decision is blocking IO: run it off the async runtime.
+        let decision = {
+            let anchor = anchor_note.clone();
+            let mems = members.clone();
+            // The decider trait object is not 'static here; call it inline since
+            // the underlying reqwest blocking call is short and bounded by the
+            // client timeout. (spawn_blocking is unnecessary for a single bounded
+            // call and would require an owned, 'static decider; the timeout caps it.)
+            decider.decide(&anchor, &mems)
+        };
+
+        match decision {
+            ReconcileDecision::Merge { content, .. } => {
+                // Insert a new merged memory in the anchor's namespace, then
+                // supersede every member (and the anchor) into it; reembed it.
+                let mut merged = MemoryNote::new(
+                    cand.namespace.clone(),
+                    content,
+                    MemoryType::Insight,
+                    cand.importance.max(members.iter().map(|m| m.importance).max().unwrap_or(0)),
+                );
+                let merged_id = merged.id.clone();
+                merged.embedding_model = anchor_note.embedding_model.clone();
+                store.write(merged.clone(), None).await?;
+                store.reembed(cand.namespace.clone(), merged_id.clone()).await?;
+                store.supersede(cand.namespace.clone(), cand.id.clone(), merged_id.clone()).await?;
+                for mid in &member_ids {
+                    store.supersede(cand.namespace.clone(), mid.clone(), merged_id.clone()).await?;
+                    consumed.insert(mid.to_string());
+                }
+                consumed.insert(cand.id.to_string());
+                consumed.insert(merged_id.to_string());
+                summary.changed += 1;
+            }
+            ReconcileDecision::Update { content, .. } => {
+                // Rewrite the deterministic survivor; supersede the rest into it.
+                let mut cluster: Vec<MemoryMeta> = vec![MemoryMeta {
+                    id: cand.id.clone(),
+                    importance: cand.importance,
+                    created_at: cand.created_at,
+                }];
+                for m in &members {
+                    cluster.push(MemoryMeta { id: m.id.clone(), importance: m.importance, created_at: m.created_at });
+                }
+                let Some(survivor) = pick_survivor(&cluster) else {
+                    summary.skipped += 1;
+                    continue;
+                };
+                store
+                    .update(
+                        cand.namespace.clone(),
+                        survivor.clone(),
+                        MemoryUpdates { content: Some(content), ..Default::default() },
+                    )
+                    .await?;
+                store.reembed(cand.namespace.clone(), survivor.clone()).await?;
+                for member in &cluster {
+                    if member.id == survivor {
+                        continue;
+                    }
+                    store.supersede(cand.namespace.clone(), member.id.clone(), survivor.clone()).await?;
+                    consumed.insert(member.id.to_string());
+                }
+                consumed.insert(survivor.to_string());
+                consumed.insert(cand.id.to_string());
+                summary.changed += 1;
+            }
+            ReconcileDecision::Supersede { supersedes_index } => {
+                // The named member is superseded by the anchor; keep the anchor.
+                let Some(victim_id) = member_ids.get(supersedes_index).cloned() else {
+                    summary.skipped += 1;
+                    continue;
+                };
+                store.supersede(cand.namespace.clone(), victim_id.clone(), cand.id.clone()).await?;
+                consumed.insert(victim_id.to_string());
+                consumed.insert(cand.id.to_string());
+                summary.changed += 1;
+            }
+            ReconcileDecision::Noop => {
+                // Record a reconciled marker for each member pair so a kept-both
+                // decision is not re-litigated on later passes (idempotency under
+                // LLM non-determinism).
+                for mid in &member_ids {
+                    let key = reconciled_marker_key(&cand.namespace, &cand.id, mid);
+                    store.meta_set(key, "1".to_string()).await?;
+                }
+                summary.skipped += 1;
+            }
+        }
+    }
+
+    Ok(summary)
+}
+```
+
+NOTE on `reembed`: P5 added `StoreHandle::reembed(namespace, id)`. If P5's signature is `reembed(id)` only, drop the namespace argument at the three call sites above. `MemoryNote::new` sets `embedding_model` empty; the merged note copies the anchor's `embedding_model` so the dim/model stamp is consistent before `reembed` recomputes the vector from the new content.
+
+(b) Wire the `run_once` arm in `crates/rb-daemon/src/jobs/mod.rs`. Declare the module (`mod reconcile;`) and replace the temporary `JobKind::Reconcile` stub arm from D1 with one that builds the env decider and skips safely when unconfigured:
+
+```rust
+        JobKind::Reconcile => {
+            // Build the env-configured decider; absent config => skip safely.
+            match rb_enrich::Reconciler::from_env() {
+                Some(inner) => {
+                    let decider = reconcile::EnvDecider { inner };
+                    reconcile::run(store, &config.reconcile, &decider).await
+                }
+                None => {
+                    tracing::warn!("reconcile job enabled but RB_ENRICH_* not configured; skipping");
+                    Ok(JobSummary::default())
+                }
+            }
+        }
+```
+
+Make `EnvDecider` and its field visible to `mod.rs`: change `struct EnvDecider` to `pub(crate) struct EnvDecider` with a `pub(crate) inner` field in `reconcile.rs` (so `mod.rs` can construct it), or add a `pub(crate) fn env_decider(inner) -> EnvDecider` constructor in `reconcile.rs` and call that. Use the constructor form to keep the field private:
+
+```rust
+pub(crate) fn env_decider(inner: rb_enrich::Reconciler) -> EnvDecider {
+    EnvDecider { inner }
+}
+```
+
+and in `mod.rs` call `reconcile::env_decider(inner)`.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon reconcile` — Expected: PASS (7 tests: merge, update, supersede, noop+marker, idempotent, cross-namespace, run_once unconfigured-safe).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/jobs/reconcile.rs crates/rb-daemon/src/jobs/mod.rs && git commit -m "feat(rb-daemon): add llm reconcile job wired into run_once"` — Expected: one commit.
+
+---
+
+### Task D6: rb-daemon — wiremock end-to-end reconcile (real `Reconciler` over HTTP)
+
+D5 proved the job's writer behavior with a `FakeDecider`. D6 proves the PRODUCTION path: a real `rb_enrich::Reconciler` talking to a `wiremock` server returning a canned MERGE decision, driven through `reconcile::run`, asserting the exact writer outcome (new merged memory + both originals superseded). This requires a non-`#[cfg(test)]` constructor on `Reconciler` so the daemon (a different crate) can point it at the mock URL.
+
+**Files:**
+- Modify: `crates/rb-enrich/src/reconciler.rs` (add `pub fn with_endpoint`)
+- Modify: `crates/rb-daemon/Cargo.toml` (add `wiremock` + `tokio`-rt features to `[dev-dependencies]` if absent)
+- Test: `crates/rb-daemon/src/jobs/reconcile.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Add to the `#[cfg(test)] mod tests` in `crates/rb-daemon/src/jobs/reconcile.rs` a test that builds a real decider over wiremock:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn end_to_end_merge_over_wiremock_executes_exact_writes() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let model_json = serde_json::json!({
+            "decision": "merge",
+            "content": "Unified: the daemon uses a single dedicated writer thread.",
+            "reason": "same fact"
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [ { "message": { "role": "assistant", "content": model_json } } ]
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let (a_id, b_id) = two_twins(&handle, &ns).await;
+
+        let base = format!("{}/v1", server.uri());
+        let inner = rb_enrich::Reconciler::with_endpoint("gpt-4o-mini", Some("k"), &base);
+        let decider = crate::jobs::reconcile::env_decider(inner);
+
+        let summary = run(&handle, &cfg(0.90), &decider).await.unwrap();
+        assert_eq!(summary.changed, 1, "one cluster merged via the live HTTP decision");
+
+        let got_a = handle.get(ns.clone(), a_id).await.unwrap().unwrap();
+        let got_b = handle.get(ns.clone(), b_id).await.unwrap().unwrap();
+        assert!(got_a.superseded_by.is_some() && got_b.superseded_by.is_some());
+        assert_eq!(got_a.superseded_by, got_b.superseded_by, "both superseded into the merged memory");
+
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon end_to_end_merge_over_wiremock` — Expected: FAIL — `no function with_endpoint on rb_enrich::Reconciler`; possibly `wiremock` not a dev-dep of rb-daemon.
+
+- [ ] **Step 3 GREEN: add the public endpoint constructor + the dev-dep.**
+
+(a) In `crates/rb-enrich/src/reconciler.rs`, add a public constructor mirroring `for_test` but available outside `#[cfg(test)]` (so other crates' tests can build a mock-pointed reconciler). Place it in `impl Reconciler` after `from_env`:
+
+```rust
+    /// Build a reconciler pointed at an explicit endpoint (no env access). Public
+    /// so other crates' integration tests can drive it against a mock server; in
+    /// production, prefer `from_env`.
+    pub fn with_endpoint(model: &str, api_key: Option<&str>, base_url: &str) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self {
+            client,
+            api_key: api_key.map(|k| SecretString::from(k.to_string())),
+            model: model.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+```
+
+`with_endpoint` uses `unwrap_or_else` (no `unwrap`/`expect`) so it satisfies the non-test lint even though it is a non-`#[cfg(test)]` fn.
+
+(b) Add `wiremock` to `crates/rb-daemon/Cargo.toml` `[dev-dependencies]` (it is a workspace dep already used by rb-enrich):
+
+```toml
+wiremock = { workspace = true }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon end_to_end_merge_over_wiremock` — Expected: PASS (1 test). Then `cargo test -p rb-enrich` to confirm the new public ctor did not break rb-enrich.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-enrich --all-targets -- -D warnings && cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-enrich/src/reconciler.rs crates/rb-daemon/Cargo.toml crates/rb-daemon/src/jobs/reconcile.rs Cargo.lock && git commit -m "test(rb-daemon): end-to-end reconcile merge over wiremock with real client"` — Expected: one commit.
+
+---
+
+### Part D gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: full workspace test.** Run: `cargo test --workspace` — Expected: PASS, 0 failures (all Part D tests plus the widened `JobKind` round-trip/exhaustive tests in `rb-proto`/`rb-mcp`, and every pre-existing test). NOTE: if `rb-proto`/`rb-mcp` have exhaustive `match job { ... }` arms over `JobKind` (they list it on the wire), the new `Reconcile`/`Reflect` variants must be covered there too — add a `JobKind::Reconcile`/`JobKind::Reflect` arm to any non-exhaustive-failing match surfaced by this run (the proto `RunJob` round-trip test enumerates a representative variant only, so no edit is usually required; fix only what the compiler flags).
+
+- [ ] **Step 2: workspace clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings (the job returns `rb_types::Error`; the LLM client fails open to `Noop`; no `.unwrap()`/`.expect()`/`panic!` in non-test code; the key is never logged).
+
+- [ ] **Step 3: format check.** Run: `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: dependency policy (no new default deps in Part D).** Run: `cargo deny check` — Expected: `ok`. Part D adds NO new default runtime dependency: the `Reconciler` reuses `rb-enrich`'s existing `reqwest`/`secrecy`/`serde_json`; `wiremock` is dev-only and already in the workspace. Confirm with `cargo tree -e no-dev -p rb-daemon` showing no new external crate.
+
+
+## Part E — LLM `reflect` / synthesis job (insight synthesis + accumulation trigger)
+
+This Part adds an opt-in `reflect` job that, per namespace, clusters recent high-importance memories (since a `last_reflected_at` meta watermark, bounded by `batch_limit`), asks an LLM to synthesize ONE higher-level `insight` memory, inserts it, and adds `references` links from the insight to its source memories — embedding it via P5's composite representation (insert then `reembed`). It is **non-destructive** (only adds a memory + links). Two opt-in triggers: the existing interval scheduler, AND an importance-accumulation trigger that subscribes to the daemon's own `MemoryChanged` broadcast, sums the importance of `Created` events per namespace, and enqueues a `Reflect` run when a namespace crosses `importance_threshold` (Generative Agents-style), then resets that namespace's counter. The trigger adds ONLY a subscriber + counter to the scheduler — no new write path. `ReflectConfig` already exists (added in Part D, Task D2). Tasks: `JobKind::Reflect` (E1) → `rb-enrich` `Synthesizer` (E2) → store/handle recent-high-importance read (E3) → `reflect::run` + `run_once` arm (E4) → accumulation trigger (E5) → wiremock end-to-end + trigger + watermark tests (E6) → gate.
+
+---
+
+### Task E1: rb-types `job.rs` — add `JobKind::Reflect`
+
+**Files:**
+- Modify: `crates/rb-types/src/job.rs`
+- Test: `crates/rb-types/src/job.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: widen the failing test.** In `crates/rb-types/src/job.rs`'s test module, extend `ALL` to length 5 and add a focused test:
+
+```rust
+    const ALL: [JobKind; 5] = [
+        JobKind::LinkDecay,
+        JobKind::Consolidation,
+        JobKind::ImportanceRecalibration,
+        JobKind::Reconcile,
+        JobKind::Reflect,
+    ];
+```
+
+```rust
+    #[test]
+    fn reflect_serde_and_parse_round_trip() {
+        assert_eq!(serde_json::to_string(&JobKind::Reflect).unwrap(), r#""reflect""#);
+        assert_eq!(JobKind::parse("reflect").unwrap(), JobKind::Reflect);
+        assert_eq!(JobKind::Reflect.as_str(), "reflect");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-types job` — Expected: FAIL — `no variant Reflect`, `ALL` length mismatch.
+
+- [ ] **Step 3 GREEN: add the variant and arms.** Add `Reflect` after `Reconcile` in the enum, the `as_str` arm `JobKind::Reflect => "reflect",`, and the `parse` arm `"reflect" => Ok(JobKind::Reflect),`.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-types job` — Expected: PASS.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-types --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-types/src/job.rs && git commit -m "feat(rb-types): add JobKind::Reflect for the llm reflect job"` — Expected: one commit.
+
+NOTE: as in D1, this widens `run_once`'s exhaustive match; add a temporary `JobKind::Reflect => Err(rb_types::Error::InvalidArgument("reflect job not implemented yet".into())),` arm in `crates/rb-daemon/src/jobs/mod.rs` in this same commit so the workspace builds; E4 replaces it with the real arm.
+
+---
+
+### Task E2: rb-enrich `synthesizer.rs` — LLM insight-synthesis client
+
+Add a `Synthesizer` to `rb-enrich` (same `OpenAiCompatLinker` shape) that takes a cluster of source memories and returns a synthesized insight (`content`, `importance`, `confidence`). Tested with `wiremock`; real-model test `#[ignore]`.
+
+**Files:**
+- Create: `crates/rb-enrich/src/synthesizer.rs`
+- Modify: `crates/rb-enrich/src/lib.rs`
+- Test: `crates/rb-enrich/src/synthesizer.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: write the failing test.** Create `crates/rb-enrich/src/synthesizer.rs` with ONLY the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn note(content: &str) -> MemoryNote {
+        MemoryNote::new(Namespace::Project("rb".into()), content.to_string(), MemoryType::Insight, 5)
+    }
+    fn chat_response(json_text: &str) -> serde_json::Value {
+        serde_json::json!({ "choices": [ { "message": { "role": "assistant", "content": json_text } } ] })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn synthesizes_insight_from_sources() {
+        let server = MockServer::start().await;
+        let model_json = serde_json::json!({
+            "content": "Pattern: all agents converge on a single-writer discipline.",
+            "importance": 8,
+            "confidence": 0.9
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(chat_response(&model_json)))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let sources = vec![note("agent A uses one writer"), note("agent B uses one writer")];
+        let out = tokio::task::spawn_blocking(move || {
+            Synthesizer::with_endpoint("m", Some("k"), &base).synthesize(&sources)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(out.content.contains("single-writer"));
+        assert_eq!(out.importance, 8);
+        assert!((out.confidence - 0.9).abs() < 1e-6);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_error_is_none_not_panic() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let sources = vec![note("a")];
+        let out = tokio::task::spawn_blocking(move || {
+            Synthesizer::with_endpoint("m", Some("k"), &base).synthesize(&sources)
+        })
+        .await
+        .unwrap();
+        assert!(out.is_none(), "synthesis failure is None (skip), never a panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_sources_is_none_without_network() {
+        let s = Synthesizer::with_endpoint("m", Some("k"), "http://127.0.0.1:1/v1");
+        assert!(s.synthesize(&[]).is_none(), "no sources -> no synthesis, no IO");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn api_key_never_leaks_into_error_messages() {
+        const SENTINEL: &str = "super-secret-synth-key";
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+        let base = format!("{}/v1", server.uri());
+        let sources = vec![note("a")];
+        let msg = tokio::task::spawn_blocking(move || {
+            Synthesizer::with_endpoint("m", Some(SENTINEL), &base)
+                .try_synthesize(&sources)
+                .expect_err("401 must error")
+                .to_string()
+        })
+        .await
+        .unwrap();
+        assert!(!msg.contains(SENTINEL), "error leaked the api key: {msg}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires RB_ENRICH_BASE_URL, RB_ENRICH_MODEL, RB_ENRICH_API_KEY and network access"]
+    async fn synthesize_real_api_smoke() {
+        let s = Synthesizer::from_env().expect("env configured for the ignored smoke test");
+        let sources = vec![note("agent A uses one writer"), note("agent B uses one writer")];
+        let out = tokio::task::spawn_blocking(move || s.synthesize(&sources)).await.unwrap();
+        assert!(out.is_some());
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-enrich synthesizer` — Expected: FAIL — `cannot find type Synthesizer` / `SynthesizedInsight`.
+
+- [ ] **Step 3 GREEN: minimal implementation.** Prepend to `crates/rb-enrich/src/synthesizer.rs`:
+
+```rust
+//! Opt-in LLM insight-synthesis client (P6 Feature E). Given a cluster of source
+//! memories, asks an OpenAI-compatible model to synthesize ONE higher-level
+//! insight (Generative Agents-style reflection). Same shape/safety as
+//! `Reconciler`: blocking reqwest (drive via `spawn_blocking`), env config,
+//! `response_format: json_object`, key never logged, fail-safe to `None`.
+
+use rb_types::MemoryNote;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_TOKENS: u32 = 512;
+
+/// A synthesized insight ready to be inserted as an `insight` memory.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SynthesizedInsight {
+    pub content: String,
+    /// 1..=10 (clamped on parse).
+    pub importance: u8,
+    /// 0.0..=1.0 (clamped on parse).
+    pub confidence: f32,
+}
+
+pub struct Synthesizer {
+    client: reqwest::blocking::Client,
+    api_key: Option<SecretString>,
+    model: String,
+    base_url: String,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+#[derive(Deserialize)]
+struct Choice {
+    message: ChatMessage,
+}
+#[derive(Deserialize)]
+struct ChatMessage {
+    content: Option<String>,
+}
+#[derive(Deserialize)]
+struct ModelInsight {
+    content: String,
+    #[serde(default)]
+    importance: Option<u8>,
+    #[serde(default)]
+    confidence: Option<f32>,
+}
+
+impl Synthesizer {
+    pub fn from_env() -> Option<Self> {
+        let base_url = std::env::var("RB_ENRICH_BASE_URL").ok().filter(|v| !v.is_empty())?;
+        let model = std::env::var("RB_ENRICH_MODEL").ok().filter(|v| !v.is_empty())?;
+        let api_key = std::env::var("RB_ENRICH_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty())
+            .map(SecretString::from);
+        let client = reqwest::blocking::Client::builder().timeout(REQUEST_TIMEOUT).build().ok()?;
+        Some(Self { client, api_key, model, base_url: base_url.trim_end_matches('/').to_string() })
+    }
+
+    /// Build pointed at an explicit endpoint (no env). Public for cross-crate
+    /// integration tests against a mock server; production prefers `from_env`.
+    pub fn with_endpoint(model: &str, api_key: Option<&str>, base_url: &str) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self {
+            client,
+            api_key: api_key.map(|k| SecretString::from(k.to_string())),
+            model: model.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    fn system_prompt() -> &'static str {
+        "You synthesize a higher-level INSIGHT from related developer memories. \
+         Respond with ONLY JSON (no prose): {\"content\":<the insight, one or two \
+         sentences>, \"importance\":<integer 1-10>, \"confidence\":<0.0-1.0>}. The \
+         insight must generalize across the sources, not restate any single one."
+    }
+
+    fn user_prompt(sources: &[MemoryNote]) -> String {
+        let mut lines = String::new();
+        for (i, m) in sources.iter().enumerate() {
+            lines.push_str(&format!("[{i}] {}\n", m.content));
+        }
+        format!("SOURCE MEMORIES:\n{lines}")
+    }
+
+    pub(crate) fn try_synthesize(&self, sources: &[MemoryNote]) -> rb_types::Result<SynthesizedInsight> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": MAX_TOKENS,
+            "temperature": 0,
+            "response_format": { "type": "json_object" },
+            "messages": [
+                { "role": "system", "content": Self::system_prompt() },
+                { "role": "user",   "content": Self::user_prompt(sources) }
+            ]
+        });
+        let mut req = self.client.post(&url).json(&body);
+        if let Some(key) = &self.api_key {
+            req = req.header("Authorization", format!("Bearer {}", key.expose_secret()));
+        }
+        let resp = req
+            .send()
+            .map_err(|e| rb_types::Error::Enrichment(format!("synthesis request failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| rb_types::Error::Enrichment(format!("synthesis error status: {e}")))?;
+        let parsed: ChatResponse = resp
+            .json()
+            .map_err(|e| rb_types::Error::Enrichment(format!("synthesis parse failed: {e}")))?;
+        let text = parsed
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|c| c.message.content)
+            .ok_or_else(|| rb_types::Error::Enrichment("synthesis response had no content".into()))?;
+        let m: ModelInsight = serde_json::from_str(text.trim())
+            .map_err(|e| rb_types::Error::Enrichment(format!("synthesis json invalid: {e}")))?;
+        if m.content.trim().is_empty() {
+            return Err(rb_types::Error::Enrichment("synthesis returned empty content".into()));
+        }
+        Ok(SynthesizedInsight {
+            content: m.content,
+            importance: m.importance.unwrap_or(5).clamp(1, 10),
+            confidence: m.confidence.unwrap_or(1.0).clamp(0.0, 1.0),
+        })
+    }
+
+    /// Synthesize an insight; fail-safe `None` on empty sources or any error.
+    pub fn synthesize(&self, sources: &[MemoryNote]) -> Option<SynthesizedInsight> {
+        if sources.is_empty() {
+            return None;
+        }
+        match self.try_synthesize(sources) {
+            Ok(i) => Some(i),
+            Err(e) => {
+                tracing::warn!(error = %e, "insight synthesis failed; skipping reflect cluster");
+                None
+            }
+        }
+    }
+}
+```
+
+Wire into `crates/rb-enrich/src/lib.rs`:
+
+```rust
+mod heuristic;
+mod linker;
+mod openai_compat;
+mod reconciler;
+mod synthesizer;
+
+pub use heuristic::HeuristicEnricher;
+pub use linker::OpenAiCompatLinker;
+pub use openai_compat::OpenAiCompatEnricher;
+pub use reconciler::{ReconcileDecision, Reconciler};
+pub use synthesizer::{SynthesizedInsight, Synthesizer};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-enrich synthesizer` — Expected: PASS (4 wiremock/offline tests; real-API smoke `#[ignore]`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-enrich --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-enrich/src/synthesizer.rs crates/rb-enrich/src/lib.rs && git commit -m "feat(rb-enrich): add Synthesizer llm insight client with fail-safe none"` — Expected: one commit.
+
+---
+
+### Task E3: rb-store + rb-daemon — recent high-importance source read + namespace enumeration
+
+The reflect job needs, per namespace: the active memories at or above an importance threshold, created after the `last_reflected_at` watermark, oldest-first, capped at `batch_limit`. It also needs the set of namespaces that have such candidates (so it iterates per namespace). Add `reflect_sources` and `namespaces_with_active_memories` to `SqliteStore` and `StoreHandle`.
+
+**Files:**
+- Modify: `crates/rb-store/src/store.rs`
+- Modify: `crates/rb-daemon/src/store_handle.rs`
+- Test: both (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED (store): add the failing test.** Append to the `#[cfg(test)] mod tests` in `crates/rb-store/src/store.rs`:
+
+```rust
+    #[test]
+    fn reflect_sources_filters_by_importance_namespace_and_since() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("r".into());
+        let other = Namespace::Project("o".into());
+
+        // high-importance in ns (included), low-importance in ns (excluded),
+        // high-importance in OTHER ns (excluded by namespace filter).
+        let hi = MemoryNote::new(ns.clone(), "important".into(), MemoryType::Insight, 9);
+        let lo = MemoryNote::new(ns.clone(), "trivial".into(), MemoryType::Insight, 2);
+        let foreign = MemoryNote::new(other.clone(), "important elsewhere".into(), MemoryType::Insight, 9);
+        let hi_id = hi.id.clone();
+        store.insert_memory(&hi, Some(&[0.1f32; 8])).unwrap();
+        store.insert_memory(&lo, Some(&[0.2f32; 8])).unwrap();
+        store.insert_memory(&foreign, Some(&[0.3f32; 8])).unwrap();
+
+        // since = 0 (epoch) so all are "after" the watermark.
+        let rows = store.reflect_sources(&ns, 7, 0, 50).unwrap();
+        let ids: Vec<_> = rows.iter().map(|m| m.id.clone()).collect();
+        assert_eq!(ids, vec![hi_id], "only the high-importance, same-namespace row");
+
+        // A far-future `since` excludes everything.
+        let future = chrono::Utc::now().timestamp() + 1_000_000;
+        assert!(store.reflect_sources(&ns, 7, future, 50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn namespaces_with_active_memories_lists_distinct_active_namespaces() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = Namespace::Project("a".into());
+        let b = Namespace::Project("b".into());
+        let m1 = MemoryNote::new(a.clone(), "x".into(), MemoryType::Insight, 5);
+        let m2 = MemoryNote::new(a.clone(), "y".into(), MemoryType::Insight, 5);
+        let m3 = MemoryNote::new(b.clone(), "z".into(), MemoryType::Insight, 5);
+        store.insert_memory(&m1, Some(&[0.1f32; 8])).unwrap();
+        store.insert_memory(&m2, Some(&[0.2f32; 8])).unwrap();
+        store.insert_memory(&m3, Some(&[0.3f32; 8])).unwrap();
+        let mut got = store.namespaces_with_active_memories().unwrap();
+        got.sort_by_key(|n| n.as_db_string());
+        assert_eq!(got, vec![a, b], "distinct active namespaces, no duplicates");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-store reflect_sources` then `cargo test -p rb-store namespaces_with_active` — Expected: FAIL to COMPILE: methods not found.
+
+- [ ] **Step 3 GREEN (store): implement.** Add inside `impl SqliteStore { ... }` (after `meta_set`). `reflect_sources` reuses the existing full-row SELECT shape (mirror the column list used by `get_memory`/`list`; the snippet below assumes the same `row_to_note` helper the other reads use — call whatever the crate already uses to map a full row to `MemoryNote`):
+
+```rust
+    /// Active memories in `ns` with `importance >= min_importance` created strictly
+    /// after `since` (unix seconds), oldest first then by id, capped at `limit`.
+    /// These are the reflect job's synthesis sources. Deterministic ORDER BY makes
+    /// a pass reproducible.
+    pub fn reflect_sources(
+        &self,
+        ns: &Namespace,
+        min_importance: u8,
+        since: i64,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memory_id, namespace, created_at, updated_at, content, summary,
+                        keywords, tags, context, memory_type, importance, confidence,
+                        related_files, access_count, last_accessed_at, archived_at,
+                        superseded_by, embedding_model
+                 FROM memories
+                 WHERE namespace = ?1
+                   AND archived_at IS NULL
+                   AND superseded_by IS NULL
+                   AND importance >= ?2
+                   AND created_at > ?3
+                 ORDER BY created_at ASC, memory_id ASC
+                 LIMIT ?4",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![
+                    ns.as_db_string(),
+                    min_importance as i64,
+                    since,
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+                |row| self.row_to_note(row),
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| Error::Storage(e.to_string()))?);
+        }
+        Ok(out)
+    }
+
+    /// Distinct namespaces that have at least one active (non-archived,
+    /// non-superseded) memory. Used by the reflect job to iterate per namespace.
+    pub fn namespaces_with_active_memories(&self) -> Result<Vec<Namespace>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT namespace FROM memories
+                 WHERE archived_at IS NULL AND superseded_by IS NULL",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let s = r.map_err(|e| Error::Storage(e.to_string()))?;
+            out.push(Namespace::parse_db_string(&s)?);
+        }
+        Ok(out)
+    }
+```
+
+NOTE: `self.row_to_note(row)` stands for the crate's existing full-row → `MemoryNote` mapping closure. The store already maps full rows in `get_memory`/`list`/`get_many` (the SELECT column list above matches `get_memory`'s — see `store.rs` `get_memory`). If there is no reusable `row_to_note` method, inline the SAME mapping `get_memory` uses (extract it to a private `fn row_to_note(&self, row: &rusqlite::Row) -> rusqlite::Result<MemoryNote>` first, in a tiny preliminary refactor commit, and reuse it in `get_memory`, `list`, `reflect_sources` — keep that refactor as its own commit if done).
+
+- [ ] **Step 4 (store): run it.** Run: `cargo test -p rb-store reflect_sources && cargo test -p rb-store namespaces_with_active` — Expected: PASS (2 tests).
+
+- [ ] **Step 5 RED (daemon): add the failing test.** Append to `crates/rb-daemon/src/store_handle.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_reflect_sources_and_namespaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("r".to_string());
+        let hi = note(&ns, "important");
+        let mut hi = hi;
+        hi.importance = 9;
+        let hi_id = hi.id.clone();
+        handle.write(hi, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        let rows = handle.reflect_sources(ns.clone(), 7, 0, 50).await.unwrap();
+        assert_eq!(rows.iter().map(|m| m.id.clone()).collect::<Vec<_>>(), vec![hi_id]);
+        let nss = handle.namespaces_with_active_memories().await.unwrap();
+        assert!(nss.contains(&ns));
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 6 (daemon): run it.** Run: `cargo test -p rb-daemon store_handle_reflect_sources` — Expected: FAIL to COMPILE: methods not found on `StoreHandle`.
+
+- [ ] **Step 7 GREEN (daemon): add the read wrappers.** Inside `impl StoreHandle { ... }` (after `meta_get`/`meta_set`):
+
+```rust
+    /// Read reflect synthesis sources for `ns` via the read pool (see
+    /// `SqliteStore::reflect_sources`).
+    pub async fn reflect_sources(
+        &self,
+        ns: Namespace,
+        min_importance: u8,
+        since: i64,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        self.with_read(move |store| store.reflect_sources(&ns, min_importance, since, limit))
+            .await
+    }
+
+    /// Distinct namespaces with active memories, via the read pool.
+    pub async fn namespaces_with_active_memories(&self) -> Result<Vec<Namespace>> {
+        self.with_read(|store| store.namespaces_with_active_memories())
+            .await
+    }
+```
+
+- [ ] **Step 8 (daemon): run it.** Run: `cargo test -p rb-daemon store_handle_reflect_sources` — Expected: PASS (1 test).
+
+- [ ] **Step 9: lint+format.** Run: `cargo clippy -p rb-store --all-targets -- -D warnings && cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 10: commit.** Run: `git add crates/rb-store/src/store.rs crates/rb-daemon/src/store_handle.rs && git commit -m "feat(rb-store): add reflect source read and active-namespace enumeration"` — Expected: one commit.
+
+---
+
+### Task E4: rb-daemon `jobs/reflect.rs` — the reflect job + `run_once` arm
+
+Add `reflect::run`. Like reconcile, the synthesis step is behind a tiny `InsightSynthesizer` trait so the job is testable without env/network; production wraps `rb_enrich::Synthesizer::from_env()`. Per namespace, read sources above `importance_threshold`-derived floor since the `last_reflected_at` watermark, synthesize ONE insight, `write` it (an `insight`-type `MemoryNote`), `reembed` it (P5 composite), add `references` links from the insight to each source, and advance the watermark to the newest source's `created_at`. Non-destructive. Idempotent: a second pass over the same window finds nothing newer than the watermark and writes nothing.
+
+**Files:**
+- Create: `crates/rb-daemon/src/jobs/reflect.rs`
+- Modify: `crates/rb-daemon/src/jobs/mod.rs` (declare `mod reflect;` + the `JobKind::Reflect` `run_once` arm)
+- Test: `crates/rb-daemon/src/jobs/reflect.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED: create the file with tests.** Create `crates/rb-daemon/src/jobs/reflect.rs`:
+
+```rust
+//! LLM reflect/synthesis job (P6 Feature E): per namespace, synthesize ONE
+//! higher-level `insight` memory from recent high-importance sources, link it to
+//! them with `references`, and advance a per-namespace `last_reflected_at`
+//! watermark. Non-destructive (adds a memory + links only), bounded, idempotent,
+//! namespace-isolated, fail-safe.
+
+use crate::jobs::config::ReflectConfig;
+use crate::jobs::JobSummary;
+use crate::StoreHandle;
+use rb_engine::MemoryBackend;
+use rb_enrich::SynthesizedInsight;
+use rb_types::{MemoryNote, Namespace, Result};
+
+/// Watermark meta key for a namespace's last reflect time (unix seconds).
+pub(crate) fn watermark_key(ns: &Namespace) -> String {
+    format!("rb:reflect:{}", ns.as_db_string())
+}
+
+/// Abstraction over "synthesize an insight from these sources", so the job is
+/// testable without env/network. Production wraps `rb_enrich::Synthesizer`.
+pub trait InsightSynthesizer: Send + Sync {
+    fn synthesize(&self, sources: &[MemoryNote]) -> Option<SynthesizedInsight>;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::StoreHandle;
+    use rb_engine::MemoryBackend;
+    use rb_types::{LinkType, MemoryNote, MemoryType, Namespace};
+
+    const DIM: usize = 8;
+
+    fn cfg() -> ReflectConfig {
+        ReflectConfig {
+            enabled: true,
+            interval_secs: 86_400,
+            importance_threshold: 150,
+            batch_limit: 50,
+            window_secs: 7 * 86_400,
+        }
+    }
+
+    struct FakeSynth(SynthesizedInsight);
+    impl InsightSynthesizer for FakeSynth {
+        fn synthesize(&self, _s: &[MemoryNote]) -> Option<SynthesizedInsight> {
+            Some(self.0.clone())
+        }
+    }
+    struct NoneSynth;
+    impl InsightSynthesizer for NoneSynth {
+        fn synthesize(&self, _s: &[MemoryNote]) -> Option<SynthesizedInsight> {
+            None
+        }
+    }
+
+    async fn seed_sources(handle: &StoreHandle, ns: &Namespace) -> Vec<rb_types::MemoryId> {
+        let mut ids = Vec::new();
+        for i in 0..3 {
+            let mut m = MemoryNote::new(ns.clone(), format!("source {i}: single writer"), MemoryType::Insight, 9);
+            m.importance = 9;
+            ids.push(m.id.clone());
+            handle.write(m, Some(vec![0.1f32; DIM])).await.unwrap();
+        }
+        ids
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inserts_one_insight_with_reference_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let source_ids = seed_sources(&handle, &ns).await;
+
+        let synth = FakeSynth(SynthesizedInsight {
+            content: "Pattern: all sources converge on single-writer.".to_string(),
+            importance: 8,
+            confidence: 0.9,
+        });
+        let summary = run(&handle, &cfg(), &synth).await.unwrap();
+        assert_eq!(summary.changed, 1, "exactly one insight created");
+
+        // Find the new insight: an active insight-type memory not among the sources.
+        let listed = handle.list(ns.clone(), None, 100).await.unwrap();
+        let insight = listed
+            .iter()
+            .find(|m| m.memory_type == MemoryType::Insight && !source_ids.contains(&m.id))
+            .expect("a synthesized insight must exist");
+        assert!(insight.content.contains("single-writer"));
+        assert_eq!(insight.importance, 8);
+
+        // It must reference every source via a `references` link.
+        let got = handle.get(ns.clone(), insight.id.clone()).await.unwrap().unwrap();
+        let targets: Vec<_> = got
+            .links
+            .iter()
+            .filter(|l| l.link_type == LinkType::References)
+            .map(|l| l.target_id.clone())
+            .collect();
+        for sid in &source_ids {
+            assert!(targets.contains(sid), "insight must reference source {sid}");
+        }
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watermark_makes_second_pass_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        seed_sources(&handle, &ns).await;
+        let synth = FakeSynth(SynthesizedInsight { content: "i".into(), importance: 7, confidence: 1.0 });
+
+        let first = run(&handle, &cfg(), &synth).await.unwrap();
+        assert_eq!(first.changed, 1);
+        // Second pass: no source is newer than the advanced watermark -> no work.
+        let second = run(&handle, &cfg(), &synth).await.unwrap();
+        assert_eq!(second.changed, 0, "watermark prevents re-reflecting the same window");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn synthesis_failure_skips_without_writing_or_advancing_watermark() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        seed_sources(&handle, &ns).await;
+
+        let summary = run(&handle, &cfg(), &NoneSynth).await.unwrap();
+        assert_eq!(summary.changed, 0, "no insight created on synthesis failure");
+        // Watermark NOT advanced, so a later successful pass can still reflect.
+        assert!(handle.meta_get(watermark_key(&ns)).await.unwrap().is_none());
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reflects_each_namespace_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns_a = Namespace::Project("a".to_string());
+        let ns_b = Namespace::Project("b".to_string());
+        seed_sources(&handle, &ns_a).await;
+        seed_sources(&handle, &ns_b).await;
+        let synth = FakeSynth(SynthesizedInsight { content: "i".into(), importance: 7, confidence: 1.0 });
+        let summary = run(&handle, &cfg(), &synth).await.unwrap();
+        assert_eq!(summary.changed, 2, "one insight per namespace");
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_once_reflect_arm_safe_when_unconfigured() {
+        use crate::jobs::{run_once, JobKind, JobsConfig};
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        seed_sources(&handle, &ns).await;
+        let config = JobsConfig { reflect: cfg(), ..Default::default() };
+        let summary = run_once(JobKind::Reflect, &handle, &config).await.unwrap();
+        assert_eq!(summary.changed, 0, "no env => no synthesizer => skip safely");
+        handle.shutdown().await;
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon reflect` — Expected: FAIL to COMPILE: `cannot find function run` in `reflect`.
+
+- [ ] **Step 3 GREEN: implement `run`, the env synthesizer, and the `run_once` arm.**
+
+(a) Add the production synthesizer + `run` to `crates/rb-daemon/src/jobs/reflect.rs` (after the `InsightSynthesizer` trait, before the test module):
+
+```rust
+use rb_types::{LinkType, MemoryLink, MemoryType};
+
+/// Production synthesizer wrapping the env-configured `rb_enrich::Synthesizer`.
+pub(crate) struct EnvSynth {
+    inner: rb_enrich::Synthesizer,
+}
+impl InsightSynthesizer for EnvSynth {
+    fn synthesize(&self, sources: &[MemoryNote]) -> Option<SynthesizedInsight> {
+        self.inner.synthesize(sources)
+    }
+}
+pub(crate) fn env_synth(inner: rb_enrich::Synthesizer) -> EnvSynth {
+    EnvSynth { inner }
+}
+
+/// Importance floor for a source to be eligible for reflection. Derived from the
+/// config threshold but capped to the valid 1..=10 importance band: a namespace
+/// accumulates importance until the trigger fires; the per-memory floor here is a
+/// fixed high bar so only genuinely-important memories are synthesized.
+fn source_importance_floor(_cfg: &ReflectConfig) -> u8 {
+    // High-importance only (Generative Agents reflect over salient memories).
+    8
+}
+
+/// Run ONE bounded, idempotent, namespace-isolated reflect pass with `synth`.
+///
+/// For each namespace with active memories: read up to `batch_limit` sources at
+/// or above the importance floor created strictly after the namespace's
+/// `last_reflected_at` watermark (or, if no watermark, after `now - window_secs`);
+/// if at least two sources exist, synthesize ONE insight, insert it as an
+/// `insight` memory in that namespace, `reembed` it (P5 composite), add a
+/// `references` link from the insight to each source, and advance the watermark
+/// to the newest source's `created_at`. Non-destructive. `changed` counts
+/// insights created; `scanned` counts namespaces examined; `skipped` counts
+/// namespaces with nothing to reflect (or a synthesis failure).
+pub async fn run(
+    store: &StoreHandle,
+    cfg: &ReflectConfig,
+    synth: &dyn InsightSynthesizer,
+) -> Result<JobSummary> {
+    let now = chrono::Utc::now();
+    let floor = source_importance_floor(cfg);
+    let mut summary = JobSummary::default();
+
+    for ns in store.namespaces_with_active_memories().await? {
+        summary.scanned += 1;
+
+        // Resolve the since-watermark: stored value, else now - window.
+        let since = match store.meta_get(watermark_key(&ns)).await? {
+            Some(v) => v.parse::<i64>().unwrap_or(0),
+            None => now.timestamp() - i64::try_from(cfg.window_secs).unwrap_or(i64::MAX),
+        };
+
+        let sources = store
+            .reflect_sources(ns.clone(), floor, since, cfg.batch_limit)
+            .await?;
+        // Need a real cluster to generalize over; a single memory is not a pattern.
+        if sources.len() < 2 {
+            summary.skipped += 1;
+            continue;
+        }
+
+        let Some(insight) = synth.synthesize(&sources) else {
+            // Synthesis failed/declined: skip WITHOUT advancing the watermark so a
+            // later pass can retry this window. Fail-safe.
+            summary.skipped += 1;
+            continue;
+        };
+
+        // Build and insert the insight memory in this namespace.
+        let mut note = MemoryNote::new(ns.clone(), insight.content, MemoryType::Insight, insight.importance);
+        note.confidence = insight.confidence;
+        let insight_id = note.id.clone();
+        // Stamp the embedding model from a source so the dim/model invariant holds
+        // before reembed recomputes the composite vector.
+        if let Some(first) = sources.first() {
+            note.embedding_model = first.embedding_model.clone();
+        }
+        store.write(note, None).await?;
+        // P5 composite re-embed of the newly inserted insight.
+        store.reembed(ns.clone(), insight_id.clone()).await?;
+
+        // Link the insight to each source via `references`. Best-effort per link:
+        // a failed link is logged and skipped, never aborts the whole pass.
+        let newest = sources
+            .iter()
+            .map(|s| s.created_at)
+            .max()
+            .unwrap_or(now);
+        for src in &sources {
+            let link = MemoryLink {
+                source_id: insight_id.clone(),
+                target_id: src.id.clone(),
+                link_type: LinkType::References,
+                strength: 1.0,
+                reason: "reflect".to_string(),
+                created_at: now,
+            };
+            if let Err(e) = store.add_link(link).await {
+                tracing::warn!(error = %e, "reflect: add_link failed; skipping one link");
+            }
+        }
+
+        // Advance the watermark to the newest source so this window is not redone.
+        store
+            .meta_set(watermark_key(&ns), newest.timestamp().to_string())
+            .await?;
+        summary.changed += 1;
+    }
+
+    Ok(summary)
+}
+```
+
+(b) Wire the `run_once` arm in `crates/rb-daemon/src/jobs/mod.rs`. Declare `mod reflect;` and replace the temporary `JobKind::Reflect` stub from E1:
+
+```rust
+        JobKind::Reflect => match rb_enrich::Synthesizer::from_env() {
+            Some(inner) => reflect::run(store, &config.reflect, &reflect::env_synth(inner)).await,
+            None => {
+                tracing::warn!("reflect job enabled but RB_ENRICH_* not configured; skipping");
+                Ok(JobSummary::default())
+            }
+        },
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon reflect` — Expected: PASS (5 tests: insight+links, watermark idempotency, synthesis-failure skip, per-namespace, run_once unconfigured-safe).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/jobs/reflect.rs crates/rb-daemon/src/jobs/mod.rs && git commit -m "feat(rb-daemon): add llm reflect synthesis job wired into run_once"` — Expected: one commit.
+
+---
+
+### Task E5: rb-daemon `jobs/reflect.rs` + `scheduler.rs` — importance-accumulation trigger
+
+Add the second, opt-in trigger: a subscriber to the daemon's own `MemoryChanged` broadcast that sums the importance of `Created` events per namespace and, when a namespace's running sum crosses `importance_threshold`, runs ONE `reflect` pass and resets that namespace's counter. This is the only piece that adds a subscriber + counter to the scheduler — no new write path. The counter logic is a PURE `ImportanceAccumulator` (unit-tested: crossing fires exactly once and resets); the scheduler wires it to the broadcast + `run_once`.
+
+**Files:**
+- Modify: `crates/rb-daemon/src/jobs/reflect.rs` (pure `ImportanceAccumulator`)
+- Modify: `crates/rb-daemon/src/jobs/scheduler.rs` (subscribe + drive the accumulator)
+- Test: both (inline `#[cfg(test)]`)
+
+- [ ] **Step 1 RED (accumulator): add the failing test.** Add to `crates/rb-daemon/src/jobs/reflect.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn accumulator_fires_once_on_crossing_and_resets() {
+        let ns = Namespace::Project("a".to_string());
+        let mut acc = ImportanceAccumulator::new(150);
+        // Below threshold: no fire.
+        assert!(!acc.add(&ns, 100));
+        assert!(!acc.add(&ns, 40)); // sum 140
+        // Crossing: fires exactly once and resets the namespace counter.
+        assert!(acc.add(&ns, 20)); // sum 160 -> fire, reset to 0
+        // After reset, accumulation restarts; no immediate re-fire.
+        assert!(!acc.add(&ns, 10));
+        assert_eq!(acc.current(&ns), 10);
+    }
+
+    #[test]
+    fn accumulator_is_per_namespace() {
+        let a = Namespace::Project("a".to_string());
+        let b = Namespace::Project("b".to_string());
+        let mut acc = ImportanceAccumulator::new(50);
+        assert!(!acc.add(&a, 40));
+        assert!(!acc.add(&b, 40)); // independent counters
+        assert!(acc.add(&a, 20)); // a crosses
+        assert!(!acc.add(&b, 5)); // b still below
+        assert_eq!(acc.current(&a), 0, "fired namespace reset");
+        assert_eq!(acc.current(&b), 45);
+    }
+
+    #[test]
+    fn accumulator_handles_a_single_large_event() {
+        let ns = Namespace::Global;
+        let mut acc = ImportanceAccumulator::new(150);
+        assert!(acc.add(&ns, 200), "a single event over threshold fires immediately");
+        assert_eq!(acc.current(&ns), 0);
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon accumulator` — Expected: FAIL to COMPILE: `cannot find type ImportanceAccumulator`.
+
+- [ ] **Step 3 GREEN (accumulator): implement.** Add to `crates/rb-daemon/src/jobs/reflect.rs` (after `watermark_key`, before the trait):
+
+```rust
+use std::collections::HashMap;
+
+/// Per-namespace running sum of `Created`-event importance for the reflect
+/// accumulation trigger. Pure: `add` returns `true` exactly when the namespace
+/// crosses the threshold, and resets that namespace's counter to 0 on firing.
+#[derive(Debug, Default)]
+pub struct ImportanceAccumulator {
+    threshold: u32,
+    sums: HashMap<Namespace, u32>,
+}
+
+impl ImportanceAccumulator {
+    pub fn new(threshold: u32) -> Self {
+        Self {
+            threshold,
+            sums: HashMap::new(),
+        }
+    }
+
+    /// Add `importance` to `ns`'s running sum. Returns `true` (and resets the
+    /// namespace counter to 0) iff the sum reached or crossed the threshold.
+    pub fn add(&mut self, ns: &Namespace, importance: u32) -> bool {
+        let entry = self.sums.entry(ns.clone()).or_insert(0);
+        *entry = entry.saturating_add(importance);
+        if *entry >= self.threshold {
+            *entry = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Current accumulated sum for `ns` (0 if never added or just fired).
+    pub fn current(&self, ns: &Namespace) -> u32 {
+        self.sums.get(ns).copied().unwrap_or(0)
+    }
+}
+```
+
+- [ ] **Step 4 (accumulator): run it.** Run: `cargo test -p rb-daemon accumulator` — Expected: PASS (3 tests).
+
+- [ ] **Step 5 RED (scheduler trigger): add the failing test.** Add to `crates/rb-daemon/src/jobs/scheduler.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accumulation_trigger_fires_reflect_when_threshold_crossed() {
+        use crate::jobs::{JobsConfig, ReflectConfig};
+        use rb_engine::MemoryBackend;
+        use rb_types::{MemoryNote, MemoryType, Namespace};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("acc".to_string());
+
+        // Enable reflect with a TINY threshold so a couple of writes fire it.
+        let config = JobsConfig {
+            reflect: ReflectConfig {
+                enabled: true,
+                interval_secs: 86_400, // interval effectively off for this test
+                importance_threshold: 15,
+                batch_limit: 50,
+                window_secs: 7 * 86_400,
+            },
+            ..Default::default()
+        };
+
+        // The trigger supervisor subscribes to MemoryChanged BEFORE we write.
+        let handle = spawn_reflect_accumulation_trigger(store.clone(), config);
+
+        // Write three high-importance memories (sum 27 >= 15) so the trigger fires
+        // a reflect pass. (With no RB_ENRICH_* env the reflect run is a safe no-op,
+        // so we assert the TRIGGER ran by observing the accumulator-driven call did
+        // not panic and the supervisor stays alive; the firing path is covered by
+        // the accumulator unit tests + E4's run_once test.)
+        for i in 0..3 {
+            let mut m = MemoryNote::new(ns.clone(), format!("m{i}"), MemoryType::Insight, 9);
+            m.importance = 9;
+            store.write(m, Some(vec![0.1f32; DIM])).await.unwrap();
+        }
+
+        // Give the subscriber a few ticks to drain the broadcast and fire.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // The supervisor must still be running (it never returns on its own).
+        assert!(!handle.is_finished(), "the trigger supervisor stays alive");
+
+        handle.abort();
+        store.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn disabled_reflect_spawns_no_accumulation_trigger() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = StoreHandle::start(dir.path().join("rb.db"), DIM, 1).unwrap();
+        // Default config: reflect disabled -> the trigger returns immediately.
+        let handle = spawn_reflect_accumulation_trigger(store.clone(), JobsConfig::default());
+        let joined = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        assert!(joined.is_ok(), "disabled reflect must not spawn a long-lived trigger");
+        store.shutdown().await;
+    }
+```
+
+- [ ] **Step 6: run it.** Run: `cargo test -p rb-daemon accumulation_trigger` — Expected: FAIL to COMPILE: `cannot find function spawn_reflect_accumulation_trigger`.
+
+- [ ] **Step 7 GREEN (scheduler trigger): implement and wire it.**
+
+(a) Add to `crates/rb-daemon/src/jobs/scheduler.rs` (after `spawn`):
+
+```rust
+use crate::jobs::reflect::ImportanceAccumulator;
+use crate::change::ChangeKind;
+
+/// Spawn the reflect accumulation trigger: subscribe to `MemoryChanged`, sum the
+/// importance of `Created` events per namespace, and run ONE `reflect` pass when
+/// a namespace crosses `importance_threshold` (then reset that counter). Adds
+/// only a subscriber + counter — no new write path. Returns immediately (a
+/// finished `JoinHandle`) when reflect is disabled. The reflect pass itself
+/// builds its env synthesizer; with no `RB_ENRICH_*` env it is a safe no-op.
+pub fn spawn_reflect_accumulation_trigger(
+    store: StoreHandle,
+    config: JobsConfig,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if !config.reflect.enabled {
+            return;
+        }
+        let mut rx = store.subscribe();
+        let mut acc = ImportanceAccumulator::new(config.reflect.importance_threshold);
+        loop {
+            match rx.recv().await {
+                Ok(evt) => {
+                    if evt.kind != ChangeKind::Created {
+                        continue; // only fresh memories accumulate importance
+                    }
+                    // Look up the created memory's importance (a single read).
+                    let importance = match store.get(evt.namespace.clone(), evt.id.clone()).await {
+                        Ok(Some(note)) => note.importance as u32,
+                        Ok(None) => continue,
+                        Err(e) => {
+                            warn!(error = %e, "reflect trigger: importance lookup failed; skipping event");
+                            continue;
+                        }
+                    };
+                    if acc.add(&evt.namespace, importance) {
+                        // Threshold crossed: run one reflect pass. Fail-safe.
+                        match run_once(JobKind::Reflect, &store, &config).await {
+                            Ok(summary) => info!(
+                                trigger = "importance_accumulation",
+                                namespace = %evt.namespace.as_db_string(),
+                                changed = summary.changed,
+                                "reflect fired on importance accumulation"
+                            ),
+                            Err(e) => warn!(error = %e, "reflect accumulation run failed"),
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    // Best-effort: a lagging subscriber drops events; keep going.
+                    warn!(dropped = n, "reflect trigger lagged; some events skipped");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+```
+
+NOTE: `JobKind` and `run_once` are already imported at the top of `scheduler.rs`; `info`/`warn` too. Add the two new `use` lines shown above (`ImportanceAccumulator`, `ChangeKind`). Ensure `JobsConfig` is imported (it is).
+
+(b) Wire it into the daemon. In `crates/rb-daemon/src/server.rs` `Daemon::run`, spawn the trigger alongside the interval scheduler and abort it on shutdown. After the existing `let scheduler = jobs::scheduler::spawn(store.clone(), jobs_config.clone());` line, add:
+
+```rust
+        let reflect_trigger =
+            jobs::scheduler::spawn_reflect_accumulation_trigger(store.clone(), jobs_config.clone());
+```
+
+and in the post-loop cleanup block, after `scheduler.abort();`, add:
+
+```rust
+        reflect_trigger.abort();
+```
+
+- [ ] **Step 8: run it.** Run: `cargo test -p rb-daemon accumulation_trigger` then `cargo test -p rb-daemon scheduler` — Expected: PASS (2 new trigger tests + the existing scheduler tests). Then `cargo build -p rb-daemon` (the `server.rs` wiring compiles).
+
+- [ ] **Step 9: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 10: commit.** Run: `git add crates/rb-daemon/src/jobs/reflect.rs crates/rb-daemon/src/jobs/scheduler.rs crates/rb-daemon/src/server.rs && git commit -m "feat(rb-daemon): add importance-accumulation trigger for the reflect job"` — Expected: one commit.
+
+---
+
+### Task E6: rb-daemon — wiremock end-to-end reflect (real `Synthesizer` over HTTP)
+
+E4 proved the job with a `FakeSynth`. E6 proves the PRODUCTION path: a real `rb_enrich::Synthesizer` over `wiremock` returning a canned insight, driven through `reflect::run`, asserting exactly one `insight` memory is inserted with `references` links to the correct sources.
+
+**Files:**
+- Test: `crates/rb-daemon/src/jobs/reflect.rs` (inline `#[cfg(test)]`) — uses `Synthesizer::with_endpoint` (public, added in E2) and the `wiremock` dev-dep (added to rb-daemon in D6)
+
+- [ ] **Step 1 RED: write the failing test.** Add to `crates/rb-daemon/src/jobs/reflect.rs`'s `#[cfg(test)] mod tests`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn end_to_end_reflect_over_wiremock_inserts_insight_with_links() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let model_json = serde_json::json!({
+            "content": "Synthesized: the system converges on single-writer discipline.",
+            "importance": 8,
+            "confidence": 0.9
+        })
+        .to_string();
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [ { "message": { "role": "assistant", "content": model_json } } ]
+            })))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let handle = StoreHandle::start(dir.path().join("rb.db"), DIM, 2).unwrap();
+        let ns = Namespace::Project("a".to_string());
+        let source_ids = seed_sources(&handle, &ns).await;
+
+        let base = format!("{}/v1", server.uri());
+        let synth = crate::jobs::reflect::env_synth(
+            rb_enrich::Synthesizer::with_endpoint("gpt-4o-mini", Some("k"), &base),
+        );
+
+        let summary = run(&handle, &cfg(), &synth).await.unwrap();
+        assert_eq!(summary.changed, 1, "one insight synthesized via live HTTP");
+
+        let listed = handle.list(ns.clone(), None, 100).await.unwrap();
+        let insight = listed
+            .iter()
+            .find(|m| m.memory_type == rb_types::MemoryType::Insight && !source_ids.contains(&m.id))
+            .expect("synthesized insight present");
+        assert!(insight.content.contains("single-writer discipline"));
+        let got = handle.get(ns.clone(), insight.id.clone()).await.unwrap().unwrap();
+        let targets: Vec<_> = got
+            .links
+            .iter()
+            .filter(|l| l.link_type == rb_types::LinkType::References)
+            .map(|l| l.target_id.clone())
+            .collect();
+        for sid in &source_ids {
+            assert!(targets.contains(sid), "insight references source {sid}");
+        }
+
+        handle.shutdown().await;
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-daemon end_to_end_reflect_over_wiremock` — Expected: FAIL initially only if `wiremock` is not yet a rb-daemon dev-dep (it was added in D6) or `Synthesizer::with_endpoint` is missing (added in E2). If both are present this may even pass on first try — that is acceptable for an integration test that exercises already-built pieces; if it passes immediately, still keep it (it locks the production wiring).
+
+- [ ] **Step 3 GREEN: (no new production code expected).** This test exercises `reflect::run` (E4), `Synthesizer::with_endpoint` (E2), and the `wiremock` dev-dep (D6) — all already built. If the test reveals a gap (e.g. `env_synth` not `pub(crate)` reachable from the test module — it is, same module), fix the minimal visibility issue. No new feature code.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-daemon end_to_end_reflect_over_wiremock` — Expected: PASS (1 test).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-daemon --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-daemon/src/jobs/reflect.rs && git commit -m "test(rb-daemon): end-to-end reflect over wiremock with real synthesizer"` — Expected: one commit.
+
+---
+
+### Part E gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: full workspace test.** Run: `cargo test --workspace` — Expected: PASS, 0 failures (all Part E tests plus the widened `JobKind` tests and every pre-existing test).
+
+- [ ] **Step 2: workspace clippy.** Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings (the reflect job + trigger return `rb_types::Error` or log-and-continue; the synthesizer fails safe to `None`; no `.unwrap()`/`.expect()`/`panic!` in non-test code; the key is never logged; the broadcast subscriber never blocks the writer — it drops on lag).
+
+- [ ] **Step 3: format check.** Run: `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: dependency policy (no new default deps in Part E).** Run: `cargo deny check` — Expected: `ok`. Part E adds NO new default runtime dependency: the `Synthesizer` reuses `rb-enrich`'s existing `reqwest`/`secrecy`/`serde_json`; the trigger reuses `tokio::broadcast` already in `rb-daemon`. Confirm with `cargo tree -e no-dev -p rb-daemon`.
+
+- [ ] **Step 5: single-writer + no-new-write-path audit.** Confirm by inspection that every mutation in `reconcile.rs` and `reflect.rs` goes through a `StoreHandle` method (`write`/`update`/`supersede`/`add_link`/`reembed`/`meta_set`) — i.e. through the single writer — and that the accumulation trigger only READS (`subscribe`, `get`) and calls `run_once` (which itself writes via the writer). No `SqliteStore` is opened or written directly outside the writer thread. This is a code-review verification, no code change.
+
+---
+
+## Final self-review (writing-plans checklist — done before this plan was finalized)
+
+- **(1) Every spec section has a Task.** Feature F (PPR): F1 pure PPR, F2 bounded subgraph read, F3 handle wrapper, F4 `graph_ppr` in `Signals`/`rank`, F5 recall wiring, F6 `rb-eval` hops-vs-PPR comparison, plus the documented scale bound (F1/F2 doc comments, verified at the F gate). Feature D (reconcile): D1 `JobKind::Reconcile`, D2 `ReconcileConfig` (disabled, `batch_limit`/`similarity_floor`, model/endpoint via rb-enrich env), D3 `Reconciler` returning MERGE/UPDATE/SUPERSEDE/NOOP, D4 meta markers, D5 the job with exact writer commands per decision + `Reembed` on content change + reconciled-watermark idempotency + namespace isolation + fail-safe, D6 wiremock end-to-end. Feature E (reflect): E1 `JobKind::Reflect`, E2 `Synthesizer`, E3 source read, E4 the job (insert `insight` + `references` links + composite embed via reembed + `last_reflected_at` watermark), E5 interval-OR-accumulation trigger off `MemoryChanged`, E6 wiremock end-to-end + trigger unit tests + watermark idempotency. Build order F → D → E enforced; each Part has a gate running `cargo test --workspace` / clippy / fmt / `cargo deny check`.
+- **(2) No placeholders.** Every step has complete, compilable test and implementation code (no "TBD"/"add error handling"/"similar to Task N"). The only deferred-to-P5 items are the explicitly-listed P5 primitives (`Reembed`, `embedding_input`, `rb-eval`, `confidence`/`contested`), which the plan references and does not re-plan, per the brief.
+- **(3) Type consistency across Tasks.** `JobKind::Reconcile` / `JobKind::Reflect`; `ReconcileConfig` / `ReflectConfig` (both added in D2 for a stable schema); `ReconcileDecision` (Merge/Update/Supersede/Noop) / `Reconciler`; `SynthesizedInsight` / `Synthesizer`; `graph_ppr` field name on `Signals`; `rb_search::{Graph, PprParams, graph_ppr_scores}`; `SubgraphEdge` and `link_subgraph` (store) / `read_link_subgraph` (handle inherent, distinct from the `MemoryBackend::link_subgraph` trait method); watermark/marker key names `rb:reflect:<ns>` (reflect) and `rb:reconciled:<ns>:<lo>:<hi>` (reconcile NOOP); meta accessors `meta_get`/`meta_set`; `ImportanceAccumulator`. All used verbatim across the Tasks that produce and consume them.

--- a/docs/plans/2026-06-02-rusty-brain-p7-apm-distribution.md
+++ b/docs/plans/2026-06-02-rusty-brain-p7-apm-distribution.md
@@ -1,0 +1,2348 @@
+# P7 — APM Package Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Implement Parts strictly in build order **A → B → C → D**; each Part ends with a gate that must be green before the next Part starts.
+
+**Goal:** Publish rusty-brain as a first-class Microsoft APM (Agent Package Manager) package — a committed `apm/apm.yml` plus bundled memory instructions/skills/prompts/hooks — and make the binary self-describing and the installer APM-aware: a read-only `rusty-brain apm emit|validate|doctor` CLI keeps the manifest in lockstep with the binary's MCP surface, and an `rb-install` APM delegation backend prefers `apm install` when `apm` is on PATH while falling back to the existing P4 direct-config installer, fail-open end to end.
+
+**Architecture:** P7 is additive and distribution-side. It adds no daemon, store, or wire-protocol changes. A new `apm` subcommand group on the `rusty-brain` binary emits the canonical stdio MCP descriptor (carrying `rb_proto::CONTRACT_VERSION`), validates a committed `apm.yml` against the package's expectations (correct stdio entry, no literal secrets, present `ref`), and runs a read-only `doctor` prerequisites probe — none of these mutate any config (mutation is APM's job). `rb-install` gains an `apm` backend that reuses P4's executable-bit PATH detection (`detect::find_binary_on_path`) to find `apm`, delegates to `apm install` via an `env_clear()`-hardened subprocess, and falls back to the existing per-CLI installer (`engine::run_install`) when `apm` is absent — every path fail-open. The package's YAML manifest declares one stdio MCP server (`command: rusty-brain`, `args: ["mcp"]`, `registry: false`) and a `dependencies.apm` mapping referencing the bundled artifacts by hash-pinnable git refs.
+
+**Tech Stack:** Rust 2021 (stable, pinned). Workspace crates touched: `rusty-brain` (new `apm` module + CLI subcommand), `rb-install` (new `apm_backend` module), plus committed data files under `apm/`. Reused: `clap` (CLI), `serde`/`serde_json` (descriptor/report types), `rb_proto::CONTRACT_VERSION` (version surfacing), `rb_install::detect::find_binary_on_path` (PATH+exec-bit detection), `rb_install::engine::run_install` (P4 fallback). One new dep — `serde_yaml_ng` (the maintained drop-in fork of `serde_yaml`; MIT/Apache-2.0, no advisory, deny-clean) — added in Part B for parsing `apm.yml` during `validate` (YAML is APM's manifest format; the workspace has no YAML parser). `serde_yaml_ng` is chosen because the original `serde_yaml` is unmaintained (RUSTSEC-2024-0320) and would fail the repo's `cargo deny check`. Tests are TDD, in-process, offline: a fake `apm` stub script on PATH asserts delegation args; a fixture test parses the committed `apm/apm.yml`; the real `apm install` smoke test is `#[ignore]`.
+
+**Reference spec:** `docs/specs/2026-06-02-rusty-brain-p7-apm-distribution.md` — §5 (package shape + manifest), §6 (`apm` CLI), §7 (`rb-install` backend), §8 (security), §9 (testing). Architecture: `docs/specs/2026-05-31-rusty-brain-architecture-design.md` §12 (interfaces/`ContractVersion`), §14 (security). Style template: `docs/plans/2026-06-02-rusty-brain-p3-deferred-features.md`.
+
+---
+
+## Hard rules (carry forward from P0–P4; apply to every task)
+
+- **TDD:** failing test first (RED), minimal implementation (GREEN), then clippy + fmt, then commit. One logical change per commit.
+- **Conventional commits**, lowercase, crate-scoped, one line, **NO AI attribution** (no "Generated with…", no `Co-Authored-By`).
+- **`rusty-brain apm` is read-only:** `emit`/`validate`/`doctor` NEVER mutate any config, never write the daemon, never spawn `apm install`. Mutation is APM's job (or `rb-install`'s fallback). `doctor` may run `<bin> --version`-style probes but writes nothing.
+- **`rb-install` APM backend is fail-open end to end:** detection failure, a missing `apm`, or a non-zero `apm install` exit logs and falls back to the P4 direct-config installer or no-ops — it NEVER breaks a user's harness setup and NEVER returns a non-zero process exit (mirrors P4 `exit_code` always-0).
+- **No secrets in `apm.yml`:** the manifest uses env interpolation only (`${VAR}`-style); `rusty-brain apm validate` rejects any literal secret (a value that looks like a `voy-…` / `sk-…` / hex/base64 API token, or a `VOYAGE_API_KEY`-keyed literal) with a non-zero exit. The committed `apm/apm.yml` contains NO secret.
+- **stdio transport only / local model unchanged:** the package's MCP entry is `transport: stdio`, `registry: false`, `command: rusty-brain`, `args: ["mcp"]`; the daemon's 0600 UDS and namespace isolation are untouched. No network surface is added.
+- **Subprocess hardening (global security rule):** any `apm` subprocess spawn uses `Command::env_clear()` then sets ONLY the vars it needs (`PATH`, `HOME`/`USERPROFILE`) — never inherit the parent environment wholesale. PATH detection for `apm` requires an executable bit (reuse `rb_install::detect::find_binary_on_path`). **TOCTOU:** re-check `apm` presence immediately before spawning `apm install`, not just at backend selection.
+- **Capture hooks stay fail-open:** the optional `apm/hooks/` artifact ports the P4 capture-hook ethos — a hook installed via the package never blocks or breaks an agent session.
+- **No-panic in non-test code:** workspace lints deny `unwrap_used`/`expect_used`/`panic`. Return `rb_types::Error`/`anyhow::Error` (binary top level) or a typed module error. Test modules opt out with `#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]`.
+- **Default closure unchanged:** `rb-install`/`rb-hooks`/`rb-agents` MUST stay out of the default `rusty-brain` (non-dev) dependency closure (CI `build-agents` job asserts this). The `apm` module lives in the `rusty-brain` binary and pulls in NO agent crate.
+- **Per-Part gate** (final task of each Part): `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`. Parts that add a dep (Part B adds `serde_yaml_ng`, the maintained fork of the unmaintained `serde_yaml`/RUSTSEC-2024-0320) also run `cargo deny check`.
+- **Commands run from the worktree root** (so commands are plain `cargo test -p <crate>`). The committed package lives at `apm/` under the repo root.
+
+## Seam map (verified against `origin/main` + the local P3 worktree; the exact code each Part builds on)
+
+| Seam | Location | Used by |
+|---|---|---|
+| `CONTRACT_VERSION: u32 = 1` | `crates/rb-proto/src/messages.rs` (re-exported `rb_proto::CONTRACT_VERSION`) | B (`apm emit` embeds it) |
+| clap `Command` enum (`Serve`/`Mcp`/`Remember`/…/`Evolve`) + `#[arg(long, global=true)] json` | `crates/rusty-brain/src/cli.rs` | B (adds `Apm { … }`) |
+| `run(cli, namespace)` → `Serve`/`Mcp` early-handled, else `run_client` | `crates/rusty-brain/src/run.rs` | B (adds an `Apm` arm BEFORE the client connect, since `apm` never touches the daemon) |
+| MCP entry contract: stdio `command: rusty-brain`, `args: ["mcp"]`; daemon auto-starts on first connect | `crates/rusty-brain/src/mcp.rs` (`run_mcp`), spec §4/§5 | A, B (`emit` descriptor mirrors this) |
+| `find_binary_on_path(name) -> Option<PathBuf>` — `$PATH` scan requiring an exec bit; no shell | `crates/rb-install/src/detect.rs` (re-exported `rb_install::find_binary_on_path`) | C (detects `apm`) |
+| `version_of(&Path) -> Option<String>` — `<bin> --version` under a 2s timeout, kills the child | `crates/rb-install/src/detect.rs` | C (optional `apm --version` in the report) |
+| `run_install(installers, hooks_bin, scope, dry_run) -> InstallReport`, `resolve_hooks_bin()`, `select_installers()` | `crates/rb-install/src/engine.rs` | C (the P4 fallback path) |
+| `InstallReport` / `AgentReport` / `AgentStatus` / `ReportStatus` JSON report types + `roll_up` | `crates/rb-install/src/report.rs` | C (the backend returns one of these) |
+| `InstallScope::{Project(PathBuf),Global}` | `rb_agents::install::InstallScope` (via `rb-install`) | C (scope plumbed to fallback + delegation cwd) |
+| `Cli`/`Command` (`Install`/`Uninstall`/`Status`) + `execute`/`render`/`exit_code` (always 0) | `crates/rb-install/src/cli.rs` | C (Install routes through the apm backend) |
+| `assert_cmd::Command::cargo_bin(...)`, fake-binary-on-PATH test pattern (`fake_claude_path`) | `crates/rb-install/tests/cli.rs` | C, D (fake `apm` stub + fixture tests) |
+| `deny.toml` permissive allowlist + crate-scoped exceptions; `[graph] all-features = true` | `deny.toml` (origin/main) | B (confirm `serde_yaml_ng` license is allowed) |
+| CI jobs `fmt`/`clippy-test`/`deny`/`audit`/`build-agents` | `.github/workflows/ci.yml` (origin/main) | D (adds an `apm-manifest` validation job) |
+
+## Build order & dependencies
+
+```text
+Part A  APM package artifacts          (independent data files: apm/apm.yml + instructions/skills/prompts/hooks; a fixture test parses + secret-scans the manifest)
+Part B  rusty-brain `apm` CLI          (emit/validate/doctor on the binary; depends on A's manifest for the round-trip + validate fixture)
+Part C  rb-install APM backend         (capability detection + delegation + P4 fallback + fail-open; reuses C's detect/engine seams; depends on nothing in A/B at compile time)
+Part D  CI manifest validation + gate  (CI job runs `rusty-brain apm validate apm/apm.yml`; final cross-Part gate)
+```
+
+Parts are mostly independent: Part C (the `rb-install` backend) compiles without Parts A/B. The ordering puts the committed package first (A) so Part B's `validate` and the round-trip test have a real manifest to assert against, and Part D wires CI once the binary subcommand exists. Part B introduces the only new dependency (`serde_yaml_ng`) and runs `cargo deny check` in its gate.
+
+---
+
+## Part A — APM package artifacts (the committed `apm/` package)
+
+This Part lands the static, hand-authored package APM consumes: the `apm.yml` manifest declaring the stdio `rusty-brain` MCP server and a `dependencies.apm` mapping of bundled artifacts, plus the bundled `instructions/`, `skills/memory/`, `prompts/`, and an optional fail-open `hooks/` entry. These are data files (no Rust crate), so the only test is a fixture test compiled into the `rusty-brain` binary's test target that reads the committed `apm/apm.yml`, asserts it parses as JSON-compatible-but-YAML-shaped text via a minimal structural check (Part A uses a string-level check; Part B upgrades to a typed YAML parse once `serde_yaml_ng` is added), confirms the stdio MCP entry is present, and scans for literal secrets.
+
+HARD RULES honored throughout: NO secret appears in any committed file (env interpolation only); the MCP entry is `transport: stdio` / `registry: false`; the bundled hook ports the fail-open ethos.
+
+---
+
+### Task A1: `apm/apm.yml` — the package manifest
+
+Author the committed manifest: one stdio MCP server plus a `dependencies.apm` mapping (object shape — APM rejects a flat list) referencing the bundled artifacts by hash-pinnable git refs.
+
+**Files:**
+- Create: apm/apm.yml
+- Create: crates/rusty-brain/tests/apm_manifest.rs
+
+**Test:** a `rusty-brain` integration test reads `apm/apm.yml` from the repo root, asserts the stdio MCP entry exists, and finds no literal secret.
+
+- [ ] **Step 1 RED: write the failing fixture test.** Create `crates/rusty-brain/tests/apm_manifest.rs` with this exact content:
+
+```rust
+//! Fixture test: the committed APM package manifest (`apm/apm.yml`) must declare
+//! the stdio `rusty-brain` MCP server and contain NO literal secret. This is the
+//! string-level guard for Part A; Part B replaces the structural checks with a
+//! typed `serde_yaml_ng` parse once that dependency exists. Run from the workspace
+//! root so the manifest path resolves relative to the repo.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::path::PathBuf;
+
+/// Resolve `<repo-root>/apm/apm.yml` from this crate's manifest dir.
+/// `CARGO_MANIFEST_DIR` is `<root>/crates/rusty-brain`, so go up two levels.
+fn manifest_path() -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    crate_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("apm").join("apm.yml"))
+        .expect("repo root resolves from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn committed_manifest_exists_and_declares_stdio_mcp_entry() {
+    let path = manifest_path();
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    // The stdio MCP entry, asserted at the string level (Part A).
+    assert!(text.contains("transport: stdio"), "manifest must use stdio transport:\n{text}");
+    assert!(text.contains("registry: false"), "manifest MCP entry must set registry: false:\n{text}");
+    assert!(text.contains("command: rusty-brain"), "manifest must declare command: rusty-brain:\n{text}");
+    assert!(text.contains(r#"["mcp"]"#) || text.contains("- mcp") || text.contains("- \"mcp\""),
+        "manifest MCP args must invoke the `mcp` subcommand:\n{text}");
+    assert!(text.contains("name: rusty-brain"), "manifest MCP entry must be named rusty-brain:\n{text}");
+}
+
+#[test]
+fn committed_manifest_has_no_literal_secret() {
+    let path = manifest_path();
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    // A real Voyage key starts `voy-`; OpenAI `sk-`. Env interpolation (${VAR})
+    // is the ONLY way a token may appear. A bare `voy-…`/`sk-…` token is a leak.
+    for needle in ["voy-", "sk-", "Bearer "] {
+        assert!(
+            !text.contains(needle),
+            "manifest must not contain a literal secret token ({needle:?}); use env interpolation:\n{text}"
+        );
+    }
+    // If VOYAGE_API_KEY is mentioned at all, it must be via interpolation, never `=`/`:` to a literal.
+    if let Some(idx) = text.find("VOYAGE_API_KEY") {
+        let rest = &text[idx..];
+        assert!(
+            rest.contains("${VOYAGE_API_KEY}") || rest.contains("$VOYAGE_API_KEY") || rest.contains("# "),
+            "VOYAGE_API_KEY may appear only via env interpolation or a comment:\n{text}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest` — Expected: FAIL — `apm/apm.yml` does not exist yet, so both tests panic in `read_to_string` (`No such file or directory`).
+
+- [ ] **Step 3 GREEN: create the manifest.** Create `apm/apm.yml` with this exact content:
+
+```yaml
+# rusty-brain — Microsoft APM (Agent Package Manager) package manifest.
+#
+# `apm install` wires this into every detected harness (GitHub Copilot, Claude
+# Code, Cursor, Codex, OpenCode, Gemini, Windsurf): it registers the stdio
+# `rusty-brain` MCP server and installs the bundled memory instructions, skills,
+# prompts, and the optional fail-open capture hook. `apm.lock.yaml` hash-pins the
+# resolved tree.
+#
+# PREREQUISITE (out of band): the `rusty-brain` binary must be on PATH
+# (cargo install / Homebrew / release artifact). APM wires AGENT CONTEXT — not
+# binaries. `rusty-brain apm doctor` checks this prerequisite.
+#
+# SECURITY: no secret appears here. The Voyage embedding key lives in the
+# environment / OS keychain and is read by the daemon, not the manifest. Any
+# token would be referenced via env interpolation (${VOYAGE_API_KEY}) only.
+# `rusty-brain apm validate apm/apm.yml` rejects any literal secret in CI.
+
+name: rusty-brain
+version: 0.1.0
+description: Shared semantic memory for AI agents — one MCP server + memory skills, prompts, instructions, and a fail-open capture hook, wired across all harnesses.
+
+dependencies:
+  # MCP servers wired into every detected harness. rusty-brain is a LOCAL stdio
+  # server: `apm` launches `rusty-brain mcp`, and the daemon auto-starts on the
+  # first MCP connection (no remote endpoint, no secret, no network surface).
+  mcp:
+    - name: rusty-brain
+      registry: false
+      transport: stdio
+      command: rusty-brain
+      args: ["mcp"]
+
+  # Bundled agent-context artifacts (instructions / skills / prompts / hooks).
+  # APM requires the MAPPING shape here (a flat list is rejected). Each entry
+  # references this package's git repo, a virtual subdirectory or file, and a
+  # hash-pinnable `ref` (resolved + hashed into apm.lock.yaml).
+  apm:
+    rusty-brain-using-memory:
+      git: brianluby/rusty-brain
+      path: apm/instructions/using-memory.md
+      ref: v0.1.0
+    rusty-brain-memory-skill:
+      git: brianluby/rusty-brain
+      path: apm/skills/memory
+      ref: v0.1.0
+    rusty-brain-recall-context:
+      git: brianluby/rusty-brain
+      path: apm/prompts/recall-context.prompt.md
+      ref: v0.1.0
+    rusty-brain-capture-hook:
+      git: brianluby/rusty-brain
+      path: apm/hooks
+      ref: v0.1.0
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest` — Expected: PASS (2 tests: `committed_manifest_exists_and_declares_stdio_mcp_entry`, `committed_manifest_has_no_literal_secret`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --test apm_manifest -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff; YAML is untouched by rustfmt).
+
+- [ ] **Step 6: commit.** Run: `git add apm/apm.yml crates/rusty-brain/tests/apm_manifest.rs && git commit -m "feat(apm): add committed apm.yml manifest with stdio rusty-brain MCP entry"` — Expected: one commit.
+
+---
+
+### Task A2: `apm/instructions/using-memory.md` — always-on context
+
+Bundle the instructions artifact: when/why an agent uses shared memory. This is always-on harness context (no test gate beyond the existing fixture test, which we extend to assert the file exists).
+
+**Files:**
+- Create: apm/instructions/using-memory.md
+- Modify: crates/rusty-brain/tests/apm_manifest.rs
+
+**Test:** the fixture test asserts the bundled instructions file exists at the path the manifest references.
+
+- [ ] **Step 1 RED: extend the fixture test.** Append this test to `crates/rusty-brain/tests/apm_manifest.rs` (inside the file, after the existing tests):
+
+```rust
+/// Resolve `<repo-root>/apm/<rel>` from this crate's manifest dir.
+fn apm_path(rel: &str) -> PathBuf {
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    crate_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("apm").join(rel))
+        .expect("repo root resolves from CARGO_MANIFEST_DIR")
+}
+
+#[test]
+fn bundled_instructions_file_exists() {
+    let path = apm_path("instructions/using-memory.md");
+    assert!(path.is_file(), "manifest references {} which must exist", path.display());
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("remember"), "instructions must mention remember:\n{text}");
+    assert!(text.contains("recall"), "instructions must mention recall:\n{text}");
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_instructions_file_exists` — Expected: FAIL — the file does not exist (`assert!(path.is_file())` fails).
+
+- [ ] **Step 3 GREEN: create the instructions file.** Create `apm/instructions/using-memory.md` with this exact content:
+
+```markdown
+# Using rusty-brain shared memory
+
+You have access to **rusty-brain**, a shared semantic-memory service exposed as
+an MCP server. It is project-scoped: every memory you store or recall belongs to
+the current project's namespace (resolved from the git root), so teammates and
+future sessions on the same project share the same memory. The daemon starts
+automatically on first use.
+
+## When to RECALL (read)
+
+Before starting non-trivial work, recall what is already known:
+
+- At the start of a session or a new task, call the recall tool with a short
+  description of what you are about to do ("auth refactor", "flaky CI on macOS").
+- When you hit a decision that smells previously-made ("why is this configured
+  this way?"), recall before re-deriving it.
+- Prefer recall over re-reading large files when the answer is a remembered
+  decision, gotcha, or convention.
+
+## When to REMEMBER (write)
+
+Store a memory when something is worth carrying across sessions — not routine
+chatter:
+
+- A non-obvious **decision** and its rationale ("we pin tokio to X because Y").
+- A **bug fix** and its root cause, so the same trap is not re-sprung.
+- A **convention** the project follows that is not written down elsewhere.
+- A **gotcha** that cost real time to discover.
+
+Set an importance (1–10) honestly: a one-off note is low; an architectural
+invariant is high. Add a short context string and tags so future recall is sharp.
+
+## What NOT to remember
+
+- Secrets, tokens, or credentials of any kind.
+- Transient state (a value true only for this one run).
+- Anything you would not want a teammate to read months from now.
+
+Memory is shared and durable. Treat it like a project wiki, not a scratchpad.
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_instructions_file_exists` — Expected: PASS.
+
+- [ ] **Step 5: lint+format.** Run: `cargo fmt --all --check` (Expected: no diff) then `cargo clippy -p rusty-brain --test apm_manifest -- -D warnings` (Expected: no warnings).
+
+- [ ] **Step 6: commit.** Run: `git add apm/instructions/using-memory.md crates/rusty-brain/tests/apm_manifest.rs && git commit -m "feat(apm): bundle using-memory instructions artifact"` — Expected: one commit.
+
+---
+
+### Task A3: `apm/skills/memory/` — the remember/recall skill
+
+Bundle the memory skill (an APM `skills/` directory). A skill is a directory with a `SKILL.md` describing the remember/recall/context workflow.
+
+**Files:**
+- Create: apm/skills/memory/SKILL.md
+- Modify: crates/rusty-brain/tests/apm_manifest.rs
+
+**Test:** the fixture test asserts the skill directory + `SKILL.md` exist and name the rusty-brain tools.
+
+- [ ] **Step 1 RED: extend the fixture test.** Append this test to `crates/rusty-brain/tests/apm_manifest.rs`:
+
+```rust
+#[test]
+fn bundled_memory_skill_exists() {
+    let dir = apm_path("skills/memory");
+    assert!(dir.is_dir(), "skill dir {} must exist", dir.display());
+    let skill = dir.join("SKILL.md");
+    assert!(skill.is_file(), "{} must exist", skill.display());
+    let text = std::fs::read_to_string(&skill).unwrap();
+    // The skill must teach the three core memory operations.
+    assert!(text.contains("remember"), "SKILL.md must describe remember:\n{text}");
+    assert!(text.contains("recall"), "SKILL.md must describe recall:\n{text}");
+    assert!(text.contains("context"), "SKILL.md must describe context:\n{text}");
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_memory_skill_exists` — Expected: FAIL — the directory/file do not exist.
+
+- [ ] **Step 3 GREEN: create the skill.** Create `apm/skills/memory/SKILL.md` with this exact content:
+
+```markdown
+---
+name: memory
+description: Store and retrieve durable project knowledge via rusty-brain shared memory. Use when a decision, bug fix, convention, or gotcha is worth carrying across sessions, or when starting a task that prior work may already inform.
+---
+
+# Memory skill (rusty-brain)
+
+This skill drives the rusty-brain MCP tools to keep durable, shared project
+knowledge. Memory is namespaced to the current project and shared across
+sessions and teammates; the daemon auto-starts on first use.
+
+## Workflow
+
+1. **Recall first.** At the start of a task, call the recall tool with a short
+   query describing the work. Skim the results before acting — a remembered
+   decision or gotcha can save a full investigation.
+2. **Work.** Do the task, noting anything non-obvious you discover.
+3. **Remember selectively.** When you learn something durable — a decision and
+   its rationale, a bug's root cause, a project convention, a costly gotcha —
+   call the remember tool. Pick an honest importance (1–10), add a one-line
+   context, and tag it.
+4. **Load context on demand.** Use the context tool to pull the project's recent
+   and most-important memories when you need a fast orientation.
+
+## Operations
+
+- **recall(query, [type], [tags], [limit])** — semantic search over project
+  memory. Returns ranked notes.
+- **remember(content, [type], [importance], [context], [tags])** — store a new
+  memory. `type` is one of the memory types (e.g. `insight`, `bug_fix`,
+  `decision`); `importance` is 1–10.
+- **context()** — the project context payload: recent + most-important memories.
+
+## Rules
+
+- Never store secrets, tokens, or credentials.
+- Don't remember transient state or routine chatter — only durable knowledge.
+- Prefer recall over re-deriving a previously-made decision.
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_memory_skill_exists` — Expected: PASS.
+
+- [ ] **Step 5: lint+format.** Run: `cargo fmt --all --check` (Expected: no diff) then `cargo clippy -p rusty-brain --test apm_manifest -- -D warnings` (Expected: no warnings).
+
+- [ ] **Step 6: commit.** Run: `git add apm/skills/memory/SKILL.md crates/rusty-brain/tests/apm_manifest.rs && git commit -m "feat(apm): bundle memory skill (remember/recall/context workflow)"` — Expected: one commit.
+
+---
+
+### Task A4: `apm/prompts/recall-context.prompt.md` — one-shot recall prompt
+
+Bundle the prompt artifact (APM `.prompt.md` form): a one-shot "load project memory" prompt.
+
+**Files:**
+- Create: apm/prompts/recall-context.prompt.md
+- Modify: crates/rusty-brain/tests/apm_manifest.rs
+
+**Test:** the fixture test asserts the prompt file exists at the manifest-referenced path.
+
+- [ ] **Step 1 RED: extend the fixture test.** Append this test to `crates/rusty-brain/tests/apm_manifest.rs`:
+
+```rust
+#[test]
+fn bundled_recall_prompt_exists() {
+    let path = apm_path("prompts/recall-context.prompt.md");
+    assert!(path.is_file(), "{} must exist", path.display());
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("recall"), "prompt must invoke recall:\n{text}");
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_recall_prompt_exists` — Expected: FAIL — file does not exist.
+
+- [ ] **Step 3 GREEN: create the prompt.** Create `apm/prompts/recall-context.prompt.md` with this exact content:
+
+```markdown
+---
+name: recall-context
+description: Load the current project's shared memory before starting work.
+---
+
+Before we begin, orient yourself using rusty-brain shared memory for this
+project:
+
+1. Call the rusty-brain **context** tool to load the project's recent and
+   most-important memories.
+2. Call **recall** with a short query describing what we are about to work on:
+   "{{task}}".
+3. Summarize, in 3–5 bullets, the decisions, conventions, and gotchas that are
+   relevant to "{{task}}". Cite the memory ids you used.
+
+If memory is empty or nothing is relevant, say so plainly and proceed — do not
+invent context.
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_recall_prompt_exists` — Expected: PASS.
+
+- [ ] **Step 5: lint+format.** Run: `cargo fmt --all --check` (Expected: no diff) then `cargo clippy -p rusty-brain --test apm_manifest -- -D warnings` (Expected: no warnings).
+
+- [ ] **Step 6: commit.** Run: `git add apm/prompts/recall-context.prompt.md crates/rusty-brain/tests/apm_manifest.rs && git commit -m "feat(apm): bundle recall-context one-shot prompt"` — Expected: one commit.
+
+---
+
+### Task A5: `apm/hooks/` — optional fail-open capture hook descriptor
+
+Bundle the optional capture-hook artifact. It documents and declares the fail-open `rusty-brain-hooks` capture hook (the P4 binary) so harnesses that support hooks can install it via APM. The hook is fail-open: it never blocks or breaks a session.
+
+**Files:**
+- Create: apm/hooks/capture.md
+- Modify: crates/rusty-brain/tests/apm_manifest.rs
+
+**Test:** the fixture test asserts the hooks artifact exists and documents fail-open behavior.
+
+- [ ] **Step 1 RED: extend the fixture test.** Append this test to `crates/rusty-brain/tests/apm_manifest.rs`:
+
+```rust
+#[test]
+fn bundled_capture_hook_exists_and_is_fail_open() {
+    let path = apm_path("hooks/capture.md");
+    assert!(path.is_file(), "{} must exist", path.display());
+    let text = std::fs::read_to_string(&path).unwrap().to_lowercase();
+    assert!(
+        text.contains("fail-open") || text.contains("fail open"),
+        "the bundled capture hook must document fail-open behavior:\n{text}"
+    );
+    assert!(text.contains("rusty-brain-hooks"), "hook must name the rusty-brain-hooks binary:\n{text}");
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_capture_hook_exists_and_is_fail_open` — Expected: FAIL — file does not exist.
+
+- [ ] **Step 3 GREEN: create the hook descriptor.** Create `apm/hooks/capture.md` with this exact content:
+
+```markdown
+---
+name: capture
+description: Optional fail-open capture hook that records agent activity into rusty-brain shared memory.
+---
+
+# Capture hook (rusty-brain)
+
+This hook wires the `rusty-brain-hooks` binary into a harness's post-tool /
+session events so notable agent activity is captured into shared memory
+automatically. It is **optional** — the MCP server alone gives full
+remember/recall — and **fail-open**: if the hook binary is missing, the daemon
+is unreachable, or anything goes wrong, the hook returns success and the agent
+session continues unblocked. A capture hook MUST NEVER block, slow, or break a
+session.
+
+## Prerequisite
+
+The `rusty-brain-hooks` binary must be on PATH (installed alongside `rusty-brain`
+via cargo / Homebrew / release artifact). If it is absent, this hook is inert and
+sessions are unaffected.
+
+## Behavior
+
+- Reads the harness's hook JSON on stdin, normalizes it, and forwards a
+  best-effort observation to the running daemon.
+- On ANY error (parse failure, missing binary, daemon down, timeout) it exits
+  successfully and emits no blocking output — fail-open by construction.
+- Captures nothing sensitive: it records activity metadata, never secrets.
+
+## Installation
+
+`apm install` wires this hook into harnesses that support a JSON hooks block.
+Harnesses without a JSON hooks surface (e.g. plugin-only CLIs) skip it; the MCP
+server still provides full memory access there.
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest bundled_capture_hook_exists_and_is_fail_open` — Expected: PASS.
+
+- [ ] **Step 5: lint+format.** Run: `cargo fmt --all --check` (Expected: no diff) then `cargo clippy -p rusty-brain --test apm_manifest -- -D warnings` (Expected: no warnings).
+
+- [ ] **Step 6: commit.** Run: `git add apm/hooks/capture.md crates/rusty-brain/tests/apm_manifest.rs && git commit -m "feat(apm): bundle optional fail-open capture hook descriptor"` — Expected: one commit.
+
+---
+
+### Task A6: Part A gate
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: workspace tests — Run:** `cargo test --workspace` — Expected: PASS, 0 failures (the new `apm_manifest` fixture test runs as part of the `rusty-brain` test target).
+
+- [ ] **Step 2: clippy — Run:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+
+- [ ] **Step 3: format — Run:** `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: supply chain — Run:** `cargo deny check` — Expected: ok (`licenses ok`, `advisories ok`, `sources ok`; `bans` may `warn` only). Part A added no dep, so this is unchanged from main.
+
+- [ ] **Step 5: commit (only if any formatting touch-up was needed) — Run:** `git add -A && git commit -m "chore(apm): part A gate green"` — Expected: a commit only if a fixup was needed; otherwise nothing to commit.
+
+---
+
+## Part B — `rusty-brain apm` CLI (emit / validate / doctor)
+
+This Part adds the read-only `apm` subcommand group to the `rusty-brain` binary. `emit` prints the canonical stdio MCP descriptor for *this* binary (command/args + `ContractVersion`), so the published manifest is generated, not hand-drifted. `validate [path]` parses an `apm.yml` and rejects embedded secrets, a missing `ref`, and a malformed/absent MCP entry, exiting non-zero on a problem. `doctor` reports prerequisites (`rusty-brain` on PATH, `apm` present, harnesses detectable) read-only. This Part adds the one new dependency, `serde_yaml_ng` (the maintained fork of the unmaintained `serde_yaml`/RUSTSEC-2024-0320), used only by `validate` to parse the manifest.
+
+HARD RULES honored throughout: `apm` commands NEVER mutate config, write the daemon, or spawn `apm install`; the descriptor mirrors the spec's stdio contract exactly; `validate` is the security checkpoint that rejects literal secrets; no `.unwrap()`/`.expect()`/`panic!` in non-test code.
+
+---
+
+### Task B1: `serde_yaml_ng` dependency
+
+Add `serde_yaml_ng` to the workspace and to the `rusty-brain` crate. It is the maintained drop-in fork of `serde_yaml` (same API), chosen because the original `serde_yaml` is unmaintained (RUSTSEC-2024-0320) and would fail the repo's `cargo deny check` advisories gate. It is MIT/Apache-2.0 (deny-clean) and used only by `apm validate` to parse the manifest. The committed `apm.yml` is generated/authored, not parsed by `emit`, so `emit` needs no new dep.
+
+**Files:**
+- Modify: Cargo.toml (workspace `[workspace.dependencies]`)
+- Modify: crates/rusty-brain/Cargo.toml (`[dependencies]`)
+
+**Test:** a compile-level smoke test in the `apm` module references `serde_yaml_ng::Value` (added in Task B3); for this task the gate is `cargo build -p rusty-brain` succeeding with the new dep wired.
+
+- [ ] **Step 1 RED: prove the dep is missing.** Run: `cargo tree -p rusty-brain 2>/dev/null | grep -i serde_yaml_ng; echo "exit=$?"` — Expected: `exit=1` (grep found nothing) — `serde_yaml_ng` is not yet a dependency.
+
+- [ ] **Step 2 GREEN: add the workspace dependency.** Edit `Cargo.toml` (workspace root) and add this line to `[workspace.dependencies]`, immediately after the existing `toml = "0.8"` line:
+
+```toml
+serde_yaml_ng = "0.10"
+```
+
+- [ ] **Step 3 GREEN: wire it into `rusty-brain`.** Edit `crates/rusty-brain/Cargo.toml` and add this line to `[dependencies]`, immediately after the existing `serde_json = { workspace = true }` line:
+
+```toml
+serde_yaml_ng = { workspace = true }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo build -p rusty-brain` (Expected: PASS — `serde_yaml_ng` resolves and the crate builds) then `cargo tree -p rusty-brain 2>/dev/null | grep -i serde_yaml_ng; echo "exit=$?"` (Expected: `exit=0` — `serde_yaml_ng v0.10.x` now appears).
+
+- [ ] **Step 5: supply-chain check (Part adds a dep) — Run:** `cargo deny check 2>&1 | tail -20; echo "exit=${PIPESTATUS[0]}"` — Expected: `exit=0`, `licenses ok`, `advisories ok`, `sources ok` — `serde_yaml_ng` (and its `unsafe-libyaml`/`indexmap` tree) are MIT/Apache-2.0 with NO open advisory, already in the allow-list. (The maintained `serde_yaml_ng` is used precisely because the original `serde_yaml` is unmaintained — RUSTSEC-2024-0320 — and would FAIL this `cargo deny check advisories` gate.) If a NEW permissive SPDX id is flagged, add only that id to the `allow` array in `deny.toml` (never a copyleft license) and re-run; if a copyleft license appears, STOP and flag it.
+
+- [ ] **Step 6: lint+format.** Run: `cargo fmt --all --check` (Expected: no diff — TOML-only) then `cargo clippy -p rusty-brain -- -D warnings` (Expected: no warnings).
+
+- [ ] **Step 7: commit.** Run: `git add Cargo.toml crates/rusty-brain/Cargo.toml Cargo.lock && git commit -m "build(rusty-brain): add serde_yaml_ng for apm manifest validation"` — Expected: one commit (include `Cargo.lock` if the repo tracks it; if `deny.toml` changed, add it too with a separate `chore:` commit per the Part B gate).
+
+---
+
+### Task B2: `apm` module — the canonical MCP descriptor (`emit`)
+
+Create the `apm` module with the descriptor type and the `emit` function that renders the canonical stdio MCP entry for this binary, carrying `rb_proto::CONTRACT_VERSION`. The descriptor is a serde struct so `emit` round-trips through `validate` (Task B4).
+
+**Files:**
+- Create: crates/rusty-brain/src/apm.rs
+- Modify: crates/rusty-brain/src/lib.rs
+
+**Test:** unit tests in `apm.rs` assert the emitted descriptor names `rusty-brain`, uses stdio/`registry: false`/`command: rusty-brain`/`args: ["mcp"]`, and embeds the live `CONTRACT_VERSION`.
+
+- [ ] **Step 1 RED: write the failing test + skeleton.** Create `crates/rusty-brain/src/apm.rs` with this exact content (the impl is a stub that fails the tests until Step 3):
+
+```rust
+//! `rusty-brain apm` — read-only manifest emit / validate / doctor.
+//!
+//! These commands keep the published APM package in lockstep with this binary's
+//! actual MCP surface and `ContractVersion`. They are STRICTLY read-only: they
+//! never mutate any harness config, never write the daemon, and never spawn
+//! `apm install` (mutation is APM's job, or `rb-install`'s fallback).
+
+use rb_proto::CONTRACT_VERSION;
+use serde::Serialize;
+
+/// The canonical stdio MCP descriptor for THIS rusty-brain binary. Serialized by
+/// `apm emit` so the published `apm.yml` MCP entry is generated, not drifted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct McpDescriptor {
+    /// MCP server name. Stable: `rusty-brain`.
+    pub name: String,
+    /// Local stdio server, not a registry reference.
+    pub registry: bool,
+    /// Transport: always `stdio`.
+    pub transport: String,
+    /// The binary to launch.
+    pub command: String,
+    /// The subcommand args: `["mcp"]`.
+    pub args: Vec<String>,
+    /// The wire contract version this binary speaks (informational; surfaced so
+    /// the package can detect binary/manifest drift).
+    pub contract_version: u32,
+}
+
+/// Build the canonical descriptor for this binary.
+#[must_use]
+pub fn descriptor() -> McpDescriptor {
+    // STUB — replaced in Step 3.
+    McpDescriptor {
+        name: String::new(),
+        registry: true,
+        transport: String::new(),
+        command: String::new(),
+        args: Vec::new(),
+        contract_version: 0,
+    }
+}
+
+/// Render the descriptor as a human-readable YAML-shaped MCP entry suitable for
+/// pasting under `dependencies.mcp` in an `apm.yml`.
+#[must_use]
+pub fn emit() -> String {
+    // STUB — replaced in Step 3.
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+
+    #[test]
+    fn descriptor_matches_the_stdio_contract() {
+        let d = descriptor();
+        assert_eq!(d.name, "rusty-brain");
+        assert!(!d.registry, "rusty-brain is a local stdio server, not a registry ref");
+        assert_eq!(d.transport, "stdio");
+        assert_eq!(d.command, "rusty-brain");
+        assert_eq!(d.args, vec!["mcp".to_string()]);
+        assert_eq!(d.contract_version, CONTRACT_VERSION);
+    }
+
+    #[test]
+    fn emit_renders_the_stdio_entry() {
+        let out = emit();
+        assert!(out.contains("name: rusty-brain"), "{out}");
+        assert!(out.contains("registry: false"), "{out}");
+        assert!(out.contains("transport: stdio"), "{out}");
+        assert!(out.contains("command: rusty-brain"), "{out}");
+        assert!(out.contains("mcp"), "{out}");
+        // The live contract version is surfaced as a comment, not a manifest field
+        // (APM's MCP schema has no contract_version key), so it never breaks parse.
+        assert!(out.contains(&format!("ContractVersion {CONTRACT_VERSION}")), "{out}");
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --lib apm::tests` — Expected: FAIL — the stub `descriptor()`/`emit()` return empties, so every assertion fails (the module is not yet declared in `lib.rs`, so this first fails to compile with an unresolved-module error; the assertions fail once Step 3a wires the module).
+
+- [ ] **Step 3a GREEN: wire the module.** Edit `crates/rusty-brain/src/lib.rs` to declare the `apm` module. Replace the module list so it reads:
+
+```rust
+pub mod apm;
+pub mod cli;
+pub mod client;
+pub mod logging;
+pub mod mcp;
+pub mod namespace_detect;
+pub mod output;
+pub mod paths;
+pub mod run;
+pub mod serve;
+```
+
+- [ ] **Step 3b GREEN: implement `descriptor` and `emit`.** In `crates/rusty-brain/src/apm.rs`, replace the stub `descriptor()` and `emit()` bodies with:
+
+```rust
+/// Build the canonical descriptor for this binary.
+#[must_use]
+pub fn descriptor() -> McpDescriptor {
+    McpDescriptor {
+        name: "rusty-brain".to_string(),
+        registry: false,
+        transport: "stdio".to_string(),
+        command: "rusty-brain".to_string(),
+        args: vec!["mcp".to_string()],
+        contract_version: CONTRACT_VERSION,
+    }
+}
+
+/// Render the descriptor as a human-readable YAML-shaped MCP entry suitable for
+/// pasting under `dependencies.mcp` in an `apm.yml`. The contract version is
+/// emitted as a COMMENT (APM's MCP schema has no `contract_version` key), so the
+/// output stays a valid manifest fragment while still surfacing drift.
+#[must_use]
+pub fn emit() -> String {
+    let d = descriptor();
+    let args = d
+        .args
+        .iter()
+        .map(|a| format!("\"{a}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "# rusty-brain MCP descriptor (ContractVersion {cv})\n\
+         - name: {name}\n  \
+           registry: {registry}\n  \
+           transport: {transport}\n  \
+           command: {command}\n  \
+           args: [{args}]\n",
+        cv = d.contract_version,
+        name = d.name,
+        registry = d.registry,
+        transport = d.transport,
+        command = d.command,
+        args = args,
+    )
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --lib apm::tests` — Expected: PASS (2 tests: `descriptor_matches_the_stdio_contract`, `emit_renders_the_stdio_entry`).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/apm.rs crates/rusty-brain/src/lib.rs && git commit -m "feat(rusty-brain): add apm module with canonical MCP descriptor + emit"` — Expected: one commit.
+
+---
+
+### Task B3: `validate` — reject secrets, missing ref, malformed MCP entry
+
+Add a `validate(yaml_text) -> Result<(), ValidationError>` that parses an `apm.yml` (via `serde_yaml_ng::Value`) and enforces the package's expectations: the stdio `rusty-brain` MCP entry must be present and well-formed, every `dependencies.apm` entry must carry a `ref`, and NO literal secret may appear.
+
+**Files:**
+- Modify: crates/rusty-brain/src/apm.rs
+
+**Test:** unit tests assert a good manifest validates, and that secret / missing-ref / malformed-MCP / non-mapping-apm manifests are each rejected with a distinct error.
+
+- [ ] **Step 1 RED: write the failing tests.** Append this to the `tests` module in `crates/rusty-brain/src/apm.rs` (inside the existing `#[cfg(test)] mod tests { ... }`):
+
+```rust
+    const GOOD: &str = r#"
+name: rusty-brain
+version: 0.1.0
+dependencies:
+  mcp:
+    - name: rusty-brain
+      registry: false
+      transport: stdio
+      command: rusty-brain
+      args: ["mcp"]
+  apm:
+    rusty-brain-memory-skill:
+      git: brianluby/rusty-brain
+      path: apm/skills/memory
+      ref: v0.1.0
+"#;
+
+    #[test]
+    fn validate_accepts_a_good_manifest() {
+        assert!(validate(GOOD).is_ok(), "the canonical manifest must validate");
+    }
+
+    #[test]
+    fn validate_rejects_a_literal_secret() {
+        let bad = GOOD.replace(
+            "version: 0.1.0",
+            "version: 0.1.0\nenv:\n  VOYAGE_API_KEY: voy-abcdef0123456789abcdef",
+        );
+        let err = validate(&bad).unwrap_err();
+        assert!(matches!(err, ValidationError::EmbeddedSecret { .. }), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_missing_ref() {
+        let bad = GOOD.replace("      ref: v0.1.0\n", "");
+        let err = validate(&bad).unwrap_err();
+        assert!(matches!(err, ValidationError::MissingRef { .. }), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_missing_mcp_entry() {
+        let bad = r#"
+name: rusty-brain
+dependencies:
+  apm:
+    x:
+      git: brianluby/rusty-brain
+      path: apm/skills/memory
+      ref: v0.1.0
+"#;
+        let err = validate(bad).unwrap_err();
+        assert!(matches!(err, ValidationError::MissingMcpEntry), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_a_malformed_mcp_entry() {
+        // transport http with no stdio rusty-brain entry => malformed for our package.
+        let bad = r#"
+name: rusty-brain
+dependencies:
+  mcp:
+    - name: rusty-brain
+      registry: false
+      transport: http
+      url: http://example
+"#;
+        let err = validate(bad).unwrap_err();
+        assert!(matches!(err, ValidationError::MalformedMcpEntry { .. }), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_flat_apm_list() {
+        // APM requires the apm dependencies to be a MAPPING; a flat list is invalid.
+        let bad = r#"
+name: rusty-brain
+dependencies:
+  mcp:
+    - name: rusty-brain
+      registry: false
+      transport: stdio
+      command: rusty-brain
+      args: ["mcp"]
+  apm:
+    - brianluby/rusty-brain/skills/memory
+"#;
+        let err = validate(bad).unwrap_err();
+        assert!(matches!(err, ValidationError::ApmNotMapping), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_unparseable_yaml() {
+        let err = validate(": this is not: valid: yaml: [").unwrap_err();
+        assert!(matches!(err, ValidationError::Parse { .. }), "{err}");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --lib apm::tests::validate` — Expected: FAIL — `validate` and `ValidationError` do not exist yet (`error[E0425]`/`error[E0433]`).
+
+- [ ] **Step 3a GREEN: add the error type + imports.** In `crates/rusty-brain/src/apm.rs`, add `use serde::Serialize;` (already present) and add this error enum just below the `McpDescriptor` definition:
+
+```rust
+/// A manifest-validation failure. Each variant maps to a distinct, stable
+/// failure mode `apm validate` reports; the CLI maps any variant to a non-zero
+/// exit.
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("manifest is not valid YAML: {message}")]
+    Parse { message: String },
+    #[error("manifest declares no MCP server (expected a stdio `rusty-brain` entry under dependencies.mcp)")]
+    MissingMcpEntry,
+    #[error("the `rusty-brain` MCP entry is malformed: {reason}")]
+    MalformedMcpEntry { reason: String },
+    #[error("dependencies.apm must be a mapping (object), not a flat list")]
+    ApmNotMapping,
+    #[error("dependencies.apm entry `{alias}` is missing a `ref` (hash-pinning requires a ref)")]
+    MissingRef { alias: String },
+    #[error("manifest contains what looks like a literal secret at `{location}` (use env interpolation instead)")]
+    EmbeddedSecret { location: String },
+}
+```
+
+Add `thiserror` to `crates/rusty-brain/Cargo.toml` `[dependencies]` (it is a workspace dep already used elsewhere) — add the line `thiserror = { workspace = true }` after `serde_yaml_ng = { workspace = true }`.
+
+- [ ] **Step 3b GREEN: implement `validate`.** Append these functions to `crates/rusty-brain/src/apm.rs` (module level, before the `tests` module):
+
+```rust
+/// Validate an `apm.yml` against the rusty-brain package's expectations.
+///
+/// Enforces: (1) a stdio `rusty-brain` MCP entry is present and well-formed;
+/// (2) `dependencies.apm` is a mapping and every entry carries a `ref`; (3) no
+/// literal secret appears anywhere. Returns the first failure found.
+///
+/// # Errors
+/// Returns a [`ValidationError`] describing the first problem detected.
+pub fn validate(yaml_text: &str) -> Result<(), ValidationError> {
+    // (3) Secret scan first — a literal secret is the highest-severity failure.
+    scan_for_secrets(yaml_text)?;
+
+    let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml_text)
+        .map_err(|e| ValidationError::Parse { message: e.to_string() })?;
+
+    let deps = doc.get("dependencies");
+
+    // (1) stdio `rusty-brain` MCP entry.
+    let mcp = deps
+        .and_then(|d| d.get("mcp"))
+        .and_then(serde_yaml_ng::Value::as_sequence);
+    let rusty = mcp
+        .into_iter()
+        .flatten()
+        .find(|e| e.get("name").and_then(serde_yaml_ng::Value::as_str) == Some("rusty-brain"));
+    let Some(entry) = rusty else {
+        return Err(ValidationError::MissingMcpEntry);
+    };
+    validate_mcp_entry(entry)?;
+
+    // (2) dependencies.apm must be a mapping with a ref on each entry.
+    if let Some(apm) = deps.and_then(|d| d.get("apm")) {
+        let Some(map) = apm.as_mapping() else {
+            return Err(ValidationError::ApmNotMapping);
+        };
+        for (alias, spec) in map {
+            let alias = alias.as_str().unwrap_or("<non-string key>").to_string();
+            let has_ref = spec
+                .get("ref")
+                .and_then(serde_yaml_ng::Value::as_str)
+                .is_some_and(|s| !s.trim().is_empty());
+            if !has_ref {
+                return Err(ValidationError::MissingRef { alias });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The stdio `rusty-brain` entry must set `registry: false`, `transport: stdio`,
+/// `command: rusty-brain`, and `args` containing `mcp`.
+fn validate_mcp_entry(entry: &serde_yaml_ng::Value) -> Result<(), ValidationError> {
+    let bad = |reason: &str| ValidationError::MalformedMcpEntry { reason: reason.to_string() };
+    if entry.get("registry").and_then(serde_yaml_ng::Value::as_bool) != Some(false) {
+        return Err(bad("registry must be false (rusty-brain is a local stdio server)"));
+    }
+    if entry.get("transport").and_then(serde_yaml_ng::Value::as_str) != Some("stdio") {
+        return Err(bad("transport must be stdio"));
+    }
+    if entry.get("command").and_then(serde_yaml_ng::Value::as_str) != Some("rusty-brain") {
+        return Err(bad("command must be rusty-brain"));
+    }
+    let args_ok = entry
+        .get("args")
+        .and_then(serde_yaml_ng::Value::as_sequence)
+        .is_some_and(|a| a.iter().any(|v| v.as_str() == Some("mcp")));
+    if !args_ok {
+        return Err(bad("args must invoke the `mcp` subcommand"));
+    }
+    Ok(())
+}
+
+/// Reject anything that looks like a literal secret. Env interpolation
+/// (`${VAR}` / `$VAR`) is always allowed; a bare token is not. Heuristics: a
+/// `voy-`/`sk-` prefixed token, a `Bearer <token>` literal, or a value assigned
+/// to a `*_API_KEY`/`*_TOKEN`/`*_SECRET` key that is NOT an interpolation.
+fn scan_for_secrets(text: &str) -> Result<(), ValidationError> {
+    for (lineno, line) in text.lines().enumerate() {
+        let loc = || format!("line {}", lineno + 1);
+        // Prefix-token heuristics: a real Voyage/OpenAI key.
+        for prefix in ["voy-", "sk-", "Bearer "] {
+            if let Some(pos) = line.find(prefix) {
+                let tail = &line[pos + prefix.len()..];
+                // A token: at least 12 of [A-Za-z0-9_-] right after the prefix.
+                let token_len = tail
+                    .chars()
+                    .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+                    .count();
+                if token_len >= 12 {
+                    return Err(ValidationError::EmbeddedSecret { location: loc() });
+                }
+            }
+        }
+        // Sensitive-key heuristic: `<KEY>: <value>` where value is a literal.
+        if let Some((key, value)) = line.split_once(':') {
+            let key_up = key.trim().to_ascii_uppercase();
+            let sensitive = key_up.ends_with("_API_KEY")
+                || key_up.ends_with("_TOKEN")
+                || key_up.ends_with("_SECRET")
+                || key_up.ends_with("_PASSWORD");
+            if sensitive {
+                let v = value.trim().trim_matches('"').trim_matches('\'');
+                let is_interpolation = v.is_empty() || v.starts_with('$') || v.starts_with("${");
+                let is_comment = v.starts_with('#');
+                if !is_interpolation && !is_comment && v.len() >= 12 {
+                    return Err(ValidationError::EmbeddedSecret { location: loc() });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --lib apm::tests` — Expected: PASS (all `validate_*` tests plus the earlier `descriptor`/`emit` tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/apm.rs crates/rusty-brain/Cargo.toml && git commit -m "feat(rusty-brain): add apm validate rejecting secrets, missing ref, malformed mcp"` — Expected: one commit.
+
+---
+
+### Task B4: emit→validate round-trip + committed-manifest validation
+
+Prove the two pillars hold together: `emit()`'s descriptor satisfies `validate` when embedded in a minimal manifest, and the committed `apm/apm.yml` validates clean.
+
+**Files:**
+- Modify: crates/rusty-brain/src/apm.rs
+
+**Test:** a round-trip test wraps `emit()` into a manifest and asserts `validate` accepts it; a second test validates the real committed `apm/apm.yml`.
+
+- [ ] **Step 1 RED: write the failing tests.** Append to the `tests` module in `crates/rusty-brain/src/apm.rs`:
+
+```rust
+    #[test]
+    fn emit_round_trips_through_validate() {
+        // Wrap the emitted MCP entry into a minimal manifest and validate it.
+        // emit() yields a leading comment + a `- name: …` list item; nest it
+        // under dependencies.mcp.
+        let entry = emit();
+        let indented = entry
+            .lines()
+            .map(|l| format!("    {l}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let manifest = format!("name: rusty-brain\ndependencies:\n  mcp:\n{indented}\n");
+        assert!(
+            validate(&manifest).is_ok(),
+            "emit() output must satisfy validate(); manifest was:\n{manifest}"
+        );
+    }
+
+    #[test]
+    fn committed_manifest_validates() {
+        let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = crate_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|root| root.join("apm").join("apm.yml"))
+            .expect("repo root");
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+        assert!(
+            validate(&text).is_ok(),
+            "the committed apm/apm.yml must validate: {:?}",
+            validate(&text)
+        );
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --lib apm::tests::emit_round_trips_through_validate apm::tests::committed_manifest_validates` — Expected: PASS (both). If `emit_round_trips_through_validate` fails, the indentation produced by `emit()` does not nest cleanly under `dependencies.mcp`; fix `emit()`'s rendering (the descriptor values are correct — only the leading-whitespace shape would need adjusting) until both pass. If `committed_manifest_validates` fails, the failure prints the `ValidationError`; correct `apm/apm.yml` to satisfy it (it should already validate from Part A).
+
+- [ ] **Step 3: (no impl change expected).** These tests assert existing behavior. If Step 2 was already green, record "no impl change needed". Only adjust `emit()` rendering if Step 2 flagged a nesting problem.
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --lib apm::tests` — Expected: PASS (full `apm` test module green).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/apm.rs && git commit -m "test(rusty-brain): assert emit/validate round-trip and committed manifest validates"` — Expected: one commit.
+
+---
+
+### Task B5: `doctor` — read-only prerequisites probe
+
+Add `doctor() -> DoctorReport`: a read-only check of `rusty-brain` on PATH, `apm` presence, and which harnesses are detectable. It writes nothing and spawns no installer. Detection reuses an executable-bit PATH scan equivalent to P4's (re-implemented locally so the `rusty-brain` binary stays free of the `rb-install` dependency).
+
+**Files:**
+- Modify: crates/rusty-brain/src/apm.rs
+
+**Test:** unit tests assert the report serializes, reports `rusty-brain` found when a fake `rusty-brain` is on PATH, and `apm` absent when it is not on the constructed PATH.
+
+- [ ] **Step 1 RED: write the failing tests.** Append to the `tests` module in `crates/rusty-brain/src/apm.rs`:
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn doctor_finds_binaries_on_a_constructed_path() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        // A fake `rusty-brain` + `apm` on PATH (executable); no `claude`/`apm` else.
+        for name in ["rusty-brain", "apm"] {
+            let p = dir.path().join(name);
+            std::fs::write(&p, "#!/bin/sh\necho ok\n").unwrap();
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        // bin_on_path scans a caller-provided PATH string (no process-global env
+        // mutation) so this test is parallel-safe.
+        assert!(bin_on_path("rusty-brain", dir.path().to_str().unwrap()).is_some());
+        assert!(bin_on_path("apm", dir.path().to_str().unwrap()).is_some());
+        assert!(bin_on_path("definitely-not-real-xyz", dir.path().to_str().unwrap()).is_none());
+
+        let report = doctor_with_path(dir.path().to_str().unwrap());
+        assert!(report.rusty_brain_on_path, "rusty-brain must be detected: {report:?}");
+        assert!(report.apm_present, "apm must be detected: {report:?}");
+        // Serializes to JSON for `--json`.
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("rusty_brain_on_path"), "{json}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn doctor_reports_apm_absent_when_not_on_path() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        // Only rusty-brain, no apm.
+        let p = dir.path().join("rusty-brain");
+        std::fs::write(&p, "#!/bin/sh\necho ok\n").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let report = doctor_with_path(dir.path().to_str().unwrap());
+        assert!(report.rusty_brain_on_path);
+        assert!(!report.apm_present, "apm must be absent: {report:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_binary_is_not_detected() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("rusty-brain");
+        std::fs::write(&p, "#!/bin/sh\necho ok\n").unwrap();
+        // 0o644 — present but NOT executable.
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            bin_on_path("rusty-brain", dir.path().to_str().unwrap()).is_none(),
+            "a non-executable file must not count as installed"
+        );
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --lib apm::tests::doctor` — Expected: FAIL — `doctor_with_path`, `bin_on_path`, and `DoctorReport` do not exist yet.
+
+- [ ] **Step 3 GREEN: implement the report + PATH scan.** Append to `crates/rusty-brain/src/apm.rs` (module level, before `tests`):
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Read-only prerequisites report for `apm doctor`. Serializes for `--json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorReport {
+    /// `rusty-brain` resolves on PATH (an executable file).
+    pub rusty_brain_on_path: bool,
+    /// `apm` resolves on PATH (an executable file).
+    pub apm_present: bool,
+    /// Harness CLIs detected on PATH (the subset of known agent CLIs found).
+    pub harnesses_detected: Vec<String>,
+}
+
+/// The harness CLI binary names APM would wire (probed read-only by `doctor`).
+const KNOWN_HARNESS_BINARIES: &[&str] = &["claude", "copilot", "cursor", "codex", "gemini"];
+
+/// Run the doctor probe against the process PATH.
+#[must_use]
+pub fn doctor() -> DoctorReport {
+    let path = std::env::var("PATH").unwrap_or_default();
+    doctor_with_path(&path)
+}
+
+/// Run the doctor probe against an explicit PATH string (testable; no env read).
+#[must_use]
+pub fn doctor_with_path(path_var: &str) -> DoctorReport {
+    let harnesses_detected = KNOWN_HARNESS_BINARIES
+        .iter()
+        .filter(|name| bin_on_path(name, path_var).is_some())
+        .map(|s| (*s).to_string())
+        .collect();
+    DoctorReport {
+        rusty_brain_on_path: bin_on_path("rusty-brain", path_var).is_some(),
+        apm_present: bin_on_path("apm", path_var).is_some(),
+        harnesses_detected,
+    }
+}
+
+/// Scan an explicit `PATH` string for an executable file named `name`. Mirrors
+/// `rb_install::detect::find_binary_on_path` but takes the PATH explicitly (so it
+/// is parallel-test-safe and the `rusty-brain` binary needs no `rb-install` dep).
+/// On unix a candidate must be a regular file with at least one execute bit.
+#[must_use]
+pub fn bin_on_path(name: &str, path_var: &str) -> Option<PathBuf> {
+    for dir in std::env::split_paths(path_var) {
+        let candidate = dir.join(name);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+        #[cfg(target_os = "windows")]
+        {
+            for ext in ["exe", "cmd", "bat"] {
+                let with_ext = dir.join(format!("{name}.{ext}"));
+                if with_ext.is_file() {
+                    return Some(with_ext);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && (meta.permissions().mode() & 0o111 != 0),
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Render a `DoctorReport` as a human-readable summary.
+#[must_use]
+pub fn render_doctor(report: &DoctorReport) -> String {
+    let mark = |b: bool| if b { "[ok]" } else { "[--]" };
+    let mut out = String::from("rusty-brain apm doctor\n");
+    out.push_str(&format!("  {} rusty-brain on PATH\n", mark(report.rusty_brain_on_path)));
+    out.push_str(&format!("  {} apm present\n", mark(report.apm_present)));
+    if report.harnesses_detected.is_empty() {
+        out.push_str("  [--] no harness CLIs detected on PATH\n");
+    } else {
+        out.push_str(&format!(
+            "  [ok] harnesses detected: {}\n",
+            report.harnesses_detected.join(", ")
+        ));
+    }
+    if !report.rusty_brain_on_path {
+        out.push_str(
+            "\nNOTE: install the rusty-brain binary first (cargo install / Homebrew / release);\n\
+             APM wires agent context, not the binary itself.\n",
+        );
+    }
+    out
+}
+```
+
+Add `tempfile` to `crates/rusty-brain/Cargo.toml` `[dev-dependencies]` if not present (it already is — confirm the line `tempfile = { workspace = true }` exists under `[dev-dependencies]`; it does in the current crate, so no change).
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --lib apm::tests` — Expected: PASS (doctor tests + all earlier `apm` tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/apm.rs && git commit -m "feat(rusty-brain): add read-only apm doctor prerequisites probe"` — Expected: one commit.
+
+---
+
+### Task B6: clap `Apm` subcommand + `run` dispatch
+
+Wire the `apm` subcommand group into the CLI (`emit`/`validate [path]`/`doctor`) and dispatch it in `run` BEFORE the daemon client connect (these commands never touch the daemon). `validate` exits non-zero on a problem; `emit`/`doctor` exit 0.
+
+**Files:**
+- Modify: crates/rusty-brain/src/cli.rs
+- Modify: crates/rusty-brain/src/run.rs
+
+**Test:** clap parse tests for `apm emit`/`apm validate <path>`/`apm doctor`; a `run`-level integration test that `apm validate` over a bad manifest returns an error (non-zero) and over a good manifest returns Ok.
+
+- [ ] **Step 1 RED: write the failing clap tests.** Append to the `tests` module in `crates/rusty-brain/src/cli.rs`:
+
+```rust
+    #[test]
+    fn parses_apm_emit() {
+        let cli = Cli::parse_from(["rusty-brain", "apm", "emit"]);
+        assert!(matches!(cli.command, Command::Apm { command: ApmCommand::Emit }));
+    }
+
+    #[test]
+    fn parses_apm_validate_with_path() {
+        let cli = Cli::parse_from(["rusty-brain", "apm", "validate", "apm/apm.yml"]);
+        match cli.command {
+            Command::Apm { command: ApmCommand::Validate { path } } => {
+                assert_eq!(path.as_deref(), Some("apm/apm.yml"));
+            }
+            other => panic!("expected apm validate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_apm_validate_without_path() {
+        let cli = Cli::parse_from(["rusty-brain", "apm", "validate"]);
+        match cli.command {
+            Command::Apm { command: ApmCommand::Validate { path } } => assert!(path.is_none()),
+            other => panic!("expected apm validate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_apm_doctor() {
+        let cli = Cli::parse_from(["rusty-brain", "apm", "doctor"]);
+        assert!(matches!(cli.command, Command::Apm { command: ApmCommand::Doctor }));
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --lib cli::tests::parses_apm` — Expected: FAIL — `Command::Apm` and `ApmCommand` do not exist (`error[E0599]`/unresolved).
+
+- [ ] **Step 3a GREEN: add the subcommand to the clap enum.** In `crates/rusty-brain/src/cli.rs`, add this variant to the `Command` enum (after the `Evolve { … }` variant):
+
+```rust
+    /// APM (Agent Package Manager) package helpers — read-only.
+    Apm {
+        #[command(subcommand)]
+        command: ApmCommand,
+    },
+```
+
+Then add this new enum just below the `Command` enum definition:
+
+```rust
+/// Read-only `rusty-brain apm` subcommands. None mutate config or the daemon.
+#[derive(Subcommand, Debug)]
+pub enum ApmCommand {
+    /// Print the canonical stdio MCP descriptor for this binary (for apm.yml).
+    Emit,
+    /// Validate an apm.yml (default `apm/apm.yml`): stdio entry, refs, no secrets.
+    /// Exits non-zero on a problem.
+    Validate {
+        /// Path to the manifest (default: `apm/apm.yml` in the current dir).
+        path: Option<String>,
+    },
+    /// Report prerequisites: rusty-brain on PATH, apm present, harnesses detected.
+    Doctor,
+}
+```
+
+- [ ] **Step 3b GREEN: write the failing dispatch test.** Append to the `tests` module in `crates/rusty-brain/src/run.rs`:
+
+```rust
+    #[tokio::test]
+    async fn apm_validate_good_manifest_is_ok_and_touches_no_daemon() {
+        use crate::cli::{ApmCommand, Cli, Command};
+        // A valid manifest written to a temp file. `apm validate` must NOT connect
+        // to a daemon: we pass socket/db paths that would fail if dialed.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("apm.yml");
+        std::fs::write(
+            &manifest,
+            "name: rusty-brain\ndependencies:\n  mcp:\n    - name: rusty-brain\n      registry: false\n      transport: stdio\n      command: rusty-brain\n      args: [\"mcp\"]\n",
+        )
+        .unwrap();
+        let cli = Cli {
+            json: false,
+            command: Command::Apm {
+                command: ApmCommand::Validate { path: Some(manifest.display().to_string()) },
+            },
+        };
+        // Point socket/db at non-existent paths; if apm dispatch tried to connect
+        // it would error. A clean Ok proves it never dialed the daemon.
+        std::env::set_var(crate::paths::SOCKET_ENV, dir.path().join("nope.sock"));
+        std::env::set_var(crate::paths::DB_ENV, dir.path().join("nope.db"));
+        let ns = rb_types::Namespace::Global;
+        let result = run(cli, ns).await;
+        std::env::remove_var(crate::paths::SOCKET_ENV);
+        std::env::remove_var(crate::paths::DB_ENV);
+        assert!(result.is_ok(), "apm validate over a good manifest must succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn apm_validate_bad_manifest_errors_nonzero() {
+        use crate::cli::{ApmCommand, Cli, Command};
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("apm.yml");
+        // No MCP entry => validation failure => Err (mapped to a non-zero exit).
+        std::fs::write(&manifest, "name: rusty-brain\ndependencies:\n  apm: {}\n").unwrap();
+        let cli = Cli {
+            json: false,
+            command: Command::Apm {
+                command: ApmCommand::Validate { path: Some(manifest.display().to_string()) },
+            },
+        };
+        let ns = rb_types::Namespace::Global;
+        let result = run(cli, ns).await;
+        assert!(result.is_err(), "apm validate over a manifest with no MCP entry must error");
+    }
+```
+
+- [ ] **Step 3c GREEN: dispatch `Apm` in `run` before the client connect.** In `crates/rusty-brain/src/run.rs`, add an `Apm` arm to the top-level `match cli.command` in `run`, BEFORE the catch-all `other => run_client(...)` arm (so `apm` never reaches `connect_or_start`):
+
+```rust
+        Command::Apm { command } => run_apm(command, cli.json),
+```
+
+Then add this function to `crates/rusty-brain/src/run.rs` (after `run`):
+
+```rust
+/// Dispatch a read-only `apm` subcommand. NEVER connects to the daemon and
+/// NEVER mutates any config. `validate` returns `Err` (non-zero exit) on a
+/// problem; `emit`/`doctor` print and return `Ok`.
+fn run_apm(command: crate::cli::ApmCommand, json: bool) -> anyhow::Result<()> {
+    use crate::apm;
+    use crate::cli::ApmCommand;
+    match command {
+        ApmCommand::Emit => {
+            println!("{}", apm::emit());
+            Ok(())
+        }
+        ApmCommand::Validate { path } => {
+            let path = path.unwrap_or_else(|| "apm/apm.yml".to_string());
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading manifest {path}"))?;
+            match apm::validate(&text) {
+                Ok(()) => {
+                    if json {
+                        println!("{{\"manifest\":{},\"valid\":true}}", json_str(&path));
+                    } else {
+                        println!("ok: {path} is a valid rusty-brain apm manifest");
+                    }
+                    Ok(())
+                }
+                // A validation failure is a real error the user must see: surface
+                // it with a non-zero exit (anyhow::Error -> ExitCode::FAILURE).
+                Err(e) => Err(anyhow::Error::new(e)).with_context(|| format!("validating {path}")),
+            }
+        }
+        ApmCommand::Doctor => {
+            let report = apm::doctor();
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string())
+                );
+            } else {
+                print!("{}", apm::render_doctor(&report));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Encode `s` as a JSON string literal without `unwrap`.
+fn json_str(s: &str) -> String {
+    serde_json::to_string(s).unwrap_or_else(|_| "\"\"".to_string())
+}
+```
+
+Also add the `Apm` arm to the `run_client` match's exhaustiveness guard: in `run_client`, the `match command` already has explicit arms; add this arm alongside the existing internal-guard arms (`Serve`/`Mcp`) so the enum stays exhaustive:
+
+```rust
+        Command::Apm { .. } => anyhow::bail!("internal: apm must be handled before run_client"),
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --lib cli::tests::parses_apm run::tests::apm_validate` — Expected: PASS (4 clap tests + 2 dispatch tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/src/cli.rs crates/rusty-brain/src/run.rs && git commit -m "feat(rusty-brain): wire apm emit/validate/doctor subcommands (read-only)"` — Expected: one commit.
+
+---
+
+### Task B7: CLI integration test — `apm` end to end through the built binary
+
+Prove the assembled binary behaves: `apm emit` prints the stdio entry, `apm validate apm/apm.yml` succeeds (exit 0), `apm validate <bad>` exits non-zero, and `apm doctor` runs read-only.
+
+**Files:**
+- Modify: crates/rusty-brain/tests/apm_manifest.rs (add CLI-driven cases)
+
+**Test:** `assert_cmd`-driven cases against the built `rusty-brain` binary.
+
+- [ ] **Step 1 RED: write the failing CLI tests.** Append to `crates/rusty-brain/tests/apm_manifest.rs`:
+
+```rust
+#[cfg(test)]
+mod cli_integration {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    fn bin() -> Command {
+        Command::cargo_bin("rusty-brain").unwrap()
+    }
+
+    fn repo_root() -> std::path::PathBuf {
+        let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        crate_dir.parent().and_then(|p| p.parent()).unwrap().to_path_buf()
+    }
+
+    #[test]
+    fn apm_emit_prints_stdio_entry() {
+        bin()
+            .args(["apm", "emit"])
+            .assert()
+            .success()
+            .stdout(contains("name: rusty-brain"))
+            .stdout(contains("transport: stdio"))
+            .stdout(contains("command: rusty-brain"));
+    }
+
+    #[test]
+    fn apm_validate_committed_manifest_succeeds() {
+        // Run from the repo root so the default `apm/apm.yml` path resolves.
+        bin()
+            .current_dir(repo_root())
+            .args(["apm", "validate", "apm/apm.yml"])
+            .assert()
+            .success()
+            .stdout(contains("valid"));
+    }
+
+    #[test]
+    fn apm_validate_bad_manifest_exits_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad = dir.path().join("apm.yml");
+        // A literal secret => validation failure => non-zero exit.
+        std::fs::write(
+            &bad,
+            "name: rusty-brain\nenv:\n  VOYAGE_API_KEY: voy-abcdef0123456789\ndependencies:\n  mcp:\n    - name: rusty-brain\n      registry: false\n      transport: stdio\n      command: rusty-brain\n      args: [\"mcp\"]\n",
+        )
+        .unwrap();
+        bin()
+            .args(["apm", "validate", bad.to_str().unwrap()])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn apm_doctor_runs_read_only() {
+        bin().args(["apm", "doctor"]).assert().success().stdout(contains("doctor"));
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rusty-brain --test apm_manifest cli_integration` — Expected: FAIL initially only if the binary is stale; since Task B6 implemented the dispatch, these should PASS after a rebuild. If `apm_validate_committed_manifest_succeeds` fails, run `rusty-brain apm validate apm/apm.yml` manually from the repo root to read the error and fix the committed manifest.
+
+- [ ] **Step 3: (no impl change expected).** These exercise Task B6's wiring through the real binary. If Step 2 is green, record "no impl change needed".
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rusty-brain --test apm_manifest` — Expected: PASS (fixture tests + CLI integration).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rusty-brain --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rusty-brain/tests/apm_manifest.rs && git commit -m "test(rusty-brain): apm emit/validate/doctor through the built binary"` — Expected: one commit.
+
+---
+
+### Task B8: Part B gate
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: workspace tests — Run:** `cargo test --workspace` — Expected: PASS, 0 failures.
+
+- [ ] **Step 2: clippy — Run:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+
+- [ ] **Step 3: format — Run:** `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: supply chain (Part B added `serde_yaml_ng`) — Run:** `cargo deny check 2>&1 | tail -20; echo "exit=${PIPESTATUS[0]}"` — Expected: `exit=0`, `licenses ok`, `advisories ok`, `sources ok` (`bans` may `warn` only). `serde_yaml_ng`/`unsafe-libyaml`/`indexmap` are MIT/Apache-2.0 with no advisory, already allow-listed. (`serde_yaml_ng` is the maintained fork; the original `serde_yaml` is unmaintained — RUSTSEC-2024-0320 — and would fail this advisories gate.)
+
+- [ ] **Step 5: default-closure guard — Run:** `cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install"; echo "exit=$?"` — Expected: `exit=1` (no match): the `apm` module pulled in NO agent crate; the default `rusty-brain` closure is unchanged.
+
+- [ ] **Step 6: commit (only if a gate fixup was needed) — Run:** `git add -A && git commit -m "chore(rusty-brain): part B gate green"` — Expected: a commit only if a fixup was needed.
+
+---
+
+## Part C — `rb-install` APM-aware backend (delegation + P4 fallback + fail-open)
+
+This Part makes `rb-install` prefer `apm install` when `apm` is on PATH, falling back to the existing P4 direct-config installer (`engine::run_install`) when it is not. Selection is by capability detection (reusing `detect::find_binary_on_path`'s executable-bit scan); delegation re-checks `apm` immediately before spawning (TOCTOU) and runs the subprocess with `env_clear()` then a minimal env; a non-zero `apm install` exit (or a missing `apm`) falls back. The whole path is fail-open: it never breaks a harness setup and never returns a non-zero process exit.
+
+HARD RULES honored throughout: `env_clear()` then only `PATH`/`HOME`; PATH detection requires an exec bit; TOCTOU re-check before spawn; fail-open with fallback; the backend lives in `rb-install` (an isolated crate), never in the default `rusty-brain` closure.
+
+---
+
+### Task C1: `apm_backend` module — capability detection
+
+Add an `apm_backend` module to `rb-install` whose `detect_apm() -> Option<PathBuf>` reuses `detect::find_binary_on_path("apm")`, plus a `Backend` enum (`Apm`/`Fallback`) chosen by detection.
+
+**Files:**
+- Create: crates/rb-install/src/apm_backend.rs
+- Modify: crates/rb-install/src/lib.rs
+
+**Test:** unit tests assert `detect_apm` returns `Some` when a fake `apm` is on PATH and `None` otherwise, and `select_backend` maps detection to the right `Backend`.
+
+- [ ] **Step 1 RED: write the failing test + skeleton.** Create `crates/rb-install/src/apm_backend.rs` with this exact content:
+
+```rust
+//! APM-aware install backend: prefer delegating to `apm install` when `apm` is
+//! on PATH (the standard, hash-pinned, multi-harness tool), and fall back to the
+//! P4 per-CLI direct-config installer otherwise. Fail-open end to end: a
+//! detection or delegation failure logs and falls back — it never breaks a
+//! harness setup and never returns a non-zero process exit.
+
+use std::path::PathBuf;
+
+use crate::detect::find_binary_on_path;
+
+/// Which install path will run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Backend {
+    /// `apm` is available; delegate to `apm install`. Carries the resolved path.
+    Apm(PathBuf),
+    /// `apm` is absent; use the P4 per-CLI direct-config installer.
+    Fallback,
+}
+
+/// Detect `apm` on PATH (an executable file). Reuses the P4 exec-bit scan.
+#[must_use]
+pub fn detect_apm() -> Option<PathBuf> {
+    find_binary_on_path("apm")
+}
+
+/// Choose the backend from detection: `apm` present => delegate, else fall back.
+#[must_use]
+pub fn select_backend() -> Backend {
+    match detect_apm() {
+        Some(path) => Backend::Apm(path),
+        None => Backend::Fallback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+    #[cfg(unix)]
+    use std::sync::Mutex;
+
+    // Serialize the PATH-mutating tests (mirrors rb-install/detect.rs).
+    #[cfg(unix)]
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(unix)]
+    fn with_fake_apm_on_path(f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("apm");
+        std::fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let old = std::env::var_os("PATH");
+        let mut paths = vec![dir.path().to_path_buf()];
+        if let Some(ref p) = old {
+            paths.extend(std::env::split_paths(p));
+        }
+        std::env::set_var("PATH", std::env::join_paths(paths).unwrap());
+        f();
+        match old {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_apm_finds_fake_on_path() {
+        with_fake_apm_on_path(|| {
+            assert!(detect_apm().is_some(), "a fake executable `apm` must be detected on PATH");
+            assert!(matches!(select_backend(), Backend::Apm(_)));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn select_backend_falls_back_when_apm_absent() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // An empty PATH guarantees `apm` is not found.
+        let old = std::env::var_os("PATH");
+        std::env::set_var("PATH", "");
+        let backend = select_backend();
+        match old {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+        assert_eq!(backend, Backend::Fallback, "no apm on PATH must fall back to the P4 installer");
+    }
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests` — Expected: FAIL — the module is not declared in `lib.rs`, so it does not compile (unresolved).
+
+- [ ] **Step 3 GREEN: declare the module + re-export.** Edit `crates/rb-install/src/lib.rs`. Add `pub mod apm_backend;` to the module list (after `pub mod engine;`), and add this to the `pub use` block:
+
+```rust
+pub use apm_backend::{detect_apm, select_backend, Backend};
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests` — Expected: PASS (2 unix tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-install --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-install/src/apm_backend.rs crates/rb-install/src/lib.rs && git commit -m "feat(rb-install): add apm capability detection + backend selection"` — Expected: one commit.
+
+---
+
+### Task C2: hardened `apm install` delegation (env_clear + TOCTOU)
+
+Add `delegate_install(apm_path, scope, dry_run) -> ApmDelegation`: a hardened subprocess spawn of `apm install`. It re-checks `apm` immediately before spawning (TOCTOU), runs with `env_clear()` then a minimal env (`PATH`, `HOME`/`USERPROFILE`), sets the working directory to the project scope, and reports success/failure. A non-zero exit or spawn error is reported (not panicked) so the caller can fall back.
+
+**Files:**
+- Modify: crates/rb-install/src/apm_backend.rs
+
+**Test:** unit tests with a fake `apm` stub that records its argv to a file (asserting `install` was the arg) and a stub that exits non-zero (asserting the delegation reports failure); a dry-run test asserts no spawn.
+
+- [ ] **Step 1 RED: write the failing tests.** Append to the `tests` module in `crates/rb-install/src/apm_backend.rs`:
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn delegate_install_spawns_apm_with_install_arg() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let argv_log = dir.path().join("argv.log");
+        // A fake apm that records its args (so we can assert `install` was passed)
+        // and exits 0.
+        let apm = dir.path().join("apm");
+        std::fs::write(
+            &apm,
+            format!("#!/bin/sh\necho \"$@\" > '{}'\nexit 0\n", argv_log.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&apm, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let result = delegate_install(&apm, &scope, false);
+        assert!(result.spawned, "delegation must spawn apm: {result:?}");
+        assert!(result.success, "the fake apm exited 0, so delegation must succeed: {result:?}");
+        let logged = std::fs::read_to_string(&argv_log).unwrap();
+        assert!(logged.contains("install"), "apm must be invoked with `install`; got: {logged:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delegate_install_reports_failure_on_nonzero_exit() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let apm = dir.path().join("apm");
+        // A fake apm that fails.
+        std::fs::write(&apm, "#!/bin/sh\nexit 7\n").unwrap();
+        std::fs::set_permissions(&apm, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let result = delegate_install(&apm, &scope, false);
+        assert!(result.spawned, "it did spawn: {result:?}");
+        assert!(!result.success, "a non-zero apm exit must report failure (caller falls back): {result:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delegate_install_dry_run_does_not_spawn() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let argv_log = dir.path().join("argv.log");
+        let apm = dir.path().join("apm");
+        std::fs::write(
+            &apm,
+            format!("#!/bin/sh\necho ran > '{}'\nexit 0\n", argv_log.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&apm, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let result = delegate_install(&apm, &scope, true);
+        assert!(!result.spawned, "a dry-run must not spawn apm: {result:?}");
+        assert!(!argv_log.exists(), "dry-run must not have run apm");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delegate_install_reports_failure_when_apm_vanished_before_spawn() {
+        // TOCTOU: pass a path that does not exist (apm vanished after detection).
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("apm-gone");
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let result = delegate_install(&gone, &scope, false);
+        assert!(!result.spawned, "a vanished apm must not be spawned: {result:?}");
+        assert!(!result.success, "a vanished apm must report failure so the caller falls back");
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests::delegate` — Expected: FAIL — `delegate_install` and `ApmDelegation` do not exist yet.
+
+- [ ] **Step 3 GREEN: implement the delegation.** Append to `crates/rb-install/src/apm_backend.rs` (module level, before `tests`):
+
+```rust
+use std::path::Path;
+use std::process::Command;
+
+use rb_agents::install::InstallScope;
+
+/// The outcome of attempting to delegate to `apm install`. Fail-open friendly:
+/// the caller falls back to the P4 installer when `success` is false.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApmDelegation {
+    /// Whether the `apm` subprocess was actually spawned (false for dry-run or a
+    /// vanished binary).
+    pub spawned: bool,
+    /// Whether `apm install` exited 0.
+    pub success: bool,
+    /// A short human note for the report (error string or "dry-run").
+    pub note: Option<String>,
+}
+
+/// Delegate to `apm install`, hardened per the global security rules.
+///
+/// - **TOCTOU:** re-checks `apm_path` is an executable file IMMEDIATELY before
+///   spawning, not just at selection time.
+/// - **Env hygiene:** `env_clear()` then sets ONLY `PATH` and `HOME`/`USERPROFILE`
+///   — the parent environment is never inherited wholesale.
+/// - **Scope:** runs in the project directory (so `apm` finds the project's
+///   `apm.yml`); Global scope uses the current directory.
+///
+/// Returns a report; it NEVER panics and NEVER propagates an error — a failure
+/// is encoded in `success: false` so the caller falls back fail-open.
+#[must_use]
+pub fn delegate_install(apm_path: &Path, scope: &InstallScope, dry_run: bool) -> ApmDelegation {
+    if dry_run {
+        return ApmDelegation { spawned: false, success: false, note: Some("dry-run".to_string()) };
+    }
+    // TOCTOU re-check: the binary must still be an executable file right now.
+    if find_binary_on_path("apm").is_none() && !is_executable_now(apm_path) {
+        return ApmDelegation {
+            spawned: false,
+            success: false,
+            note: Some("apm not present at spawn time".to_string()),
+        };
+    }
+    let cwd = match scope {
+        InstallScope::Project(p) => p.clone(),
+        InstallScope::Global => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+    };
+
+    let mut cmd = Command::new(apm_path);
+    cmd.arg("install");
+    cmd.current_dir(&cwd);
+    // Subprocess hardening: never inherit the parent env wholesale.
+    cmd.env_clear();
+    if let Some(path) = std::env::var_os("PATH") {
+        cmd.env("PATH", path);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        cmd.env("HOME", home);
+    }
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        cmd.env("USERPROFILE", home);
+    }
+
+    match cmd.status() {
+        Ok(status) => ApmDelegation {
+            spawned: true,
+            success: status.success(),
+            note: status.success().then(|| "apm install ok".to_string()).or_else(|| {
+                Some(format!("apm install exited with {status}"))
+            }),
+        },
+        Err(e) => ApmDelegation {
+            spawned: false,
+            success: false,
+            note: Some(format!("failed to spawn apm: {e}")),
+        },
+    }
+}
+
+/// True if `path` is, right now, an executable regular file (TOCTOU re-check).
+#[cfg(unix)]
+fn is_executable_now(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && (meta.permissions().mode() & 0o111 != 0),
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable_now(path: &Path) -> bool {
+    path.is_file()
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests` — Expected: PASS (detection + delegation tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-install --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-install/src/apm_backend.rs && git commit -m "feat(rb-install): add hardened apm install delegation (env_clear + toctou)"` — Expected: one commit.
+
+---
+
+### Task C3: `install_with_apm_awareness` — delegate-then-fallback orchestrator
+
+Add the orchestrator `install_with_apm_awareness(scope, dry_run) -> InstallReport`: select the backend; if `Apm`, delegate; on delegation success return an `apm`-shaped report; on delegation failure (or `Fallback`), run the P4 `engine::run_install`. Fail-open: any path yields an `InstallReport`, never an error.
+
+**Files:**
+- Modify: crates/rb-install/src/apm_backend.rs
+
+**Test:** with a fake `apm` exiting 0, the report shows the apm delegation succeeded; with a fake `apm` exiting non-zero, the report shows the fallback ran (no panic, report present); with no `apm`, the fallback runs.
+
+- [ ] **Step 1 RED: write the failing tests.** Append to the `tests` module in `crates/rb-install/src/apm_backend.rs`:
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn install_delegates_to_apm_when_present_and_succeeds() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let apm = dir.path().join("apm");
+        std::fs::write(&apm, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&apm, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let old = std::env::var_os("PATH");
+        let mut paths = vec![dir.path().to_path_buf()];
+        if let Some(ref p) = old {
+            paths.extend(std::env::split_paths(p));
+        }
+        std::env::set_var("PATH", std::env::join_paths(paths).unwrap());
+
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let report = install_with_apm_awareness(&scope, false);
+
+        match old {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+        // The apm-delegation report carries an "apm" pseudo-agent marked configured.
+        assert!(
+            report.agents.iter().any(|a| a.agent == "apm"
+                && matches!(a.status, crate::report::AgentStatus::Configured)),
+            "a successful apm delegation must report the `apm` agent as configured: {report:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_falls_back_when_apm_fails() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let apm = dir.path().join("apm");
+        // apm exits non-zero => orchestrator must fall back to the P4 installer.
+        std::fs::write(&apm, "#!/bin/sh\nexit 9\n").unwrap();
+        std::fs::set_permissions(&apm, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let old = std::env::var_os("PATH");
+        let mut paths = vec![dir.path().to_path_buf()];
+        if let Some(ref p) = old {
+            paths.extend(std::env::split_paths(p));
+        }
+        std::env::set_var("PATH", std::env::join_paths(paths).unwrap());
+
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let report = install_with_apm_awareness(&scope, false);
+
+        match old {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+        // A failed apm delegation must NOT mark `apm` configured; the fallback ran
+        // (the P4 installer reports per-CLI agents — claude-code/gemini/codex —
+        // which on CI are NotFound, so the report is still well-formed and non-panicking).
+        assert!(
+            !report.agents.iter().any(|a| a.agent == "apm"
+                && matches!(a.status, crate::report::AgentStatus::Configured)),
+            "a failed apm delegation must not be reported as a configured apm agent: {report:?}"
+        );
+        // The fallback installer's per-CLI agents are present in the report.
+        assert!(
+            report.agents.iter().any(|a| a.agent == "claude-code"),
+            "the P4 fallback installer must have run: {report:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_falls_back_when_apm_absent() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let old = std::env::var_os("PATH");
+        std::env::set_var("PATH", ""); // no apm
+        let scope = rb_agents::install::InstallScope::Project(dir.path().to_path_buf());
+        let report = install_with_apm_awareness(&scope, false);
+        match old {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+        // With no apm, the P4 fallback runs; its per-CLI agents appear.
+        assert!(
+            report.agents.iter().any(|a| a.agent == "claude-code"),
+            "no apm => the P4 fallback installer must run: {report:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests::install` — Expected: FAIL — `install_with_apm_awareness` does not exist yet.
+
+- [ ] **Step 3 GREEN: implement the orchestrator.** Append to `crates/rb-install/src/apm_backend.rs` (module level, before `tests`):
+
+```rust
+use crate::engine::{resolve_hooks_bin, run_install, select_installers};
+use crate::report::{AgentReport, AgentStatus, InstallReport};
+
+/// Install rusty-brain agent context, APM-aware and fail-open.
+///
+/// 1. Detect `apm`. If present, delegate to `apm install` (hardened spawn).
+/// 2. On delegation success, return an `apm`-shaped report.
+/// 3. On delegation failure OR no `apm`, fall back to the P4 direct-config
+///    installer ([`run_install`]) across all built-in CLIs.
+///
+/// Always returns an [`InstallReport`]; never errors and never panics. A
+/// `dry_run` reports what WOULD happen without spawning `apm` or writing config.
+#[must_use]
+pub fn install_with_apm_awareness(scope: &InstallScope, dry_run: bool) -> InstallReport {
+    let scope_label = match scope {
+        InstallScope::Project(_) => "project",
+        InstallScope::Global => "global",
+    };
+    if let Backend::Apm(apm_path) = select_backend() {
+        if dry_run {
+            // Report the delegation we WOULD perform; do not spawn or fall back.
+            let agent = AgentReport {
+                agent: "apm".to_string(),
+                status: AgentStatus::WouldConfigure,
+                config_path: None,
+                version: crate::detect::version_of(&apm_path),
+                error: None,
+            };
+            return InstallReport::roll_up(scope_label, true, vec![agent]);
+        }
+        let delegation = delegate_install(&apm_path, scope, false);
+        if delegation.success {
+            let agent = AgentReport {
+                agent: "apm".to_string(),
+                status: AgentStatus::Configured,
+                config_path: None,
+                version: crate::detect::version_of(&apm_path),
+                error: None,
+            };
+            return InstallReport::roll_up(scope_label, false, vec![agent]);
+        }
+        // Delegation failed — log and fall through to the fail-open P4 fallback.
+        tracing_note(&format!(
+            "apm delegation failed ({}); falling back to the direct-config installer",
+            delegation.note.unwrap_or_default()
+        ));
+    }
+    // Fallback: the P4 per-CLI direct-config installer across all built-ins.
+    let hooks_bin = resolve_hooks_bin();
+    match select_installers(None) {
+        Ok(installers) => run_install(&installers, &hooks_bin, scope, dry_run),
+        // select_installers(None) cannot error, but stay fail-open: an empty
+        // report is a neutral NoChanges, never a panic.
+        Err(_) => InstallReport::roll_up(scope_label, dry_run, Vec::new()),
+    }
+}
+
+/// Emit a best-effort note without taking a hard `tracing` dependency surface;
+/// `rb-install` already depends on nothing for logging, so write to stderr.
+fn tracing_note(msg: &str) {
+    eprintln!("rusty-brain-install: {msg}");
+}
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-install --lib apm_backend::tests` — Expected: PASS (all detection/delegation/orchestrator tests).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-install --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-install/src/apm_backend.rs && git commit -m "feat(rb-install): add apm-aware install orchestrator with p4 fallback"` — Expected: one commit.
+
+---
+
+### Task C4: route `Install` through the APM-aware backend
+
+Make the `rusty-brain-install install` command use `install_with_apm_awareness` instead of going straight to `run_install`, while `uninstall`/`status` keep the existing P4 behavior (APM owns un-wiring; the bespoke uninstall only touches OUR sentinel blocks). Add an `--no-apm` escape hatch to force the P4 path.
+
+**Files:**
+- Modify: crates/rb-install/src/cli.rs
+
+**Test:** clap parse test for `install --no-apm`; an `execute`-level test asserting the install path produces a report (the fake-`apm` behavior is covered by C3's unit tests; here we assert wiring + the flag).
+
+- [ ] **Step 1 RED: write the failing tests.** Append to the `tests` module in `crates/rb-install/src/cli.rs`:
+
+```rust
+    #[test]
+    fn parses_install_with_no_apm_flag() {
+        let cli = Cli::try_parse_from(["rusty-brain-install", "install", "--no-apm"]).unwrap();
+        match cli.command {
+            Command::Install { no_apm, .. } => assert!(no_apm, "--no-apm must force the P4 path"),
+            _ => panic!("expected install"),
+        }
+    }
+
+    #[test]
+    fn install_execute_returns_a_report() {
+        // In CI no `apm` and no agent CLIs are present, so this exercises the
+        // orchestrator's fallback path end to end and must return a report (never
+        // error). We use a temp cwd so the project scope is isolated.
+        let dir = tempfile::tempdir().unwrap();
+        let cli = Cli::try_parse_from([
+            "rusty-brain-install",
+            "--json",
+            "install",
+            "--no-apm",
+            "--dry-run",
+        ])
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = execute(&cli);
+        std::env::set_current_dir(prev).unwrap();
+        let (report, json) = result.expect("install execute must return a report");
+        assert!(json, "--json forces json");
+        assert!(report.dry_run, "a dry-run report");
+    }
+```
+
+Add `use tempfile` to the test deps if missing — `tempfile` is already in `rb-install` `[dev-dependencies]`, so no Cargo change.
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-install --lib cli::tests::parses_install_with_no_apm_flag cli::tests::install_execute_returns_a_report` — Expected: FAIL — the `no_apm` field does not exist on `Command::Install`.
+
+- [ ] **Step 3a GREEN: add the `--no-apm` flag.** In `crates/rb-install/src/cli.rs`, add a `no_apm` field to the `Install` variant of `Command`:
+
+```rust
+    /// Merge our sentinel-marked hook block into each CLI's config.
+    Install {
+        /// Restrict to these agents (claude-code, gemini, codex; opencode is
+        /// deferred — it needs a JS/TS plugin).
+        #[arg(long, value_delimiter = ',')]
+        agents: Option<Vec<String>>,
+        /// Install into the per-user (global) config instead of the project.
+        #[arg(long)]
+        global: bool,
+        /// Compute and print the report without writing any file.
+        #[arg(long)]
+        dry_run: bool,
+        /// Force the P4 direct-config installer even if `apm` is on PATH.
+        #[arg(long)]
+        no_apm: bool,
+    },
+```
+
+- [ ] **Step 3b GREEN: route `Install` through the orchestrator.** In `crates/rb-install/src/cli.rs`, change the `Command::Install` arm of `execute` to use the APM-aware orchestrator unless `--no-apm` or specific `--agents` are requested (an explicit agent subset implies the bespoke per-CLI path, which APM does not express). Replace the existing `Command::Install { agents, global, dry_run } => { … }` arm with:
+
+```rust
+        Command::Install {
+            agents,
+            global,
+            dry_run,
+            no_apm,
+        } => {
+            // An explicit --agents subset, or --no-apm, forces the P4 path (APM
+            // wires all harnesses at once and has no per-agent subset concept).
+            if *no_apm || agents.is_some() {
+                let installers = select_installers(agents.as_deref()).map_err(|e| e.to_string())?;
+                run_install(&installers, &hooks_bin, &scope_for(*global), *dry_run)
+            } else {
+                crate::apm_backend::install_with_apm_awareness(&scope_for(*global), *dry_run)
+            }
+        }
+```
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-install --lib cli::tests` — Expected: PASS (new tests + existing CLI tests). Also run `cargo test -p rb-install` to confirm the binary integration tests still pass.
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-install --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-install/src/cli.rs && git commit -m "feat(rb-install): route install through the apm-aware backend with --no-apm escape"` — Expected: one commit.
+
+---
+
+### Task C5: binary integration test — fake `apm` delegation + fallback + ignored smoke
+
+Prove the assembled `rusty-brain-install` binary delegates to a fake `apm` (asserting the recorded argv) and falls back when `apm` is absent, plus an `#[ignore]` real-`apm` smoke test.
+
+**Files:**
+- Create: crates/rb-install/tests/apm.rs
+
+**Test:** `assert_cmd`-driven cases with a fake `apm` stub on the child's PATH; an `#[ignore]` smoke test requiring a real `apm`.
+
+- [ ] **Step 1 RED: write the failing integration test.** Create `crates/rb-install/tests/apm.rs` with this exact content:
+
+```rust
+//! Integration tests for the `rusty-brain-install` binary's APM-aware backend.
+//! A FAKE `apm` stub on the child's PATH records its argv so we can assert
+//! delegation; with no `apm` the binary falls back to the P4 installer. The real
+//! `apm install` smoke test is `#[ignore]` (needs the apm binary + network).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+/// Write a fake `apm` into `dir` that records its argv to `argv.log` and exits
+/// with `exit_code`. Returns the PATH string (fake dir prepended) for the child.
+#[cfg(unix)]
+fn fake_apm(dir: &std::path::Path, exit_code: i32) -> String {
+    use std::os::unix::fs::PermissionsExt as _;
+    let bin = dir.join("apm");
+    let log = dir.join("argv.log");
+    std::fs::write(
+        &bin,
+        format!("#!/bin/sh\necho \"$@\" >> '{}'\nexit {exit_code}\n", log.display()),
+    )
+    .unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let existing = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", dir.display(), existing)
+}
+
+#[cfg(unix)]
+#[test]
+fn install_delegates_to_fake_apm() {
+    let apm_dir = tempfile::tempdir().unwrap();
+    let proj = tempfile::tempdir().unwrap();
+    let path = fake_apm(apm_dir.path(), 0);
+
+    Command::cargo_bin("rusty-brain-install")
+        .unwrap()
+        .current_dir(proj.path())
+        .env("PATH", &path)
+        .args(["--json", "install"])
+        .assert()
+        .success()
+        .stdout(contains("\"agent\": \"apm\"").or(contains("apm")));
+
+    // The fake apm recorded `install` in its argv log: delegation truly happened.
+    let log = std::fs::read_to_string(apm_dir.path().join("argv.log")).unwrap();
+    assert!(log.contains("install"), "the binary must have invoked `apm install`; got: {log:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_falls_back_when_apm_absent() {
+    let proj = tempfile::tempdir().unwrap();
+    // A PATH with NO apm (and no agent CLIs): the binary must fall back and still
+    // exit successfully (fail-open) — the report lists the per-CLI agents.
+    Command::cargo_bin("rusty-brain-install")
+        .unwrap()
+        .current_dir(proj.path())
+        .env("PATH", "/nonexistent-empty-path")
+        .args(["--json", "install"])
+        .assert()
+        .success()
+        .stdout(contains("claude-code"));
+}
+
+#[cfg(unix)]
+#[test]
+fn failing_apm_falls_back_fail_open() {
+    let apm_dir = tempfile::tempdir().unwrap();
+    let proj = tempfile::tempdir().unwrap();
+    // A fake apm that exits non-zero => the binary falls back and STILL exits 0.
+    let path = fake_apm(apm_dir.path(), 11);
+    Command::cargo_bin("rusty-brain-install")
+        .unwrap()
+        .current_dir(proj.path())
+        .env("PATH", &path)
+        .args(["--json", "install"])
+        .assert()
+        .success() // fail-open: never a non-zero process exit
+        .stdout(contains("claude-code")); // the P4 fallback ran
+}
+
+/// REAL smoke test: requires `apm` on PATH and network. Run manually with
+/// `cargo test -p rb-install --test apm -- --ignored`.
+#[ignore = "requires a real apm binary + network"]
+#[test]
+fn real_apm_install_smoke() {
+    let proj = tempfile::tempdir().unwrap();
+    // Copy the committed apm/apm.yml into the project so `apm install` has a
+    // manifest to act on.
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap()
+        .to_path_buf();
+    let src = root.join("apm").join("apm.yml");
+    std::fs::copy(&src, proj.path().join("apm.yml")).unwrap();
+    Command::cargo_bin("rusty-brain-install")
+        .unwrap()
+        .current_dir(proj.path())
+        .args(["--json", "install"])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: run it.** Run: `cargo test -p rb-install --test apm` — Expected: the three non-ignored unix tests run. They should PASS given Task C4's wiring; if `install_delegates_to_fake_apm` fails because the report shows no `apm` agent, confirm the orchestrator's success path runs (a fake apm exiting 0). The `real_apm_install_smoke` test is skipped (ignored).
+
+- [ ] **Step 3: (no impl change expected).** These exercise C1–C4 through the real binary. If Step 2 is green, record "no impl change needed".
+
+- [ ] **Step 4: run it.** Run: `cargo test -p rb-install` — Expected: PASS (unit + all integration tests, the smoke test ignored).
+
+- [ ] **Step 5: lint+format.** Run: `cargo clippy -p rb-install --all-targets -- -D warnings` (Expected: no warnings) then `cargo fmt --all` (Expected: no diff).
+
+- [ ] **Step 6: commit.** Run: `git add crates/rb-install/tests/apm.rs && git commit -m "test(rb-install): fake-apm delegation, fail-open fallback, ignored real smoke"` — Expected: one commit.
+
+---
+
+### Task C6: Part C gate
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: agent-crate tests — Run:** `cargo test -p rb-agents -p rb-hooks -p rb-install` — Expected: PASS, 0 failures (the smoke test stays `#[ignore]`).
+
+- [ ] **Step 2: workspace tests — Run:** `cargo test --workspace` — Expected: PASS, 0 failures.
+
+- [ ] **Step 3: clippy — Run:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+
+- [ ] **Step 4: format — Run:** `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 5: default-closure guard — Run:** `cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install"; echo "exit=$?"` — Expected: `exit=1` (no match): the `apm_backend` work stayed inside `rb-install`; the default `rusty-brain` closure is unchanged.
+
+- [ ] **Step 6: supply chain — Run:** `cargo deny check` — Expected: ok (`licenses ok`, `advisories ok`, `sources ok`; `bans` may `warn` only). Part C added no dep.
+
+- [ ] **Step 7: commit (only if a gate fixup was needed) — Run:** `git add -A && git commit -m "chore(rb-install): part C gate green"` — Expected: a commit only if a fixup was needed.
+
+---
+
+## Part D — CI manifest validation + final gate
+
+This Part wires the committed manifest into CI: a new `apm-manifest` job runs `rusty-brain apm validate apm/apm.yml`, so a drift between the binary's MCP surface and the published manifest, or any introduced secret, breaks the build. The Part ends with the full cross-Part gate.
+
+HARD RULES honored throughout: the CI step is read-only validation (it never runs `apm install`); the existing default `clippy-test`/`build-agents` jobs are untouched.
+
+---
+
+### Task D1: CI `apm-manifest` validation job
+
+Add a CI job that builds `rusty-brain` and runs `apm validate` over the committed manifest.
+
+**Files:**
+- Modify: .github/workflows/ci.yml
+
+**Test:** a YAML-parse + key-presence assertion (the CI file is not Rust; we validate its structure with `python3 -c`).
+
+- [ ] **Step 1 RED: prove the job is absent.** Run: `grep -n "apm-manifest" .github/workflows/ci.yml; echo "exit=$?"` — Expected: `exit=1` (no match) — the job does not exist yet.
+
+- [ ] **Step 2 GREEN: add the job.** Edit `.github/workflows/ci.yml` and add this job under `jobs:` (append after the existing `build-agents` job, preserving indentation — two-space top-level job keys):
+
+```yaml
+  apm-manifest:
+    name: apm manifest validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build rusty-brain
+        run: cargo build -p rusty-brain
+      - name: Validate the committed APM manifest (read-only; rejects secrets/missing ref/malformed MCP entry)
+        run: cargo run -p rusty-brain -- apm validate apm/apm.yml
+```
+
+- [ ] **Step 3: run it.** Run: `grep -n "apm-manifest" .github/workflows/ci.yml` (Expected: PASS — matches the job key) then validate the YAML parses and the existing jobs are intact: **Run:** `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); j=d['jobs']; assert 'apm-manifest' in j; assert 'clippy-test' in j and j['clippy-test']['steps'][-1]['run']=='cargo test --workspace'; assert 'build-agents' in j; print('ok', sorted(j))"` (Expected: prints `ok [...]` including `apm-manifest`, confirming the default `clippy-test` job is unchanged).
+
+- [ ] **Step 4: locally mirror the CI step — Run:** `cargo run -p rusty-brain -- apm validate apm/apm.yml; echo "exit=$?"` — Expected: prints the `ok:` line and `exit=0` (the committed manifest validates exactly as CI will check).
+
+- [ ] **Step 5: lint+format — Run:** `cargo fmt --all --check` — Expected: no diff (the workflow edit touches no Rust).
+
+- [ ] **Step 6: commit — Run:** `git add .github/workflows/ci.yml && git commit -m "ci: validate the committed apm manifest with rusty-brain apm validate"` — Expected: one commit.
+
+---
+
+### Task D2: final cross-Part gate
+
+**Files:**
+- (none — verification only)
+
+- [ ] **Step 1: full workspace tests — Run:** `cargo test --workspace` — Expected: PASS, 0 failures. Confirms Parts A–D compose: the `apm` CLI, the committed manifest fixture, and the `rb-install` apm backend all green.
+
+- [ ] **Step 2: clippy (all features) — Run:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Expected: no warnings.
+
+- [ ] **Step 3: format — Run:** `cargo fmt --all --check` — Expected: no diff.
+
+- [ ] **Step 4: supply chain — Run:** `cargo deny check 2>&1 | tail -20; echo "exit=${PIPESTATUS[0]}"` — Expected: `exit=0`, `licenses ok`, `advisories ok`, `sources ok` (`bans` may `warn` only). Confirms `serde_yaml_ng` (the only new dep, from Part B) is accepted.
+
+- [ ] **Step 5: default-closure guard — Run:** `cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install"; echo "exit=$?"` — Expected: `exit=1` (no match): the default `rusty-brain` binary closure never pulls in an agent crate. The `apm` module added only `serde_yaml_ng`/`thiserror`, no agent crate.
+
+- [ ] **Step 6: committed-manifest validation (mirrors CI) — Run:** `cargo run -p rusty-brain -- apm validate apm/apm.yml; echo "exit=$?"` — Expected: `exit=0`, the `ok:` line printed.
+
+- [ ] **Step 7: emit→validate round-trip (mirrors CI intent) — Run:** `cargo run -p rusty-brain -- apm emit` — Expected: prints the canonical stdio MCP entry (with the `ContractVersion` comment), matching the committed manifest's MCP block.
+
+- [ ] **Step 8: ignored real smoke remains opt-in — Run:** `cargo test -p rb-install --test apm -- --list 2>/dev/null | grep -i "real_apm_install_smoke"; echo "exit=$?"` — Expected: `exit=0` — the smoke test is present but `#[ignore]` (not run in the default suite; run manually with `-- --ignored` when a real `apm` is installed).
+
+- [ ] **Step 9: commit (only if a final fixup was needed) — Run:** `git add -A && git commit -m "chore(apm): p7 final gate green"` — Expected: a commit only if a fixup was needed.

--- a/docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md
+++ b/docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md
@@ -1,0 +1,169 @@
+# rusty-brain — P5: Retrieval Quality & Measurement — Design Spec
+
+- **Status:** Draft (brainstormed and approved; pending written-spec review)
+- **Date:** 2026-06-02
+- **Author:** Brian Luby
+- **Depends on:** P0–P4 (workspace, store, engine, daemon, MCP, enrichment, evolution jobs, agent surface)
+- **References:** `docs/specs/2026-05-31-rusty-brain-architecture-design.md` (§9 data model, §10 embeddings, §11 search/ranking, §15 testing). Derived from a verified deep-research survey of A-MEM, Mem0/Mem0g, Zep/Graphiti, HippoRAG, and Generative Agents (sources in §10).
+
+---
+
+## 1. Context & Motivation
+
+A research survey of the agentic-memory field (24/25 extracted claims verified unanimously against primary papers) confirmed rusty-brain's design is on solid ground — its recency+importance+relevance ranking mirrors Generative Agents, and its evolution jobs mirror the field's first-class treatment of consolidation/forgetting. The survey also surfaced four concrete, low-risk improvements that the current code does not yet implement, and one meta-lesson: **the popular memory benchmark (LOCOMO) is unreliable** (an audit found 64% of its answer key wrong), so quality changes must be validated against our *own* measurement, not borrowed leaderboards.
+
+This phase delivers that measurement harness first, then three retrieval-quality improvements gated by it. Concrete gaps in today's code:
+
+- **Vectors are built from raw `content` alone.** `rb-engine` computes a summary, keywords, tags, and context during enrichment, then embeds only `note.content` (`crates/rb-engine/src/engine.rs:147`), discarding query-aligned signal. A-MEM embeds the *composite* (content + keywords + tags + context) and retrieves better for it.
+- **Ranking is a weighted linear sum of normalized scores** (`crates/rb-search/src/rank.rs`), which assumes cosine-similarity, reciprocal-keyword-rank, and reciprocal-graph-hops are on comparable, calibrated scales. They are not. Reciprocal Rank Fusion (RRF) — the de-facto hybrid-search standard, used by Zep — fuses *rank positions* and is scale-free.
+- **`confidence` is stored but never used at query time.** The `Signals` struct in `rank.rs` has no confidence field. A single wrong, high-matching memory can dominate recall — the **context-poisoning** failure mode.
+- **Contradictions are invisible at recall.** `LinkType::Contradicts` exists and is writable, but recall/get never tell the agent that a returned memory is contested.
+
+## 2. Goals
+
+1. A reproducible, offline, CI-gated **regression harness** (`rb-eval`) that measures recall quality and guards against ranking regressions.
+2. **RRF fusion** available as a configurable, eval-comparable alternative to linear ranking.
+3. **Composite embeddings** (enriched representation) with a safe, idempotent re-embed transition.
+4. **Confidence-weighted ranking** and **contradiction surfacing** as context-poisoning mitigations, using data already in the schema.
+5. Zero new default runtime dependencies. No change to the single-writer discipline, namespace isolation, or fail-closed/ fail-open rules.
+
+## 3. Non-Goals
+
+- No chasing of external leaderboards (LOCOMO and similar are explicitly distrusted; we build our own fixtures).
+- No cross-encoder / neural reranker in the default build (local-first; reserved behind a feature if ever).
+- No LLM on the default read or write path (LLM-assisted evolution is P6).
+- No multi-host or networked surface.
+
+## 4. Locked Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Eval harness scope | **Offline regression harness** (committed fixtures + `DeterministicProvider`, CI gate; optional `#[ignore]` real-model mode) | Lean, fast, deterministic; guards regressions and relative ordering without network. Absolute semantic quality is the real-model mode's job. |
+| RRF rollout | **Opt-in; `Linear` stays default; eval-gated flip** | Backward-compatible and data-driven — flip the default only when `rb-eval` shows RRF wins. |
+| RRF design | **Two-stage hybrid** (RRF fuses FTS/vector/graph rank lists → importance/recency/confidence applied as priors) | Compares linear against a *real* RRF design, not a strawman; keeps the metadata priors that already work. |
+| Composite embedding transition | **`embedding_input_version` stamp + `Reembed` write command + `rusty-brain reembed` batch command** | One idempotent mechanism covers the corpus transition, future model swaps, and P6's per-memory re-embed. Matches A-MEM/Mem0 (re-embed on mutation) + vector-DB practice (batch re-index). |
+| Confidence in ranking | **Multiplicative dampener with a floor** | A low-confidence memory is suppressed regardless of match quality (the poisoning goal), but never fully zeroed. |
+| Contradiction surfacing | **Read-side annotation, fail-open** | Uses the existing `contradicts` link; a lookup failure degrades to unflagged results, never fails recall. |
+
+## 5. Build Order
+
+`H → B → A → C`, then a phase gate. H is first so B/A/C are measurable; the others are independent of each other but all consume H.
+
+```text
+H  rb-eval offline regression harness        (gates everything below)
+B  RRF two-stage fusion mode                  (pure rb-search; eval-compared)
+A  composite embedding + reembed primitive    (engine + store + meta + CLI)
+C  confidence dampener + contradiction flag   (rb-search + engine + proto/mcp)
+```
+
+---
+
+## 6. Feature H — `rb-eval` offline regression harness
+
+**Crate:** new `crates/rb-eval` — a dev/measurement crate, **excluded from the `rusty-brain` binary's dependency closure** (not a workspace default-member of the binary build path; built and run in CI and locally). Depends on `rb-engine`, `rb-store`, `rb-search`, `rb-embed` (`DeterministicProvider`).
+
+**Components:**
+- `fixtures/` — committed JSON: a small coding-memory corpus (typed notes with content + enrichment fields), a set of golden queries each with expected-relevant `memory_id`s, and near-duplicate clusters for dedup scoring. Authored to exercise FTS, vector, and graph paths.
+- `corpus.rs` — fixture loader and validation (fail fast on malformed fixtures).
+- `metrics.rs` — pure functions: `recall_at_k`, `mrr`, `dedup_precision`, latency percentiles (p50/p99). Unit-tested independently.
+- `runner.rs` — builds an in-memory store, ingests fixtures through `rb-engine` with `DeterministicProvider`, runs each golden query through recall, computes metrics, and asserts each metric ≥ its committed baseline.
+- `baselines.json` — committed metric baselines; CI fails on regression. Updating a baseline is a reviewed, intentional commit.
+
+**Data flow:** load fixtures → `engine.remember` each (deterministic vectors) → for each golden query, `engine.recall` → compute metrics vs expected → assert ≥ baseline.
+
+**Honest framing (documented in the crate README):** offline + `DeterministicProvider` guards **ranking determinism, regression detection, and relative-ordering invariants** ("did change X reorder results vs the committed baseline?"). It does **not** measure absolute semantic quality — that requires the optional `#[ignore]` real-model mode (Voyage or `local`), run manually for spot checks. This limit is stated explicitly, in the spirit of the architecture spec's sqlite-vec scale honesty (§11).
+
+**Error handling:** test-only crate; failures are assertion failures with readable diffs (expected vs actual ranking). The crate may `#![allow(clippy::unwrap_used, clippy::expect_used)]` as test code; no panics leak into shipped crates.
+
+**Testing:** the harness *is* the test; plus unit tests for each metric function on hand-checked inputs.
+
+## 7. Feature B — RRF two-stage hybrid fusion
+
+**Crate:** `rb-search` only (pure functions; no new deps).
+
+**Design:** add `FusionMode { Linear, Rrf }`. `Linear` remains the default and is the existing `rank()`. `Rrf` is a new path:
+- **Stage 1 — rank fusion.** Each retrieval path (FTS, vector, graph) contributes a ranked candidate list. RRF score per candidate = `Σ_paths 1 / (k + rank_path)` with a documented default `k = 60`. Missing from a list ⇒ that path contributes nothing (no penalty), matching today's "missing signal = 0" rule. Rank for the vector path derives from ascending distance; for graph, from ascending hops.
+- **Stage 2 — priors.** Apply `importance`, `recency` (the existing 30-day-half-life exponential), and `confidence` (Feature C) as multiplicative priors on the fused score. Documented, configurable weights; pure and deterministic (stable sort, `total_cmp`).
+
+**Configuration:** `FusionMode` selected via the existing weights/config plumbing read by the engine on recall. Default `Linear` preserves current behavior byte-for-byte.
+
+**Data flow:** candidates (already carrying `keyword_rank`, `vector_distance`, `graph_hops` in `Signals`) → derive per-path ranks → RRF fuse → apply priors → sort → truncate to `limit`.
+
+**Testing:** `rank_rrf` unit tests (RRF arithmetic on known lists, determinism, prior application, non-finite-input sanitization mirroring `rank()`); `rb-eval` runs the full fixture set under both modes and reports the metric delta. The default flips to `Rrf` only in a later commit if and when the eval shows a win.
+
+## 8. Feature A — composite embedding input + re-embed primitive
+
+**Crates:** `rb-engine` (embed input), `rb-store` + `rb-daemon` (re-embed write path + stamp), `rusty-brain` (CLI).
+
+**Embed input:** a pure `embedding_input(note) -> String` (in `rb-engine`) composes `content` + keywords + tags + context (newline-joined, documented order). It replaces `note.content` at `engine.rs:147`. Enrichment already runs before the embed call, so the fields are populated. **The query stays embedded raw** — only the *document* representation changes (A-MEM does the same; query symmetry is not required).
+
+**Schema / invariants (additive migration):**
+- New `meta` key `embedding_input_version` (e.g. `"v2-composite"`), seeded at init, sitting alongside the existing `embedding_model` / `embedding_dim` invariants (architecture spec §9).
+- New `memories.embedding_input_version` column (TEXT) stamped per row at write, alongside the existing `embedding_model` stamp. Additive, file-discovered, checksummed migration — must pass the existing CI reproducibility gate (§15).
+
+**Re-embed primitive:**
+- New `WriteCommand::Reembed { id }` in `crates/rb-daemon/src/store_handle.rs` and a store path that recomputes a single memory's vector and `UPDATE`s `memory_vectors` (today vectors are write-once via `INSERT` at `store.rs:818`; this adds the update path the system has so far avoided by making content immutable, `engine.rs:386`).
+- `rusty-brain reembed` CLI → a `Request::RunJob`-style daemon request that batch-scans active memories whose stamped `(embedding_model, embedding_input_version)` ≠ current and re-embeds them through the single writer. **Bounded and idempotent** (a row already at current stamps is skipped; a second run over unchanged data writes nothing) — same discipline as the evolution jobs.
+
+**Transition semantics:** after upgrading, the corpus is mixed (old vectors built from content-only, new from composite) until `reembed` runs. This is tolerated and documented; recall still functions (cosine space is unchanged; only document text representation shifts). `reembed` is the explicit, user-triggered convergence step.
+
+**Rationale (from research):** comparable systems re-embed *on mutation, per-memory* (A-MEM on evolution, Mem0 on UPDATE) and *batch re-index* on a global model/template change (general vector-DB practice). There is no "lazy on access" pattern in this class; it is unnecessary here because content is immutable today. The same `Reembed` primitive is what P6's content-mutating jobs (reconcile/reflection) will call.
+
+**Error handling:** embedding failures surface via the existing `Error::Embedding` path; `reembed` batches fail-safe (a failed row is logged and retried next run, never fatal). Dim contract (`seed_or_verify_dim`) is unchanged and still fail-closed.
+
+**Testing:** `embedding_input` pure-fn unit tests (field composition, ordering, empty fields); `Reembed` idempotency + stamp-skip tests; migration reproducibility test (fresh DB exercises the new column); `rb-eval` recall comparison content-only vs composite under the real-model `#[ignore]` mode (deterministic vectors can't show semantic lift, so this comparison is real-model-only and documented as such).
+
+## 9. Feature C — confidence-weighted ranking + contradiction surfacing
+
+**Crates:** `rb-search` (confidence factor), `rb-store`/`rb-engine` (contradiction lookup + annotation), `rb-proto`/`rb-mcp`/`rusty-brain` (result-shape field + display).
+
+**Confidence dampener:** add `confidence: f32` to the `Signals` struct and apply it as a multiplicative dampener on the final score: `score *= floor + (1 - floor) * confidence`, with a documented, configurable `floor` (e.g. `0.5`) so a low-confidence memory is meaningfully suppressed but never fully zeroed. Applies in both `Linear` and `Rrf` (as a Stage-2 prior). Pure and deterministic.
+
+**Contradiction surfacing:** add a boolean `contested` to recall/list/context result rows and the `get` payload, set when the memory has at least one *active* `contradicts` link (inbound or outbound). Computed read-side over `memory_links` for the result set after ranking (reuse the existing link-loading path). **Fail-open:** if the contradiction lookup errors, results are returned unflagged rather than failing recall — surfacing contested state is best-effort enrichment, never a gate on retrieval.
+
+**Wire/contract:** the new `contested` field is additive to the MCP result schema and CLI output; `ContractVersion` (architecture spec §12) bumps so clients can detect the richer shape. Defaulting absent → `false` keeps older clients correct.
+
+**Data flow:** recall → rank (confidence-aware) → for the top `limit` results, batch-load `contradicts` links → set `contested` → return.
+
+**Testing:** confidence-dampening unit tests (low-confidence memory ranks below an otherwise-equal high-confidence one; floor honored); a "poison" scenario in `rb-eval` (a low-confidence wrong memory must rank below the high-confidence correct one); a contradiction integration test (create A, create B, link `A contradicts B`, recall → both flagged `contested`); fail-open test (forced lookup error → results returned, unflagged).
+
+---
+
+## 10. Sources (verified research)
+
+- A-MEM (atomic notes; composite embedding; evolve-and-re-embed neighbors on insert) — <https://arxiv.org/abs/2502.12110>
+- Mem0 / Mem0g (ADD/UPDATE/DELETE/NOOP; re-embed on UPDATE) — <https://arxiv.org/html/2504.19413v1>
+- Zep / Graphiti (hybrid retrieval reranked by RRF/MMR/cross-encoder) — <https://arxiv.org/html/2501.13956v1>, <https://neo4j.com/blog/developer/graphiti-knowledge-graph-memory/>
+- HippoRAG (graph-centric retrieval) — <https://arxiv.org/abs/2405.14831>
+- Generative Agents (recency·importance·relevance retrieval) — <https://ar5iv.labs.arxiv.org/html/2304.03442>
+- LOCOMO benchmark audit (answer-key unreliability) — <https://dev.to/penfieldlabs/we-audited-locomo-64-of-the-answer-key-is-wrong-and-the-judge-accepts-up-to-63-of-intentionally-33lg>
+- Context poisoning (failure mode motivating confidence/contradiction defenses) — <https://www.agentpatterns.tech/en/failures/context-poisoning>
+
+## 11. Testing Strategy (phase-wide)
+
+- TDD throughout; workspace lints stay `deny` for `unwrap_used`/`expect_used`/`panic` outside tests.
+- `rb-eval` is the CI regression gate for ranking changes (B, A, C). Real-model comparisons are `#[ignore]`, run manually.
+- New migration (A) must pass the existing fresh-DB reproducibility gate (architecture spec §15).
+- No live network in CI; deterministic fixtures and `DeterministicProvider` only.
+- Per-phase gate: `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`. A-adds-a-dep? No new deps in P5 — `cargo deny check` still runs and must stay green.
+
+## 12. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Deterministic vectors can't prove semantic lift for composite embeddings (A) | Real-model `#[ignore]` comparison; offline harness guards regressions, not absolute quality (documented). |
+| RRF tuned to fixtures, not real corpora | `k` documented and configurable; flip-the-default decision requires real-model eval, not just fixtures. |
+| `Reembed` introduces the first vector-update path (previously write-once) | Bounded, idempotent, single-writer; integration tests for idempotency and the dim contract. |
+| `contested` flag adds recall latency | Batched single lookup over the result set only; fail-open; measured by `rb-eval` latency metric. |
+
+## 13. Traceability
+
+| Research finding | P5 feature |
+|---|---|
+| A-MEM embeds composite, not content alone | A — composite `embedding_input` |
+| A-MEM/Mem0 re-embed on mutation; vector-DBs batch re-index | A — `Reembed` primitive + `reembed` command |
+| Zep reranks with RRF | B — RRF two-stage fusion |
+| Generative Agents = recency·importance·relevance | (already in `rank.rs`); B priors preserve it |
+| Context poisoning; confidence unused at query time | C — confidence dampener |
+| `contradicts` link writable but invisible at recall | C — contradiction surfacing |
+| LOCOMO answer key 64% wrong; SOTA claims contested | H — own offline eval, not borrowed leaderboards |

--- a/docs/specs/2026-06-02-rusty-brain-p6-llm-evolution.md
+++ b/docs/specs/2026-06-02-rusty-brain-p6-llm-evolution.md
@@ -1,0 +1,156 @@
+# rusty-brain — P6: LLM-Assisted Evolution — Design Spec
+
+- **Status:** Draft (brainstormed and approved; pending written-spec review)
+- **Date:** 2026-06-02
+- **Author:** Brian Luby
+- **Depends on:** P0–P4, **and P5** (reuses the `Reembed` primitive, composite `embedding_input`, the `rb-eval` harness, and complements P5's confidence/contradiction surfacing)
+- **References:** `docs/specs/2026-05-31-rusty-brain-architecture-design.md` (§8 broadcast, §9 data model, §11 ranking, §17 P3 evolution jobs), `docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md`. Derived from the verified research survey (sources in §9).
+
+---
+
+## 1. Context & Motivation
+
+P3 shipped LLM-free evolution jobs (link decay, cosine-threshold consolidation, importance recalibration) behind the daemon's job scaffolding. The research survey shows the next tier of value in the field is **LLM-assisted** evolution — used by A-MEM, Mem0, and Generative Agents — which rusty-brain can adopt *without* compromising its LLM-free, low-latency default path, because the machinery already exists:
+
+- `rb-enrich` already speaks an OpenAI-compatible endpoint (`crates/rb-enrich/src/openai_compat.rs`) and already proposes links via an LLM (`linker.rs`).
+- The jobs scaffolding (`run_once`, `JobKind`, `JobsConfig` TOML, the in-daemon scheduler, `Request::RunJob`) already drives opt-in, off-by-default, bounded, fail-safe jobs through the single writer.
+- The change-broadcast (`MemoryChanged` on `tokio::broadcast`, architecture spec §8) already carries every committed write — an untapped trigger source.
+- P5 adds the `Reembed` primitive these jobs need when they mutate a memory's text.
+
+Three gaps the current jobs cannot address:
+
+1. **Consolidation can only merge, never reconcile.** Today's job clusters by cosine ≥ a threshold (`crates/rb-store/src/store.rs:282` `near_duplicates`) and picks a survivor by importance/recency (`jobs/consolidation.rs::pick_survivor`). It cannot decide *update vs supersede vs keep-both*, and cannot detect that two close memories actually *contradict*.
+2. **Consolidation removes redundancy but never creates higher-level knowledge.** Generative Agents periodically *reflect*: cluster recent memories and synthesize an insight. rusty-brain already has an `insight` memory type and a `references` link type — the data model is ready, the job is missing.
+3. **The graph signal is crude.** Ranking uses `1/(1+hops)` over a fixed-depth CTE. HippoRAG shows graph-centric retrieval (Personalized PageRank seeded by vector hits) surfaces structurally-central memories that hop-distance misses.
+
+## 2. Goals
+
+1. An opt-in **`reconcile`** job: LLM-decided ADD/UPDATE/SUPERSEDE/NOOP over near-duplicate clusters.
+2. An opt-in **`reflect`** job: synthesize higher-level `insight` memories from clusters of recent high-importance memories, with an importance-accumulation trigger.
+3. A **Personalized PageRank** graph signal for ranking, computed over the existing SQLite link graph.
+4. Everything off by default, bounded, idempotent, fail-safe, single-writer; **no new default runtime dependencies** (PPR is pure; the LLM jobs reuse `rb-enrich`).
+
+## 3. Non-Goals
+
+- No LLM on the default read or write path. Reconcile/reflect run only when explicitly enabled.
+- No external graph database (PPR runs over `memory_links` in SQLite — Zep/Graphiti's Neo4j model is rejected as non-local-first).
+- No replacement of the LLM-free P3 jobs — the LLM jobs *complement* them; the operator chooses.
+- No cross-namespace operations — every job stays namespace-isolated and fails closed, exactly as P3.
+
+## 4. Locked Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| LLM jobs default state | **Off by default; opt-in via `JobsConfig` TOML** | Preserves the LLM-free, low-latency default; respects the fail-open capture rule and the dependency budget. |
+| LLM transport | **Reuse `rb-enrich` OpenAI-compatible client** | No new dependency; one place for endpoint/key/timeout/masking. |
+| `reconcile` vs `consolidation` | **Complementary, not a replacement** | Operator enables one; cosine consolidation stays the LLM-free option. |
+| `reflect` trigger | **Interval OR importance-accumulation off the change-broadcast** | Mirrors Generative Agents' cumulative-importance reflection; reuses existing broadcast, no new write path. |
+| Content-mutating writes | **Go through the writer + P5 `Reembed`** | Single-writer discipline; mutated text stays consistent with its vector. |
+| Graph signal | **Personalized PageRank, pure, over the bounded subgraph** | Local-first; no new deps; documented scale bound like sqlite-vec. |
+| Idempotency under LLM non-determinism | **Watermarks + supersede/state markers bound re-processing** | A second pass over unchanged data does no work despite a non-deterministic model. |
+
+## 5. Build Order
+
+```text
+F  Personalized PageRank graph signal   (pure rb-search; independent; eval-validated first)
+D  LLM reconcile job                     (jobs + rb-enrich + P5 Reembed)
+E  LLM reflect/synthesis job             (jobs + rb-enrich + broadcast trigger)
+```
+
+F is sequenced first because it is pure, dependency-free, and immediately measurable via `rb-eval`; D and E are independent of each other and both reuse P5's `Reembed`.
+
+---
+
+## 6. Feature F — Personalized PageRank graph signal
+
+**Crate:** `rb-search` (pure; no new deps), with a bounded subgraph read from `rb-store`.
+
+**Design:** replace/augment the `1/(1+hops)` graph term with a Personalized PageRank score:
+- **Personalization vector:** the recall seeds (FTS + vector hits) weighted by their pre-graph scores — PPR restarts toward the seeds, so structurally-central memories *near the seeds* score highest.
+- **Graph:** the `memory_links` adjacency, edges weighted by `strength` (the `0..1` column already on every link). Damping `d = 0.85` (documented, configurable).
+- **Computation:** power iteration to a fixed iteration cap or convergence epsilon (documented), over a **bounded subgraph** — nodes reachable within N hops of the seeds, capped at a configured node budget. Stable node ordering ⇒ deterministic output.
+- **Output:** a normalized PPR score per candidate, fed into ranking as the graph signal (the Stage-2 graph prior under P5's `Rrf`, or the graph term under `Linear`).
+
+**Data flow:** recall gathers seeds → load the bounded link subgraph around them → run PPR → attach `graph_ppr` to `Signals` → rank.
+
+**Scale honesty (documented):** PPR is bounded by the subgraph node budget; beyond it the graph signal degrades gracefully to the seed neighborhood. Stated as a known limit, like the sqlite-vec brute-force ceiling (architecture spec §11).
+
+**Error handling:** pure computation; a missing/empty graph yields a zero graph signal (no penalty), matching today's "missing signal = 0".
+
+**Testing:** PPR unit tests on hand-computed small graphs (known stationary distributions), convergence, determinism, strength-weighting, and seed sensitivity; `rb-eval` graph-recall scenario comparing `1/(1+hops)` vs PPR (deterministic vectors are fine here — graph structure, not embeddings, drives the result).
+
+## 7. Feature D — LLM `reconcile` job
+
+**Crates:** `rb-daemon/src/jobs` (new job arm), `rb-enrich` (reconcile decision call), reusing P5 `Reembed`.
+
+**Design:** a new `JobKind::Reconcile` with its own `run_once` arm and `ReconcileConfig` (in `JobsConfig`, `enabled = false`). For each near-duplicate cluster (reusing `near_duplicates`, namespace-scoped), call an `rb-enrich` function that returns one decision per cluster:
+- **MERGE** — synthesize merged content; insert a new memory; supersede the members into it.
+- **UPDATE** — rewrite the survivor's content to subsume the rest; supersede the others.
+- **SUPERSEDE** — one member supersedes another (staleness/contradiction), keep the survivor.
+- **NOOP** — distinct despite vector closeness; record a "reconciled" marker so the pair is not re-examined.
+
+All writes funnel through the single writer: `Insert`/`Update`/`Supersede` + `Reembed` (content changed ⇒ vector must follow). Reuses `pick_survivor`-style determinism for any non-LLM tiebreak.
+
+**Config:** `ReconcileConfig { enabled: bool, batch_limit: usize, similarity_floor: f32, model/endpoint via rb-enrich env }`. Default disabled. The cosine `consolidation` job is unchanged and remains the LLM-free option; operators enable at most one.
+
+**Idempotency under LLM non-determinism:** only clusters above `similarity_floor` are considered; a processed pair is marked (reconciled watermark / superseded state) so a second pass over unchanged data does nothing, even though the model itself is non-deterministic. Documented as a caveat.
+
+**Error handling:** fail-safe — an LLM/network error logs and skips the cluster, never fatal (reuse the writer's `catch_unwind` + reopen path). Bounded `batch_limit` per pass. API key never logged (existing `rb-enrich` masking).
+
+**Testing:** in-process with `wiremock` (already a dep) serving canned decisions; assert the exact writer commands per decision (MERGE/UPDATE/SUPERSEDE/NOOP); idempotency (second pass writes nothing); namespace isolation (never merges across namespaces); fail-safe (HTTP error → cluster skipped, job summary records it). Real-model test `#[ignore]`.
+
+## 8. Feature E — LLM `reflect` / synthesis job
+
+**Crates:** `rb-daemon/src/jobs` (new job arm + trigger), `rb-enrich` (synthesis call), `rb-daemon` scheduler (accumulation trigger), reusing composite embedding from P5.
+
+**Design:** a new `JobKind::Reflect` with `ReflectConfig` (`enabled = false`). Per namespace, cluster recent high-importance memories (since a `last_reflected_at` watermark, bounded by `batch_limit`), call `rb-enrich` to synthesize an `insight`-type memory, insert it (importance/confidence from the synthesis), and add `references` links from the insight to its source memories. The new insight is embedded via P5's composite `embedding_input`. **Non-destructive** — it only adds a memory and links.
+
+**Trigger:** two modes, both opt-in:
+- **Interval** — the existing scheduler, like the P3 jobs.
+- **Importance-accumulation** — the daemon subscribes to its own `MemoryChanged` broadcast and sums the importance of `Created` events per namespace; when the running sum crosses `importance_threshold` (default ~150, à la Generative Agents' reflection trigger), it enqueues a `Reflect` run and resets the counter. This adds *only* a subscriber + counter to the scheduler — no new write path.
+
+**Config:** `ReflectConfig { enabled: bool, importance_threshold: u32, batch_limit: usize, window, model/endpoint via rb-enrich env }`.
+
+**Idempotency / convergence:** a `last_reflected_at` watermark (in `meta`, per namespace) prevents re-reflecting the same window; reflecting a window with nothing new is a no-op. The synthesized insight is ordinary memory, so it is itself subject to recall, decay, and consolidation.
+
+**Error handling:** fail-safe (synthesis error → log, skip, never fatal); bounded batch; key masked.
+
+**Testing:** in-process with `wiremock` returning a canned synthesis; assert one `insight` memory inserted with `references` links to the correct sources; trigger unit test (accumulated importance crosses the threshold → exactly one run enqueued, counter resets); watermark test (second run over the same window does nothing). Real-model test `#[ignore]`.
+
+---
+
+## 9. Sources (verified research)
+
+- A-MEM (memory evolution: LLM updates neighbors' context/keywords/tags on insert, then re-embeds) — <https://arxiv.org/abs/2502.12110>
+- Mem0 / Mem0g (LLM ADD/UPDATE/DELETE/NOOP over top-s; directed labeled graph; recency-favoring conflict resolution) — <https://arxiv.org/html/2504.19413v1>
+- Generative Agents (reflection synthesizes higher-level insights; triggered when cumulative importance exceeds a threshold) — <https://ar5iv.labs.arxiv.org/html/2304.03442>
+- HippoRAG (LLMs + KG + Personalized PageRank; vectors only seed) — <https://arxiv.org/abs/2405.14831>
+- Zep / Graphiti (n-hop traversal + reranking; bi-temporal supersede) — <https://arxiv.org/html/2501.13956v1>
+
+## 10. Testing Strategy (phase-wide)
+
+- TDD; workspace `deny` lints unchanged.
+- LLM jobs tested in-process against `wiremock`; **no live network in CI**; real-model tests `#[ignore]`.
+- All jobs: off-by-default, bounded, idempotent, fail-safe, namespace-isolated — asserted per the P3 jobs test pattern.
+- F validated by `rb-eval` (P5) graph-recall comparison.
+- Per-phase gate: `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`; `cargo deny check` (no new default deps expected — verify).
+
+## 11. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| LLM non-determinism breaks idempotency | Watermarks + supersede/reconciled markers; act only above `similarity_floor`; documented caveat. |
+| `reconcile` destroys information via a bad MERGE | Supersede (soft, reversible) not hard-delete; namespace-isolated; bounded batch; real-model review before enabling. |
+| Reflection floods the store with low-value insights | Importance-accumulation trigger gates frequency; insights are normal memories subject to decay/consolidation; `batch_limit`. |
+| PPR cost on large graphs | Bounded subgraph + iteration cap; documented scale limit; measured via `rb-eval` latency. |
+| Cost/latency of LLM jobs | Off by default; bounded batches; timeouts via `rb-enrich`; operator opts in knowingly. |
+
+## 12. Traceability
+
+| Research finding | P6 feature |
+|---|---|
+| Mem0 LLM ADD/UPDATE/DELETE/NOOP over similar memories | D — reconcile job |
+| A-MEM evolves + re-embeds neighbors on insert | D — reconcile + P5 `Reembed` |
+| Generative Agents reflection (synthesize insights; cumulative-importance trigger) | E — reflect job + accumulation trigger |
+| HippoRAG Personalized PageRank seeded by vector hits | F — PPR graph signal |
+| Zep no-LLM-at-query-time default | F runs at query time and is LLM-free; LLM stays in opt-in write-time jobs (D/E) |

--- a/docs/specs/2026-06-02-rusty-brain-p7-apm-distribution.md
+++ b/docs/specs/2026-06-02-rusty-brain-p7-apm-distribution.md
@@ -1,0 +1,137 @@
+# rusty-brain — P7: APM Package Distribution — Design Spec
+
+- **Status:** Draft (brainstormed and approved; pending written-spec review)
+- **Date:** 2026-06-02
+- **Author:** Brian Luby
+- **Depends on:** P0–P4 (esp. P4 `rb-mcp`, `rb-hooks`, `rb-install`). Independent of P5/P6.
+- **References:** `docs/specs/2026-05-31-rusty-brain-architecture-design.md` (§12 interfaces/ContractVersion, §14 security), P4 (`rb-install`/`rb-hooks` multi-CLI installer). APM docs: <https://microsoft.github.io/apm/>, <https://github.com/microsoft/apm>, <https://microsoft.github.io/apm/guides/mcp-servers/>.
+
+---
+
+## 1. Context & Motivation
+
+APM (Microsoft **Agent Package Manager**) is a manifest-driven dependency manager for AI-agent context. A single `apm.yml` declares the instructions, skills, prompts, agents, hooks, plugins, and **MCP servers** a project needs; `apm install` reproduces that exact setup across every detected harness (GitHub Copilot, Claude Code, Cursor, Codex, OpenCode, Gemini, Windsurf), and `apm.lock.yaml` hash-pins the resolved tree the way `package-lock.json` does for npm. `apm install --mcp <name>` wires an MCP server into every client in one step.
+
+This overlaps almost exactly with what P4's `rb-install` does by hand: it edits each harness's config to register rusty-brain. APM does the same job in a **standard, hash-pinned, reproducible, multi-harness** way that users already adopt for the rest of their agent toolchain. rusty-brain already exposes the right surface to plug in: a stdio MCP server (`rusty-brain mcp`), a daemon that auto-starts on first connect (architecture spec §8), and capture hooks (`rb-hooks`).
+
+P7 publishes rusty-brain as a first-class APM package so a user can add project-wide, cross-harness shared memory with one `apm install`, and makes `rb-install` **APM-aware** — delegating to APM when present, falling back to the bespoke installer otherwise. This is distribution/ecosystem work, deliberately separated from P5/P6.
+
+## 2. Goals
+
+1. A maintained **APM package** for rusty-brain: an `apm.yml` declaring the MCP server plus bundled memory **skills / prompts / instructions / hooks**, so `apm install` wires shared memory into all supported harnesses.
+2. **`rb-install` APM-awareness:** detect `apm`, and prefer delegating to `apm install --mcp` (with the bundled artifacts) over hand-editing configs; fall back to the existing P4 installer when `apm` is absent.
+3. A `rusty-brain apm` CLI to **emit and validate** the manifest/descriptor (so the package stays in lockstep with the binary's actual MCP surface and `ContractVersion`).
+4. Hash-pinned, secret-free, fail-open install — no regression to rusty-brain's security model.
+
+## 3. Non-Goals
+
+- **Not reimplementing APM** or hosting a registry. rusty-brain produces a package APM consumes.
+- **Not distributing the rusty-brain binary via APM.** APM wires *agent context* (MCP config, skills, prompts), not arbitrary binaries. The binary is installed separately (cargo/Homebrew/release artifact); the package documents and checks this prerequisite.
+- No change to the daemon, store, or wire protocol beyond a CLI subcommand and an `rb-install` backend.
+- No secrets in `apm.yml` (the Voyage key stays in env/keychain; the manifest uses env interpolation only).
+
+## 4. Locked Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Integration direction | **Publish rusty-brain as an APM package** (distribution-side) | Highest leverage: one `apm install` wires memory into 7 harnesses; reuses the existing MCP server + P4 hooks. |
+| MCP entry form | **stdio**: `command: rusty-brain`, `args: ["mcp"]`, `registry: false` | rusty-brain is a local binary; the daemon auto-starts on first MCP connect. No remote endpoint, no secret in the manifest. |
+| Binary delivery | **Out of band** (cargo/brew/release); package checks the prerequisite | APM scope is agent context, not binary install; stated honestly. |
+| `rb-install` relationship | **APM-aware delegation with fallback** | Prefer the standard tool when available; keep the bespoke installer working where it isn't. Fail-open either way. |
+| Manifest authority | **Generated/validated by `rusty-brain apm`** | The package's MCP descriptor and `ContractVersion` stay in sync with the binary, not hand-maintained and drifting. |
+| Package contents | **MCP server + memory skills + prompts + instructions + optional capture hooks** | Wiring the server is necessary but not sufficient; agents need the skills/prompts that teach *when* to remember/recall. |
+
+## 5. Package Shape
+
+A versioned APM package lives in-repo (e.g. `apm/` at the repo root, or a dedicated `rusty-brain-apm` repo referenced as `brianluby/rusty-brain`). It contains:
+
+```text
+apm/
+  apm.yml                      # the manifest (MCP server + bundled artifacts)
+  instructions/
+    using-memory.md            # when/why to use shared memory (always-on context)
+  skills/
+    memory/                    # skill: remember/recall/context workflow
+  prompts/
+    recall-context.prompt.md   # one-shot "load project memory" prompt
+  hooks/                       # optional: capture hooks (ported from rb-hooks), fail-open
+```
+
+**Manifest (illustrative — exact fields pinned against APM docs at implementation time):**
+
+```yaml
+# apm.yml
+dependencies:
+  mcp:
+    - name: rusty-brain
+      registry: false
+      transport: stdio
+      command: rusty-brain
+      args: ["mcp"]
+  apm:
+    # skills/prompts/instructions referenced as virtual subdirectories / files
+    rusty-brain-memory:
+      git: brianluby/rusty-brain
+      path: apm/skills/memory
+      ref: v0.1.0           # hash-pinned via apm.lock.yaml
+```
+
+APM reference forms this relies on (verified from the docs): `owner/repo`, pinned `owner/repo#v1.0.0`, virtual subdirectory `owner/repo/skills/...`, virtual file `owner/repo/prompts/x.prompt.md`, and the object form `{ git, path, ref, alias }`; MCP entries live under `dependencies.mcp` and support `stdio`/registry/`remote` shapes. `apm.lock.yaml` pins the resolved tree with content hashes.
+
+**Consumption:** in any project, `apm install` (after referencing the package) wires the `rusty-brain` MCP server and installs the skills/prompts/instructions into every detected harness; the daemon auto-starts on first MCP connect and resolves the project namespace from git root / `CLAUDE.md` as today. No rusty-brain-specific namespace machinery is needed.
+
+## 6. `rusty-brain apm` CLI
+
+A new subcommand group on the existing binary:
+
+- `rusty-brain apm emit` — print the canonical `apm.yml` MCP descriptor for *this* binary (command/args, `ContractVersion`, recommended skills/prompts), so the published manifest is generated, not hand-written.
+- `rusty-brain apm validate [path]` — validate an `apm.yml` against the rusty-brain package's expectations (correct MCP entry, no embedded secrets, version/ref present) and against the APM schema shape; non-zero exit on problems. Used in CI.
+- `rusty-brain apm doctor` — check prerequisites: `rusty-brain` on PATH, `apm` present, harnesses detected; report what `apm install` will wire. Read-only.
+
+These are thin, read-only/validation commands — no daemon writes, no config mutation (mutation is APM's job).
+
+## 7. `rb-install` APM-aware backend
+
+`rb-install` gains an `apm` backend selected by capability detection:
+
+1. **Detect `apm`** on PATH (and a project `apm.yml`).
+2. **If present:** delegate — ensure the rusty-brain MCP entry + bundled artifacts are declared, then invoke `apm install` (or `apm install --mcp rusty-brain ...`). APM performs the hash-pinned, multi-harness wiring.
+3. **If absent:** fall back to the existing P4 direct-config installer (Claude Code / Gemini / Codex / …).
+
+**Fail-open** is preserved end to end (architecture spec §6, P4 rule): a delegation or detection failure logs and falls back or no-ops; it never breaks the user's harness setup. Subprocess spawning for `apm` follows the security rule — `env_clear()` then set only the needed vars (global security policy), never inherit the parent environment wholesale.
+
+## 8. Security
+
+- **No secrets in the manifest.** The Voyage API key stays in env/OS keychain (architecture spec §14); `apm.yml` uses env interpolation only (APM supports `$TOKEN`-style values) and CI's `rusty-brain apm validate` rejects any literal secret.
+- **Hash-pinning** via `apm.lock.yaml` gives supply-chain integrity on the bundled skills/prompts/hooks — an improvement over hand-copied config.
+- **Local transport unchanged.** The MCP server is local stdio; the daemon's 0600 UDS and server-side namespace isolation are untouched. No network surface is added.
+- **Capture hooks stay fail-open** (P4 rule): a hook installed via the package must never block or break an agent session.
+- **TOCTOU/PATH:** binary-prerequisite and `apm` detection re-check immediately before use; PATH detection requires an executable bit (carried forward from the P4 `rb-install` hardening).
+
+## 9. Testing Strategy
+
+- `rusty-brain apm emit`/`validate` unit + integration tests: emitted descriptor round-trips through `validate`; `validate` rejects embedded secrets, missing `ref`, and malformed MCP entries.
+- `rb-install` APM backend: in-process tests with a **fake `apm`** on PATH (a stub script) asserting correct delegation arguments; fallback test when `apm` is absent asserting the P4 installer runs; fail-open test (stub `apm` exits non-zero → fallback/no-op, session unbroken).
+- Manifest fixture test: the committed `apm/apm.yml` parses, declares the stdio `rusty-brain` MCP entry, and contains no literal secret.
+- A real `apm install` smoke test is `#[ignore]` (requires the `apm` binary + network) — run manually, not in CI.
+- Per-phase gate: `cargo test --workspace`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo fmt --all --check`; `cargo deny check`. No new default runtime deps expected (CLI/validation reuse `clap`/`serde`/`toml`; subprocess via `std`).
+
+## 10. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| APM schema/CLI drift (fast-moving project) | Pin exact fields against the docs at implementation; `rusty-brain apm validate` centralizes the schema assumptions; smoke test catches breakage. |
+| Users expect `apm install` to install the binary too | `apm doctor` + package instructions state the binary prerequisite explicitly; clear error if `rusty-brain` is not on PATH. |
+| Delegation path breaks an existing harness setup | Fail-open with fallback to the P4 installer; never mutate config directly in the APM path. |
+| Secret leakage into a committed `apm.yml` | `validate` rejects literal secrets in CI; env interpolation only. |
+| Divergence between published manifest and binary surface | Manifest is *generated* by `rusty-brain apm emit`; CI regenerates and diffs. |
+
+## 11. Traceability
+
+| Driver | P7 feature |
+|---|---|
+| APM wires MCP servers across 7 harnesses in one step | stdio `rusty-brain` MCP package entry |
+| APM installs skills/prompts/instructions/hooks | bundled memory skills/prompts/instructions/(hooks) |
+| P4 `rb-install` hand-edits each harness config | APM-aware delegation with P4 fallback |
+| `ContractVersion` drift risk (architecture spec §12) | `rusty-brain apm emit`/`validate` keep the manifest in sync |
+| Security model (architecture spec §14; global secret/subprocess rules) | no secrets in manifest; hash-pinning; `env_clear()`; fail-open hooks |


### PR DESCRIPTION
## Summary

Adds **design specs** and **task-by-task TDD implementation plans** for three future phases of rusty-brain. Docs-only — no code or behavior changes. The roadmap is derived from a verified deep-research survey of the agentic-memory field (A-MEM, Mem0/Mem0g, Zep/Graphiti, HippoRAG, Generative Agents); 24/25 surveyed claims passed unanimous adversarial verification against primary sources. Every proposed feature is mapped to a verified research finding **and** an existing rusty-brain seam.

## What changed

`docs/specs/` (3 design docs, architecture-spec style):
- `2026-06-02-rusty-brain-p5-retrieval-quality.md`
- `2026-06-02-rusty-brain-p6-llm-evolution.md`
- `2026-06-02-rusty-brain-p7-apm-distribution.md`

`docs/plans/` (3 implementation plans, P0–P3 house style — header, Hard rules, Seam map, Build order, RED/GREEN/commit Tasks, per-Part gates):
- `2026-06-02-rusty-brain-p5-retrieval-quality.md` — 4 parts / 25 tasks
- `2026-06-02-rusty-brain-p6-llm-evolution.md` — 3 parts / 18 tasks
- `2026-06-02-rusty-brain-p7-apm-distribution.md` — 4 parts / 22 tasks

## The three phases

- **P5 — Retrieval Quality & Measurement** (`H → B → A → C`): a `rb-eval` offline regression harness first (LOCOMO is unreliable — build our own), then RRF two-stage fusion (opt-in, eval-gated), composite embeddings (embed the enriched representation, not raw `content`, with a `Reembed` primitive for the corpus transition), and confidence-weighted ranking + contradiction surfacing (context-poisoning defenses using data already in the schema).
- **P6 — LLM-Assisted Evolution** (`F → D → E`): Personalized PageRank graph signal (pure, over the existing SQLite link graph), an opt-in LLM `reconcile` job (ADD/UPDATE/SUPERSEDE/NOOP), and an opt-in `reflect` synthesis job (cluster recent memories into `insight` notes, importance-accumulation trigger). Reuses `rb-enrich` + the jobs scaffolding; **depends on P5**.
- **P7 — APM Distribution**: publish rusty-brain as a Microsoft [APM](https://microsoft.github.io/apm/) package (stdio MCP entry + bundled skills/prompts/instructions/hooks) so `apm install` wires shared memory into all 7 harnesses; makes `rb-install` APM-aware with a P4 fallback.

## Reviewer notes

- **Docs-only** — no code paths touched, nothing to run. Spec self-review and plan checks done: no placeholder violations, all code fences balanced/tagged, type/name consistency verified across tasks.
- **Execution order is P5 → P6** (P6 reuses P5's `Reembed` / `embedding_input` / `rb-eval`). P7 is independent.
- **P7 adds one dependency: `serde_yaml_ng`** (maintained fork) for manifest validation — deliberately not `serde_yaml`, which is unmaintained (RUSTSEC-2024-0320) and would fail `cargo deny check`. `deny.toml` may want a one-line touch at implementation.
- A few P5 plan steps (A6/A7/C4/C5) specify mechanical wiring by exact method/SQL/field names rather than reprinting code that mirrors earlier tasks; one RED test uses an `unimplemented!` with its fill-in spelled out beneath it.
- This branch forked at the **P3 HEAD**; `main` is at P4. The roadmap references P4's `rb-install`/`rb-hooks` (which exist on `main`) and is forward-looking.

## Test plan

N/A (documentation). Verified: markdownlint conventions (fenced blocks tagged), fence balance, placeholder scan, internal cross-reference consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase P5 design specification covering retrieval quality improvements, including evaluation system, alternative ranking methods, and enhanced result processing
  * Added Phase P6 design specification for LLM-assisted memory evolution with reconciliation, reflection, and graph ranking features
  * Added Phase P7 design specification for APM package distribution with CLI tooling and security standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->