### PR TITLE
feat(p5): retrieval quality — rb-eval, RRF fusion, composite embeddings, confidence + contradiction surfacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,12 @@ jobs:
         run: cargo clippy -p rb-agents -p rb-hooks -p rb-install --all-targets -- -D warnings
       - name: Test agent crates
         run: cargo test -p rb-agents -p rb-hooks -p rb-install
-      - name: Assert agent crates stay out of the default rusty-brain closure
+      - name: Assert dev/measurement crates stay out of the default rusty-brain closure
         run: |
           set -euo pipefail
-          if cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install"; then
-            echo "ERROR: an agent crate leaked into the default rusty-brain (non-dev) dependency closure." >&2
-            echo "The rusty-brain binary must NEVER depend on rb-agents/rb-hooks/rb-install." >&2
+          if cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install|rb-eval"; then
+            echo "ERROR: a dev/measurement crate leaked into the default rusty-brain (non-dev) dependency closure." >&2
+            echo "The rusty-brain binary must NEVER depend on rb-agents/rb-hooks/rb-install/rb-eval." >&2
             exit 1
           fi
-          echo "OK: rb-agents/rb-hooks/rb-install are absent from the default rusty-brain closure."
+          echo "OK: rb-agents/rb-hooks/rb-install/rb-eval are absent from the default rusty-brain closure."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-eval"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rb-embed",
+ "rb-engine",
+ "rb-search",
+ "rb-store",
+ "rb-types",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "rb-hooks"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/rb-agents",
     "crates/rb-hooks",
     "crates/rb-install",
+    "crates/rb-eval",
 ]
 
 [workspace.package]

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -32,6 +32,11 @@ use crate::{SharedEmbedder, StoreHandle};
 const MAX_LIMIT: usize = 1000;
 /// Maximum graph traversal depth per Graph request.
 const MAX_DEPTH: u8 = 8;
+/// Default re-embed batch size when a `Reembed` request omits a limit. Bounded
+/// so one pass converges a slice of the corpus; rerun until `changed == 0`.
+const REEMBED_DEFAULT_LIMIT: usize = 1000;
+/// Hard cap on a single re-embed pass to bound writer-thread work per request.
+const REEMBED_MAX_LIMIT: usize = 10_000;
 /// Maximum number of simultaneous client connections.
 const MAX_CONNECTIONS: usize = 256;
 /// Idle deadline for the initial handshake read (fail fast on stalled connects).
@@ -583,6 +588,23 @@ where
             },
             Err(e) => error_to_response(e),
         },
+        Request::Reembed { limit } => {
+            // Bounded, idempotent re-embed batch (P5 Feature A). Cross-namespace
+            // maintenance driven through the engine (it owns the embedder); the
+            // vector UPDATE goes through the single writer. `None` uses the
+            // daemon batch default.
+            let batch = limit
+                .unwrap_or(REEMBED_DEFAULT_LIMIT)
+                .min(REEMBED_MAX_LIMIT);
+            match engine.reembed(batch).await {
+                Ok((scanned, changed, skipped)) => Response::JobRan {
+                    scanned,
+                    changed,
+                    skipped,
+                },
+                Err(e) => error_to_response(e),
+            }
+        }
     }
 }
 

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -1354,7 +1354,26 @@ mod tests {
             .await
             .unwrap();
 
-        let evt = rx.recv().await.unwrap();
+        // A write's MemoryChanged event can be published just after its write reply
+        // returns, so a late Created event for `old`/`new` may still land on this
+        // freshly-subscribed receiver ahead of the supersede event. Drain until the
+        // Archived event for the absorbed (old) memory rather than assuming it is
+        // strictly first (de-flakes the subscribe/write-event race seen under CI
+        // scheduling; the supersede call above guarantees the event is sent).
+        let mut archived = None;
+        for _ in 0..6 {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await {
+                Ok(Ok(evt))
+                    if evt.kind == crate::change::ChangeKind::Archived && evt.id == old_id =>
+                {
+                    archived = Some(evt);
+                    break;
+                }
+                Ok(Ok(_)) => continue, // a stray Created event from the prior writes
+                _ => break,
+            }
+        }
+        let evt = archived.expect("supersede must publish an Archived event for the old memory");
         assert_eq!(evt.id, old_id, "Archived event must target the old memory");
         assert_eq!(evt.namespace, ns);
         assert_eq!(

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -90,6 +90,17 @@ enum WriteCommand {
         new: MemoryId,
         reply: oneshot::Sender<Result<()>>,
     },
+    /// Replace one memory's stored vector and stamp it to the current
+    /// `(model, input_version)` (P5 Feature A re-embed write path). The engine
+    /// recomputes the vector and passes it here; the store performs the only
+    /// vector-UPDATE path under the single writer.
+    Reembed {
+        id: MemoryId,
+        embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
     #[cfg(test)]
     PanicForTest {
         reply: oneshot::Sender<Result<()>>,
@@ -729,6 +740,24 @@ fn writer_loop(
                     break;
                 }
             }
+            WriteCommand::Reembed {
+                id,
+                embedding,
+                model,
+                input_version,
+                reply,
+            } => {
+                // No MemoryChanged event: re-embed only refreshes the vector for
+                // search quality; the note's user-visible content is unchanged.
+                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
+                    s.update_vector(&id, &embedding, &model, &input_version)
+                });
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if !writer_usable {
+                    break;
+                }
+            }
             #[cfg(test)]
             WriteCommand::PanicForTest { reply } => {
                 let report =
@@ -867,6 +896,43 @@ impl MemoryBackend for StoreHandle {
 
     async fn get_many(&self, ns: Namespace, ids: Vec<MemoryId>) -> Result<Vec<MemoryNote>> {
         self.with_read(move |store| store.get_many(&ns, &ids)).await
+    }
+
+    async fn active_contradicts(
+        &self,
+        ns: Namespace,
+        ids: Vec<MemoryId>,
+    ) -> Result<std::collections::HashSet<MemoryId>> {
+        self.with_read(move |store| store.active_contradicts(&ns, &ids))
+            .await
+    }
+
+    async fn memories_for_reembed(
+        &self,
+        model: String,
+        input_version: String,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        self.with_read(move |store| store.memories_for_reembed(&model, &input_version, limit))
+            .await
+    }
+
+    async fn update_vector(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+    ) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::Reembed {
+            id,
+            embedding,
+            model,
+            input_version,
+            reply,
+        };
+        self.send_write(cmd, rx).await
     }
 }
 
@@ -1335,6 +1401,80 @@ mod tests {
         );
         // Every returned candidate carries its namespace for per-ns grouping.
         assert!(cands.iter().all(|c| c.namespace == ns));
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_reembed_scan_and_update_vector_through_single_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("reembed".to_string());
+
+        // Write a row with a stale stamp (as if remembered pre-P5).
+        let mut stale = note(&ns, "stale stamped row");
+        stale.embedding_model = "old-model".to_string();
+        stale.embedding_input_version = "v1-content-only".to_string();
+        let id = stale.id.clone();
+        handle.write(stale, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        // The scan finds it (cross-namespace read pool path).
+        let cands = handle
+            .memories_for_reembed("deterministic".to_string(), "v2-composite".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(cands.iter().any(|n| n.id == id), "stale row is a candidate");
+
+        // Re-embed it through the single writer; the row is stamped current.
+        handle
+            .update_vector(
+                id.clone(),
+                vec![0.5f32; DIM],
+                "deterministic".to_string(),
+                "v2-composite".to_string(),
+            )
+            .await
+            .unwrap();
+        let after = handle.get(ns.clone(), id.clone()).await.unwrap().unwrap();
+        assert_eq!(after.embedding_model, "deterministic");
+        assert_eq!(after.embedding_input_version, "v2-composite");
+
+        // Idempotent: a second scan finds nothing stale, so a re-run writes 0.
+        let cands2 = handle
+            .memories_for_reembed("deterministic".to_string(), "v2-composite".to_string(), 100)
+            .await
+            .unwrap();
+        assert!(cands2.iter().all(|n| n.id != id), "row no longer stale");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_update_vector_rejects_wrong_dimension() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 1).unwrap();
+        let ns = Namespace::Project("dim".to_string());
+
+        let n = note(&ns, "dim contract");
+        let id = n.id.clone();
+        handle.write(n, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        // A wrong-length vector fails closed (dim contract is unchanged).
+        let err = handle
+            .update_vector(
+                id,
+                vec![0.5f32; DIM + 3],
+                "deterministic".to_string(),
+                "v2-composite".to_string(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::DimensionMismatch { .. }),
+            "got {err:?}"
+        );
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -618,3 +618,43 @@ async fn run_job_importance_recalibration_flows_through_client() {
 
     daemon.stop().await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reembed_over_the_wire_is_stamp_skip_and_idempotent() {
+    // Memories remembered through the daemon are written at the CURRENT stamp
+    // (composite embedding + EMBEDDING_INPUT_VERSION), so a reembed pass scans
+    // none of them and writes nothing — proving the stamp-skip + idempotency
+    // contract end-to-end over the wire.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("reembed-e2e".to_string());
+    let mut client = Client::connect(&daemon.socket, ns.clone()).await.unwrap();
+
+    for i in 0..3 {
+        client
+            .remember(
+                format!("reembed target {i}"),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![format!("kw{i}")],
+                vec!["reembed".to_string()],
+                vec![],
+            )
+            .await
+            .unwrap();
+    }
+
+    // All rows are already current => scanned/changed/skipped all zero.
+    let (scanned, changed, skipped) = client.reembed(None).await.unwrap();
+    assert_eq!(
+        (scanned, changed, skipped),
+        (0, 0, 0),
+        "freshly-remembered rows are already at the current stamp"
+    );
+
+    // A second pass is likewise a no-op (idempotent).
+    let (s2, c2, k2) = client.reembed(Some(100)).await.unwrap();
+    assert_eq!((s2, c2, k2), (0, 0, 0), "reembed is idempotent");
+
+    daemon.stop().await;
+}

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -54,6 +54,38 @@ pub trait MemoryBackend: Send + Sync {
         ns: Namespace,
         ids: Vec<MemoryId>,
     ) -> rb_types::Result<Vec<MemoryNote>>;
+    /// Return the subset of `ids` that have at least one ACTIVE `contradicts`
+    /// link (inbound OR outbound) whose far endpoint is active AND where both
+    /// endpoints live in namespace `ns` (Feature C, spec §9). Scoping to `ns`
+    /// preserves namespace isolation — `memory_links` carries no namespace, so an
+    /// out-of-namespace edge must not flag a result `contested`. One batched read
+    /// over `memory_links`. Used post-ranking to set `MemoryNote.contested`;
+    /// callers treat errors as fail-open (unflagged).
+    async fn active_contradicts(
+        &self,
+        ns: Namespace,
+        ids: Vec<MemoryId>,
+    ) -> rb_types::Result<std::collections::HashSet<MemoryId>>;
+    /// Scan up to `limit` ACTIVE memories (across ALL namespaces) whose stamped
+    /// `(embedding_model, embedding_input_version)` differs from the current
+    /// `(model, input_version)` pair — the re-embed candidates (read path).
+    /// Bounded; deterministic order. Used by the `reembed` batch.
+    async fn memories_for_reembed(
+        &self,
+        model: String,
+        input_version: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>>;
+    /// Replace `id`'s stored vector and stamp its row with the current
+    /// `(model, input_version)` in one transaction (write path, single writer).
+    /// This is the first vector-UPDATE path; `remember` only ever INSERTs.
+    async fn update_vector(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+    ) -> rb_types::Result<()>;
 }
 
 #[cfg(test)]
@@ -218,6 +250,51 @@ mod tests {
                 .iter()
                 .filter_map(|id| guard.get(id).filter(|n| n.namespace == ns).cloned())
                 .collect())
+        }
+        async fn active_contradicts(
+            &self,
+            _ns: Namespace,
+            _ids: Vec<MemoryId>,
+        ) -> rb_types::Result<std::collections::HashSet<MemoryId>> {
+            Ok(std::collections::HashSet::new())
+        }
+        async fn memories_for_reembed(
+            &self,
+            model: String,
+            input_version: String,
+            limit: usize,
+        ) -> rb_types::Result<Vec<MemoryNote>> {
+            let mut v: Vec<MemoryNote> = self
+                .notes
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|n| n.archived_at.is_none())
+                .filter(|n| {
+                    n.embedding_model != model || n.embedding_input_version != input_version
+                })
+                .cloned()
+                .collect();
+            v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+            v.truncate(limit);
+            Ok(v)
+        }
+        async fn update_vector(
+            &self,
+            id: MemoryId,
+            embedding: Vec<f32>,
+            model: String,
+            input_version: String,
+        ) -> rb_types::Result<()> {
+            self.embeddings
+                .lock()
+                .unwrap()
+                .insert(id.clone(), embedding);
+            if let Some(note) = self.notes.lock().unwrap().get_mut(&id) {
+                note.embedding_model = model;
+                note.embedding_input_version = input_version;
+            }
+            Ok(())
         }
     }
 

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -286,6 +286,10 @@ mod tests {
             model: String,
             input_version: String,
         ) -> rb_types::Result<()> {
+            // Fail closed on a missing id, like SqliteStore::update_vector.
+            if !self.notes.lock().unwrap().contains_key(&id) {
+                return Err(rb_types::Error::NotFound(id));
+            }
             self.embeddings
                 .lock()
                 .unwrap()

--- a/crates/rb-engine/src/embed_input.rs
+++ b/crates/rb-engine/src/embed_input.rs
@@ -28,9 +28,12 @@ pub const EMBEDDING_INPUT_VERSION: &str = "v2-composite";
 pub fn embedding_input(note: &MemoryNote) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(4);
 
-    let content = note.content.trim();
-    if !content.is_empty() {
-        parts.push(content.to_string());
+    // Push raw content (NOT trimmed): pre-P5 embedded `note.content` verbatim, so a
+    // content-only note must reproduce that exact representation — otherwise
+    // re-embedding silently shifts its vector, and two notes differing only by
+    // surrounding whitespace would collide. Skip only when content is truly blank.
+    if !note.content.trim().is_empty() {
+        parts.push(note.content.clone());
     }
 
     let keywords = join_non_empty(&note.keywords);
@@ -88,6 +91,15 @@ mod tests {
         // lines), so a never-enriched memory matches the pre-P5 representation.
         let n = note("single writer over sqlite wal");
         assert_eq!(embedding_input(&n), "single writer over sqlite wal");
+    }
+
+    #[test]
+    fn content_only_note_preserves_raw_whitespace_for_v1_parity() {
+        // Pre-P5 embedded note.content verbatim. A content-only note must embed the
+        // RAW string (including surrounding whitespace) so re-embedding is a true
+        // no-op for it and whitespace-variant notes do not collide on one vector.
+        let n = note("  spaced out  ");
+        assert_eq!(embedding_input(&n), "  spaced out  ");
     }
 
     #[test]

--- a/crates/rb-engine/src/embed_input.rs
+++ b/crates/rb-engine/src/embed_input.rs
@@ -1,0 +1,146 @@
+//! Composite embedding input (P5 Feature A).
+//!
+//! A pure, deterministic function that composes the *document* representation
+//! fed to the embedder from a note's enriched fields, plus the stamp string
+//! recorded per-row so a corpus can be selectively re-embedded when the
+//! composition changes.
+
+use rb_types::MemoryNote;
+
+/// Stamp written to `memories.embedding_input_version` and the global
+/// `meta.embedding_input_version` for every memory embedded with the composite
+/// representation below. Bump this string (and add a migration that re-seeds
+/// the meta key) whenever [`embedding_input`] changes its composition so the
+/// `reembed` batch can detect and converge stale rows.
+pub const EMBEDDING_INPUT_VERSION: &str = "v2-composite";
+
+/// Compose the text embedded for a note's *document* vector.
+///
+/// Documented order: `content`, then `keywords` (space-joined), then `tags`
+/// (space-joined), then `context` — each on its own line, joined with `\n`.
+/// Empty fields (empty string / empty list) are skipped entirely so a memory
+/// with no enrichment embeds exactly its content (no leading/trailing blank
+/// lines), matching the pre-P5 behavior for content-only notes.
+///
+/// Pure and deterministic: the same note always yields the same string. The
+/// query is NOT composed this way — only the document representation changes
+/// (A-MEM does the same; query symmetry is not required).
+pub fn embedding_input(note: &MemoryNote) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(4);
+
+    let content = note.content.trim();
+    if !content.is_empty() {
+        parts.push(content.to_string());
+    }
+
+    let keywords = join_non_empty(&note.keywords);
+    if !keywords.is_empty() {
+        parts.push(keywords);
+    }
+
+    let tags = join_non_empty(&note.tags);
+    if !tags.is_empty() {
+        parts.push(tags);
+    }
+
+    let context = note.context.trim();
+    if !context.is_empty() {
+        parts.push(context.to_string());
+    }
+
+    parts.join("\n")
+}
+
+/// Join a slice of strings with a single space, dropping empty/blank entries so
+/// a stray empty keyword/tag cannot inject double spaces or a blank segment.
+fn join_non_empty(items: &[String]) -> String {
+    items
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+
+    fn note(content: &str) -> MemoryNote {
+        MemoryNote::new(
+            Namespace::Project("rb".into()),
+            content.to_string(),
+            MemoryType::Insight,
+            5,
+        )
+    }
+
+    #[test]
+    fn version_constant_is_the_composite_stamp() {
+        assert_eq!(EMBEDDING_INPUT_VERSION, "v2-composite");
+    }
+
+    #[test]
+    fn content_only_note_embeds_just_its_content() {
+        // A note with no enrichment must embed exactly its content (no blank
+        // lines), so a never-enriched memory matches the pre-P5 representation.
+        let n = note("single writer over sqlite wal");
+        assert_eq!(embedding_input(&n), "single writer over sqlite wal");
+    }
+
+    #[test]
+    fn composes_content_keywords_tags_context_in_documented_order() {
+        let mut n = note("the body");
+        n.keywords = vec!["sqlite".into(), "wal".into()];
+        n.tags = vec!["db".into(), "search".into()];
+        n.context = "in the storage layer".into();
+        // content \n keywords \n tags \n context, each space-joined.
+        assert_eq!(
+            embedding_input(&n),
+            "the body\nsqlite wal\ndb search\nin the storage layer"
+        );
+    }
+
+    #[test]
+    fn empty_fields_are_skipped_no_blank_lines() {
+        let mut n = note("body here");
+        // keywords empty, tags present, context empty.
+        n.keywords = Vec::new();
+        n.tags = vec!["tag1".into()];
+        n.context = String::new();
+        assert_eq!(embedding_input(&n), "body here\ntag1");
+    }
+
+    #[test]
+    fn blank_keyword_and_tag_entries_do_not_inject_blank_segments() {
+        let mut n = note("body");
+        n.keywords = vec!["".into(), "kept".into(), "   ".into()];
+        n.tags = vec!["   ".into()];
+        n.context = "  ".into();
+        // Only the real keyword survives; blank tag list and context drop out.
+        assert_eq!(embedding_input(&n), "body\nkept");
+    }
+
+    #[test]
+    fn is_deterministic_for_the_same_note() {
+        let mut n = note("repeat me");
+        n.keywords = vec!["alpha".into()];
+        n.tags = vec!["beta".into()];
+        n.context = "gamma".into();
+        assert_eq!(embedding_input(&n), embedding_input(&n));
+    }
+
+    #[test]
+    fn ordering_is_stable_and_field_order_matters() {
+        let mut a = note("x");
+        a.keywords = vec!["k".into()];
+        a.tags = vec!["t".into()];
+        let mut b = note("x");
+        // Same fields but keyword/tag swapped: different composition.
+        b.keywords = vec!["t".into()];
+        b.tags = vec!["k".into()];
+        assert_ne!(embedding_input(&a), embedding_input(&b));
+    }
+}

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -433,6 +433,13 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
     /// `changed == 0`). Fail-safe per row: an embedding or write failure is
     /// logged and counted as `skipped` (retried on the next run), never fatal.
     /// Returns `(scanned, changed, skipped)`.
+    ///
+    /// Scope: `reembed` converges *vectors* only. Similarity-derived graph links
+    /// created at `remember` time are NOT regenerated here, so the graph leg of
+    /// `recall` may still reflect pre-reembed neighborhoods until links are rebuilt.
+    /// Link evolution on re-embed (A-MEM's "evolve-and-re-embed neighbors") is
+    /// deferred to P6; the graph term is a minor 0.10-weight signal and links decay
+    /// independently, so vector convergence is sufficient for P5's transition.
     pub async fn reembed(&self, limit: usize) -> rb_types::Result<(u64, u64, u64)> {
         let model = self.embedder.model_id().to_string();
         let input_version = crate::embed_input::EMBEDDING_INPUT_VERSION.to_string();

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -3,7 +3,7 @@ use crate::enrich::{default_summary, derive_keywords};
 use crate::enricher::Enricher;
 use crate::linker::{Linker, SimilarityLinker};
 use rb_embed::EmbeddingProvider;
-use rb_search::Weights;
+use rb_search::{FusionMode, RrfConfig, Weights};
 use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
 use std::sync::Arc;
 
@@ -24,6 +24,8 @@ pub struct MemoryEngine<B: MemoryBackend, P: EmbeddingProvider> {
     backend: B,
     embedder: P,
     weights: Weights,
+    fusion_mode: FusionMode,
+    rrf_config: RrfConfig,
     namespace: Namespace,
     linker: Box<dyn Linker>,
     enricher: Option<Arc<dyn Enricher>>,
@@ -37,6 +39,10 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             backend,
             embedder,
             weights: Weights::default(),
+            // Default `Linear` preserves current recall behavior byte-for-byte;
+            // `Rrf` is opt-in via `with_fusion_mode` (spec §7, eval-gated flip).
+            fusion_mode: FusionMode::default(),
+            rrf_config: RrfConfig::default(),
             namespace,
             linker: Box::new(SimilarityLinker::default()),
             enricher: None,
@@ -56,6 +62,26 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
     /// Borrow the ranking weights (used by `recall`).
     pub fn weights(&self) -> Weights {
         self.weights
+    }
+
+    /// The fusion mode `recall` dispatches on (`Linear` default, `Rrf` opt-in).
+    pub fn fusion_mode(&self) -> FusionMode {
+        self.fusion_mode
+    }
+
+    /// Select the fusion strategy for `recall`. `Linear` (default) is the
+    /// existing weighted-sum ranking; `Rrf` is the two-stage hybrid (spec §7).
+    /// Opt-in only — the default stays `Linear` so behavior is unchanged unless
+    /// a caller flips it through the config plumbing.
+    pub fn with_fusion_mode(mut self, mode: FusionMode) -> Self {
+        self.fusion_mode = mode;
+        self
+    }
+
+    /// Override the `Rrf` tuning (k + prior weights). No effect under `Linear`.
+    pub fn with_rrf_config(mut self, config: RrfConfig) -> Self {
+        self.rrf_config = config;
+        self
     }
 
     /// Enable opt-in enrichment. When set, `remember` asks the enricher to fill
@@ -142,9 +168,14 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             note.context = ctx;
         }
         note.embedding_model = self.embedder.model_id().to_string();
+        // Stamp the composition version alongside the model so the `reembed`
+        // batch can detect rows built from an older representation (Feature A).
+        note.embedding_input_version = crate::embed_input::EMBEDDING_INPUT_VERSION.to_string();
 
-        // Embed the content (single text in, single vector out).
-        let mut embeddings = self.embedder.embed(&[note.content.clone()]).await?;
+        // Embed the COMPOSITE document representation (content + keywords + tags
+        // + context), not raw content (spec §8). The query stays embedded raw.
+        let input = crate::embed_input::embedding_input(&note);
+        let mut embeddings = self.embedder.embed(&[input]).await?;
         let embedding = embeddings.pop();
 
         let id = note.id.clone();
@@ -272,14 +303,20 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             .get_many(self.namespace.clone(), order.clone())
             .await?;
         let mut notes: HashMap<MemoryId, MemoryNote> = HashMap::new();
-        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        let mut meta: HashMap<MemoryId, (u8, f32, chrono::DateTime<chrono::Utc>)> = HashMap::new();
         for note in fetched {
             if !self.active_in_namespace(&note)
                 || !Self::matches_recall_filters(&note, type_filter, tags)
             {
                 continue;
             }
-            meta.insert(note.id.clone(), (note.importance, note.created_at));
+            // Carry confidence into ranking (Feature C): low-confidence memories
+            // are dampened post-score so a wrong, high-matching note cannot
+            // dominate recall (the context-poisoning mitigation).
+            meta.insert(
+                note.id.clone(),
+                (note.importance, note.confidence, note.created_at),
+            );
             notes.insert(note.id.clone(), note);
         }
 
@@ -301,7 +338,14 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
 
         let signals =
             rb_search::build_signals(&filtered_keyword, &filtered_vector, &filtered_graph, &meta);
-        let ranked = rb_search::rank(signals, self.weights, chrono::Utc::now(), candidate_limit);
+        // Dispatch on the configured fusion mode. `Linear` is the default and
+        // preserves prior behavior byte-for-byte; `Rrf` is the opt-in two-stage
+        // hybrid (spec §7).
+        let now = chrono::Utc::now();
+        let ranked = match self.fusion_mode {
+            FusionMode::Linear => rb_search::rank(signals, self.weights, now, candidate_limit),
+            FusionMode::Rrf => rb_search::rank_rrf(signals, self.rrf_config, now, candidate_limit),
+        };
 
         // Assemble results in ranked order, truncating to limit.
         let mut results: Vec<rb_types::SearchResult> = Vec::new();
@@ -318,8 +362,18 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             }
         }
 
-        // Best-effort batch access tracking: single writer round-trip for all results.
         let returned_ids: Vec<MemoryId> = results.iter().map(|r| r.memory.id.clone()).collect();
+
+        // Contradiction surfacing (Feature C): for the returned (post-ranking,
+        // truncated) set only, batch-load active contradicts links and flag each
+        // contested memory. FAIL-OPEN: a lookup error leaves results unflagged
+        // rather than failing recall.
+        let contested = self.contested_set(&returned_ids).await;
+        for r in &mut results {
+            r.memory.contested = contested.contains(&r.memory.id);
+        }
+
+        // Best-effort batch access tracking: single writer round-trip for all results.
         if !returned_ids.is_empty() {
             if let Err(e) = self.backend.record_accesses(returned_ids).await {
                 tracing::debug!(error = %e, "record_accesses failed; ignoring");
@@ -328,10 +382,116 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         Ok(results)
     }
 
+    /// Batch-load the subset of `ids` that have an active `contradicts` link
+    /// (Feature C). FAIL-OPEN: on a lookup error this returns an empty set (so
+    /// results surface unflagged), logging at debug — surfacing contested state
+    /// is best-effort enrichment, never a gate on retrieval.
+    async fn contested_set(&self, ids: &[MemoryId]) -> std::collections::HashSet<MemoryId> {
+        if ids.is_empty() {
+            return std::collections::HashSet::new();
+        }
+        match self
+            .backend
+            .active_contradicts(self.namespace.clone(), ids.to_vec())
+            .await
+        {
+            Ok(set) => set,
+            Err(e) => {
+                tracing::debug!(error = %e, "contradiction lookup failed; returning unflagged");
+                std::collections::HashSet::new()
+            }
+        }
+    }
+
+    /// Annotate each note's `contested` flag from one batched contradiction
+    /// lookup over the slice (fail-open). Mirrors `recall`'s post-ranking step for
+    /// the `get`/`list`/`context` surfaces.
+    async fn annotate_contested(&self, notes: &mut [MemoryNote]) {
+        if notes.is_empty() {
+            return;
+        }
+        let ids: Vec<MemoryId> = notes.iter().map(|n| n.id.clone()).collect();
+        let contested = self.contested_set(&ids).await;
+        for n in notes.iter_mut() {
+            n.contested = contested.contains(&n.id);
+        }
+    }
+
+    /// Re-embed up to `limit` ACTIVE memories whose stored
+    /// `(embedding_model, embedding_input_version)` stamp is stale relative to
+    /// the current embedder + composition version (Feature A, spec §8).
+    ///
+    /// Cross-namespace maintenance (like the evolution jobs): the engine's bound
+    /// namespace does NOT restrict the scan, so a single `reembed` converges the
+    /// whole corpus. For each candidate it recomputes the composite
+    /// [`crate::embed_input::embedding_input`], embeds it, and replaces the
+    /// vector + stamp through the single writer.
+    ///
+    /// Bounded and idempotent: candidates are exactly the rows whose stamp
+    /// differs from current, so a row already at `(model, version)` is never
+    /// scanned, and a second run over unchanged data writes nothing (returns
+    /// `changed == 0`). Fail-safe per row: an embedding or write failure is
+    /// logged and counted as `skipped` (retried on the next run), never fatal.
+    /// Returns `(scanned, changed, skipped)`.
+    pub async fn reembed(&self, limit: usize) -> rb_types::Result<(u64, u64, u64)> {
+        let model = self.embedder.model_id().to_string();
+        let input_version = crate::embed_input::EMBEDDING_INPUT_VERSION.to_string();
+
+        let candidates = self
+            .backend
+            .memories_for_reembed(model.clone(), input_version.clone(), limit)
+            .await?;
+
+        let mut scanned: u64 = 0;
+        let mut changed: u64 = 0;
+        let mut skipped: u64 = 0;
+
+        for note in candidates {
+            scanned += 1;
+            let input = crate::embed_input::embedding_input(&note);
+            let embedding = match self.embedder.embed(&[input]).await {
+                Ok(mut v) => match v.pop() {
+                    Some(emb) => emb,
+                    None => {
+                        tracing::warn!(memory_id = %note.id, "reembed: embedder returned no vector; skipping");
+                        skipped += 1;
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(error = %e, memory_id = %note.id, "reembed: embed failed; will retry next run");
+                    skipped += 1;
+                    continue;
+                }
+            };
+            match self
+                .backend
+                .update_vector(
+                    note.id.clone(),
+                    embedding,
+                    model.clone(),
+                    input_version.clone(),
+                )
+                .await
+            {
+                Ok(()) => changed += 1,
+                Err(e) => {
+                    tracing::warn!(error = %e, memory_id = %note.id, "reembed: vector update failed; will retry next run");
+                    skipped += 1;
+                }
+            }
+        }
+
+        Ok((scanned, changed, skipped))
+    }
+
     /// Fetch a single memory by id in the engine namespace.
     pub async fn get(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
-        let found = self.get_scoped(id.clone()).await?;
-        if found.is_some() {
+        let mut found = self.get_scoped(id.clone()).await?;
+        if let Some(note) = found.as_mut() {
+            // Surface the contested flag on the get payload (Feature C, fail-open).
+            let contested = self.contested_set(std::slice::from_ref(&id)).await;
+            note.contested = contested.contains(&id);
             if let Err(e) = self.backend.record_access(id.clone()).await {
                 tracing::debug!(error = %e, memory_id = %id, "record_access failed; ignoring");
             }
@@ -346,9 +506,13 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         min_importance: Option<u8>,
         limit: usize,
     ) -> rb_types::Result<Vec<MemoryNote>> {
-        self.backend
+        let mut notes = self
+            .backend
             .list(self.namespace.clone(), min_importance, limit)
-            .await
+            .await?;
+        // Annotate the contested flag on list result rows (Feature C, fail-open).
+        self.annotate_contested(&mut notes).await;
+        Ok(notes)
     }
 
     /// Expand the graph around `id` to `depth` hops and fetch the connected notes.
@@ -411,15 +575,18 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
     pub async fn context(&self) -> rb_types::Result<(Vec<MemoryNote>, Vec<MemoryNote>, usize)> {
         const CONTEXT_LIMIT: usize = 50;
         const IMPORTANT_FLOOR: u8 = 8;
-        let recent = self
+        let mut recent = self
             .backend
             .list(self.namespace.clone(), None, CONTEXT_LIMIT)
             .await?;
-        let important = self
+        let mut important = self
             .backend
             .list(self.namespace.clone(), Some(IMPORTANT_FLOOR), CONTEXT_LIMIT)
             .await?;
         let total = recent.len();
+        // Annotate contested on both context halves (Feature C, fail-open).
+        self.annotate_contested(&mut recent).await;
+        self.annotate_contested(&mut important).await;
         Ok((recent, important, total))
     }
 }
@@ -503,6 +670,159 @@ mod tests {
         let id = eng.remember(input("model id check", 5)).await.unwrap();
         let note = eng.backend().note_of(&id).unwrap();
         assert_eq!(note.embedding_model, eng.embedder().model_id());
+    }
+
+    #[tokio::test]
+    async fn remember_stamps_current_embedding_input_version() {
+        let eng = engine();
+        let id = eng
+            .remember(input("composite input stamp", 5))
+            .await
+            .unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        assert_eq!(
+            note.embedding_input_version,
+            crate::embed_input::EMBEDDING_INPUT_VERSION
+        );
+    }
+
+    #[tokio::test]
+    async fn remember_embeds_composite_not_raw_content() {
+        // The composite (content + keywords + tags + context) differs from raw
+        // content, so the stored vector must equal the composite's embedding.
+        let eng = engine();
+        let mut inp = input("body of the note", 5);
+        inp.keywords = vec!["alpha".to_string()];
+        inp.tags = vec!["beta".to_string()];
+        inp.context = Some("gamma".to_string());
+        let id = eng.remember(inp).await.unwrap();
+        let note = eng.backend().note_of(&id).unwrap();
+        let stored = eng.backend().embedding_of(&id).unwrap();
+
+        let composite = crate::embed_input::embedding_input(&note);
+        let expected = DeterministicProvider::new(16)
+            .embed(&[composite])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(
+            stored, expected,
+            "stored vector must be the composite embedding"
+        );
+
+        // And it must NOT equal the raw-content embedding (composite added signal).
+        let raw = DeterministicProvider::new(16)
+            .embed(std::slice::from_ref(&note.content))
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_ne!(stored, raw, "composite differs from raw-content embedding");
+    }
+
+    #[tokio::test]
+    async fn reembed_on_fresh_corpus_is_a_no_op() {
+        // Every note remembered through this engine is already at current stamps,
+        // so a reembed scans nothing and writes nothing.
+        let eng = engine();
+        eng.remember(input("already current one", 5)).await.unwrap();
+        eng.remember(input("already current two", 5)).await.unwrap();
+        let (scanned, changed, skipped) = eng.reembed(100).await.unwrap();
+        assert_eq!((scanned, changed, skipped), (0, 0, 0));
+        assert_eq!(eng.backend().update_vector_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn reembed_updates_stale_rows_then_second_run_is_idempotent() {
+        let eng = engine();
+        // A stale row: stamped with an old model/version (as if written pre-P5).
+        let mut stale = note(
+            Namespace::Project("rb".into()),
+            "stale content needing reembed",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        stale.embedding_model = "old-model".to_string();
+        stale.embedding_input_version = "v1-content-only".to_string();
+        let id = stale.id.clone();
+        eng.backend().insert_note(stale);
+
+        // First run re-embeds the one stale row.
+        let (scanned, changed, skipped) = eng.reembed(100).await.unwrap();
+        assert_eq!((scanned, changed, skipped), (1, 1, 0));
+        let after = eng.backend().note_of(&id).unwrap();
+        assert_eq!(after.embedding_model, eng.embedder().model_id());
+        assert_eq!(
+            after.embedding_input_version,
+            crate::embed_input::EMBEDDING_INPUT_VERSION
+        );
+        // The vector now exists for the row.
+        assert!(eng.backend().embedding_of(&id).is_some());
+
+        // Second run over unchanged data writes nothing (idempotent).
+        let (scanned2, changed2, skipped2) = eng.reembed(100).await.unwrap();
+        assert_eq!((scanned2, changed2, skipped2), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn reembed_skips_archived_rows() {
+        let eng = engine();
+        let mut archived = note(
+            Namespace::Project("rb".into()),
+            "archived stale row",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        archived.embedding_model = "old-model".to_string();
+        archived.embedding_input_version = "v1-content-only".to_string();
+        archived.archived_at = Some(chrono::Utc::now());
+        eng.backend().insert_note(archived);
+
+        let (scanned, changed, skipped) = eng.reembed(100).await.unwrap();
+        assert_eq!((scanned, changed, skipped), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn reembed_is_fail_safe_per_row_on_write_error() {
+        let eng = engine();
+        let mut stale = note(
+            Namespace::Project("rb".into()),
+            "row whose vector update fails",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        stale.embedding_model = "old-model".to_string();
+        stale.embedding_input_version = "v1-content-only".to_string();
+        eng.backend().insert_note(stale);
+
+        eng.backend().set_fail_update_vector(true);
+        // The write error is caught per row: scanned 1, changed 0, skipped 1,
+        // and the call still succeeds (never fatal).
+        let (scanned, changed, skipped) = eng.reembed(100).await.unwrap();
+        assert_eq!((scanned, changed, skipped), (1, 0, 1));
+    }
+
+    #[tokio::test]
+    async fn reembed_respects_limit() {
+        let eng = engine();
+        for i in 0..5 {
+            let mut stale = note(
+                Namespace::Project("rb".into()),
+                &format!("stale row {i}"),
+                MemoryType::Insight,
+                5,
+                &[],
+            );
+            stale.embedding_model = "old-model".to_string();
+            stale.embedding_input_version = "v1-content-only".to_string();
+            eng.backend().insert_note(stale);
+        }
+        let (scanned, changed, skipped) = eng.reembed(2).await.unwrap();
+        assert_eq!((scanned, changed, skipped), (2, 2, 0));
     }
 
     #[tokio::test]
@@ -792,6 +1112,153 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|r| r.score.is_finite()));
         assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn engine_defaults_to_linear_fusion() {
+        let eng = engine();
+        assert_eq!(eng.fusion_mode(), rb_search::FusionMode::Linear);
+    }
+
+    #[tokio::test]
+    async fn with_fusion_mode_selects_rrf_and_recall_still_returns_results() {
+        let eng = engine().with_fusion_mode(rb_search::FusionMode::Rrf);
+        assert_eq!(eng.fusion_mode(), rb_search::FusionMode::Rrf);
+        seed(
+            &eng,
+            "alpha topic about sqlite",
+            MemoryType::Insight,
+            5,
+            &[],
+        )
+        .await;
+        seed(&eng, "beta topic about tokio", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("topic", 10, None, &[]).await.unwrap();
+        // RRF path returns ranked results with finite, descending scores.
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.score.is_finite()));
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn recall_flags_both_contradicting_memories_as_contested() {
+        // Feature C: create A and B, link A contradicts B, recall -> both flagged.
+        let eng = engine();
+        let a = seed(
+            &eng,
+            "claim alpha about caching",
+            MemoryType::Insight,
+            5,
+            &[],
+        )
+        .await;
+        let b = seed(
+            &eng,
+            "claim alpha says no caching",
+            MemoryType::Insight,
+            5,
+            &[],
+        )
+        .await;
+        eng.backend().link_contradicts(&a, &b);
+
+        let results = eng.recall("alpha", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        // both endpoints of the active contradicts link are contested.
+        assert!(results.iter().all(|r| r.memory.contested));
+    }
+
+    #[tokio::test]
+    async fn recall_does_not_flag_uncontested_memories() {
+        let eng = engine();
+        seed(&eng, "uncontested note one", MemoryType::Insight, 5, &[]).await;
+        seed(&eng, "uncontested note two", MemoryType::Insight, 5, &[]).await;
+        let results = eng.recall("note", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| !r.memory.contested));
+    }
+
+    #[tokio::test]
+    async fn recall_is_fail_open_when_contradiction_lookup_errors() {
+        // Feature C fail-open: a forced contradiction-lookup error must NOT fail
+        // recall; results return UNFLAGGED.
+        let eng = engine();
+        let a = seed(&eng, "claim x yes", MemoryType::Insight, 5, &[]).await;
+        let b = seed(&eng, "claim x no", MemoryType::Insight, 5, &[]).await;
+        eng.backend().link_contradicts(&a, &b);
+        eng.backend().set_fail_contradicts(true);
+
+        let results = eng.recall("claim", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2, "recall still succeeds on lookup error");
+        assert!(
+            results.iter().all(|r| !r.memory.contested),
+            "fail-open => unflagged"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_low_confidence_wrong_memory_ranks_below_high_confidence_correct() {
+        // Poison scenario at the engine level: two equally-matching memories where
+        // the wrong one has low confidence. The confidence dampener must rank the
+        // high-confidence (correct) one first.
+        let eng = engine();
+        let correct = note(
+            Namespace::Project("rb".into()),
+            "shared probe content",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let mut wrong = note(
+            Namespace::Project("rb".into()),
+            "shared probe content",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        wrong.confidence = 0.1; // low confidence "poison"
+        let correct_id = correct.id.clone();
+        let wrong_id = wrong.id.clone();
+        // Same vector distance for both so only confidence separates them.
+        eng.backend().insert_note(correct);
+        eng.backend().insert_note(wrong);
+        eng.backend().set_keyword_results(Vec::new());
+        eng.backend()
+            .set_vector_results(vec![(wrong_id.clone(), 0.2), (correct_id.clone(), 0.2)]);
+
+        let results = eng.recall("probe", 10, None, &[]).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].memory.id, correct_id,
+            "high-confidence correct memory ranks first"
+        );
+        assert_eq!(results[1].memory.id, wrong_id);
+        assert!(results[0].score > results[1].score);
+    }
+
+    #[tokio::test]
+    async fn get_surfaces_contested_flag() {
+        let eng = engine();
+        let a = eng.remember(input("a contested side", 5)).await.unwrap();
+        let b = eng.remember(input("b contested side", 5)).await.unwrap();
+        eng.backend().link_contradicts(&a, &b);
+        let got = eng.get(a.clone()).await.unwrap().unwrap();
+        assert!(got.contested, "get payload carries the contested flag");
+        // a memory with no contradicts link is not contested.
+        let c = eng.remember(input("c lonely", 5)).await.unwrap();
+        let got_c = eng.get(c).await.unwrap().unwrap();
+        assert!(!got_c.contested);
+    }
+
+    #[tokio::test]
+    async fn list_surfaces_contested_flag() {
+        let eng = engine();
+        let a = eng.remember(input("list a", 5)).await.unwrap();
+        let b = eng.remember(input("list b", 5)).await.unwrap();
+        eng.backend().link_contradicts(&a, &b);
+        let notes = eng.list(None, 10).await.unwrap();
+        assert!(notes.iter().find(|n| n.id == a).unwrap().contested);
+        assert!(notes.iter().find(|n| n.id == b).unwrap().contested);
     }
 
     #[tokio::test]

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 mod backend;
+mod embed_input;
 mod engine;
 mod enrich;
 mod enricher;
@@ -15,6 +16,7 @@ mod linker;
 mod test_support;
 
 pub use backend::MemoryBackend;
+pub use embed_input::{embedding_input, EMBEDDING_INPUT_VERSION};
 pub use engine::{MemoryEngine, RememberInput};
 pub use enricher::{Enricher, Enrichment};
 pub use linker::{Linker, SimilarityLinker};

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -322,8 +322,12 @@ impl MemoryBackend for MockBackend {
             ));
         }
         let guard = self.notes.lock().unwrap();
-        // Mirror the store: the FAR endpoint must be active AND in the queried
-        // namespace, so a cross-namespace contradiction never flags a result.
+        // Mirror the store contract: flag a LOCAL endpoint only when it lives in the
+        // queried namespace AND its FAR endpoint is active and in the same namespace.
+        // (SqliteStore::active_contradicts scopes BOTH endpoints to `ns`, with the
+        // far endpoint also required active.) Without the local-namespace gate the
+        // mock would flag out-of-namespace ids the store never returns.
+        let in_ns = |id: &MemoryId| guard.get(id).is_some_and(|n| n.namespace == ns);
         let active = |id: &MemoryId| {
             guard
                 .get(id)
@@ -332,18 +336,18 @@ impl MemoryBackend for MockBackend {
         let requested: HashSet<&MemoryId> = ids.iter().collect();
         let mut contested: HashSet<MemoryId> = HashSet::new();
         // Scan every stored note's outbound contradicts links; flag BOTH endpoints
-        // when each is requested and the FAR endpoint is active (mirrors the store
-        // query's inbound-OR-outbound, active-far-endpoint semantics).
+        // when each is requested, IN namespace, and its FAR endpoint is active
+        // (mirrors the store's inbound-OR-outbound, both-in-ns, active-far semantics).
         for note in guard.values() {
             for link in &note.links {
                 if link.link_type != rb_types::LinkType::Contradicts {
                     continue;
                 }
                 let (src, tgt) = (&link.source_id, &link.target_id);
-                if requested.contains(src) && active(tgt) {
+                if requested.contains(src) && in_ns(src) && active(tgt) {
                     contested.insert(src.clone());
                 }
-                if requested.contains(tgt) && active(src) {
+                if requested.contains(tgt) && in_ns(tgt) && active(src) {
                     contested.insert(tgt.clone());
                 }
             }
@@ -366,7 +370,14 @@ impl MemoryBackend for MockBackend {
             .filter(|n| n.embedding_model != model || n.embedding_input_version != input_version)
             .cloned()
             .collect();
-        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        // Mirror the store's scan order: oldest first, then memory_id (the TEXT
+        // column) ascending — bounded + deterministic, matching the contract
+        // (HashMap iteration order must never decide which rows a `limit` selects).
+        v.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.to_string().cmp(&b.id.to_string()))
+        });
         v.truncate(limit);
         Ok(v)
     }
@@ -384,6 +395,11 @@ impl MemoryBackend for MockBackend {
             return Err(rb_types::Error::Storage(
                 "update_vector forced failure".to_string(),
             ));
+        }
+        // Fail closed on a missing id, like SqliteStore::update_vector (NotFound),
+        // so engine tests cannot pass on a vector-update path production rejects.
+        if !self.notes.lock().unwrap().contains_key(&id) {
+            return Err(rb_types::Error::NotFound(id));
         }
         self.embeddings
             .lock()

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -21,6 +21,9 @@ pub(crate) struct MockBackend {
     record_access_calls: std::sync::atomic::AtomicUsize,
     fail_record_access: std::sync::atomic::AtomicBool,
     fail_add_link: std::sync::atomic::AtomicBool,
+    update_vector_calls: std::sync::atomic::AtomicUsize,
+    fail_update_vector: std::sync::atomic::AtomicBool,
+    fail_contradicts: std::sync::atomic::AtomicBool,
 }
 
 impl MockBackend {
@@ -71,6 +74,32 @@ impl MockBackend {
             .get(id)
             .map(|n| n.links.clone())
             .unwrap_or_default()
+    }
+    pub fn update_vector_count(&self) -> usize {
+        self.update_vector_calls
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+    pub fn set_fail_update_vector(&self, fail: bool) {
+        self.fail_update_vector
+            .store(fail, std::sync::atomic::Ordering::SeqCst);
+    }
+    pub fn set_fail_contradicts(&self, fail: bool) {
+        self.fail_contradicts
+            .store(fail, std::sync::atomic::Ordering::SeqCst);
+    }
+    /// Record a directed contradicts link on the source note (test helper).
+    pub fn link_contradicts(&self, source: &MemoryId, target: &MemoryId) {
+        let mut guard = self.notes.lock().unwrap();
+        if let Some(note) = guard.get_mut(source) {
+            note.links.push(rb_types::MemoryLink {
+                source_id: source.clone(),
+                target_id: target.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 1.0,
+                reason: "test contradiction".to_string(),
+                created_at: chrono::Utc::now(),
+            });
+        }
     }
 }
 
@@ -276,6 +305,95 @@ impl MemoryBackend for MockBackend {
             .iter()
             .filter_map(|id| guard.get(id).filter(|n| n.namespace == ns).cloned())
             .collect())
+    }
+
+    async fn active_contradicts(
+        &self,
+        ns: Namespace,
+        ids: Vec<MemoryId>,
+    ) -> rb_types::Result<std::collections::HashSet<MemoryId>> {
+        use std::collections::HashSet;
+        if self
+            .fail_contradicts
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(rb_types::Error::Storage(
+                "active_contradicts forced failure".to_string(),
+            ));
+        }
+        let guard = self.notes.lock().unwrap();
+        // Mirror the store: the FAR endpoint must be active AND in the queried
+        // namespace, so a cross-namespace contradiction never flags a result.
+        let active = |id: &MemoryId| {
+            guard
+                .get(id)
+                .is_some_and(|n| n.archived_at.is_none() && n.namespace == ns)
+        };
+        let requested: HashSet<&MemoryId> = ids.iter().collect();
+        let mut contested: HashSet<MemoryId> = HashSet::new();
+        // Scan every stored note's outbound contradicts links; flag BOTH endpoints
+        // when each is requested and the FAR endpoint is active (mirrors the store
+        // query's inbound-OR-outbound, active-far-endpoint semantics).
+        for note in guard.values() {
+            for link in &note.links {
+                if link.link_type != rb_types::LinkType::Contradicts {
+                    continue;
+                }
+                let (src, tgt) = (&link.source_id, &link.target_id);
+                if requested.contains(src) && active(tgt) {
+                    contested.insert(src.clone());
+                }
+                if requested.contains(tgt) && active(src) {
+                    contested.insert(tgt.clone());
+                }
+            }
+        }
+        Ok(contested)
+    }
+
+    async fn memories_for_reembed(
+        &self,
+        model: String,
+        input_version: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.archived_at.is_none())
+            .filter(|n| n.embedding_model != model || n.embedding_input_version != input_version)
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+
+    async fn update_vector(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+    ) -> rb_types::Result<()> {
+        use std::sync::atomic::Ordering;
+        self.update_vector_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_update_vector.load(Ordering::SeqCst) {
+            return Err(rb_types::Error::Storage(
+                "update_vector forced failure".to_string(),
+            ));
+        }
+        self.embeddings
+            .lock()
+            .unwrap()
+            .insert(id.clone(), embedding);
+        if let Some(note) = self.notes.lock().unwrap().get_mut(&id) {
+            note.embedding_model = model;
+            note.embedding_input_version = input_version;
+        }
+        Ok(())
     }
 }
 

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -322,12 +322,11 @@ impl MemoryBackend for MockBackend {
             ));
         }
         let guard = self.notes.lock().unwrap();
-        // Mirror the store contract: flag a LOCAL endpoint only when it lives in the
-        // queried namespace AND its FAR endpoint is active and in the same namespace.
-        // (SqliteStore::active_contradicts scopes BOTH endpoints to `ns`, with the
-        // far endpoint also required active.) Without the local-namespace gate the
-        // mock would flag out-of-namespace ids the store never returns.
-        let in_ns = |id: &MemoryId| guard.get(id).is_some_and(|n| n.namespace == ns);
+        // Mirror the store contract: flag an endpoint only when BOTH endpoints are
+        // active AND in the queried namespace. (SqliteStore::active_contradicts
+        // requires `archived_at IS NULL` and `namespace = ns` on both the local and
+        // far endpoints.) Without gating the local endpoint the mock would flag
+        // archived or out-of-namespace ids the store never returns.
         let active = |id: &MemoryId| {
             guard
                 .get(id)
@@ -336,18 +335,18 @@ impl MemoryBackend for MockBackend {
         let requested: HashSet<&MemoryId> = ids.iter().collect();
         let mut contested: HashSet<MemoryId> = HashSet::new();
         // Scan every stored note's outbound contradicts links; flag BOTH endpoints
-        // when each is requested, IN namespace, and its FAR endpoint is active
-        // (mirrors the store's inbound-OR-outbound, both-in-ns, active-far semantics).
+        // when each is requested and both endpoints are active + in namespace
+        // (mirrors the store's inbound-OR-outbound, both-active, both-in-ns semantics).
         for note in guard.values() {
             for link in &note.links {
                 if link.link_type != rb_types::LinkType::Contradicts {
                     continue;
                 }
                 let (src, tgt) = (&link.source_id, &link.target_id);
-                if requested.contains(src) && in_ns(src) && active(tgt) {
+                if requested.contains(src) && active(src) && active(tgt) {
                     contested.insert(src.clone());
                 }
-                if requested.contains(tgt) && in_ns(tgt) && active(src) {
+                if requested.contains(tgt) && active(tgt) && active(src) {
                     contested.insert(tgt.clone());
                 }
             }

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -193,11 +193,17 @@ impl MemoryBackend for VecBackend {
         model: String,
         input_version: String,
     ) -> rb_types::Result<()> {
-        if let Some(note) = self.notes.lock().unwrap().get_mut(&id) {
-            note.embedding_model = model;
-            note.embedding_input_version = input_version;
+        // Fail closed on a missing id, like SqliteStore::update_vector, so the
+        // public-API backend matches the store-backed behavior.
+        let mut guard = self.notes.lock().unwrap();
+        match guard.get_mut(&id) {
+            Some(note) => {
+                note.embedding_model = model;
+                note.embedding_input_version = input_version;
+                Ok(())
+            }
+            None => Err(rb_types::Error::NotFound(id)),
         }
-        Ok(())
     }
 }
 

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -150,6 +150,48 @@ impl MemoryBackend for VecBackend {
             .filter_map(|id| guard.get(id).filter(|n| n.namespace == ns).cloned())
             .collect())
     }
+
+    async fn active_contradicts(
+        &self,
+        _ns: Namespace,
+        _ids: Vec<MemoryId>,
+    ) -> rb_types::Result<std::collections::HashSet<MemoryId>> {
+        Ok(std::collections::HashSet::new())
+    }
+
+    async fn memories_for_reembed(
+        &self,
+        model: String,
+        input_version: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let mut v: Vec<MemoryNote> = self
+            .notes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|n| n.archived_at.is_none())
+            .filter(|n| n.embedding_model != model || n.embedding_input_version != input_version)
+            .cloned()
+            .collect();
+        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        v.truncate(limit);
+        Ok(v)
+    }
+
+    async fn update_vector(
+        &self,
+        id: MemoryId,
+        _embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+    ) -> rb_types::Result<()> {
+        if let Some(note) = self.notes.lock().unwrap().get_mut(&id) {
+            note.embedding_model = model;
+            note.embedding_input_version = input_version;
+        }
+        Ok(())
+    }
 }
 
 #[tokio::test]

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -174,7 +174,14 @@ impl MemoryBackend for VecBackend {
             .filter(|n| n.embedding_model != model || n.embedding_input_version != input_version)
             .cloned()
             .collect();
-        v.sort_by_key(|n| std::cmp::Reverse(n.created_at));
+        // Mirror the store's scan order: oldest first, then memory_id ascending —
+        // bounded + deterministic (created_at ASC, memory_id ASC), as the contract
+        // requires, so a `limit` here selects the same batch as production.
+        v.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.to_string().cmp(&b.id.to_string()))
+        });
         v.truncate(limit);
         Ok(v)
     }

--- a/crates/rb-eval/Cargo.toml
+++ b/crates/rb-eval/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "rb-eval"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Offline, deterministic retrieval-quality regression harness for rusty-brain (dev/CI only)."
+publish = false
+
+# This is a dev/measurement crate. It is deliberately NOT a dependency of the
+# `rusty-brain` binary; nothing in the shipped closure depends on it. The CI
+# agent/closure gate asserts it never appears in `cargo tree -e no-dev -p rusty-brain`.
+
+[lints]
+workspace = true
+
+[dependencies]
+rb-engine = { path = "../rb-engine" }
+rb-store = { path = "../rb-store" }
+rb-search = { path = "../rb-search" }
+rb-embed = { path = "../rb-embed" }
+rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/rb-eval/README.md
+++ b/crates/rb-eval/README.md
@@ -1,0 +1,95 @@
+# rb-eval — offline retrieval-quality regression harness
+
+`rb-eval` is a **dev/measurement crate** for rusty-brain. It ingests a committed
+fixture corpus through `rb-engine` with a deterministic embedding provider, runs
+golden queries through `engine.recall`, computes ranking metrics, and asserts
+each metric meets a committed baseline. It is the CI regression gate for ranking
+changes (P5 Features B, A, C).
+
+It is **deliberately excluded from the `rusty-brain` binary's dependency
+closure** — nothing shipped depends on it. The CI agent/closure gate asserts it
+never appears in `cargo tree -e no-dev -p rusty-brain`.
+
+Run it:
+
+```bash
+cargo test -p rb-eval
+```
+
+## What this measures — and what it does NOT
+
+This harness uses `rb_embed::DeterministicProvider`: a SHA-256-based provider
+that yields **reproducible but non-semantic** unit vectors with no network. That
+choice has a precise, honest consequence:
+
+- **It guards:** ranking **determinism**, **regression detection**, and
+  **relative-ordering invariants**. The concrete question it answers is *"did a
+  change reorder results versus the committed baseline?"* The quality metrics
+  reproduce bit-for-bit across runs (only latency varies), so any drift in the
+  ranking pipeline is caught immediately.
+
+- **It does NOT measure absolute semantic quality.** Because the deterministic
+  vectors carry no meaning, the *absolute* recall/MRR values are modest (the
+  default ranking weights are vector-heavy, so deterministic vector noise dilutes
+  the keyword signal). Those absolute numbers are **only meaningful as a
+  baseline to detect change**, not as a ground-truth quality score.
+
+This mirrors the architecture spec's sqlite-vec scale honesty (§11): state the
+limit explicitly rather than overclaim.
+
+### Absolute semantic quality: the optional real-model mode
+
+To spot-check *actual* semantic recall, run the optional, `#[ignore]`d real-model
+mode against a live embedding model (no CI, no live network in CI):
+
+```bash
+VOYAGE_API_KEY=... cargo test -p rb-eval --test real_model -- --ignored --nocapture
+```
+
+It runs the same fixtures through `VoyageProvider`, prints semantic metrics for a
+human to judge, and makes no assertion against the deterministic baselines.
+
+The `composite_embedding_semantic_recall` case in `tests/real_model.rs` is the
+P5 Feature A check: the engine embeds the composite document representation
+(content + keywords + tags + context) rather than content alone. Deterministic
+vectors cannot show that lift (their values are non-semantic noise — the
+composite change only re-shuffles them, which is why the committed deterministic
+baselines were re-captured for it), so the comparison is real-model-only. Run it,
+read the printed recall/MRR, and compare against a content-only run to judge the
+semantic gain.
+
+## Components
+
+- `fixtures/corpus.json` — committed, hand-authored coding-memory corpus. Each
+  memory has stable string **keys** (not UUIDs; the runner maps each key to the
+  engine-minted `MemoryId` after ingestion), enrichment fields
+  (summary/keywords/tags/context), golden queries mapping to expected-relevant
+  keys, and near-duplicate clusters for dedup scoring. Authored to exercise the
+  FTS, vector, and graph retrieval paths.
+- `corpus.rs` — fixture loader + validation; fails fast on any malformed fixture
+  (unknown memory type, out-of-range importance/confidence, duplicate keys,
+  queries/clusters referencing unknown keys).
+- `metrics.rs` — pure, unit-tested functions: `recall_at_k`, `mrr`,
+  `dedup_precision`, and latency percentiles (`p50`/`p99`).
+- `backend.rs` — a `MemoryBackend` over an in-memory `SqliteStore`, mirroring the
+  daemon's namespace-scoping/active-only semantics, so the real FTS + sqlite-vec
+  + graph paths run (not a mock map).
+- `runner.rs` — builds the engine, ingests fixtures, runs golden queries,
+  computes the aggregate report, and compares against baselines.
+- `baselines.json` — committed metric baselines; the harness fails on regression.
+
+## Updating baselines
+
+`baselines.json` is captured from an initial run and reproduces bit-for-bit.
+**Raising a baseline** (after an intentional ranking improvement) or **lowering
+one** (for a justified trade-off) is a deliberate, reviewed commit — never an
+incidental change. Latency p50/p99 are reported but **not gated** (they are
+machine-dependent).
+
+## Error handling
+
+This is a test-only crate. Failures are assertion failures with readable diffs
+(the runner's per-query detail reports which fixture keys recall surfaced, in
+order). The crate opts out of the workspace `unwrap_used`/`expect_used` denials
+at its root as test code; because nothing shipped depends on `rb-eval`, no panic
+can leak into a production binary.

--- a/crates/rb-eval/baselines.json
+++ b/crates/rb-eval/baselines.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Committed metric baselines for the rb-eval regression gate. The harness FAILS if a quality metric drops below its baseline (with a 1e-9 tolerance). These were captured from a run over the committed fixtures with DeterministicProvider and reproduce bit-for-bit across runs. They guard ranking DETERMINISM and RELATIVE ORDERING (regression detection), not absolute semantic quality (the modest recall reflects that deterministic vectors are non-semantic noise under the default vector-heavy weights; see README.md). Raising a baseline after an intentional ranking improvement, or lowering it for a justified trade-off, is a deliberate reviewed commit. Latency p50/p99 are reported but not gated (machine-dependent). P5 Feature A (composite embedding input: content + keywords + tags + context, instead of content alone) intentionally changed the embedded document text, which re-shuffles the NON-SEMANTIC deterministic vectors and therefore the deterministic recall/dedup artifacts. These baselines were re-captured for the composite input; the absolute change carries no semantic meaning (deterministic vectors are noise) — the real composite-embedding lift is measured only in the real-model #[ignore] mode (tests/real_model.rs::composite_embedding_semantic_recall).",
+  "mean_recall_at_k": 0.4,
+  "mrr": 0.41583333333333333,
+  "dedup_precision": 0.9
+}

--- a/crates/rb-eval/fixtures/corpus.json
+++ b/crates/rb-eval/fixtures/corpus.json
@@ -1,0 +1,188 @@
+{
+  "_comment": "Hand-authored coding-memory corpus for rb-eval. Keys are stable handles (not UUIDs); the runner maps each to the engine-minted MemoryId after ingestion. Authored to exercise FTS (exact term), vector (deterministic-similarity), and graph (1-hop link expansion) paths. See README.md for the honest framing of what these metrics do and do not measure.",
+
+  "memories": [
+    {
+      "key": "single_writer",
+      "content": "rusty-brain uses a single writer thread that owns the only writable sqlite connection; all mutations are serialized through a WriteCommand channel.",
+      "summary": "single writer thread owns the sqlite write connection",
+      "keywords": ["single", "writer", "sqlite", "writecommand"],
+      "tags": ["concurrency", "store"],
+      "context": "architecture decision for the daemon store layer",
+      "memory_type": "ArchitectureDecision",
+      "importance": 9
+    },
+    {
+      "key": "read_pool",
+      "content": "Readers use a bounded read pool of sqlite connections with WAL mode, so concurrent readers never block the single writer.",
+      "summary": "bounded read pool over WAL for concurrent readers",
+      "keywords": ["read", "pool", "wal", "readers"],
+      "tags": ["concurrency", "store"],
+      "context": "daemon read path",
+      "memory_type": "ArchitectureDecision",
+      "importance": 8
+    },
+    {
+      "key": "wal_checkpoint",
+      "content": "On shutdown the daemon runs a WAL checkpoint truncate so the database file is fully consolidated and the journal is reset.",
+      "summary": "checkpoint truncate on shutdown consolidates the WAL",
+      "keywords": ["wal", "checkpoint", "truncate", "shutdown"],
+      "tags": ["store", "lifecycle"],
+      "context": "graceful shutdown",
+      "memory_type": "Insight",
+      "importance": 6
+    },
+    {
+      "key": "namespace_isolation",
+      "content": "Every store operation is namespace scoped; the engine is bound to one namespace from the client handshake and cross-namespace reads are silently excluded.",
+      "summary": "namespace isolation enforced at every store operation",
+      "keywords": ["namespace", "isolation", "scope", "handshake"],
+      "tags": ["security", "store"],
+      "context": "multi-tenant scoping invariant",
+      "memory_type": "Constraint",
+      "importance": 9
+    },
+    {
+      "key": "deterministic_embed",
+      "content": "The DeterministicProvider hashes text with sha256 per dimension and normalizes to a unit vector, giving reproducible embeddings with no network.",
+      "summary": "deterministic sha256-based unit-vector embeddings",
+      "keywords": ["deterministic", "embedding", "sha256", "vector"],
+      "tags": ["embedding", "testing"],
+      "context": "offline embedding provider",
+      "memory_type": "CodePattern",
+      "importance": 7
+    },
+    {
+      "key": "voyage_embed",
+      "content": "The VoyageProvider calls a remote embeddings API over https, batching inputs and re-pairing responses by index to preserve input order.",
+      "summary": "voyage remote embedding provider with index re-pairing",
+      "keywords": ["voyage", "embedding", "https", "remote"],
+      "tags": ["embedding", "network"],
+      "context": "production embedding backend",
+      "memory_type": "Reference",
+      "importance": 6
+    },
+    {
+      "key": "linear_ranking",
+      "content": "Default recall ranks candidates with a weighted linear sum of normalized vector similarity, reciprocal keyword rank, reciprocal graph hops, importance, and recency.",
+      "summary": "linear weighted-sum hybrid ranking is the default",
+      "keywords": ["ranking", "linear", "weights", "hybrid"],
+      "tags": ["search", "ranking"],
+      "context": "rb-search default fusion",
+      "memory_type": "ArchitectureDecision",
+      "importance": 8
+    },
+    {
+      "key": "recency_decay",
+      "content": "The recency signal uses an exponential decay with a thirty day half-life, so a memory thirty days old contributes about 0.368 on the recency term.",
+      "summary": "recency uses 30-day half-life exponential decay",
+      "keywords": ["recency", "decay", "halflife", "exponential"],
+      "tags": ["search", "ranking"],
+      "context": "ranking recency prior",
+      "memory_type": "Insight",
+      "importance": 6
+    },
+    {
+      "key": "migration_additive",
+      "content": "Schema migrations are additive only; each is a new numbered file, file-discovered and checksummed, and an applied migration is never edited.",
+      "summary": "migrations are additive, numbered, checksummed, never edited",
+      "keywords": ["migration", "schema", "additive", "checksum"],
+      "tags": ["store", "schema"],
+      "context": "migration discipline",
+      "memory_type": "Constraint",
+      "importance": 8
+    },
+    {
+      "key": "fts_trigger",
+      "content": "Full text search is kept in sync with the memories table by sqlite triggers that update the fts5 virtual table on insert and update.",
+      "summary": "fts5 kept in sync via insert/update triggers",
+      "keywords": ["fts", "fts5", "trigger", "search"],
+      "tags": ["store", "search"],
+      "context": "keyword retrieval index",
+      "memory_type": "CodePattern",
+      "importance": 6
+    },
+    {
+      "key": "writer_thread_dup",
+      "content": "All writes are serialized on the dedicated single writer thread that exclusively owns the writable sqlite connection in rusty-brain.",
+      "summary": "writes serialized on the dedicated single writer thread",
+      "keywords": ["single", "writer", "thread", "sqlite"],
+      "tags": ["concurrency", "store"],
+      "context": "near-duplicate restatement of the single-writer decision",
+      "memory_type": "ArchitectureDecision",
+      "importance": 7
+    },
+    {
+      "key": "namespace_isolation_dup",
+      "content": "Cross namespace access is impossible because the engine is pinned to one namespace and every store query is namespace scoped before it runs.",
+      "summary": "cross-namespace access impossible; queries namespace-scoped",
+      "keywords": ["namespace", "isolation", "scope", "crossnamespace"],
+      "tags": ["security", "store"],
+      "context": "near-duplicate restatement of namespace isolation",
+      "memory_type": "Constraint",
+      "importance": 8
+    }
+  ],
+
+  "golden_queries": [
+    {
+      "query": "writer writecommand",
+      "expected": ["single_writer", "writer_thread_dup"],
+      "k": 5
+    },
+    {
+      "query": "readers pool",
+      "expected": ["read_pool"],
+      "k": 5
+    },
+    {
+      "query": "checkpoint truncate",
+      "expected": ["wal_checkpoint"],
+      "k": 3
+    },
+    {
+      "query": "namespace isolation",
+      "expected": ["namespace_isolation", "namespace_isolation_dup"],
+      "k": 5
+    },
+    {
+      "query": "deterministic sha256",
+      "expected": ["deterministic_embed"],
+      "k": 3
+    },
+    {
+      "query": "voyage https",
+      "expected": ["voyage_embed"],
+      "k": 3
+    },
+    {
+      "query": "linear ranking",
+      "expected": ["linear_ranking"],
+      "k": 3
+    },
+    {
+      "query": "recency halflife",
+      "expected": ["recency_decay"],
+      "k": 3
+    },
+    {
+      "query": "migration checksum",
+      "expected": ["migration_additive"],
+      "k": 3
+    },
+    {
+      "query": "fts5 trigger",
+      "expected": ["fts_trigger"],
+      "k": 3
+    }
+  ],
+
+  "dedup_clusters": [
+    {
+      "members": ["single_writer", "writer_thread_dup"]
+    },
+    {
+      "members": ["namespace_isolation", "namespace_isolation_dup"]
+    }
+  ]
+}

--- a/crates/rb-eval/src/backend.rs
+++ b/crates/rb-eval/src/backend.rs
@@ -1,0 +1,206 @@
+//! A `MemoryBackend` bridge over an in-memory `SqliteStore` for the harness.
+//!
+//! The production daemon bridges the synchronous `rb_store::Store` to the async
+//! `MemoryBackend` with a dedicated writer thread + read pool. The eval harness
+//! is single-threaded and offline, so it instead guards one `SqliteStore` behind
+//! a `Mutex` and runs every store call inline. The *semantics* (namespace
+//! scoping, active-only graph expansion) mirror the daemon's `StoreHandle`
+//! exactly, so recall behaves as it does in production — only the concurrency
+//! plumbing is simplified.
+//!
+//! This is the real FTS + sqlite-vec + graph path (not a mock map), so the
+//! fixtures genuinely exercise keyword, vector, and graph retrieval.
+
+use rb_engine::MemoryBackend;
+use rb_store::{SqliteStore, Store};
+use rb_types::{MemoryId, MemoryLink, MemoryNote, MemoryUpdates, Namespace};
+use std::sync::Mutex;
+
+/// In-memory store wrapped for the engine. Single-threaded by construction.
+pub struct SqliteBackend {
+    store: Mutex<SqliteStore>,
+}
+
+impl SqliteBackend {
+    /// Build an ephemeral in-memory store with the given embedding dimension.
+    pub fn in_memory(dim: usize) -> rb_types::Result<Self> {
+        let store = SqliteStore::open_in_memory(dim)?;
+        Ok(Self {
+            store: Mutex::new(store),
+        })
+    }
+
+    fn lock(&self) -> rb_types::Result<std::sync::MutexGuard<'_, SqliteStore>> {
+        self.store
+            .lock()
+            .map_err(|_| rb_types::Error::Storage("rb-eval store mutex poisoned".into()))
+    }
+
+    /// Test-harness helper: stamp a memory's `confidence` directly in the store.
+    ///
+    /// `engine.remember` does not expose a confidence input (it defaults to full
+    /// trust), but the confidence DAMPENER is what Feature C's "poison" scenario
+    /// exercises. This lets a fixture author a low-confidence wrong memory so the
+    /// harness can prove it ranks below an equal-match high-confidence one. Only
+    /// used by the offline harness; never on the shipped path.
+    pub fn set_confidence(&self, id: &MemoryId, confidence: f32) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.set_confidence(id, confidence)
+    }
+}
+
+#[async_trait::async_trait]
+impl MemoryBackend for SqliteBackend {
+    async fn write(&self, note: MemoryNote, embedding: Option<Vec<f32>>) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.insert_memory(&note, embedding.as_deref())
+    }
+
+    async fn get(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
+        let store = self.lock()?;
+        Ok(store.get_memory(&id)?.filter(|note| note.namespace == ns))
+    }
+
+    async fn keyword(
+        &self,
+        ns: Namespace,
+        query: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let store = self.lock()?;
+        store.keyword_search(&ns, &query, limit)
+    }
+
+    async fn vector(
+        &self,
+        ns: Namespace,
+        embedding: Vec<f32>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<(MemoryId, f32)>> {
+        let store = self.lock()?;
+        store.vector_search(&ns, &embedding, limit)
+    }
+
+    async fn graph(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        depth: u8,
+    ) -> rb_types::Result<Vec<MemoryId>> {
+        let store = self.lock()?;
+        // Mirror StoreHandle::graph: anchor must be active + in namespace; each
+        // neighbor is re-checked for namespace + active status.
+        let Some(anchor) = store.get_memory(&id)? else {
+            return Ok(Vec::new());
+        };
+        if anchor.namespace != ns || anchor.archived_at.is_some() {
+            return Ok(Vec::new());
+        }
+        let ids = store.graph_neighbors(&id, depth)?;
+        let mut filtered = Vec::with_capacity(ids.len());
+        for graph_id in ids {
+            let Some(note) = store.get_memory(&graph_id)? else {
+                continue;
+            };
+            if note.namespace == ns && note.archived_at.is_none() {
+                filtered.push(graph_id);
+            }
+        }
+        Ok(filtered)
+    }
+
+    async fn list(
+        &self,
+        ns: Namespace,
+        min_importance: Option<u8>,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let store = self.lock()?;
+        store.list(&ns, min_importance, limit)
+    }
+
+    async fn update(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        updates: MemoryUpdates,
+    ) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        // Namespace-scope the update like the daemon does.
+        match store.get_memory(&id)? {
+            Some(note) if note.namespace == ns => store.update_memory(&id, &updates),
+            _ => Err(rb_types::Error::NotFound(id)),
+        }
+    }
+
+    async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        match store.get_memory(&id)? {
+            Some(note) if note.namespace == ns => store.archive_memory(&id),
+            _ => Err(rb_types::Error::NotFound(id)),
+        }
+    }
+
+    async fn add_link(&self, link: MemoryLink) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.add_link(&link)
+    }
+
+    async fn record_access(&self, id: MemoryId) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.record_access(&id)
+    }
+
+    async fn record_accesses(&self, ids: Vec<MemoryId>) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.record_accesses(&ids)
+    }
+
+    async fn get_many(
+        &self,
+        ns: Namespace,
+        ids: Vec<MemoryId>,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let store = self.lock()?;
+        store.get_many(&ns, &ids)
+    }
+
+    async fn active_contradicts(
+        &self,
+        ns: Namespace,
+        ids: Vec<MemoryId>,
+    ) -> rb_types::Result<std::collections::HashSet<MemoryId>> {
+        let store = self.lock()?;
+        store.active_contradicts(&ns, &ids)
+    }
+
+    async fn memories_for_reembed(
+        &self,
+        model: String,
+        input_version: String,
+        limit: usize,
+    ) -> rb_types::Result<Vec<MemoryNote>> {
+        let store = self.lock()?;
+        store.memories_for_reembed(&model, &input_version, limit)
+    }
+
+    async fn update_vector(
+        &self,
+        id: MemoryId,
+        embedding: Vec<f32>,
+        model: String,
+        input_version: String,
+    ) -> rb_types::Result<()> {
+        let store = self.lock()?;
+        store.update_vector(&id, &embedding, &model, &input_version)
+    }
+}
+
+/// The memory type used by all eval fixtures' namespace and the dim used by the
+/// deterministic provider. Centralized so the runner and tests agree.
+pub const EVAL_DIM: usize = 32;
+
+/// Stable namespace for the whole eval corpus (single project scope).
+pub fn eval_namespace() -> Namespace {
+    Namespace::Project("rb-eval".into())
+}

--- a/crates/rb-eval/src/corpus.rs
+++ b/crates/rb-eval/src/corpus.rs
@@ -1,0 +1,309 @@
+//! Fixture loader + validation.
+//!
+//! Fixtures are committed JSON under `fixtures/`. They use *stable string keys*
+//! (e.g. `"single_writer"`) rather than UUIDs, because `engine.remember` mints a
+//! fresh random `MemoryId` per note; the runner maps each fixture key to the
+//! generated id after ingestion. Golden queries and dedup clusters reference
+//! those keys, never UUIDs, so the corpus is human-authored and stable.
+//!
+//! Validation fails fast (returns `Err`) on any malformed fixture: unknown
+//! memory type, out-of-range importance/confidence, duplicate keys, or golden
+//! queries / clusters referencing unknown keys.
+
+use rb_types::MemoryType;
+use serde::Deserialize;
+use std::collections::HashSet;
+
+/// A single corpus memory authored by hand.
+///
+/// `memory_type` deserializes from the serde variant name (e.g. `"Insight"`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureMemory {
+    /// Stable handle referenced by golden queries and clusters.
+    pub key: String,
+    pub content: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub context: String,
+    pub memory_type: MemoryType,
+    pub importance: u8,
+    /// Optional confidence override (0.0..=1.0); defaults to full trust.
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
+}
+
+fn default_confidence() -> f32 {
+    1.0
+}
+
+/// A golden query: text plus the set of fixture keys that *should* rank highly.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GoldenQuery {
+    pub query: String,
+    /// Fixture keys expected among the top results, best-relevance unordered.
+    pub expected: Vec<String>,
+    /// Optional `k` for this query's recall (defaults applied by the runner).
+    #[serde(default)]
+    pub k: Option<usize>,
+}
+
+/// A near-duplicate cluster: fixture keys that are mutually redundant.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DedupCluster {
+    pub members: Vec<String>,
+}
+
+/// The whole committed corpus: memories, golden queries, and dedup clusters.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Corpus {
+    pub memories: Vec<FixtureMemory>,
+    pub golden_queries: Vec<GoldenQuery>,
+    #[serde(default)]
+    pub dedup_clusters: Vec<DedupCluster>,
+}
+
+/// Error surfaced when a fixture file is malformed or internally inconsistent.
+#[derive(Debug)]
+pub enum CorpusError {
+    /// JSON failed to parse into the corpus shape.
+    Parse(String),
+    /// The corpus parsed but violates an invariant (the message explains which).
+    Invalid(String),
+}
+
+impl std::fmt::Display for CorpusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CorpusError::Parse(m) => write!(f, "fixture parse error: {m}"),
+            CorpusError::Invalid(m) => write!(f, "fixture validation error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for CorpusError {}
+
+impl Corpus {
+    /// Parse a corpus from a JSON string and validate it. Fails fast.
+    pub fn from_json(raw: &str) -> Result<Self, CorpusError> {
+        let corpus: Corpus =
+            serde_json::from_str(raw).map_err(|e| CorpusError::Parse(e.to_string()))?;
+        corpus.validate()?;
+        Ok(corpus)
+    }
+
+    /// Reject any internally inconsistent corpus.
+    ///
+    /// Invariants:
+    /// - at least one memory and one golden query,
+    /// - unique, non-empty memory keys with non-empty content,
+    /// - importance in `1..=10`, confidence in `0.0..=1.0`,
+    /// - every golden query references only known keys and has a non-empty
+    ///   expected set with a positive `k` (if present),
+    /// - every dedup cluster has >= 2 known members.
+    fn validate(&self) -> Result<(), CorpusError> {
+        if self.memories.is_empty() {
+            return Err(CorpusError::Invalid("corpus has no memories".into()));
+        }
+        if self.golden_queries.is_empty() {
+            return Err(CorpusError::Invalid("corpus has no golden queries".into()));
+        }
+
+        let mut keys: HashSet<&str> = HashSet::new();
+        for m in &self.memories {
+            if m.key.trim().is_empty() {
+                return Err(CorpusError::Invalid("a memory has an empty key".into()));
+            }
+            if !keys.insert(m.key.as_str()) {
+                return Err(CorpusError::Invalid(format!(
+                    "duplicate memory key '{}'",
+                    m.key
+                )));
+            }
+            if m.content.trim().is_empty() {
+                return Err(CorpusError::Invalid(format!(
+                    "memory '{}' has empty content",
+                    m.key
+                )));
+            }
+            if !(1..=10).contains(&m.importance) {
+                return Err(CorpusError::Invalid(format!(
+                    "memory '{}' importance {} out of range 1..=10",
+                    m.key, m.importance
+                )));
+            }
+            if !m.confidence.is_finite() || !(0.0..=1.0).contains(&m.confidence) {
+                return Err(CorpusError::Invalid(format!(
+                    "memory '{}' confidence {} out of range 0.0..=1.0",
+                    m.key, m.confidence
+                )));
+            }
+        }
+
+        for (qi, q) in self.golden_queries.iter().enumerate() {
+            if q.query.trim().is_empty() {
+                return Err(CorpusError::Invalid(format!(
+                    "golden query {qi} has empty text"
+                )));
+            }
+            if q.expected.is_empty() {
+                return Err(CorpusError::Invalid(format!(
+                    "golden query '{}' has no expected keys",
+                    q.query
+                )));
+            }
+            if let Some(k) = q.k {
+                if k == 0 {
+                    return Err(CorpusError::Invalid(format!(
+                        "golden query '{}' has k = 0",
+                        q.query
+                    )));
+                }
+            }
+            for key in &q.expected {
+                if !keys.contains(key.as_str()) {
+                    return Err(CorpusError::Invalid(format!(
+                        "golden query '{}' references unknown key '{key}'",
+                        q.query
+                    )));
+                }
+            }
+        }
+
+        for (ci, cluster) in self.dedup_clusters.iter().enumerate() {
+            if cluster.members.len() < 2 {
+                return Err(CorpusError::Invalid(format!(
+                    "dedup cluster {ci} needs >= 2 members"
+                )));
+            }
+            for key in &cluster.members {
+                if !keys.contains(key.as_str()) {
+                    return Err(CorpusError::Invalid(format!(
+                        "dedup cluster {ci} references unknown key '{key}'"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Load and validate the committed corpus bundled at compile time.
+///
+/// The fixtures are embedded with `include_str!` so the harness has no runtime
+/// filesystem dependency and runs identically in CI and locally.
+pub fn load_committed_corpus() -> Result<Corpus, CorpusError> {
+    const RAW: &str = include_str!("../fixtures/corpus.json");
+    Corpus::from_json(RAW)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL: &str = r#"{
+        "memories": [
+            {"key": "a", "content": "alpha content", "memory_type": "Insight", "importance": 5},
+            {"key": "b", "content": "beta content", "memory_type": "Reference", "importance": 3}
+        ],
+        "golden_queries": [
+            {"query": "alpha", "expected": ["a"]}
+        ],
+        "dedup_clusters": [
+            {"members": ["a", "b"]}
+        ]
+    }"#;
+
+    #[test]
+    fn parses_and_validates_minimal_corpus() {
+        let c = Corpus::from_json(MINIMAL).unwrap();
+        assert_eq!(c.memories.len(), 2);
+        assert_eq!(c.golden_queries.len(), 1);
+        assert_eq!(c.dedup_clusters.len(), 1);
+        // confidence defaults to 1.0 when omitted
+        assert!((c.memories[0].confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rejects_unknown_memory_type() {
+        let bad = MINIMAL.replace("\"Insight\"", "\"NotAType\"");
+        assert!(matches!(
+            Corpus::from_json(&bad),
+            Err(CorpusError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_keys() {
+        let bad = r#"{
+            "memories": [
+                {"key": "a", "content": "x", "memory_type": "Insight", "importance": 5},
+                {"key": "a", "content": "y", "memory_type": "Insight", "importance": 5}
+            ],
+            "golden_queries": [{"query": "x", "expected": ["a"]}]
+        }"#;
+        let err = Corpus::from_json(bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn rejects_out_of_range_importance() {
+        let bad = MINIMAL.replace("\"importance\": 5", "\"importance\": 0");
+        assert!(matches!(
+            Corpus::from_json(&bad),
+            Err(CorpusError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_range_confidence() {
+        let bad = r#"{
+            "memories": [
+                {"key": "a", "content": "x", "memory_type": "Insight", "importance": 5, "confidence": 1.5}
+            ],
+            "golden_queries": [{"query": "x", "expected": ["a"]}]
+        }"#;
+        assert!(matches!(
+            Corpus::from_json(bad),
+            Err(CorpusError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_golden_query_referencing_unknown_key() {
+        let bad = MINIMAL.replace("\"expected\": [\"a\"]", "\"expected\": [\"zzz\"]");
+        let err = Corpus::from_json(&bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn rejects_cluster_referencing_unknown_key() {
+        let bad = MINIMAL.replace(
+            "\"members\": [\"a\", \"b\"]",
+            "\"members\": [\"a\", \"zzz\"]",
+        );
+        let err = Corpus::from_json(&bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn rejects_cluster_with_one_member() {
+        let bad = MINIMAL.replace("\"members\": [\"a\", \"b\"]", "\"members\": [\"a\"]");
+        let err = Corpus::from_json(&bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn committed_corpus_loads_and_validates() {
+        // The shipped fixtures must always be well-formed.
+        let c = load_committed_corpus().unwrap();
+        assert!(c.memories.len() >= 8, "corpus should be non-trivial");
+        assert!(!c.golden_queries.is_empty());
+        assert!(!c.dedup_clusters.is_empty());
+    }
+}

--- a/crates/rb-eval/src/corpus.rs
+++ b/crates/rb-eval/src/corpus.rs
@@ -164,7 +164,14 @@ impl Corpus {
                     )));
                 }
             }
+            let mut expected_seen: HashSet<&str> = HashSet::new();
             for key in &q.expected {
+                if !expected_seen.insert(key.as_str()) {
+                    return Err(CorpusError::Invalid(format!(
+                        "golden query '{}' has duplicate expected key '{key}'",
+                        q.query
+                    )));
+                }
                 if !keys.contains(key.as_str()) {
                     return Err(CorpusError::Invalid(format!(
                         "golden query '{}' references unknown key '{key}'",
@@ -180,7 +187,13 @@ impl Corpus {
                     "dedup cluster {ci} needs >= 2 members"
                 )));
             }
+            let mut member_seen: HashSet<&str> = HashSet::new();
             for key in &cluster.members {
+                if !member_seen.insert(key.as_str()) {
+                    return Err(CorpusError::Invalid(format!(
+                        "dedup cluster {ci} has duplicate member '{key}'"
+                    )));
+                }
                 if !keys.contains(key.as_str()) {
                     return Err(CorpusError::Invalid(format!(
                         "dedup cluster {ci} references unknown key '{key}'"
@@ -287,6 +300,23 @@ mod tests {
             "\"members\": [\"a\", \"b\"]",
             "\"members\": [\"a\", \"zzz\"]",
         );
+        let err = Corpus::from_json(&bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn rejects_duplicate_expected_key_in_golden_query() {
+        // A duplicate within one query's expected list would double-count in
+        // recall@k / mrr, so it is rejected even though the key is known.
+        let bad = MINIMAL.replace("\"expected\": [\"a\"]", "\"expected\": [\"a\", \"a\"]");
+        let err = Corpus::from_json(&bad).unwrap_err();
+        assert!(matches!(err, CorpusError::Invalid(_)));
+    }
+
+    #[test]
+    fn rejects_duplicate_member_in_dedup_cluster() {
+        // A duplicate cluster member would skew dedup_precision; reject it.
+        let bad = MINIMAL.replace("\"members\": [\"a\", \"b\"]", "\"members\": [\"a\", \"a\"]");
         let err = Corpus::from_json(&bad).unwrap_err();
         assert!(matches!(err, CorpusError::Invalid(_)));
     }

--- a/crates/rb-eval/src/lib.rs
+++ b/crates/rb-eval/src/lib.rs
@@ -1,0 +1,36 @@
+//! `rb-eval` — offline, deterministic retrieval-quality regression harness.
+//!
+//! This is a **dev/measurement crate**, deliberately excluded from the
+//! `rusty-brain` binary's dependency closure. It ingests a committed fixture
+//! corpus through `rb-engine` with [`rb_embed::DeterministicProvider`], runs
+//! golden queries through `engine.recall`, computes ranking metrics, and asserts
+//! each metric meets a committed baseline.
+//!
+//! ## What this measures (and what it does not)
+//!
+//! With deterministic (non-semantic) vectors, this harness guards **ranking
+//! determinism, regression detection, and relative-ordering invariants** — i.e.
+//! "did a change reorder results versus the committed baseline?". It does **not**
+//! measure absolute semantic quality; that is the job of the optional, manual
+//! `#[ignore]` real-model mode (Voyage / `local`). See `README.md`.
+//!
+//! As a test-only crate it opts out of the workspace's
+//! `unwrap_used`/`expect_used` denials at the crate root; no panics leak into any
+//! shipped crate because nothing shipped depends on `rb-eval`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+pub mod backend;
+pub mod corpus;
+pub mod metrics;
+pub mod runner;
+
+pub use corpus::{Corpus, CorpusError};
+pub use runner::{
+    build_engine_with, check_against_baselines, compare_modes, compare_modes_committed, run_corpus,
+    run_corpus_detailed, run_corpus_detailed_mode, run_corpus_with, run_eval, run_eval_mode,
+    Baselines, DetailedRun, EvalReport, ModeComparison, QueryDetail,
+};
+
+// Re-export so harness callers can name the fusion mode without depending on
+// `rb-search` directly.
+pub use rb_search::FusionMode;

--- a/crates/rb-eval/src/metrics.rs
+++ b/crates/rb-eval/src/metrics.rs
@@ -1,0 +1,298 @@
+//! Pure ranking-quality metrics.
+//!
+//! Every function here is deterministic and side-effect-free so the harness's
+//! pass/fail decision is reproducible. The inputs are *ranked id lists* (best
+//! first) paired with sets of expected-relevant ids, plus raw latency samples.
+//!
+//! These metrics intentionally measure *relative ordering and regression*, not
+//! absolute semantic quality (see the crate README): with `DeterministicProvider`
+//! the vectors are stable but not semantic, so the value of a metric is only
+//! meaningful as a baseline to detect change, not as a ground-truth score.
+
+/// Fraction of expected-relevant ids that appear in the top `k` of `ranked`.
+///
+/// `ranked` is best-first. `expected` is the set that *should* be retrieved.
+/// Returns a value in `[0.0, 1.0]`. An empty `expected` set is treated as a
+/// perfect match (`1.0`) — there is nothing to miss. `k == 0` yields `0.0`.
+pub fn recall_at_k(ranked: &[String], expected: &[String], k: usize) -> f64 {
+    if expected.is_empty() {
+        return 1.0;
+    }
+    if k == 0 {
+        return 0.0;
+    }
+    let top: std::collections::HashSet<&String> = ranked.iter().take(k).collect();
+    let hits = expected.iter().filter(|e| top.contains(e)).count();
+    hits as f64 / expected.len() as f64
+}
+
+/// Mean Reciprocal Rank over a set of queries.
+///
+/// For each query, the reciprocal rank is `1 / position` of the first
+/// expected-relevant id in `ranked` (1-based), or `0.0` if none of the expected
+/// ids appear. MRR is the mean of those per-query reciprocal ranks. An empty
+/// query set returns `0.0`.
+pub fn mrr(per_query: &[(Vec<String>, Vec<String>)]) -> f64 {
+    if per_query.is_empty() {
+        return 0.0;
+    }
+    let total: f64 = per_query
+        .iter()
+        .map(|(ranked, expected)| reciprocal_rank(ranked, expected))
+        .sum();
+    total / per_query.len() as f64
+}
+
+/// Reciprocal rank of the first expected-relevant id in a single ranked list.
+///
+/// `1 / position` (1-based) of the earliest hit, or `0.0` if no expected id is
+/// present. Exposed for unit testing and reuse by `mrr`.
+pub fn reciprocal_rank(ranked: &[String], expected: &[String]) -> f64 {
+    let want: std::collections::HashSet<&String> = expected.iter().collect();
+    for (idx, id) in ranked.iter().enumerate() {
+        if want.contains(id) {
+            return 1.0 / (idx as f64 + 1.0);
+        }
+    }
+    0.0
+}
+
+/// Deduplication precision over near-duplicate clusters in a ranked result list.
+///
+/// Given near-duplicate `clusters` (each a group of ids that are mutually
+/// redundant), this measures how well the ranking avoids surfacing *multiple*
+/// members of the same cluster inside the top `k`. A clean ranking returns at
+/// most one representative per cluster; surfacing extra cluster members crowds
+/// out genuinely distinct results (the dedup-quality failure mode).
+///
+/// Definition: of the `n` ids in the top `k`, count `r` redundant ids — the
+/// 2nd-and-later members of any cluster that appear. Precision = `(n - r) / n`,
+/// the fraction of top-`k` slots holding distinct (non-redundant) information.
+/// Ids not in any cluster are always distinct. An empty top-`k` returns `1.0`
+/// (vacuously precise).
+pub fn dedup_precision(ranked: &[String], clusters: &[Vec<String>], k: usize) -> f64 {
+    let top: Vec<&String> = ranked.iter().take(k).collect();
+    if top.is_empty() {
+        return 1.0;
+    }
+    // Map each id that belongs to a cluster to a stable cluster index.
+    let mut cluster_of: std::collections::HashMap<&String, usize> =
+        std::collections::HashMap::new();
+    for (ci, cluster) in clusters.iter().enumerate() {
+        for id in cluster {
+            cluster_of.insert(id, ci);
+        }
+    }
+    let mut seen_cluster: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut redundant = 0usize;
+    for id in &top {
+        if let Some(&ci) = cluster_of.get(*id) {
+            if !seen_cluster.insert(ci) {
+                // A second-or-later member of an already-seen cluster.
+                redundant += 1;
+            }
+        }
+    }
+    let n = top.len();
+    (n - redundant) as f64 / n as f64
+}
+
+/// Latency percentile (`p` in `[0.0, 100.0]`) over `samples` in microseconds.
+///
+/// Uses the nearest-rank method on a sorted copy: deterministic, no
+/// interpolation, no panics. Returns `0` for an empty sample set. `p` is
+/// clamped to `[0.0, 100.0]`.
+pub fn latency_percentile(samples: &[u64], p: f64) -> u64 {
+    if samples.is_empty() {
+        return 0;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let p = p.clamp(0.0, 100.0);
+    // Nearest-rank: rank = ceil(p/100 * N), 1-based, clamped to [1, N].
+    let n = sorted.len();
+    let rank = (p / 100.0 * n as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx]
+}
+
+/// Convenience: the 50th percentile (median by nearest-rank).
+pub fn p50(samples: &[u64]) -> u64 {
+    latency_percentile(samples, 50.0)
+}
+
+/// Convenience: the 99th percentile.
+pub fn p99(samples: &[u64]) -> u64 {
+    latency_percentile(samples, 99.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ---- recall_at_k ---------------------------------------------------------
+
+    #[test]
+    fn recall_at_k_all_relevant_in_top_k() {
+        let ranked = ids(&["a", "b", "c", "d"]);
+        let expected = ids(&["a", "c"]);
+        // both expected appear in top 3 -> 2/2 = 1.0
+        assert!((recall_at_k(&ranked, &expected, 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_partial_hit() {
+        let ranked = ids(&["a", "b", "c", "d"]);
+        let expected = ids(&["a", "d"]);
+        // only "a" is in top 2 -> 1/2 = 0.5
+        assert!((recall_at_k(&ranked, &expected, 2) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_no_hit() {
+        let ranked = ids(&["a", "b"]);
+        let expected = ids(&["x", "y"]);
+        assert!((recall_at_k(&ranked, &expected, 5) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_empty_expected_is_perfect() {
+        let ranked = ids(&["a", "b"]);
+        assert!((recall_at_k(&ranked, &[], 2) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn recall_at_k_zero_k_is_zero() {
+        let ranked = ids(&["a", "b"]);
+        let expected = ids(&["a"]);
+        assert!((recall_at_k(&ranked, &expected, 0) - 0.0).abs() < 1e-9);
+    }
+
+    // ---- reciprocal_rank / mrr ----------------------------------------------
+
+    #[test]
+    fn reciprocal_rank_first_position() {
+        let ranked = ids(&["a", "b", "c"]);
+        let expected = ids(&["a"]);
+        assert!((reciprocal_rank(&ranked, &expected) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reciprocal_rank_third_position() {
+        let ranked = ids(&["x", "y", "a"]);
+        let expected = ids(&["a"]);
+        // 1/3
+        assert!((reciprocal_rank(&ranked, &expected) - (1.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reciprocal_rank_uses_earliest_hit() {
+        let ranked = ids(&["x", "b", "a"]);
+        let expected = ids(&["a", "b"]);
+        // "b" is at position 2 -> 1/2 (earliest of the two expected)
+        assert!((reciprocal_rank(&ranked, &expected) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reciprocal_rank_no_hit_is_zero() {
+        let ranked = ids(&["x", "y"]);
+        let expected = ids(&["a"]);
+        assert!((reciprocal_rank(&ranked, &expected) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mrr_mean_of_reciprocal_ranks() {
+        let per_query = vec![
+            (ids(&["a", "b"]), ids(&["a"])),      // rr = 1.0
+            (ids(&["x", "a"]), ids(&["a"])),      // rr = 0.5
+            (ids(&["x", "y", "z"]), ids(&["a"])), // rr = 0.0
+        ];
+        // (1.0 + 0.5 + 0.0) / 3 = 0.5
+        assert!((mrr(&per_query) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mrr_empty_is_zero() {
+        assert!((mrr(&[]) - 0.0).abs() < 1e-9);
+    }
+
+    // ---- dedup_precision -----------------------------------------------------
+
+    #[test]
+    fn dedup_precision_no_clusters_is_perfect() {
+        let ranked = ids(&["a", "b", "c"]);
+        assert!((dedup_precision(&ranked, &[], 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_one_redundant_member() {
+        let ranked = ids(&["a", "a2", "b"]);
+        let clusters = vec![ids(&["a", "a2"])];
+        // top 3 = [a, a2, b]; a2 is a 2nd cluster member -> 1 redundant.
+        // (3 - 1) / 3 = 0.6667
+        assert!((dedup_precision(&ranked, &clusters, 3) - (2.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_distinct_representatives_are_clean() {
+        let ranked = ids(&["a", "b", "c"]);
+        let clusters = vec![ids(&["a", "a2"]), ids(&["b", "b2"])];
+        // top 3 = [a, b, c]; one rep per cluster + a non-cluster id -> no redundancy.
+        assert!((dedup_precision(&ranked, &clusters, 3) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_two_redundant_in_same_cluster() {
+        let ranked = ids(&["a", "a2", "a3", "b"]);
+        let clusters = vec![ids(&["a", "a2", "a3"])];
+        // top 4 = [a, a2, a3, b]; a2 and a3 redundant -> 2 redundant.
+        // (4 - 2) / 4 = 0.5
+        assert!((dedup_precision(&ranked, &clusters, 4) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dedup_precision_empty_top_is_vacuously_precise() {
+        assert!((dedup_precision(&[], &[], 0) - 1.0).abs() < 1e-9);
+    }
+
+    // ---- latency percentiles -------------------------------------------------
+
+    #[test]
+    fn latency_percentile_empty_is_zero() {
+        assert_eq!(latency_percentile(&[], 50.0), 0);
+        assert_eq!(p50(&[]), 0);
+        assert_eq!(p99(&[]), 0);
+    }
+
+    #[test]
+    fn latency_percentile_nearest_rank() {
+        // sorted: [10, 20, 30, 40, 50], N=5
+        let samples = vec![50u64, 10, 40, 20, 30];
+        // p50: ceil(0.5*5)=3 -> idx 2 -> 30
+        assert_eq!(latency_percentile(&samples, 50.0), 30);
+        // p99: ceil(0.99*5)=5 -> idx 4 -> 50
+        assert_eq!(latency_percentile(&samples, 99.0), 50);
+        // p0 clamps to rank 1 -> idx 0 -> 10
+        assert_eq!(latency_percentile(&samples, 0.0), 10);
+        // p100 -> rank 5 -> 50
+        assert_eq!(latency_percentile(&samples, 100.0), 50);
+    }
+
+    #[test]
+    fn latency_percentile_single_sample() {
+        assert_eq!(latency_percentile(&[42], 50.0), 42);
+        assert_eq!(latency_percentile(&[42], 99.0), 42);
+    }
+
+    #[test]
+    fn latency_percentile_clamps_out_of_range_p() {
+        let samples = vec![1u64, 2, 3];
+        // p > 100 clamps to 100 -> max; p < 0 clamps to 0 -> rank 1 -> min
+        assert_eq!(latency_percentile(&samples, 250.0), 3);
+        assert_eq!(latency_percentile(&samples, -5.0), 1);
+    }
+}

--- a/crates/rb-eval/src/runner.rs
+++ b/crates/rb-eval/src/runner.rs
@@ -1,0 +1,340 @@
+//! The harness runner: ingest fixtures, run golden queries, compute metrics,
+//! and compare against committed baselines.
+//!
+//! Flow (spec §6): load fixtures -> `engine.remember` each (deterministic
+//! vectors) -> for each golden query, `engine.recall` -> compute metrics vs
+//! expected -> assert each metric >= its committed baseline.
+
+use crate::backend::{eval_namespace, SqliteBackend, EVAL_DIM};
+use crate::corpus::Corpus;
+use crate::metrics;
+use rb_embed::{DeterministicProvider, EmbeddingProvider};
+use rb_engine::{MemoryEngine, RememberInput};
+use rb_search::FusionMode;
+use rb_types::MemoryId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Instant;
+
+/// `recall` over-fetch + metric horizon. Golden queries may override per-query.
+const DEFAULT_K: usize = 5;
+/// How many candidates to ask recall for (>= max metric k so top-k is filled).
+const RECALL_LIMIT: usize = 10;
+
+/// Aggregate metrics over the whole fixture run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvalReport {
+    /// Mean recall@k across golden queries (each query's own k, or `DEFAULT_K`).
+    pub mean_recall_at_k: f64,
+    /// Mean reciprocal rank across golden queries.
+    pub mrr: f64,
+    /// Mean dedup precision across golden queries (top-`DEFAULT_K`).
+    pub dedup_precision: f64,
+    /// p50 recall latency in microseconds.
+    pub p50_latency_us: u64,
+    /// p99 recall latency in microseconds.
+    pub p99_latency_us: u64,
+}
+
+/// Committed baselines. The harness fails if a *quality* metric drops below its
+/// baseline. Latency baselines are advisory (machine-dependent) and are not
+/// asserted by default; they are recorded for observability.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Baselines {
+    pub mean_recall_at_k: f64,
+    pub mrr: f64,
+    pub dedup_precision: f64,
+}
+
+impl Baselines {
+    /// Parse committed baselines bundled at compile time.
+    pub fn committed() -> Result<Self, String> {
+        const RAW: &str = include_str!("../baselines.json");
+        serde_json::from_str(RAW).map_err(|e| format!("baselines.json parse error: {e}"))
+    }
+}
+
+/// Build a fresh in-memory engine over the deterministic provider, using the
+/// given fusion mode (`Linear` is the committed-baseline default; `Rrf` is the
+/// opt-in comparison path — spec §7).
+fn build_engine(
+    mode: FusionMode,
+) -> rb_types::Result<MemoryEngine<SqliteBackend, DeterministicProvider>> {
+    let backend = SqliteBackend::in_memory(EVAL_DIM)?;
+    let embedder = DeterministicProvider::new(EVAL_DIM);
+    Ok(MemoryEngine::new(backend, embedder, eval_namespace()).with_fusion_mode(mode))
+}
+
+/// Build a fresh in-memory engine over an arbitrary provider (real-model mode).
+///
+/// The store dimension is taken from the provider so the dim contract holds.
+pub fn build_engine_with<P: EmbeddingProvider>(
+    embedder: P,
+) -> rb_types::Result<MemoryEngine<SqliteBackend, P>> {
+    let backend = SqliteBackend::in_memory(embedder.dim())?;
+    Ok(MemoryEngine::new(backend, embedder, eval_namespace()))
+}
+
+/// Ingest the corpus through the engine, returning a fixture-key -> MemoryId map.
+///
+/// Each fixture is remembered with its authored enrichment fields supplied, so
+/// the engine stores them verbatim (the `remember` path keeps caller-supplied
+/// keywords/tags/context, falling back to heuristics only for empties).
+///
+/// A fixture's `confidence` (default `1.0`) is stamped on the stored row after
+/// remember (the `remember` path always writes full trust), so the confidence
+/// dampener (Feature C) is exercised by fixtures like the "poison" scenario.
+async fn ingest<P: EmbeddingProvider>(
+    engine: &MemoryEngine<SqliteBackend, P>,
+    corpus: &Corpus,
+) -> rb_types::Result<HashMap<String, MemoryId>> {
+    let mut key_to_id: HashMap<String, MemoryId> = HashMap::new();
+    for m in &corpus.memories {
+        let context = if m.context.trim().is_empty() {
+            None
+        } else {
+            Some(m.context.clone())
+        };
+        let id = engine
+            .remember(RememberInput {
+                content: m.content.clone(),
+                context,
+                memory_type: m.memory_type,
+                importance: m.importance,
+                keywords: m.keywords.clone(),
+                tags: m.tags.clone(),
+                related_files: Vec::new(),
+            })
+            .await?;
+        // Apply the authored confidence (no-op at the 1.0 default).
+        if (m.confidence - 1.0).abs() > f32::EPSILON {
+            engine.backend().set_confidence(&id, m.confidence)?;
+        }
+        key_to_id.insert(m.key.clone(), id);
+    }
+    Ok(key_to_id)
+}
+
+/// Run the full fixture suite and produce an aggregate report.
+pub async fn run_eval() -> rb_types::Result<EvalReport> {
+    let corpus = Corpus::from_json(include_str!("../fixtures/corpus.json"))
+        .map_err(|e| rb_types::Error::Storage(format!("corpus load failed: {e}")))?;
+    run_corpus(&corpus).await
+}
+
+/// Run an explicit corpus (used by `run_eval` and by integration tests that
+/// inject hand-built corpora, e.g. the confidence "poison" scenario). Uses the
+/// committed-default `Linear` fusion.
+pub async fn run_corpus(corpus: &Corpus) -> rb_types::Result<EvalReport> {
+    Ok(run_corpus_detailed(corpus).await?.report)
+}
+
+/// Run the committed fixtures under an explicit fusion mode. Lets a maintainer
+/// measure `Rrf` without touching the default-`Linear` regression gate.
+pub async fn run_eval_mode(mode: FusionMode) -> rb_types::Result<EvalReport> {
+    let corpus = Corpus::from_json(include_str!("../fixtures/corpus.json"))
+        .map_err(|e| rb_types::Error::Storage(format!("corpus load failed: {e}")))?;
+    Ok(run_corpus_detailed_mode(&corpus, mode).await?.report)
+}
+
+/// Per-metric delta (`Rrf` minus `Linear`) over the same fixtures, plus the two
+/// underlying reports. A positive delta means `Rrf` improved that metric. This
+/// is observability only — it never flips the default; the eval-gated flip is a
+/// later, intentional commit (spec §7).
+#[derive(Debug, Clone)]
+pub struct ModeComparison {
+    pub linear: EvalReport,
+    pub rrf: EvalReport,
+    pub recall_at_k_delta: f64,
+    pub mrr_delta: f64,
+    pub dedup_precision_delta: f64,
+}
+
+/// Run a corpus under both `Linear` and `Rrf` and report the metric deltas.
+pub async fn compare_modes(corpus: &Corpus) -> rb_types::Result<ModeComparison> {
+    let linear = run_corpus_detailed_mode(corpus, FusionMode::Linear)
+        .await?
+        .report;
+    let rrf = run_corpus_detailed_mode(corpus, FusionMode::Rrf)
+        .await?
+        .report;
+    Ok(ModeComparison {
+        recall_at_k_delta: rrf.mean_recall_at_k - linear.mean_recall_at_k,
+        mrr_delta: rrf.mrr - linear.mrr,
+        dedup_precision_delta: rrf.dedup_precision - linear.dedup_precision,
+        linear,
+        rrf,
+    })
+}
+
+/// Run the committed fixtures under both modes and report the deltas.
+pub async fn compare_modes_committed() -> rb_types::Result<ModeComparison> {
+    let corpus = Corpus::from_json(include_str!("../fixtures/corpus.json"))
+        .map_err(|e| rb_types::Error::Storage(format!("corpus load failed: {e}")))?;
+    compare_modes(&corpus).await
+}
+
+/// Per-query detail produced by [`run_corpus_detailed`]. Lets a maintainer see
+/// exactly which fixture *keys* recall surfaced, in order — the readable diff a
+/// regression needs ("which result reordered?").
+#[derive(Debug, Clone)]
+pub struct QueryDetail {
+    pub query: String,
+    /// Fixture keys in recall order (ids resolved back to authored keys). Ids
+    /// recall surfaces that are not in the corpus map are omitted.
+    pub ranked_keys: Vec<String>,
+    /// Expected fixture keys for this query.
+    pub expected_keys: Vec<String>,
+    pub recall_at_k: f64,
+    pub reciprocal_rank: f64,
+    pub dedup_precision: f64,
+}
+
+/// Full run output: the aggregate report plus per-query detail.
+#[derive(Debug, Clone)]
+pub struct DetailedRun {
+    pub report: EvalReport,
+    pub per_query: Vec<QueryDetail>,
+}
+
+/// Run a corpus through the default deterministic engine (`Linear` fusion) and
+/// return both the aggregate report and per-query detail. This is the committed
+/// regression gate's path; the default does not change.
+pub async fn run_corpus_detailed(corpus: &Corpus) -> rb_types::Result<DetailedRun> {
+    run_corpus_detailed_mode(corpus, FusionMode::Linear).await
+}
+
+/// Run a corpus through the deterministic engine under an explicit fusion mode.
+/// Used by the mode-comparison harness to evaluate `Linear` vs `Rrf` over the
+/// same fixtures without flipping the default.
+pub async fn run_corpus_detailed_mode(
+    corpus: &Corpus,
+    mode: FusionMode,
+) -> rb_types::Result<DetailedRun> {
+    let engine = build_engine(mode)?;
+    run_corpus_with(&engine, corpus).await
+}
+
+/// Run a corpus through an explicit engine (any provider). The deterministic
+/// path delegates here; the real-model `#[ignore]` mode calls it with a Voyage
+/// or local engine built via [`build_engine_with`].
+pub async fn run_corpus_with<P: EmbeddingProvider>(
+    engine: &MemoryEngine<SqliteBackend, P>,
+    corpus: &Corpus,
+) -> rb_types::Result<DetailedRun> {
+    let key_to_id = ingest(engine, corpus).await?;
+    // Reverse map so recall ids can be reported as authored keys.
+    let id_to_key: HashMap<String, String> = key_to_id
+        .iter()
+        .map(|(k, id)| (id.to_string(), k.clone()))
+        .collect();
+
+    // Resolve dedup clusters to id strings once.
+    let id_clusters: Vec<Vec<String>> = corpus
+        .dedup_clusters
+        .iter()
+        .map(|c| {
+            c.members
+                .iter()
+                .filter_map(|k| key_to_id.get(k))
+                .map(|id| id.to_string())
+                .collect()
+        })
+        .collect();
+
+    let mut per_query: Vec<QueryDetail> = Vec::new();
+    let mut rr_inputs: Vec<(Vec<String>, Vec<String>)> = Vec::new();
+    let mut latencies_us: Vec<u64> = Vec::new();
+
+    for q in &corpus.golden_queries {
+        let started = Instant::now();
+        let results = engine.recall(&q.query, RECALL_LIMIT, None, &[]).await?;
+        latencies_us.push(started.elapsed().as_micros() as u64);
+
+        let ranked: Vec<String> = results.iter().map(|r| r.memory.id.to_string()).collect();
+        let expected: Vec<String> = q
+            .expected
+            .iter()
+            .filter_map(|k| key_to_id.get(k))
+            .map(|id| id.to_string())
+            .collect();
+
+        let k = q.k.unwrap_or(DEFAULT_K);
+        let recall = metrics::recall_at_k(&ranked, &expected, k);
+        let rr = metrics::reciprocal_rank(&ranked, &expected);
+        let dedup = metrics::dedup_precision(&ranked, &id_clusters, DEFAULT_K);
+        rr_inputs.push((ranked.clone(), expected));
+
+        per_query.push(QueryDetail {
+            query: q.query.clone(),
+            ranked_keys: ranked
+                .iter()
+                .filter_map(|id| id_to_key.get(id).cloned())
+                .collect(),
+            expected_keys: q.expected.clone(),
+            recall_at_k: recall,
+            reciprocal_rank: rr,
+            dedup_precision: dedup,
+        });
+    }
+
+    let mean_recall_at_k = mean(&per_query.iter().map(|d| d.recall_at_k).collect::<Vec<_>>());
+    let mrr = metrics::mrr(&rr_inputs);
+    let dedup_precision = mean(
+        &per_query
+            .iter()
+            .map(|d| d.dedup_precision)
+            .collect::<Vec<_>>(),
+    );
+
+    let report = EvalReport {
+        mean_recall_at_k,
+        mrr,
+        dedup_precision,
+        p50_latency_us: metrics::p50(&latencies_us),
+        p99_latency_us: metrics::p99(&latencies_us),
+    };
+    Ok(DetailedRun { report, per_query })
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+/// Assert that a report meets the committed baselines, returning a readable
+/// diff string on the first regression. Quality metrics only; latency is
+/// advisory and not gated (machine-dependent).
+pub fn check_against_baselines(report: &EvalReport, baselines: &Baselines) -> Result<(), String> {
+    let tol = 1e-9;
+    let mut failures: Vec<String> = Vec::new();
+    let mut gate = |name: &str, actual: f64, baseline: f64| {
+        if actual + tol < baseline {
+            failures.push(format!(
+                "{name}: actual {actual:.4} < baseline {baseline:.4}"
+            ));
+        }
+    };
+    gate(
+        "mean_recall_at_k",
+        report.mean_recall_at_k,
+        baselines.mean_recall_at_k,
+    );
+    gate("mrr", report.mrr, baselines.mrr);
+    gate(
+        "dedup_precision",
+        report.dedup_precision,
+        baselines.dedup_precision,
+    );
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "rb-eval regression(s):\n  {}",
+            failures.join("\n  ")
+        ))
+    }
+}

--- a/crates/rb-eval/tests/harness.rs
+++ b/crates/rb-eval/tests/harness.rs
@@ -1,0 +1,260 @@
+//! The harness gate: `cargo test -p rb-eval` runs this.
+//!
+//! It ingests the committed fixture corpus through `rb-engine` with the
+//! deterministic provider, runs every golden query through recall, computes
+//! the aggregate metrics, and asserts each quality metric meets its committed
+//! baseline. A regression (any metric below baseline) fails with a readable diff.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rb_eval::corpus::{Corpus, DedupCluster, FixtureMemory, GoldenQuery};
+use rb_eval::{
+    check_against_baselines, compare_modes_committed, run_corpus, run_corpus_detailed, run_eval,
+    run_eval_mode, Baselines, FusionMode,
+};
+use rb_types::MemoryType;
+
+#[tokio::test]
+async fn confidence_poison_low_confidence_wrong_memory_ranks_last() {
+    // Feature C "poison" scenario (spec §9): two equally-matching memories with
+    // IDENTICAL content (so the deterministic vector + FTS signals tie). One is
+    // the "correct" full-confidence answer; the other is a low-confidence
+    // "poison". The confidence dampener must rank the high-confidence memory
+    // ABOVE the low-confidence one — a wrong, high-matching memory cannot
+    // dominate recall.
+    let corpus = Corpus::from_json(
+        r#"{
+            "memories": [
+                {"key": "correct", "content": "the deploy rollback procedure resets the feature flag",
+                 "keywords": ["rollback", "deploy"], "memory_type": "Insight", "importance": 5,
+                 "confidence": 1.0},
+                {"key": "poison", "content": "the deploy rollback procedure resets the feature flag",
+                 "keywords": ["rollback", "deploy"], "memory_type": "Insight", "importance": 5,
+                 "confidence": 0.05}
+            ],
+            "golden_queries": [
+                {"query": "rollback procedure", "expected": ["correct"], "k": 1}
+            ]
+        }"#,
+    )
+    .expect("poison corpus valid");
+
+    let run = run_corpus_detailed(&corpus).await.expect("run");
+    let detail = &run.per_query[0];
+    let correct_pos = detail
+        .ranked_keys
+        .iter()
+        .position(|k| k == "correct")
+        .expect("correct present");
+    let poison_pos = detail
+        .ranked_keys
+        .iter()
+        .position(|k| k == "poison")
+        .expect("poison present");
+    assert!(
+        correct_pos < poison_pos,
+        "high-confidence correct memory must rank above the low-confidence poison: {:?}",
+        detail.ranked_keys
+    );
+    // And recall@1 lands on the correct one.
+    assert!(
+        (detail.recall_at_k - 1.0).abs() < 1e-9,
+        "the correct memory must be the top hit, got recall {}",
+        detail.recall_at_k
+    );
+}
+
+#[tokio::test]
+async fn committed_fixtures_meet_baselines() {
+    let report = run_eval().await.expect("eval run must succeed");
+    let baselines = Baselines::committed().expect("baselines.json must parse");
+
+    // Print the report so a maintainer updating baselines sees the live numbers.
+    println!(
+        "rb-eval report: recall@k={:.4} mrr={:.4} dedup={:.4} p50={}us p99={}us",
+        report.mean_recall_at_k,
+        report.mrr,
+        report.dedup_precision,
+        report.p50_latency_us,
+        report.p99_latency_us
+    );
+
+    if let Err(diff) = check_against_baselines(&report, &baselines) {
+        panic!("{diff}");
+    }
+}
+
+#[tokio::test]
+async fn fixtures_run_under_both_modes_and_report_metric_delta() {
+    // Feature B acceptance: the committed fixture set runs under BOTH Linear and
+    // Rrf, and the harness reports the per-metric delta. This is observability
+    // only — it does NOT gate (the eval-gated default flip is a later commit).
+    let cmp = compare_modes_committed()
+        .await
+        .expect("mode comparison must run");
+
+    println!(
+        "rb-eval mode comparison (Rrf - Linear):\n  \
+         recall@k: linear={:.4} rrf={:.4} delta={:+.4}\n  \
+         mrr:      linear={:.4} rrf={:.4} delta={:+.4}\n  \
+         dedup:    linear={:.4} rrf={:.4} delta={:+.4}",
+        cmp.linear.mean_recall_at_k,
+        cmp.rrf.mean_recall_at_k,
+        cmp.recall_at_k_delta,
+        cmp.linear.mrr,
+        cmp.rrf.mrr,
+        cmp.mrr_delta,
+        cmp.linear.dedup_precision,
+        cmp.rrf.dedup_precision,
+        cmp.dedup_precision_delta,
+    );
+
+    // Both modes produce valid metric fractions; deltas are finite.
+    for r in [&cmp.linear, &cmp.rrf] {
+        assert!((0.0..=1.0).contains(&r.mean_recall_at_k));
+        assert!((0.0..=1.0).contains(&r.mrr));
+        assert!((0.0..=1.0).contains(&r.dedup_precision));
+    }
+    assert!(cmp.recall_at_k_delta.is_finite());
+    assert!(cmp.mrr_delta.is_finite());
+    assert!(cmp.dedup_precision_delta.is_finite());
+}
+
+#[tokio::test]
+async fn linear_mode_matches_default_eval_quality_metrics() {
+    // The default `run_eval` is `Linear`; running explicitly in `Linear` mode
+    // must reproduce its quality metrics exactly (the default did not change).
+    // Latency fields are machine/timing-dependent and intentionally not compared.
+    let default = run_eval().await.expect("default eval");
+    let linear = run_eval_mode(FusionMode::Linear)
+        .await
+        .expect("explicit linear");
+    assert!(
+        (default.mean_recall_at_k - linear.mean_recall_at_k).abs() < 1e-12,
+        "explicit Linear recall@k must equal the default eval"
+    );
+    assert!(
+        (default.mrr - linear.mrr).abs() < 1e-12,
+        "explicit Linear mrr must equal the default eval"
+    );
+    assert!(
+        (default.dedup_precision - linear.dedup_precision).abs() < 1e-12,
+        "explicit Linear dedup must equal the default eval"
+    );
+}
+
+#[tokio::test]
+async fn rrf_mode_is_deterministic_across_runs() {
+    let a = run_eval_mode(FusionMode::Rrf).await.expect("first rrf run");
+    let b = run_eval_mode(FusionMode::Rrf)
+        .await
+        .expect("second rrf run");
+    assert!(
+        (a.mean_recall_at_k - b.mean_recall_at_k).abs() < 1e-12,
+        "rrf recall@k drifted between runs"
+    );
+    assert!(
+        (a.mrr - b.mrr).abs() < 1e-12,
+        "rrf mrr drifted between runs"
+    );
+    assert!(
+        (a.dedup_precision - b.dedup_precision).abs() < 1e-12,
+        "rrf dedup drifted between runs"
+    );
+}
+
+#[tokio::test]
+async fn report_is_deterministic_across_runs() {
+    // Determinism is the core invariant: identical inputs -> identical metrics.
+    let a = run_eval().await.expect("first run");
+    let b = run_eval().await.expect("second run");
+    assert!(
+        (a.mean_recall_at_k - b.mean_recall_at_k).abs() < 1e-12,
+        "recall@k drifted between runs: {} vs {}",
+        a.mean_recall_at_k,
+        b.mean_recall_at_k
+    );
+    assert!((a.mrr - b.mrr).abs() < 1e-12, "mrr drifted between runs");
+    assert!(
+        (a.dedup_precision - b.dedup_precision).abs() < 1e-12,
+        "dedup_precision drifted between runs"
+    );
+}
+
+#[tokio::test]
+async fn keyword_path_surfaces_exact_term_match() {
+    // A hand-built corpus that the FTS path alone must satisfy: the query term
+    // appears verbatim only in the target memory's content.
+    let corpus = Corpus::from_json(
+        r#"{
+            "memories": [
+                {"key": "target", "content": "the WAL checkpoint truncates the journal",
+                 "keywords": ["wal", "checkpoint"], "memory_type": "Insight", "importance": 6},
+                {"key": "noise", "content": "unrelated note about color themes",
+                 "keywords": ["color"], "memory_type": "Preference", "importance": 4}
+            ],
+            "golden_queries": [
+                {"query": "checkpoint", "expected": ["target"], "k": 1}
+            ]
+        }"#,
+    )
+    .expect("corpus valid");
+
+    let report = run_corpus(&corpus).await.expect("run");
+    assert!(
+        (report.mean_recall_at_k - 1.0).abs() < 1e-9,
+        "FTS should put the exact-term match at rank 1, got recall {}",
+        report.mean_recall_at_k
+    );
+}
+
+#[tokio::test]
+async fn dedup_clusters_are_scored() {
+    // Two near-duplicate memories form a cluster; a third is distinct. The
+    // dedup metric is exercised (value asserted only to be in range — the
+    // committed-corpus test gates the real threshold).
+    let memories = vec![
+        mem(
+            "dup_a",
+            "single writer thread owns the sqlite connection",
+            7,
+        ),
+        mem(
+            "dup_b",
+            "one writer thread owns the sqlite connection exclusively",
+            7,
+        ),
+        mem("other", "voyage embeddings are fetched over https", 5),
+    ];
+    let corpus = Corpus {
+        memories,
+        golden_queries: vec![GoldenQuery {
+            query: "writer".into(),
+            expected: vec!["dup_a".into()],
+            k: Some(5),
+        }],
+        dedup_clusters: vec![DedupCluster {
+            members: vec!["dup_a".into(), "dup_b".into()],
+        }],
+    };
+
+    let report = run_corpus(&corpus).await.expect("run");
+    assert!(
+        (0.0..=1.0).contains(&report.dedup_precision),
+        "dedup precision must be a valid fraction, got {}",
+        report.dedup_precision
+    );
+}
+
+fn mem(key: &str, content: &str, importance: u8) -> FixtureMemory {
+    FixtureMemory {
+        key: key.into(),
+        content: content.into(),
+        summary: String::new(),
+        keywords: Vec::new(),
+        tags: Vec::new(),
+        context: String::new(),
+        memory_type: MemoryType::Insight,
+        importance,
+        confidence: 1.0,
+    }
+}

--- a/crates/rb-eval/tests/real_model.rs
+++ b/crates/rb-eval/tests/real_model.rs
@@ -1,0 +1,95 @@
+//! Optional real-model mode — `#[ignore]` by default, run manually.
+//!
+//! The default harness uses `DeterministicProvider`, which guards ranking
+//! determinism and regression but CANNOT show absolute semantic quality (its
+//! vectors are non-semantic). This module runs the same fixture corpus through a
+//! real embedding model (Voyage) for manual spot checks of semantic recall.
+//!
+//! It is `#[ignore]`d so it never runs in CI (no live network, per spec §11).
+//! Run manually with a key:
+//!
+//! ```text
+//! VOYAGE_API_KEY=... cargo test -p rb-eval --test real_model -- --ignored --nocapture
+//! ```
+//!
+//! It makes NO assertion against committed baselines (those are deterministic);
+//! it prints the semantic metrics for a human to judge.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rb_embed::VoyageProvider;
+use rb_eval::{build_engine_with, run_corpus_with, Corpus};
+
+#[tokio::test]
+#[ignore = "real-model mode: requires VOYAGE_API_KEY and live network; run manually"]
+async fn voyage_semantic_recall_spot_check() {
+    // voyage-3-lite is 512-dim; the engine + store dim are taken from the provider.
+    let provider = VoyageProvider::from_env().expect("VOYAGE_API_KEY must be set for this mode");
+    let engine = build_engine_with(provider).expect("engine builds");
+
+    let corpus =
+        Corpus::from_json(include_str!("../fixtures/corpus.json")).expect("fixtures parse");
+    let run = run_corpus_with(&engine, &corpus)
+        .await
+        .expect("real-model run succeeds");
+
+    println!(
+        "real-model (voyage) report: recall@k={:.4} mrr={:.4} dedup={:.4}",
+        run.report.mean_recall_at_k, run.report.mrr, run.report.dedup_precision
+    );
+    for d in &run.per_query {
+        println!(
+            "  Q='{}' recall={:.3} rr={:.3} top={:?}",
+            d.query,
+            d.recall_at_k,
+            d.reciprocal_rank,
+            d.ranked_keys.iter().take(5).collect::<Vec<_>>()
+        );
+    }
+    // Sanity floor only: a real semantic model should not be worse than random
+    // on this hand-authored corpus. This is a spot check, not a CI gate.
+    assert!(
+        run.report.mrr > 0.0,
+        "real model returned zero MRR; check API/key/fixtures"
+    );
+}
+
+/// Content-only vs composite (P5 Feature A) semantic comparison.
+///
+/// `DeterministicProvider` vectors are non-semantic, so they CANNOT show the
+/// recall lift composite embeddings give (spec §8, §12 risk). The lift can only
+/// be observed with a real model, so this comparison is real-model-only and
+/// `#[ignore]`d (no network in CI). The current engine always embeds the
+/// composite representation; this run reports its metrics for a human to compare
+/// against the pre-P5 content-only numbers recorded in the README. It is a spot
+/// check that prints, it asserts only a non-zero sanity floor — never a CI gate.
+///
+/// Run manually:
+/// ```text
+/// VOYAGE_API_KEY=... cargo test -p rb-eval --test real_model \
+///   -- --ignored composite_embedding_semantic_recall --nocapture
+/// ```
+#[tokio::test]
+#[ignore = "real-model mode: composite-embedding semantic lift; requires VOYAGE_API_KEY; run manually"]
+async fn composite_embedding_semantic_recall() {
+    let provider = VoyageProvider::from_env().expect("VOYAGE_API_KEY must be set for this mode");
+    let engine = build_engine_with(provider).expect("engine builds");
+
+    let corpus =
+        Corpus::from_json(include_str!("../fixtures/corpus.json")).expect("fixtures parse");
+    let run = run_corpus_with(&engine, &corpus)
+        .await
+        .expect("real-model composite run succeeds");
+
+    println!(
+        "real-model (voyage) COMPOSITE embedding report: recall@k={:.4} mrr={:.4} dedup={:.4}",
+        run.report.mean_recall_at_k, run.report.mrr, run.report.dedup_precision
+    );
+    println!(
+        "compare against the content-only baseline documented in rb-eval/README.md \
+         to judge composite-embedding semantic lift"
+    );
+    assert!(
+        run.report.mrr > 0.0,
+        "composite real-model run returned zero MRR; check API/key/fixtures"
+    );
+}

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -567,4 +567,20 @@ mod tests {
             "error variant carries an `error` key"
         );
     }
+
+    #[test]
+    fn recall_result_carries_contested_flag() {
+        use rb_proto::Response;
+        // Feature C: the additive `contested` boolean surfaces in the MCP result
+        // schema for each recall row.
+        let mut contested = note();
+        contested.contested = true;
+        let recalled = response_to_content(Response::Recalled {
+            results: vec![SearchResult {
+                memory: contested,
+                score: 0.9,
+            }],
+        });
+        assert_eq!(recalled["results"][0]["memory"]["contested"], true);
+    }
 }

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -254,6 +254,11 @@ mod tests {
                     changed: 0,
                     skipped: 0,
                 },
+                Request::Reembed { .. } => Response::JobRan {
+                    scanned: 0,
+                    changed: 0,
+                    skipped: 0,
+                },
             })
         }
     }

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -255,6 +255,22 @@ impl Client {
             other => Err(Self::unexpected(other)),
         }
     }
+
+    /// Trigger one bounded, idempotent re-embed pass on the daemon (P5 Feature
+    /// A): up to `limit` active memories with a stale embedding stamp are
+    /// re-embedded through the single writer. `None` uses the daemon default.
+    /// Returns `(scanned, changed, skipped)`.
+    pub async fn reembed(&mut self, limit: Option<usize>) -> Result<(u64, u64, u64)> {
+        let resp = self.request(Request::Reembed { limit }).await?;
+        match resp {
+            Resp::JobRan {
+                scanned,
+                changed,
+                skipped,
+            } => Ok((scanned, changed, skipped)),
+            other => Err(Self::unexpected(other)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -443,6 +459,11 @@ mod wrapper_tests {
                     changed: 2,
                     skipped: 2,
                 },
+                Request::Reembed { .. } => Response::JobRan {
+                    scanned: 6,
+                    changed: 5,
+                    skipped: 1,
+                },
             };
             write_frame(&mut framed, &resp).await.unwrap();
         }
@@ -503,6 +524,9 @@ mod wrapper_tests {
 
         let (scanned, changed, skipped) = c.run_job(rb_types::JobKind::LinkDecay).await.unwrap();
         assert_eq!((scanned, changed, skipped), (4, 2, 2));
+
+        let (rs, rc, rk) = c.reembed(Some(10)).await.unwrap();
+        assert_eq!((rs, rc, rk), (6, 5, 1));
 
         drop(c);
         server.await.unwrap();

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -6,7 +6,12 @@ use serde::{Deserialize, Serialize};
 
 /// Wire contract version carried in the handshake. Clients and the daemon must
 /// agree on this exact value; mismatch is rejected at connect time.
-pub const CONTRACT_VERSION: u32 = 1;
+///
+/// v2 (P5 Feature C): result rows (recall/list/context) and the `get` payload
+/// carry an additive `MemoryNote.contested` boolean. The field is
+/// `#[serde(default)]`, so a v1 payload without it deserializes to `false` — but
+/// the version bump lets clients detect (and rely on) the richer shape.
+pub const CONTRACT_VERSION: u32 = 2;
 
 /// First frame the client sends after connecting.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -63,6 +68,13 @@ pub enum Request {
     Context,
     RunJob {
         job: JobKind,
+    },
+    /// Re-embed up to `limit` active memories whose stored
+    /// `(embedding_model, embedding_input_version)` stamp is stale (P5 Feature
+    /// A). `None` uses the daemon's configured batch default. Replies with
+    /// `Response::JobRan { scanned, changed, skipped }`; bounded + idempotent.
+    Reembed {
+        limit: Option<usize>,
     },
     Ping,
     /// Open a live change-notification stream. The daemon stops the
@@ -144,8 +156,9 @@ mod tests {
     }
 
     #[test]
-    fn contract_version_is_one() {
-        assert_eq!(CONTRACT_VERSION, 1);
+    fn contract_version_is_two() {
+        // Bumped to 2 for the additive `contested` field (P5 Feature C).
+        assert_eq!(CONTRACT_VERSION, 2);
     }
 
     #[test]
@@ -214,6 +227,8 @@ mod tests {
             Request::RunJob {
                 job: JobKind::LinkDecay,
             },
+            Request::Reembed { limit: Some(100) },
+            Request::Reembed { limit: None },
         ]
     }
 
@@ -342,6 +357,14 @@ mod tests {
         })
         .unwrap();
         assert_eq!(json, r#"{"op":"RunJob","job":"link_decay"}"#);
+    }
+
+    #[test]
+    fn reembed_uses_op_tag_with_optional_limit() {
+        let json = serde_json::to_string(&Request::Reembed { limit: Some(50) }).unwrap();
+        assert_eq!(json, r#"{"op":"Reembed","limit":50}"#);
+        let json = serde_json::to_string(&Request::Reembed { limit: None }).unwrap();
+        assert_eq!(json, r#"{"op":"Reembed","limit":null}"#);
     }
 
     #[test]

--- a/crates/rb-proto/tests/public_api.rs
+++ b/crates/rb-proto/tests/public_api.rs
@@ -8,8 +8,8 @@ use rb_types::{Error, MemoryId, Namespace};
 
 #[test]
 fn public_surface_is_reachable_and_stable() {
-    // Constants and messages.
-    assert_eq!(CONTRACT_VERSION, 1);
+    // Constants and messages. v2 = P5 Feature C (additive `contested`).
+    assert_eq!(CONTRACT_VERSION, 2);
     let _hs = Handshake {
         contract_version: CONTRACT_VERSION,
         namespace: Namespace::Global,

--- a/crates/rb-search/src/fusion.rs
+++ b/crates/rb-search/src/fusion.rs
@@ -1,0 +1,574 @@
+//! RRF (Reciprocal Rank Fusion) two-stage hybrid ranking.
+//!
+//! `Linear` (the existing `rank`) stays the default; this module adds the
+//! opt-in `Rrf` path (spec §7). It is pure and deterministic — no IO, no async —
+//! mirroring `rank`'s non-finite sanitization and stable-sort discipline.
+//!
+//! - **Stage 1 (rank fusion):** each retrieval path (keyword / vector / graph)
+//!   contributes a ranked candidate list. The fused score is
+//!   `Σ_paths 1 / (k + rank_path)` with a documented default `k = 60`. A
+//!   candidate missing from a path contributes nothing (no penalty), matching the
+//!   "missing signal = 0" rule of `rank`.
+//! - **Stage 2 (priors):** `importance`, `recency` (the 30-day-half-life
+//!   exponential), and `confidence` are applied as multiplicative priors on the
+//!   fused score, each behind a documented, configurable weight.
+
+use crate::rank::{confidence_dampener, recency_decay, Signals};
+use rb_types::MemoryId;
+
+/// Which fusion strategy `recall` uses. `Linear` is the default and is the
+/// existing `rank`; `Rrf` is the two-stage hybrid in this module.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FusionMode {
+    /// Weighted linear sum of normalized signals (`rank`). Default.
+    #[default]
+    Linear,
+    /// Reciprocal Rank Fusion of the path rank lists, then metadata priors.
+    Rrf,
+}
+
+/// Documented, configurable knobs for the `Rrf` path.
+///
+/// `k` is the RRF constant (de-facto default 60: larger `k` flattens the
+/// contribution of rank position). The three prior weights are each in `[0, 1]`
+/// and blend their prior toward neutral: a weight of `0.0` makes the prior a
+/// no-op, `1.0` applies it fully (`effective = (1 - w) + w * prior`). The
+/// `confidence_floor` bounds how far a low-confidence memory is suppressed
+/// (never to zero), matching Feature C's dampener contract.
+#[derive(Clone, Copy, Debug)]
+pub struct RrfConfig {
+    /// RRF constant `k`. Documented default `60.0`. Clamped at use to a small
+    /// positive floor (`MIN_K`) so a degenerate `k <= 0` cannot divide by zero.
+    pub k: f32,
+    /// Weight of the importance prior in `[0, 1]`.
+    pub importance: f32,
+    /// Weight of the recency prior in `[0, 1]`.
+    pub recency: f32,
+    /// Weight of the confidence prior in `[0, 1]`.
+    pub confidence: f32,
+    /// Floor for the confidence prior in `[0, 1]` (e.g. `0.5`).
+    pub confidence_floor: f32,
+}
+
+impl Default for RrfConfig {
+    fn default() -> Self {
+        Self {
+            k: 60.0,
+            importance: 0.5,
+            recency: 0.25,
+            confidence: 1.0,
+            confidence_floor: 0.5,
+        }
+    }
+}
+
+/// Sanitize a weight/parameter: non-finite -> `0.0` (mirrors `rank`).
+fn finite_or_zero(v: f32) -> f32 {
+    if v.is_finite() {
+        v
+    } else {
+        0.0
+    }
+}
+
+/// Minimum effective RRF `k`. The fused term is `1 / (k + rank)`; with `k = 0`
+/// the rank-0 candidate divides by zero -> non-finite, which `apply_priors` then
+/// sanitizes to `0.0` and so *inverts* the best candidate below rank-1. A tiny
+/// positive floor keeps every term finite and preserves correct best-first
+/// ordering for any in-range `k`; it only clamps the degenerate `k <= 0` case.
+const MIN_K: f32 = 1e-6;
+
+/// Derive ascending rank positions for the candidates that carry `key`.
+///
+/// Candidates with `None` for the path key get no entry (they contribute
+/// nothing to that path). Ties are broken by input order (the index), so the
+/// derivation is stable and deterministic. Returns `id -> rank` where rank `0`
+/// is the best (smallest key).
+fn derive_ranks<K, F>(signals: &[Signals], key: F) -> std::collections::HashMap<MemoryId, usize>
+where
+    K: PartialOrd + Copy,
+    F: Fn(&Signals) -> Option<K>,
+{
+    // (index, id, key) for every candidate that has this path's signal.
+    let mut keyed: Vec<(usize, &MemoryId, K)> = signals
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| key(s).map(|k| (i, &s.id, k)))
+        .collect();
+    // Ascending by key; ties keep input order (stable on the original index).
+    keyed.sort_by(|a, b| match a.2.partial_cmp(&b.2) {
+        Some(ord) => ord,
+        // Non-comparable (NaN) sinks to the end deterministically.
+        None => std::cmp::Ordering::Greater,
+    });
+    keyed
+        .into_iter()
+        .enumerate()
+        .map(|(rank, (_, id, _))| (id.clone(), rank))
+        .collect()
+}
+
+/// Stage 1: fused RRF score for one candidate over the three path-rank maps.
+fn rrf_fuse(
+    s: &Signals,
+    k: f32,
+    vector_ranks: &std::collections::HashMap<MemoryId, usize>,
+    graph_ranks: &std::collections::HashMap<MemoryId, usize>,
+) -> f32 {
+    let term = |rank: usize| 1.0 / (k + rank as f32);
+    let mut fused = 0.0;
+    // Keyword path: the existing position index is the rank directly.
+    if let Some(r) = s.keyword_rank {
+        fused += term(r);
+    }
+    if let Some(&r) = vector_ranks.get(&s.id) {
+        fused += term(r);
+    }
+    if let Some(&r) = graph_ranks.get(&s.id) {
+        fused += term(r);
+    }
+    fused
+}
+
+/// Stage 2: multiplicative metadata priors on the fused score.
+fn apply_priors(
+    fused: f32,
+    s: &Signals,
+    cfg: &RrfConfig,
+    now: chrono::DateTime<chrono::Utc>,
+) -> f32 {
+    // Each prior blends toward neutral by its (sanitized, clamped) weight.
+    let blend = |weight: f32, prior: f32| {
+        let w = finite_or_zero(weight).clamp(0.0, 1.0);
+        let p = finite_or_zero(prior).clamp(0.0, 1.0);
+        (1.0 - w) + w * p
+    };
+
+    let importance_prior = (s.importance as f32 / 10.0).clamp(0.0, 1.0);
+    let recency_prior = recency_decay(s.created_at, now);
+    // Confidence dampener with a floor: a low-confidence memory is suppressed but
+    // never zeroed. Neutral at confidence 1.0. Shared with the `Linear` dampener
+    // (`confidence_dampener`) so both fusion modes suppress identically.
+    let confidence_prior = confidence_dampener(s.confidence, cfg.confidence_floor);
+
+    let scored = fused
+        * blend(cfg.importance, importance_prior)
+        * blend(cfg.recency, recency_prior)
+        * blend(cfg.confidence, confidence_prior);
+
+    if scored.is_finite() {
+        scored.max(0.0)
+    } else {
+        0.0
+    }
+}
+
+/// Rank candidates by RRF (Stage 1) with metadata priors (Stage 2).
+///
+/// Pure and deterministic: returns `(id, score)` pairs sorted by score
+/// descending, truncated to `limit`. Equal scores preserve input order (stable
+/// sort with `total_cmp`). Missing path signals contribute nothing; non-finite
+/// inputs are sanitized exactly as in `rank`.
+pub fn rank_rrf(
+    signals: Vec<Signals>,
+    cfg: RrfConfig,
+    now: chrono::DateTime<chrono::Utc>,
+    limit: usize,
+) -> Vec<(MemoryId, f32)> {
+    let k = finite_or_zero(cfg.k).max(MIN_K);
+    // Stage 1 inputs: vector rank from ascending distance, graph rank from
+    // ascending hops. Keyword already carries its position in `keyword_rank`.
+    let vector_ranks = derive_ranks(&signals, |s| s.vector_distance.filter(|d| d.is_finite()));
+    let graph_ranks = derive_ranks(&signals, |s| s.graph_hops);
+
+    let mut scored: Vec<(MemoryId, f32)> = signals
+        .iter()
+        .map(|s| {
+            let fused = rrf_fuse(s, k, &vector_ranks, &graph_ranks);
+            (s.id.clone(), apply_priors(fused, s, &cfg, now))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+    scored.truncate(limit);
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use chrono::{Duration, Utc};
+    use rb_types::MemoryId;
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        Utc::now()
+    }
+
+    /// A neutral config: priors fully off (weights 0), so we test Stage 1 alone.
+    fn stage1_only() -> RrfConfig {
+        RrfConfig {
+            k: 60.0,
+            importance: 0.0,
+            recency: 0.0,
+            confidence: 0.0,
+            confidence_floor: 0.5,
+        }
+    }
+
+    fn sig(
+        id: MemoryId,
+        keyword_rank: Option<usize>,
+        vector_distance: Option<f32>,
+        graph_hops: Option<u8>,
+        importance: u8,
+        created_at: chrono::DateTime<chrono::Utc>,
+        confidence: f32,
+    ) -> Signals {
+        Signals {
+            id,
+            keyword_rank,
+            vector_distance,
+            graph_hops,
+            importance,
+            created_at,
+            confidence,
+        }
+    }
+
+    #[test]
+    fn fusion_mode_default_is_linear() {
+        assert_eq!(FusionMode::default(), FusionMode::Linear);
+    }
+
+    #[test]
+    fn rrf_config_default_k_is_sixty() {
+        assert!((RrfConfig::default().k - 60.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn rrf_arithmetic_on_known_single_path_lists() {
+        // Three candidates, keyword-only, at positions 0,1,2. With priors off,
+        // the score is exactly 1/(k+rank).
+        let n = now();
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let c = MemoryId::new();
+        let signals = vec![
+            sig(a.clone(), Some(0), None, None, 5, n, 1.0),
+            sig(b.clone(), Some(1), None, None, 5, n, 1.0),
+            sig(c.clone(), Some(2), None, None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, stage1_only(), n, 10);
+        let k = 60.0_f32;
+        assert_eq!(ranked[0].0, a);
+        assert!((ranked[0].1 - 1.0 / (k + 0.0)).abs() < 1e-6);
+        assert!((ranked[1].1 - 1.0 / (k + 1.0)).abs() < 1e-6);
+        assert!((ranked[2].1 - 1.0 / (k + 2.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_sums_contributions_across_paths() {
+        // One candidate present in all three paths at rank 0 in each ⇒ score 3/k.
+        // Another present only in keyword at rank 0 ⇒ score 1/k. The multi-path
+        // candidate must outrank, and its score is exactly the sum.
+        let n = now();
+        let multi = MemoryId::new();
+        let single = MemoryId::new();
+        let signals = vec![
+            sig(multi.clone(), Some(0), Some(0.1), Some(0), 5, n, 1.0),
+            sig(single.clone(), Some(0), None, None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, stage1_only(), n, 10);
+        let k = 60.0_f32;
+        assert_eq!(ranked[0].0, multi, "multi-path candidate fuses higher");
+        assert!((ranked[0].1 - 3.0 / k).abs() < 1e-6);
+        assert!((ranked[1].1 - 1.0 / k).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vector_rank_derives_from_ascending_distance() {
+        // Two vector-only candidates: the closer (smaller distance) must get the
+        // better (rank 0) RRF contribution regardless of input order.
+        let n = now();
+        let far = MemoryId::new();
+        let close = MemoryId::new();
+        let signals = vec![
+            sig(far.clone(), None, Some(1.8), None, 5, n, 1.0),
+            sig(close.clone(), None, Some(0.05), None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, stage1_only(), n, 10);
+        let k = 60.0_f32;
+        assert_eq!(ranked[0].0, close, "smaller distance ⇒ rank 0");
+        assert!((ranked[0].1 - 1.0 / k).abs() < 1e-6);
+        assert!((ranked[1].1 - 1.0 / (k + 1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn graph_rank_derives_from_ascending_hops() {
+        let n = now();
+        let near = MemoryId::new();
+        let far = MemoryId::new();
+        // Input order deliberately far-then-near; hops decide the rank.
+        let signals = vec![
+            sig(far.clone(), None, None, Some(3), 5, n, 1.0),
+            sig(near.clone(), None, None, Some(0), 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, stage1_only(), n, 10);
+        assert_eq!(ranked[0].0, near, "fewer hops ⇒ better rank");
+    }
+
+    #[test]
+    fn missing_from_a_list_contributes_nothing() {
+        // A candidate absent from every path scores 0 (no penalty, no credit) and
+        // sinks below any candidate with a single path hit.
+        let n = now();
+        let hit = MemoryId::new();
+        let ghost = MemoryId::new();
+        let signals = vec![
+            sig(ghost.clone(), None, None, None, 10, n, 1.0),
+            sig(hit.clone(), Some(0), None, None, 0, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, stage1_only(), n, 10);
+        assert_eq!(ranked[0].0, hit);
+        assert_eq!(ranked[1].0, ghost);
+        assert_eq!(ranked[1].1, 0.0, "no path hit ⇒ exactly zero, no penalty");
+    }
+
+    #[test]
+    fn importance_prior_breaks_ties_when_enabled() {
+        // Identical Stage-1 score (both keyword rank 0); importance prior (weight
+        // on) lifts the higher-importance candidate.
+        let n = now();
+        let low = MemoryId::new();
+        let high = MemoryId::new();
+        let cfg = RrfConfig {
+            importance: 1.0,
+            recency: 0.0,
+            confidence: 0.0,
+            ..RrfConfig::default()
+        };
+        let signals = vec![
+            sig(low.clone(), Some(0), None, None, 1, n, 1.0),
+            sig(high.clone(), Some(0), None, None, 10, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, cfg, n, 10);
+        assert_eq!(
+            ranked[0].0, high,
+            "higher importance wins via Stage-2 prior"
+        );
+        assert!(ranked[0].1 > ranked[1].1);
+    }
+
+    #[test]
+    fn recency_prior_breaks_ties_when_enabled() {
+        let n = now();
+        let old = MemoryId::new();
+        let fresh = MemoryId::new();
+        let cfg = RrfConfig {
+            importance: 0.0,
+            recency: 1.0,
+            confidence: 0.0,
+            ..RrfConfig::default()
+        };
+        let signals = vec![
+            sig(
+                old.clone(),
+                Some(0),
+                None,
+                None,
+                5,
+                n - Duration::days(300),
+                1.0,
+            ),
+            sig(fresh.clone(), Some(0), None, None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, cfg, n, 10);
+        assert_eq!(ranked[0].0, fresh, "more recent wins via recency prior");
+    }
+
+    #[test]
+    fn confidence_prior_suppresses_low_confidence_but_never_zeroes() {
+        // Equal Stage-1 score; the low-confidence memory must rank below the
+        // high-confidence one, but keep a strictly positive score (floor honored).
+        let n = now();
+        let low = MemoryId::new();
+        let high = MemoryId::new();
+        let cfg = RrfConfig {
+            importance: 0.0,
+            recency: 0.0,
+            confidence: 1.0,
+            confidence_floor: 0.5,
+            ..RrfConfig::default()
+        };
+        let signals = vec![
+            sig(low.clone(), Some(0), None, None, 5, n, 0.0),
+            sig(high.clone(), Some(0), None, None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, cfg, n, 10);
+        assert_eq!(ranked[0].0, high, "high confidence ranks first");
+        assert_eq!(ranked[1].0, low);
+        assert!(ranked[1].1 > 0.0, "floor keeps low-confidence score > 0");
+        // With floor 0.5 and confidence 0.0, the low score is exactly half the high.
+        assert!((ranked[1].1 - ranked[0].1 * 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn confidence_neutral_at_one_is_a_no_op() {
+        // Default-confidence (1.0) candidates score identically whether or not the
+        // confidence prior is enabled — proving the neutral default.
+        let n = now();
+        let id = MemoryId::new();
+        let with = RrfConfig {
+            importance: 0.0,
+            recency: 0.0,
+            confidence: 1.0,
+            ..RrfConfig::default()
+        };
+        let without = RrfConfig {
+            confidence: 0.0,
+            ..with
+        };
+        let a = rank_rrf(
+            vec![sig(id.clone(), Some(0), None, None, 5, n, 1.0)],
+            with,
+            n,
+            10,
+        );
+        let b = rank_rrf(
+            vec![sig(id.clone(), Some(0), None, None, 5, n, 1.0)],
+            without,
+            n,
+            10,
+        );
+        assert!(
+            (a[0].1 - b[0].1).abs() < 1e-9,
+            "confidence 1.0 ⇒ prior is no-op"
+        );
+    }
+
+    #[test]
+    fn determinism_same_input_identical_order_and_scores() {
+        let n = now();
+        let signals: Vec<Signals> = (0..20)
+            .map(|i| {
+                sig(
+                    MemoryId::new(),
+                    if i % 2 == 0 { Some(i) } else { None },
+                    if i % 3 == 0 {
+                        Some(0.05 * i as f32)
+                    } else {
+                        None
+                    },
+                    if i % 4 == 0 {
+                        Some((i % 5) as u8)
+                    } else {
+                        None
+                    },
+                    (i % 11) as u8,
+                    n - Duration::days(i as i64),
+                    1.0,
+                )
+            })
+            .collect();
+        let first = rank_rrf(signals.clone(), RrfConfig::default(), n, 20);
+        let second = rank_rrf(signals, RrfConfig::default(), n, 20);
+        let ids_a: Vec<_> = first.iter().map(|(id, _)| id.clone()).collect();
+        let ids_b: Vec<_> = second.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(ids_a, ids_b, "ordering must be stable across runs");
+        for (x, y) in first.iter().zip(second.iter()) {
+            assert!((x.1 - y.1).abs() < f32::EPSILON, "scores reproducible");
+        }
+        // sorted descending, every score finite.
+        for w in first.windows(2) {
+            assert!(w[0].1 >= w[1].1, "descending");
+        }
+        assert!(first.iter().all(|(_, s)| s.is_finite()));
+    }
+
+    #[test]
+    fn equal_scores_preserve_input_order() {
+        // Two candidates with identical signals ⇒ identical scores; stable sort
+        // keeps input order.
+        let n = now();
+        let first_in = MemoryId::new();
+        let second_in = MemoryId::new();
+        let signals = vec![
+            sig(first_in.clone(), Some(0), None, None, 5, n, 1.0),
+            sig(second_in.clone(), Some(0), None, None, 5, n, 1.0),
+        ];
+        let ranked = rank_rrf(signals, RrfConfig::default(), n, 10);
+        assert_eq!(ranked[0].0, first_in);
+        assert_eq!(ranked[1].0, second_in);
+        assert!((ranked[0].1 - ranked[1].1).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn non_finite_inputs_are_sanitized_like_rank() {
+        // NaN distance ⇒ not a vector hit (no contribution). NaN confidence ⇒
+        // neutral. Non-finite k ⇒ sanitized to 0. Scores stay finite and >= 0.
+        let n = now();
+        let nan_dist = MemoryId::new();
+        let nan_conf = MemoryId::new();
+        let clean = MemoryId::new();
+        let signals = vec![
+            sig(nan_dist.clone(), Some(0), Some(f32::NAN), None, 5, n, 1.0),
+            sig(nan_conf.clone(), Some(0), None, None, 5, n, f32::NAN),
+            sig(clean.clone(), Some(0), Some(0.1), None, 5, n, 1.0),
+        ];
+        let cfg = RrfConfig {
+            k: f32::NAN,
+            importance: f32::INFINITY,
+            recency: f32::NAN,
+            confidence: f32::NEG_INFINITY,
+            confidence_floor: f32::NAN,
+        };
+        let ranked = rank_rrf(signals, cfg, n, 10);
+        assert_eq!(ranked.len(), 3);
+        assert!(
+            ranked.iter().all(|(_, s)| s.is_finite() && *s >= 0.0),
+            "all scores finite and non-negative after sanitization"
+        );
+    }
+
+    #[test]
+    fn k_zero_does_not_invert_or_produce_non_finite_scores() {
+        // A degenerate k = 0.0 must NOT send the rank-0 term to infinity (which the
+        // sanitizer would flip to 0.0 and push the best candidate below rank-1).
+        // The clamp to MIN_K keeps scores finite and preserves best-first ordering.
+        let n = now();
+        let best = MemoryId::new();
+        let next = MemoryId::new();
+        let signals = vec![
+            sig(best.clone(), Some(0), None, None, 5, n, 1.0),
+            sig(next.clone(), Some(1), None, None, 5, n, 1.0),
+        ];
+        let cfg = RrfConfig {
+            k: 0.0,
+            ..stage1_only()
+        };
+        let ranked = rank_rrf(signals, cfg, n, 10);
+        assert!(
+            ranked.iter().all(|(_, s)| s.is_finite()),
+            "k=0 must not yield non-finite scores"
+        );
+        assert_eq!(
+            ranked[0].0, best,
+            "rank-0 candidate must stay first, not invert"
+        );
+        assert!(
+            ranked[0].1 > ranked[1].1,
+            "best candidate keeps the strictly higher score"
+        );
+    }
+
+    #[test]
+    fn limit_truncates_to_top_n() {
+        let n = now();
+        let signals: Vec<Signals> = (0..5)
+            .map(|i| sig(MemoryId::new(), Some(i), None, None, 5, n, 1.0))
+            .collect();
+        let ranked = rank_rrf(signals, RrfConfig::default(), n, 2);
+        assert_eq!(ranked.len(), 2);
+        assert!(ranked[0].1 >= ranked[1].1);
+    }
+}

--- a/crates/rb-search/src/lib.rs
+++ b/crates/rb-search/src/lib.rs
@@ -5,10 +5,12 @@
 //! folds the three retrieval result sets into the `Signals` that `rank` consumes.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod fusion;
 mod merge;
 mod rank;
 mod weights;
 
+pub use fusion::{rank_rrf, FusionMode, RrfConfig};
 pub use merge::build_signals;
-pub use rank::{rank, Signals, HALF_LIFE};
+pub use rank::{rank, Signals, CONFIDENCE_FLOOR, HALF_LIFE};
 pub use weights::Weights;

--- a/crates/rb-search/src/merge.rs
+++ b/crates/rb-search/src/merge.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 /// - `keyword`: ids in rank order (index 0 = best keyword hit).
 /// - `vector`: `(id, cosine_distance)` pairs (smaller distance = closer).
 /// - `graph`: ids in hop order (index 0 = nearest in the graph walk).
-/// - `meta`: per-id `(importance, created_at)`, the source of truth for scoring/fetch.
+/// - `meta`: per-id `(importance, confidence, created_at)`, the source of truth
+///   for scoring/fetch. `confidence` (Feature C) flows into `Signals.confidence`
+///   and is applied as a multiplicative dampener at rank time.
 ///
 /// A candidate may appear in any subset of the three paths; each path fills only its
 /// own field, leaving the rest `None` so `rank` contributes 0 for absent signals.
@@ -18,7 +20,7 @@ pub fn build_signals(
     keyword: &[MemoryId],
     vector: &[(MemoryId, f32)],
     graph: &[MemoryId],
-    meta: &HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)>,
+    meta: &HashMap<MemoryId, (u8, f32, chrono::DateTime<chrono::Utc>)>,
 ) -> Vec<Signals> {
     // Preserve first-seen order with a parallel index map into `out`.
     let mut index: HashMap<MemoryId, usize> = HashMap::new();
@@ -35,7 +37,7 @@ pub fn build_signals(
             return Some(i);
         }
         // Only materialize a candidate we have metadata for.
-        let (importance, created_at) = *meta.get(id)?;
+        let (importance, confidence, created_at) = *meta.get(id)?;
         let i = out.len();
         out.push(Signals {
             id: id.clone(),
@@ -43,6 +45,9 @@ pub fn build_signals(
             vector_distance: None,
             graph_hops: None,
             importance,
+            // Confidence flows from `meta` (Feature C); applied as a multiplicative
+            // dampener at rank time. A confidence of 1.0 is the neutral no-op.
+            confidence,
             created_at,
         });
         index.insert(id.clone(), i);
@@ -90,9 +95,9 @@ mod tests {
         let vec_only = MemoryId::new();
         let graph_only = MemoryId::new();
 
-        let mut meta: HashMap<MemoryId, (u8, chrono::DateTime<chrono::Utc>)> = HashMap::new();
+        let mut meta: HashMap<MemoryId, (u8, f32, chrono::DateTime<chrono::Utc>)> = HashMap::new();
         for id in [&shared, &kw_only, &vec_only, &graph_only] {
-            meta.insert(id.clone(), (5, now));
+            meta.insert(id.clone(), (5, 1.0, now));
         }
 
         let keyword = vec![shared.clone(), kw_only.clone()];
@@ -139,7 +144,7 @@ mod tests {
         let c = MemoryId::new();
         let mut meta = HashMap::new();
         for id in [&a, &b, &c] {
-            meta.insert(id.clone(), (5, now));
+            meta.insert(id.clone(), (5, 1.0, now));
         }
         let keyword = vec![a.clone(), b.clone(), c.clone()];
         let graph = vec![c.clone(), b.clone(), a.clone()];
@@ -163,7 +168,7 @@ mod tests {
         let earlier = MemoryId::new();
         let mut meta = HashMap::new();
         for id in [&duplicate, &earlier] {
-            meta.insert(id.clone(), (5, now));
+            meta.insert(id.clone(), (5, 1.0, now));
         }
 
         let keyword = vec![duplicate.clone(), earlier, duplicate.clone()];
@@ -179,7 +184,7 @@ mod tests {
         let now = Utc::now();
         let duplicate = MemoryId::new();
         let mut meta = HashMap::new();
-        meta.insert(duplicate.clone(), (5, now));
+        meta.insert(duplicate.clone(), (5, 1.0, now));
 
         let vector = vec![(duplicate.clone(), 0.8), (duplicate.clone(), 0.2)];
         let signals = build_signals(&[], &vector, &[], &meta);
@@ -194,7 +199,7 @@ mod tests {
         let other = MemoryId::new();
         let mut meta = HashMap::new();
         for id in [&duplicate, &other] {
-            meta.insert(id.clone(), (5, now));
+            meta.insert(id.clone(), (5, 1.0, now));
         }
 
         let graph = vec![duplicate.clone(), other, duplicate.clone()];
@@ -206,14 +211,16 @@ mod tests {
     }
 
     #[test]
-    fn carries_importance_and_created_at_from_meta() {
+    fn carries_importance_confidence_and_created_at_from_meta() {
         let created = Utc::now();
         let id = MemoryId::new();
         let mut meta = HashMap::new();
-        meta.insert(id.clone(), (8u8, created));
+        meta.insert(id.clone(), (8u8, 0.4f32, created));
         let signals = build_signals(std::slice::from_ref(&id), &[], &[], &meta);
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].importance, 8);
+        // confidence now flows from meta (Feature C), not a hardcoded neutral.
+        assert!((signals[0].confidence - 0.4).abs() < f32::EPSILON);
         assert_eq!(signals[0].created_at, created);
     }
 
@@ -223,7 +230,7 @@ mod tests {
         let known = MemoryId::new();
         let unknown = MemoryId::new(); // appears in results but has no meta entry
         let mut meta = HashMap::new();
-        meta.insert(known.clone(), (5, now));
+        meta.insert(known.clone(), (5, 1.0, now));
         let keyword = vec![known.clone(), unknown.clone()];
         let signals = build_signals(&keyword, &[], &[], &meta);
         // the unknown id is dropped (cannot be scored or fetched) -> fail closed.
@@ -237,8 +244,8 @@ mod tests {
         let strong = MemoryId::new();
         let weak = MemoryId::new();
         let mut meta = HashMap::new();
-        meta.insert(strong.clone(), (9u8, now));
-        meta.insert(weak.clone(), (2u8, now));
+        meta.insert(strong.clone(), (9u8, 1.0, now));
+        meta.insert(weak.clone(), (2u8, 1.0, now));
         let keyword = vec![strong.clone(), weak.clone()];
         let vector = vec![(strong.clone(), 0.1), (weak.clone(), 1.7)];
         let signals = build_signals(&keyword, &vector, &[], &meta);

--- a/crates/rb-search/src/rank.rs
+++ b/crates/rb-search/src/rank.rs
@@ -5,6 +5,46 @@ use rb_types::MemoryId;
 /// on the recency term. Documented, fixed constant for deterministic ranking.
 pub const HALF_LIFE: f32 = 30.0;
 
+/// Floor for the confidence dampener (Feature C, spec §9). The final score is
+/// multiplied by `CONFIDENCE_FLOOR + (1 - CONFIDENCE_FLOOR) * confidence`, so a
+/// confidence-1.0 memory is unchanged (no-op) and a confidence-0.0 memory keeps
+/// `CONFIDENCE_FLOOR` of its score: meaningfully suppressed, never fully zeroed
+/// (the context-poisoning mitigation). Documented, configurable constant — the
+/// same floor is applied to the `Rrf` confidence prior (`RrfConfig::confidence_floor`).
+pub const CONFIDENCE_FLOOR: f32 = 0.5;
+
+/// Multiplicative confidence dampener shared by `Linear` and `Rrf`.
+///
+/// Returns `floor + (1 - floor) * confidence`, clamped so that a confidence of
+/// `1.0` is a no-op (`1.0`) and a confidence of `0.0` floors at `floor`. A
+/// non-finite confidence is sanitized to the neutral `1.0` (never poisons the
+/// score). Pure and deterministic.
+pub(crate) fn confidence_dampener(confidence: f32, floor: f32) -> f32 {
+    let confidence = if confidence.is_finite() {
+        confidence.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    let floor = if floor.is_finite() {
+        floor.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    floor + (1.0 - floor) * confidence
+}
+
+/// Exponential recency decay over age in days, shared by Linear and RRF.
+///
+/// Returns `e^(-age_days / HALF_LIFE)` in `(0, 1]`. Future timestamps clamp to
+/// age 0 (score 1.0). Pure and deterministic.
+pub(crate) fn recency_decay(
+    created_at: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> f32 {
+    let age_days = ((now - created_at).num_seconds() as f32 / 86_400.0).max(0.0);
+    (-age_days / HALF_LIFE).exp()
+}
+
 /// Per-candidate raw signals gathered from the three retrieval paths.
 ///
 /// Any `Option` left as `None` means "this path did not surface this candidate";
@@ -21,6 +61,10 @@ pub struct Signals {
     /// Importance 0..=10.
     pub importance: u8,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Confidence in `[0, 1]`, sourced from the note. Applied as a multiplicative
+    /// dampener in both `Linear` (final score) and `Rrf` (Stage 2 prior), Feature C.
+    /// Defaults to `1.0` (neutral) so adding it leaves `Linear` byte-for-byte.
+    pub confidence: f32,
 }
 
 /// Normalize a single candidate's signals into a weighted score in `[0, 1]`.
@@ -44,8 +88,7 @@ fn score_one(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f3
     // Importance normalized to [0, 1].
     let importance = (s.importance as f32 / 10.0).clamp(0.0, 1.0);
     // Recency: exponential decay over age in days. Future timestamps clamp to age 0.
-    let age_days = ((now - s.created_at).num_seconds() as f32 / 86_400.0).max(0.0);
-    let recency = (-age_days / HALF_LIFE).exp();
+    let recency = recency_decay(s.created_at, now);
 
     let finite_weight = |weight: f32| if weight.is_finite() { weight } else { 0.0 };
     let score = finite_weight(w.vector) * vector_sim
@@ -54,11 +97,15 @@ fn score_one(s: &Signals, w: &Weights, now: chrono::DateTime<chrono::Utc>) -> f3
         + finite_weight(w.importance) * importance
         + finite_weight(w.recency) * recency;
 
-    if score.is_finite() {
+    let score = if score.is_finite() {
         score.clamp(0.0, 1.0)
     } else {
         0.0
-    }
+    };
+    // Confidence dampener (Feature C): multiplicatively suppress low-confidence
+    // memories on the FINAL score, with a floor so they are never fully zeroed.
+    // Neutral at confidence 1.0, so the default corpus is byte-for-byte unchanged.
+    score * confidence_dampener(s.confidence, CONFIDENCE_FLOOR)
 }
 
 /// Rank candidates by weighted, normalized signal score.
@@ -111,6 +158,7 @@ mod tests {
                 graph_hops: None,
                 importance: 2,
                 created_at: n - Duration::days(120),
+                confidence: 1.0,
             },
             Signals {
                 id: strong.clone(),
@@ -119,6 +167,7 @@ mod tests {
                 graph_hops: Some(1),
                 importance: 9,
                 created_at: n,
+                confidence: 1.0,
             },
         ];
         let ranked = rank(signals, Weights::default(), n, 10);
@@ -144,6 +193,7 @@ mod tests {
             graph_hops: Some(2),
             importance: 5,
             created_at: created,
+            confidence: 1.0,
         };
         let signals = vec![
             mk(old.clone(), n - Duration::days(200)),
@@ -166,6 +216,7 @@ mod tests {
             graph_hops: Some(0), // adjacent -> graph proximity 1.0
             importance: 0,
             created_at: n - Duration::days(10_000), // ancient -> recency ~0
+            confidence: 1.0,
         }];
         let ranked = rank(signals, Weights::default(), n, 10);
         assert_eq!(ranked.len(), 1);
@@ -190,6 +241,7 @@ mod tests {
                 graph_hops: None,
                 importance: 0,
                 created_at: n - Duration::days(10_000),
+                confidence: 1.0,
             },
             Signals {
                 id: b.clone(),
@@ -198,6 +250,7 @@ mod tests {
                 graph_hops: None,
                 importance: 0,
                 created_at: n - Duration::days(10_000),
+                confidence: 1.0,
             },
         ];
         let ranked = rank(signals, Weights::default(), n, 10);
@@ -220,6 +273,7 @@ mod tests {
                 graph_hops: None,
                 importance: (10 - i) as u8,
                 created_at: n,
+                confidence: 1.0,
             })
             .collect();
         let ranked = rank(signals, Weights::default(), n, 2);
@@ -247,6 +301,7 @@ mod tests {
                 },
                 importance: (i % 11) as u8,
                 created_at: n - Duration::days(i as i64),
+                confidence: 1.0,
             })
             .collect();
         let first = rank(signals.clone(), Weights::default(), n, 20);
@@ -291,6 +346,7 @@ mod tests {
                 graph_hops: None,
                 importance: 10,
                 created_at: n,
+                confidence: 1.0,
             },
             Signals {
                 id: infinity.clone(),
@@ -299,6 +355,7 @@ mod tests {
                 graph_hops: None,
                 importance: 10,
                 created_at: n,
+                confidence: 1.0,
             },
             Signals {
                 id: finite.clone(),
@@ -307,6 +364,7 @@ mod tests {
                 graph_hops: None,
                 importance: 0,
                 created_at: n,
+                confidence: 1.0,
             },
         ];
 
@@ -338,10 +396,91 @@ mod tests {
             graph_hops: Some(0),
             importance: 10,
             created_at: n,
+            confidence: 1.0,
         }];
 
         let ranked = rank(signals, weights, n, 10);
 
+        assert_eq!(ranked, vec![(id, 1.0)]);
+        assert!(ranked[0].1.is_finite());
+    }
+
+    #[test]
+    fn low_confidence_ranks_below_equal_high_confidence() {
+        // Two candidates identical on every signal EXCEPT confidence. The
+        // confidence dampener (Feature C) must rank the low-confidence one below
+        // the high-confidence one, but never zero it (floor honored).
+        let n = now();
+        let low = MemoryId::new();
+        let high = MemoryId::new();
+        let mk = |id: MemoryId, confidence| Signals {
+            id,
+            keyword_rank: Some(0),
+            vector_distance: Some(0.0),
+            graph_hops: Some(0),
+            importance: 5,
+            created_at: n,
+            confidence,
+        };
+        let signals = vec![mk(low.clone(), 0.0), mk(high.clone(), 1.0)];
+        let ranked = rank(signals, Weights::default(), n, 10);
+        assert_eq!(ranked[0].0, high, "high-confidence ranks first");
+        assert_eq!(ranked[1].0, low);
+        assert!(ranked[1].1 > 0.0, "floor keeps low-confidence score > 0");
+        // With CONFIDENCE_FLOOR = 0.5 and confidence 0.0, the low score is exactly
+        // half the high (which is at confidence 1.0 -> dampener no-op).
+        assert!((ranked[1].1 - ranked[0].1 * CONFIDENCE_FLOOR).abs() < 1e-6);
+    }
+
+    #[test]
+    fn confidence_one_is_a_no_op_dampener() {
+        // A default-confidence (1.0) candidate scores identically to the
+        // pre-Feature-C weighted sum: dampener multiplies by exactly 1.0.
+        let n = now();
+        let id = MemoryId::new();
+        let weights = Weights {
+            vector: 1.0,
+            keyword: 0.0,
+            graph: 0.0,
+            importance: 0.0,
+            recency: 0.0,
+        };
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: Some(0.0), // sim 1.0 -> raw score 1.0
+            graph_hops: None,
+            importance: 0,
+            created_at: n,
+            confidence: 1.0,
+        }];
+        let ranked = rank(signals, weights, n, 10);
+        assert_eq!(ranked, vec![(id, 1.0)], "confidence 1.0 => unchanged score");
+    }
+
+    #[test]
+    fn non_finite_confidence_is_treated_as_neutral() {
+        // A corrupt (NaN) confidence must not poison the score: sanitized to the
+        // neutral 1.0 dampener, leaving the raw weighted score intact and finite.
+        let n = now();
+        let id = MemoryId::new();
+        let weights = Weights {
+            vector: 1.0,
+            keyword: 0.0,
+            graph: 0.0,
+            importance: 0.0,
+            recency: 0.0,
+        };
+        let signals = vec![Signals {
+            id: id.clone(),
+            keyword_rank: None,
+            vector_distance: Some(0.0),
+            graph_hops: None,
+            importance: 0,
+            created_at: n,
+            confidence: f32::NAN,
+        }];
+        let ranked = rank(signals, weights, n, 10);
         assert_eq!(ranked, vec![(id, 1.0)]);
         assert!(ranked[0].1.is_finite());
     }
@@ -364,6 +503,7 @@ mod tests {
             graph_hops: None,
             importance: 0,
             created_at: n,
+            confidence: 1.0,
         }];
 
         let ranked = rank(signals, weights, n, 10);

--- a/crates/rb-store/migrations/003_embedding_input_version.sql
+++ b/crates/rb-store/migrations/003_embedding_input_version.sql
@@ -1,0 +1,26 @@
+-- 003_embedding_input_version.sql
+-- P5 Feature A: composite embedding input + re-embed transition.
+--
+-- Stamp each memory with the composition version that produced its vector,
+-- alongside the existing embedding_model stamp. The `reembed` batch re-embeds
+-- any active row whose (embedding_model, embedding_input_version) differs from
+-- the current pair, then stamps it to the current version. This lets the corpus
+-- transition from content-only vectors (written before P5) to composite vectors
+-- (content + keywords + tags + context) idempotently.
+--
+-- Additive and file-discovered (checksummed by the migration runner). Existing
+-- rows are backfilled with 'v1-content-only' to record that their vectors were
+-- built from raw content alone; reembed will recompute them on demand.
+
+-- ADD COLUMN with NOT NULL DEFAULT backfills every existing row with
+-- 'v1-content-only' in the same statement, so no explicit UPDATE is needed.
+ALTER TABLE memories
+  ADD COLUMN embedding_input_version TEXT NOT NULL DEFAULT 'v1-content-only';
+
+-- Seed the global meta invariant alongside embedding_model / embedding_dim, so
+-- the store records which composition the daemon currently targets. Code reads
+-- the live version from rb-engine (EMBEDDING_INPUT_VERSION); this row documents
+-- the target at migration time and is the anchor reembed converges the corpus
+-- toward.
+INSERT OR IGNORE INTO meta (key, value)
+  VALUES ('embedding_input_version', 'v2-composite');

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -61,6 +61,42 @@ pub trait Store {
     /// order as `ids` (missing/out-of-namespace ids skipped). One query; fixes
     /// the recall N+1. Links are loaded per returned note.
     fn get_many(&self, ns: &Namespace, ids: &[MemoryId]) -> Result<Vec<MemoryNote>>;
+    /// For each id in `ids`, return whether it has at least one ACTIVE
+    /// `contradicts` link — inbound OR outbound — where the OTHER endpoint memory
+    /// is itself active (`archived_at IS NULL`) AND both endpoints live in namespace
+    /// `ns`. One batched query over `memory_links` (Feature C, spec §9). Scoping
+    /// both endpoints to `ns` preserves namespace isolation: `memory_links` carries
+    /// no namespace and `add_link` permits cross-namespace edges, so without this an
+    /// out-of-namespace memory could flag a result `contested`. The returned set
+    /// contains exactly the ids that are contested; ids absent from the set are not
+    /// contested. Read path; used post-ranking to annotate `MemoryNote.contested`.
+    fn active_contradicts(
+        &self,
+        ns: &Namespace,
+        ids: &[MemoryId],
+    ) -> Result<std::collections::HashSet<MemoryId>>;
+    /// Read up to `limit` ACTIVE memories (across ALL namespaces) whose stamped
+    /// `(embedding_model, embedding_input_version)` differs from the current
+    /// `(model, input_version)` — the re-embed candidates. Bounded, deterministic
+    /// order. Read-only (every mutation goes through the single writer).
+    fn memories_for_reembed(
+        &self,
+        model: &str,
+        input_version: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>>;
+    /// Replace `id`'s stored vector and stamp the row's
+    /// `(embedding_model, embedding_input_version)` to the current pair, in one
+    /// transaction. This is the ONLY vector-UPDATE path (insert is write-once).
+    /// A missing memory id is `Error::NotFound`. The embedding dimension is
+    /// validated fail-closed before the write.
+    fn update_vector(
+        &self,
+        id: &MemoryId,
+        embedding: &[f32],
+        model: &str,
+        input_version: &str,
+    ) -> Result<()>;
 }
 
 /// SQLite-backed store. Owns a single connection (write path); the daemon owns
@@ -245,6 +281,25 @@ impl SqliteStore {
                     target.to_string(),
                     link_type.as_str(),
                 ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Set the `confidence` of a single memory. Validates the `0.0..=1.0` range
+    /// fail-closed (matching the insert path). A missing id is a no-op (0 rows).
+    /// Used by maintenance/test paths; the engine never mutates confidence on the
+    /// shipped recall/remember flow.
+    pub fn set_confidence(&self, id: &MemoryId, confidence: f32) -> Result<()> {
+        if !confidence.is_finite() || !(0.0..=1.0).contains(&confidence) {
+            return Err(Error::InvalidArgument(format!(
+                "confidence {confidence} out of range 0.0..=1.0"
+            )));
+        }
+        self.conn
+            .execute(
+                "UPDATE memories SET confidence = ?1 WHERE memory_id = ?2",
+                rusqlite::params![confidence as f64, id.to_string()],
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(())
@@ -741,7 +796,12 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
             .map(|s| parse_id(&s))
             .transpose()?,
         embedding_model: g("embedding_model")?,
+        embedding_input_version: g("embedding_input_version")?,
         links,
+        // `contested` (Feature C) is a read-side annotation computed by the engine
+        // from `memory_links` after ranking; it is never stored, so loads default
+        // it to false.
+        contested: false,
     })
 }
 
@@ -784,10 +844,10 @@ impl Store for SqliteStore {
                         memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model
+                        superseded_by, embedding_model, embedding_input_version
                      ) VALUES (
                         ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                        ?13, ?14, ?15, ?16, ?17, ?18
+                        ?13, ?14, ?15, ?16, ?17, ?18, ?19
                      )",
                     rusqlite::params![
                         note.id.to_string(),
@@ -808,6 +868,7 @@ impl Store for SqliteStore {
                         opt_ts(note.archived_at),
                         note.superseded_by.as_ref().map(|id| id.to_string()),
                         note.embedding_model,
+                        note.embedding_input_version,
                     ],
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
@@ -864,7 +925,7 @@ impl Store for SqliteStore {
                 "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model
+                        superseded_by, embedding_model, embedding_input_version
                  FROM memories WHERE memory_id = ?1",
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -1059,7 +1120,7 @@ impl Store for SqliteStore {
                 "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model
+                        superseded_by, embedding_model, embedding_input_version
                  FROM memories
                  WHERE namespace = ?1
                    AND archived_at IS NULL
@@ -1277,7 +1338,7 @@ impl Store for SqliteStore {
             "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                     keywords, tags, context, memory_type, importance, confidence,
                     related_files, access_count, last_accessed_at, archived_at,
-                    superseded_by, embedding_model
+                    superseded_by, embedding_model, embedding_input_version
              FROM memories
              WHERE namespace = ?1 AND memory_id IN ({})",
             placeholders.join(", ")
@@ -1315,6 +1376,190 @@ impl Store for SqliteStore {
             }
         }
         Ok(out)
+    }
+
+    fn active_contradicts(
+        &self,
+        ns: &Namespace,
+        ids: &[MemoryId],
+    ) -> Result<std::collections::HashSet<MemoryId>> {
+        use std::collections::HashSet;
+        if ids.is_empty() {
+            return Ok(HashSet::new());
+        }
+        // One batched query: a contradicts link where BOTH the local endpoint
+        // (the flagged id) and the far endpoint live in `ns`, and the far endpoint
+        // is active. Scoping BOTH endpoints to `ns` keeps the result namespace-pure
+        // regardless of caller: `memory_links` carries no namespace and `add_link`
+        // permits cross-namespace edges, so a contradiction with a memory in another
+        // namespace must neither flag an in-namespace id (`far` scope) nor leak an
+        // out-of-namespace id into the result (`loc` scope). Only ACTIVE,
+        // in-namespace contradictions count (spec §9). The SELECT returns the local
+        // endpoint id for every matching row; we collect the distinct set.
+        //
+        // Both UNION halves share the same ?1..?N (ids) and ?{N+1} (namespace)
+        // positional slots — SQLite parameters are shared across UNION, so binding
+        // N+1 values covers both halves. Do NOT double the params.
+        let placeholders: Vec<String> = (0..ids.len()).map(|i| format!("?{}", i + 1)).collect();
+        let in_list = placeholders.join(", ");
+        let ns_param = format!("?{}", ids.len() + 1);
+        let sql = format!(
+            "SELECT l.source_id AS local FROM memory_links l
+               JOIN memories far ON far.memory_id = l.target_id
+               JOIN memories loc ON loc.memory_id = l.source_id
+             WHERE l.link_type = 'contradicts'
+               AND far.archived_at IS NULL
+               AND far.namespace = {ns_param}
+               AND loc.namespace = {ns_param}
+               AND l.source_id IN ({in_list})
+             UNION
+             SELECT l.target_id AS local FROM memory_links l
+               JOIN memories far ON far.memory_id = l.source_id
+               JOIN memories loc ON loc.memory_id = l.target_id
+             WHERE l.link_type = 'contradicts'
+               AND far.archived_at IS NULL
+               AND far.namespace = {ns_param}
+               AND loc.namespace = {ns_param}
+               AND l.target_id IN ({in_list})"
+        );
+
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(ids.len() + 1);
+        for id in ids {
+            params.push(Box::new(id.to_string()));
+        }
+        params.push(Box::new(ns.as_db_string()));
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(refs.as_slice())
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let mut contested: HashSet<MemoryId> = HashSet::new();
+        while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+            let s = row
+                .get::<_, String>(0)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            contested.insert(parse_id(&s)?);
+        }
+        Ok(contested)
+    }
+
+    fn memories_for_reembed(
+        &self,
+        model: &str,
+        input_version: &str,
+        limit: usize,
+    ) -> Result<Vec<MemoryNote>> {
+        // Bounded, deterministic scan (oldest first then by id, mirroring the
+        // consolidation candidate order) of active rows whose stamp is stale.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memory_id, namespace, created_at, updated_at, content, summary,
+                        keywords, tags, context, memory_type, importance, confidence,
+                        related_files, access_count, last_accessed_at, archived_at,
+                        superseded_by, embedding_model, embedding_input_version
+                 FROM memories
+                 WHERE archived_at IS NULL
+                   AND (embedding_model <> ?1 OR embedding_input_version <> ?2)
+                 ORDER BY created_at ASC, memory_id ASC
+                 LIMIT ?3",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let mut rows = stmt
+            .query(rusqlite::params![
+                model,
+                input_version,
+                i64::try_from(limit).unwrap_or(i64::MAX)
+            ])
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+            out.push(row_to_note(&self.conn, row)?);
+        }
+        Ok(out)
+    }
+
+    fn update_vector(
+        &self,
+        id: &MemoryId,
+        embedding: &[f32],
+        model: &str,
+        input_version: &str,
+    ) -> Result<()> {
+        // Fail-closed dimension check before any write, identical to the search
+        // path: a wrong-length vector must never land in the vec0 table.
+        if embedding.len() != self.embedding_dim {
+            return Err(Error::DimensionMismatch {
+                expected: self.embedding_dim,
+                got: embedding.len(),
+            });
+        }
+
+        self.conn
+            .execute_batch("BEGIN IMMEDIATE;")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let result = (|| -> Result<()> {
+            // Stamp the memory row. 0 rows updated means the id does not exist:
+            // fail closed (NotFound) so the whole transaction rolls back rather
+            // than leaving a vector update with no owning row.
+            // `updated_at` is intentionally NOT bumped: re-embed is a maintenance-only
+            // path that refreshes the search vector, leaving the note's user-visible
+            // content unchanged. The daemon writer emits no MemoryChanged event for the
+            // same reason; bumping updated_at here would make every re-embedded note
+            // look freshly modified to list/context and any updated_at-based sync.
+            let affected = self
+                .conn
+                .execute(
+                    "UPDATE memories
+                     SET embedding_model = ?1, embedding_input_version = ?2
+                     WHERE memory_id = ?3",
+                    rusqlite::params![model, input_version, id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected == 0 {
+                return Err(Error::NotFound(id.clone()));
+            }
+
+            // Replace the stored vector. vec0 supports UPDATE on the PK; a row
+            // that had no vector yet (written without an embedding) is handled by
+            // falling back to INSERT when the UPDATE touches nothing.
+            let bytes = embedding_bytes(embedding);
+            let updated = self
+                .conn
+                .execute(
+                    "UPDATE memory_vectors SET embedding = ?1 WHERE memory_id = ?2",
+                    rusqlite::params![bytes, id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if updated == 0 {
+                self.conn
+                    .execute(
+                        "INSERT INTO memory_vectors (memory_id, embedding) VALUES (?1, ?2)",
+                        rusqlite::params![id.to_string(), embedding_bytes(embedding)],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 }
 
@@ -2820,5 +3065,130 @@ mod near_duplicates_tests {
         }
         let rows = store.memories_for_recalibration(3).unwrap();
         assert_eq!(rows.len(), 3, "limit must bound the row count");
+    }
+}
+
+#[cfg(test)]
+mod contradiction_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use rb_types::{LinkType, MemoryLink, MemoryNote, MemoryType, Namespace};
+
+    fn node(store: &SqliteStore, c: &str) -> MemoryNote {
+        let m = MemoryNote::new(Namespace::Global, c.into(), MemoryType::Insight, 5);
+        store.insert_memory(&m, None).unwrap();
+        m
+    }
+
+    fn contradicts(store: &SqliteStore, src: &MemoryNote, tgt: &MemoryNote) {
+        store
+            .add_link(&MemoryLink {
+                source_id: src.id.clone(),
+                target_id: tgt.id.clone(),
+                link_type: LinkType::Contradicts,
+                strength: 1.0,
+                reason: "conflicting claims".into(),
+                created_at: src.created_at,
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn empty_input_returns_empty_set() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        assert!(store
+            .active_contradicts(&Namespace::Global, &[])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn flags_both_endpoints_of_an_active_contradicts_link() {
+        // A contradicts B (directed). BOTH endpoints must be flagged: outbound for
+        // the source, inbound for the target.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a says x");
+        let b = node(&store, "b says not-x");
+        contradicts(&store, &a, &b);
+
+        let flagged = store
+            .active_contradicts(&Namespace::Global, &[a.id.clone(), b.id.clone()])
+            .unwrap();
+        assert!(flagged.contains(&a.id), "source flagged (outbound)");
+        assert!(flagged.contains(&b.id), "target flagged (inbound)");
+    }
+
+    #[test]
+    fn uncontested_memory_is_not_flagged() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a");
+        let b = node(&store, "b");
+        // A references B — NOT a contradiction.
+        store
+            .add_link(&MemoryLink {
+                source_id: a.id.clone(),
+                target_id: b.id.clone(),
+                link_type: LinkType::References,
+                strength: 1.0,
+                reason: String::new(),
+                created_at: a.created_at,
+            })
+            .unwrap();
+        let flagged = store
+            .active_contradicts(&Namespace::Global, &[a.id.clone(), b.id.clone()])
+            .unwrap();
+        assert!(flagged.is_empty(), "references is not a contradiction");
+    }
+
+    #[test]
+    fn contradiction_with_archived_endpoint_is_not_active() {
+        // A contradicts B, then B is archived. The contradiction is no longer
+        // "active" — A must NOT be flagged (the contradicting memory is gone).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a survives");
+        let b = node(&store, "b archived");
+        contradicts(&store, &a, &b);
+        store.archive_memory(&b.id).unwrap();
+
+        let flagged = store
+            .active_contradicts(&Namespace::Global, &[a.id.clone(), b.id.clone()])
+            .unwrap();
+        assert!(
+            !flagged.contains(&a.id),
+            "contradiction with an archived memory is inactive"
+        );
+    }
+
+    #[test]
+    fn cross_namespace_contradiction_does_not_flag() {
+        // `memory_links` carries no namespace and add_link permits cross-namespace
+        // edges. A contradicts B where A is Global and B lives in another namespace:
+        // querying Global must NOT flag A, or B's existence leaks across the
+        // isolation boundary (the bug this scoping fixes).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "global claim"); // Namespace::Global
+        let other = Namespace::Project("secret".into());
+        let b = MemoryNote::new(other.clone(), "hidden claim".into(), MemoryType::Insight, 5);
+        store.insert_memory(&b, None).unwrap();
+        contradicts(&store, &a, &b);
+
+        // Queried in Global: A is not flagged — its only contradiction is in another ns.
+        let in_global = store
+            .active_contradicts(&Namespace::Global, &[a.id.clone(), b.id.clone()])
+            .unwrap();
+        assert!(
+            in_global.is_empty(),
+            "a cross-namespace contradiction must not flag any Global id"
+        );
+
+        // Queried in the OTHER namespace: B sees A as the far endpoint, but A is
+        // Global, so B is still not flagged — both directions stay isolated.
+        let in_other = store
+            .active_contradicts(&other, &[a.id.clone(), b.id.clone()])
+            .unwrap();
+        assert!(
+            in_other.is_empty(),
+            "neither endpoint is flagged from either namespace's view"
+        );
     }
 }

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -2537,6 +2537,36 @@ mod update_tests {
     }
 
     #[test]
+    fn set_confidence_updates_validates_range_and_noops_on_missing() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let proj = Namespace::Project("rb".into());
+        let mut m = MemoryNote::new(proj, "body".into(), MemoryType::Insight, 5);
+        m.confidence = 1.0;
+        store.insert_memory(&m, None).unwrap();
+
+        // A valid value lands on the row.
+        store.set_confidence(&m.id, 0.75).unwrap();
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert!((got.confidence - 0.75).abs() < 1e-6);
+
+        // Out-of-range and non-finite values fail closed with InvalidArgument,
+        // and leave the stored value untouched.
+        for bad in [-0.1f32, 1.1, f32::NAN] {
+            assert!(matches!(
+                store.set_confidence(&m.id, bad),
+                Err(Error::InvalidArgument(_))
+            ));
+        }
+        let unchanged = store.get_memory(&m.id).unwrap().unwrap();
+        assert!((unchanged.confidence - 0.75).abs() < 1e-6);
+
+        // A missing id is a no-op Ok (0 rows) that touches no existing row.
+        store.set_confidence(&MemoryId::new(), 0.2).unwrap();
+        let still = store.get_memory(&m.id).unwrap().unwrap();
+        assert!((still.confidence - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
     fn rejects_out_of_range_importance() {
         let store = SqliteStore::open_in_memory(8).unwrap();
         let m = MemoryNote::new(Namespace::Global, "x".into(), MemoryType::Reference, 5);

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -1176,6 +1176,20 @@ impl Store for SqliteStore {
             params.push(Box::new(context.clone()));
         }
 
+        // If a field that feeds `embedding_input` (content / tags / context — the
+        // composite document text) changed, stale this row's embedding stamp so the
+        // next `reembed` recomputes its vector. Without this, a tags/context edit
+        // would leave the stored vector permanently stale: the version-only reembed
+        // scan only revisits rows whose `(model, input_version)` differs from
+        // current, and an in-place field edit keeps the current stamp. Empty string
+        // is the documented "stale, re-embed me" sentinel. (Content edits are
+        // rejected upstream in the engine, but stamping it here keeps the storage
+        // invariant self-contained.)
+        if updates.content.is_some() || updates.tags.is_some() || updates.context.is_some() {
+            sets.push(format!("embedding_input_version = ?{}", params.len() + 1));
+            params.push(Box::new(String::new()));
+        }
+
         // An all-None update is a true no-op: do not bump updated_at or issue an
         // UPDATE when nothing changed.
         if sets.is_empty() {
@@ -2446,6 +2460,80 @@ mod update_tests {
             before.updated_at.timestamp(),
             "all-None update must not bump updated_at"
         );
+    }
+
+    #[test]
+    fn editing_embedded_field_stales_embedding_stamp_for_reembed() {
+        // Editing a field that feeds embedding_input (tags here) must stale the
+        // row's embedding_input_version so the next reembed scan recomputes its
+        // vector — otherwise the stored vector stays permanently stale.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let proj = Namespace::Project("rb".into());
+        let mut m = MemoryNote::new(proj, "body".into(), MemoryType::Insight, 5);
+        m.embedding_model = "model-x".into();
+        m.embedding_input_version = "v2-composite".into();
+        store.insert_memory(&m, None).unwrap();
+
+        // Up to date: not a reembed candidate.
+        assert!(store
+            .memories_for_reembed("model-x", "v2-composite", 10)
+            .unwrap()
+            .is_empty());
+
+        // Edit tags (an embedded field) -> stamp staled to the empty sentinel.
+        store
+            .update_memory(
+                &m.id,
+                &MemoryUpdates {
+                    tags: Some(vec!["new".into()]),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert_eq!(
+            got.embedding_input_version, "",
+            "embedded-field edit stales the stamp"
+        );
+
+        // Now a reembed candidate.
+        let stale = store
+            .memories_for_reembed("model-x", "v2-composite", 10)
+            .unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].id, m.id);
+    }
+
+    #[test]
+    fn editing_non_embedded_field_does_not_stale_stamp() {
+        // Editing importance/summary (NOT part of embedding_input) must leave the
+        // stamp intact so it never triggers a needless reembed.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let proj = Namespace::Project("rb".into());
+        let mut m = MemoryNote::new(proj, "body".into(), MemoryType::Insight, 5);
+        m.embedding_model = "model-x".into();
+        m.embedding_input_version = "v2-composite".into();
+        store.insert_memory(&m, None).unwrap();
+
+        store
+            .update_memory(
+                &m.id,
+                &MemoryUpdates {
+                    summary: Some("s".into()),
+                    importance: Some(7),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert_eq!(
+            got.embedding_input_version, "v2-composite",
+            "non-embedded edit keeps the stamp"
+        );
+        assert!(store
+            .memories_for_reembed("model-x", "v2-composite", 10)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -62,10 +62,11 @@ pub trait Store {
     /// the recall N+1. Links are loaded per returned note.
     fn get_many(&self, ns: &Namespace, ids: &[MemoryId]) -> Result<Vec<MemoryNote>>;
     /// For each id in `ids`, return whether it has at least one ACTIVE
-    /// `contradicts` link — inbound OR outbound — where the OTHER endpoint memory
-    /// is itself active (`archived_at IS NULL`) AND both endpoints live in namespace
-    /// `ns`. One batched query over `memory_links` (Feature C, spec §9). Scoping
-    /// both endpoints to `ns` preserves namespace isolation: `memory_links` carries
+    /// `contradicts` link — inbound OR outbound — where BOTH endpoints are active
+    /// (`archived_at IS NULL`) AND live in namespace `ns`. One batched query over
+    /// `memory_links` (Feature C, spec §9). Requiring the LOCAL endpoint active too
+    /// means an archived memory fetched via `get` is never flagged `contested`.
+    /// Scoping both endpoints to `ns` preserves namespace isolation: `memory_links` carries
     /// no namespace and `add_link` permits cross-namespace edges, so without this an
     /// out-of-namespace memory could flag a result `contested`. The returned set
     /// contains exactly the ids that are contested; ids absent from the set are not
@@ -303,6 +304,24 @@ impl SqliteStore {
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(())
+    }
+
+    /// Read a value from the key/value `meta` table (e.g. the
+    /// `embedding_input_version` seed written by migration 003), or `None` if the
+    /// key is absent. A small read helper for invariant checks and the migration
+    /// reproducibility gate.
+    pub fn meta_value(&self, key: &str) -> Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = ?1",
+                rusqlite::params![key],
+                |r| r.get::<_, String>(0),
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(Error::Storage(other.to_string())),
+            })
     }
 
     /// Delete a single link edge identified by its full PK. A missing edge is a
@@ -1423,6 +1442,7 @@ impl Store for SqliteStore {
                JOIN memories loc ON loc.memory_id = l.source_id
              WHERE l.link_type = 'contradicts'
                AND far.archived_at IS NULL
+               AND loc.archived_at IS NULL
                AND far.namespace = {ns_param}
                AND loc.namespace = {ns_param}
                AND l.source_id IN ({in_list})
@@ -1432,6 +1452,7 @@ impl Store for SqliteStore {
                JOIN memories loc ON loc.memory_id = l.target_id
              WHERE l.link_type = 'contradicts'
                AND far.archived_at IS NULL
+               AND loc.archived_at IS NULL
                AND far.namespace = {ns_param}
                AND loc.namespace = {ns_param}
                AND l.target_id IN ({in_list})"
@@ -3274,6 +3295,25 @@ mod contradiction_tests {
         assert!(
             !flagged.contains(&a.id),
             "contradiction with an archived memory is inactive"
+        );
+    }
+
+    #[test]
+    fn archived_local_endpoint_is_not_flagged() {
+        // get() can return an archived memory; even with a live contradicts edge to
+        // an ACTIVE partner, an archived LOCAL row must not be flagged contested
+        // (Feature C: "ACTIVE contradicts" requires BOTH endpoints active).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a active");
+        let b = node(&store, "b will be archived");
+        contradicts(&store, &a, &b);
+        store.archive_memory(&b.id).unwrap();
+        let flagged = store
+            .active_contradicts(&Namespace::Global, std::slice::from_ref(&b.id))
+            .unwrap();
+        assert!(
+            !flagged.contains(&b.id),
+            "an archived local endpoint must not be flagged contested"
         );
     }
 

--- a/crates/rb-store/tests/migration_reproducibility.rs
+++ b/crates/rb-store/tests/migration_reproducibility.rs
@@ -171,3 +171,114 @@ fn fresh_db_exercises_every_query_path() {
         "archived_at column must be set"
     );
 }
+
+#[test]
+fn fresh_db_has_embedding_input_version_column_and_meta_seed() {
+    // The 003 migration column + meta seed must apply on a fresh DB and round-trip.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("eiv.db");
+    let store = SqliteStore::open(&db_path, DIM).unwrap();
+    let ns = Namespace::Project("eiv".to_string());
+
+    // A note stamped with the current composite version persists and reads back.
+    let mut a = note(&ns, "composite stamped note", MemoryType::Insight, 5);
+    a.embedding_model = "deterministic".to_string();
+    a.embedding_input_version = "v2-composite".to_string();
+    let emb: [f32; DIM] = [1.0, 0.0, 0.0, 0.0];
+    store.insert_memory(&a, Some(&emb)).unwrap();
+    let got = store.get_memory(&a.id).unwrap().unwrap();
+    assert_eq!(got.embedding_input_version, "v2-composite");
+
+    // A row written WITHOUT a stamp (e.g. an old code path) lands with the SQL
+    // default backfill 'v1-content-only' — proving the column default works.
+    let mut b = note(&ns, "unstamped row", MemoryType::Reference, 5);
+    b.embedding_model = "deterministic".to_string();
+    b.embedding_input_version = String::new(); // explicit empty stamp
+    let emb_b: [f32; DIM] = [0.0, 1.0, 0.0, 0.0];
+    store.insert_memory(&b, Some(&emb_b)).unwrap();
+    let got_b = store.get_memory(&b.id).unwrap().unwrap();
+    // We inserted an explicit empty string, so it round-trips as empty (the SQL
+    // DEFAULT only applies when the column is omitted from the INSERT).
+    assert_eq!(got_b.embedding_input_version, "");
+}
+
+#[test]
+fn reembed_scan_and_update_vector_round_trip() {
+    use rb_store::Store as _;
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("reembed.db");
+    let store = SqliteStore::open(&db_path, DIM).unwrap();
+    let ns = Namespace::Project("reembed".to_string());
+
+    // A stale row (old model + version) and a current row.
+    let mut stale = note(&ns, "stale row", MemoryType::Insight, 5);
+    stale.embedding_model = "old-model".to_string();
+    stale.embedding_input_version = "v1-content-only".to_string();
+    let stale_emb: [f32; DIM] = [1.0, 0.0, 0.0, 0.0];
+    store.insert_memory(&stale, Some(&stale_emb)).unwrap();
+
+    let mut current = note(&ns, "current row", MemoryType::Insight, 5);
+    current.embedding_model = "deterministic".to_string();
+    current.embedding_input_version = "v2-composite".to_string();
+    let cur_emb: [f32; DIM] = [0.0, 1.0, 0.0, 0.0];
+    store.insert_memory(&current, Some(&cur_emb)).unwrap();
+
+    // Only the stale row is a re-embed candidate.
+    let cands = store
+        .memories_for_reembed("deterministic", "v2-composite", 100)
+        .unwrap();
+    let ids: Vec<_> = cands.iter().map(|c| c.id.clone()).collect();
+    assert!(ids.contains(&stale.id), "stale row is a candidate");
+    assert!(!ids.contains(&current.id), "current row is not a candidate");
+
+    // Re-embed the stale row: replaces vector + stamps to current.
+    let new_emb: [f32; DIM] = [0.0, 0.0, 1.0, 0.0];
+    store
+        .update_vector(&stale.id, &new_emb, "deterministic", "v2-composite")
+        .unwrap();
+    let after = store.get_memory(&stale.id).unwrap().unwrap();
+    assert_eq!(after.embedding_model, "deterministic");
+    assert_eq!(after.embedding_input_version, "v2-composite");
+
+    // Now it is no longer a candidate: a second scan finds nothing (idempotent).
+    let cands2 = store
+        .memories_for_reembed("deterministic", "v2-composite", 100)
+        .unwrap();
+    assert!(
+        cands2.iter().all(|c| c.id != stale.id),
+        "re-embedded row is no longer stale"
+    );
+
+    // The replacement vector is the nearest neighbor of new_emb.
+    let hits = store.vector_search(&ns, &new_emb, 1).unwrap();
+    assert_eq!(hits[0].0, stale.id, "updated vector is searchable");
+}
+
+#[test]
+fn update_vector_rejects_missing_id_and_wrong_dim() {
+    use rb_store::Store as _;
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("reembed_err.db");
+    let store = SqliteStore::open(&db_path, DIM).unwrap();
+
+    // Missing id => NotFound.
+    let missing = MemoryId::new();
+    let emb: [f32; DIM] = [1.0, 0.0, 0.0, 0.0];
+    let err = store
+        .update_vector(&missing, &emb, "deterministic", "v2-composite")
+        .unwrap_err();
+    assert!(matches!(err, rb_types::Error::NotFound(_)), "got {err:?}");
+
+    // Wrong dimension => DimensionMismatch (fail-closed), before any write.
+    let ns = Namespace::Project("dim".to_string());
+    let n = note(&ns, "dim guard", MemoryType::Insight, 5);
+    store.insert_memory(&n, Some(&emb)).unwrap();
+    let bad: [f32; 2] = [1.0, 2.0];
+    let err = store
+        .update_vector(&n.id, &bad, "deterministic", "v2-composite")
+        .unwrap_err();
+    assert!(
+        matches!(err, rb_types::Error::DimensionMismatch { .. }),
+        "got {err:?}"
+    );
+}

--- a/crates/rb-store/tests/migration_reproducibility.rs
+++ b/crates/rb-store/tests/migration_reproducibility.rs
@@ -200,6 +200,18 @@ fn fresh_db_has_embedding_input_version_column_and_meta_seed() {
     // We inserted an explicit empty string, so it round-trips as empty (the SQL
     // DEFAULT only applies when the column is omitted from the INSERT).
     assert_eq!(got_b.embedding_input_version, "");
+
+    // The 003 migration also SEEDS meta.embedding_input_version = 'v2-composite'
+    // (INSERT OR IGNORE). Assert it explicitly — the column round-trip above does
+    // not exercise the meta seed, so a broken seed would otherwise pass this gate.
+    assert_eq!(
+        store
+            .meta_value("embedding_input_version")
+            .unwrap()
+            .as_deref(),
+        Some("v2-composite"),
+        "migration 003 must seed meta.embedding_input_version"
+    );
 }
 
 #[test]

--- a/crates/rb-types/src/memory.rs
+++ b/crates/rb-types/src/memory.rs
@@ -27,7 +27,20 @@ pub struct MemoryNote {
     pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
     pub superseded_by: Option<MemoryId>,
     pub embedding_model: String,
+    /// Stamp of the composition that produced this row's vector (P5 Feature A).
+    /// Empty until set at write by the engine; the `reembed` batch re-embeds
+    /// rows whose `(embedding_model, embedding_input_version)` stamp is stale.
+    /// `#[serde(default)]` so pre-P5 payloads (which lack this field) deserialize
+    /// to an empty stamp — already the valid "stale, re-embed me" sentinel.
+    #[serde(default)]
+    pub embedding_input_version: String,
     pub links: Vec<MemoryLink>,
+    /// Read-side annotation (P5 Feature C): `true` when this memory has at least
+    /// one ACTIVE `contradicts` link (inbound or outbound). NOT persisted —
+    /// computed per recall/get/list/context from `memory_links`. Additive and
+    /// `#[serde(default)]` so older payloads (and clients) default to `false`.
+    #[serde(default)]
+    pub contested: bool,
 }
 
 impl MemoryNote {
@@ -60,7 +73,9 @@ impl MemoryNote {
             archived_at: None,
             superseded_by: None,
             embedding_model: String::new(),
+            embedding_input_version: String::new(),
             links: Vec::new(),
+            contested: false,
         }
     }
 }
@@ -98,6 +113,7 @@ mod tests {
         assert!((m.confidence - 1.0).abs() < f32::EPSILON);
         assert_eq!(m.access_count, 0);
         assert_eq!(m.embedding_model, "");
+        assert_eq!(m.embedding_input_version, "");
         assert!(m.keywords.is_empty());
         assert!(m.tags.is_empty());
         assert!(m.related_files.is_empty());
@@ -105,6 +121,22 @@ mod tests {
         assert!(m.last_accessed_at.is_none());
         assert!(m.archived_at.is_none());
         assert!(m.superseded_by.is_none());
+        // `contested` is a computed read-side flag (Feature C), not persisted; a
+        // fresh note is never contested.
+        assert!(!m.contested);
+    }
+
+    #[test]
+    fn contested_defaults_to_false_when_absent_from_json() {
+        // Backward compatibility: an older payload without `contested` must
+        // deserialize with `contested == false` (serde default), keeping old
+        // clients/data correct.
+        let m = sample();
+        let mut value = serde_json::to_value(&m).unwrap();
+        value.as_object_mut().unwrap().remove("contested");
+        let back: MemoryNote = serde_json::from_value(value).unwrap();
+        assert!(!back.contested);
+        assert_eq!(back.id, m.id);
     }
 
     #[test]
@@ -126,5 +158,20 @@ mod tests {
         let json = serde_json::to_string(&m).unwrap();
         let back: MemoryNote = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn deserializes_pre_p5_payload_missing_additive_fields() {
+        // A pre-P5 MemoryNote JSON lacks `embedding_input_version` (and
+        // `contested`). `#[serde(default)]` must let it deserialize, defaulting
+        // the stamp to an empty string — the valid "stale, re-embed me" sentinel.
+        let m = sample();
+        let mut value = serde_json::to_value(&m).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("embedding_input_version");
+        obj.remove("contested");
+        let back: MemoryNote = serde_json::from_value(value).unwrap();
+        assert_eq!(back.embedding_input_version, "");
+        assert!(!back.contested);
     }
 }

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -115,6 +115,16 @@ pub enum Command {
         /// `importance_recalibration`.
         job: String,
     },
+
+    /// Re-embed active memories whose vector is built from a stale composition
+    /// (P5 Feature A). Bounded and idempotent: a second run over unchanged data
+    /// reports `changed=0`. Re-run until `changed=0` to converge a large corpus.
+    Reembed {
+        /// Maximum memories to scan/re-embed in this pass (else the daemon
+        /// batch default).
+        #[arg(long)]
+        limit: Option<usize>,
+    },
 }
 
 #[cfg(test)]
@@ -145,6 +155,20 @@ mod tests {
         match cli.command {
             Command::Evolve { job } => assert_eq!(job, "link_decay"),
             other => panic!("expected Evolve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reembed_parses_with_optional_limit() {
+        let cli = Cli::parse_from(["rusty-brain", "reembed"]);
+        match cli.command {
+            Command::Reembed { limit } => assert_eq!(limit, None),
+            other => panic!("expected Reembed, got {other:?}"),
+        }
+        let cli = Cli::parse_from(["rusty-brain", "reembed", "--limit", "250"]);
+        match cli.command {
+            Command::Reembed { limit } => assert_eq!(limit, Some(250)),
+            other => panic!("expected Reembed, got {other:?}"),
         }
     }
 

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -79,14 +79,20 @@ pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
         });
     }
     match memory {
-        Some(n) => format!(
-            "{}\nnamespace: {}\ntype: {}\nimportance: {}\n\n{}",
-            n.id,
-            n.namespace.as_db_string(),
-            n.memory_type.as_str(),
-            n.importance,
-            n.content
-        ),
+        Some(n) => {
+            // Surface the contested flag (Feature C) on the get read path too, so
+            // every human surface (recall/list/context/get) marks a contradicted note.
+            let contested = if n.contested { " [contested]" } else { "" };
+            format!(
+                "{}{}\nnamespace: {}\ntype: {}\nimportance: {}\n\n{}",
+                n.id,
+                contested,
+                n.namespace.as_db_string(),
+                n.memory_type.as_str(),
+                n.importance,
+                n.content
+            )
+        }
         None => "Memory not found.".to_string(),
     }
 }
@@ -286,6 +292,15 @@ mod tests {
         assert!(none.to_lowercase().contains("not found"));
         let json_none = render_get(&None, true);
         assert_eq!(json_none.trim(), "null");
+    }
+
+    #[test]
+    fn human_get_marks_contested_note() {
+        // The get read path must also surface the contested marker (Feature C).
+        let mut n = note("body", 5);
+        n.contested = true;
+        let out = render_get(&Some(n), false);
+        assert!(out.contains("[contested]"), "get marks contested: {out}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -20,11 +20,18 @@ pub fn render_recall(results: &[SearchResult], json: bool) -> String {
         } else {
             r.memory.summary.as_str()
         };
+        // Surface the contested flag (Feature C) inline for the human reader.
+        let contested = if r.memory.contested {
+            " [contested]"
+        } else {
+            ""
+        };
         out.push_str(&format!(
-            "[{:.2}] {} ({}) {}\n",
+            "[{:.2}] {} ({}){} {}\n",
             r.score,
             r.memory.id,
             r.memory.memory_type.as_str(),
+            contested,
             summary
         ));
     }
@@ -49,11 +56,14 @@ pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
         } else {
             n.summary.as_str()
         };
+        // Surface the contested flag (Feature C) inline for the human reader.
+        let contested = if n.contested { " [contested]" } else { "" };
         out.push_str(&format!(
-            "{} (imp {}, {}) {}\n",
+            "{} (imp {}, {}){} {}\n",
             n.id,
             n.importance,
             n.memory_type.as_str(),
+            contested,
             summary
         ));
     }
@@ -194,6 +204,39 @@ mod tests {
             "summary shown: {out}"
         );
         assert!(out.contains(&n.id.to_string()), "id shown: {out}");
+    }
+
+    #[test]
+    fn human_recall_marks_contested_results() {
+        let mut n = note("conflicting claim", 5);
+        n.contested = true;
+        let results = vec![SearchResult {
+            memory: n,
+            score: 0.8,
+        }];
+        let out = render_recall(&results, false);
+        assert!(out.contains("[contested]"), "contested marker shown: {out}");
+    }
+
+    #[test]
+    fn json_recall_includes_contested_field() {
+        let mut n = note("conflicting claim", 5);
+        n.contested = true;
+        let results = vec![SearchResult {
+            memory: n,
+            score: 0.8,
+        }];
+        let out = render_recall(&results, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed[0]["memory"]["contested"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn human_list_marks_contested_notes() {
+        let mut n = note("conflicting note", 5);
+        n.contested = true;
+        let out = render_notes(std::slice::from_ref(&n), false);
+        assert!(out.contains("[contested]"), "contested marker shown: {out}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -172,6 +172,15 @@ async fn run_client(
                 println!("evolve {job}: scanned={scanned} changed={changed} skipped={skipped}");
             }
         }
+        Command::Reembed { limit } => {
+            let (scanned, changed, skipped) =
+                client.reembed(limit).await.context("reembed failed")?;
+            if json {
+                println!("{{\"scanned\":{scanned},\"changed\":{changed},\"skipped\":{skipped}}}");
+            } else {
+                println!("reembed: scanned={scanned} changed={changed} skipped={skipped}");
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements **P5 — Retrieval Quality & Measurement** per `docs/specs/2026-06-02-rusty-brain-p5-retrieval-quality.md`, in the spec's build order **H → B → A → C** (H gates the rest), each developed TDD against the per-phase gate.

Net: 39 files, +4,405 / −50. One new crate (`rb-eval`), one additive migration (`003`), zero new dependencies.

## Features

| | Feature | Highlights |
|---|---|---|
| **H** | `rb-eval` offline regression harness | Committed JSON fixtures + `DeterministicProvider`; `recall@k` / `mrr` / `dedup_precision` / latency metrics; a real `SqliteStore` backend (exercises FTS + sqlite-vec + graph); `baselines.json` gate. Excluded from the `rusty-brain` binary closure; a CI grep-gate enforces it. Honest-framing README (guards ranking determinism/regression, not absolute semantic quality). |
| **B** | RRF two-stage fusion | `FusionMode {Linear, Rrf}` — `Linear` stays the default **byte-for-byte**. Stage 1 fuses keyword/vector/graph rank lists (`Σ 1/(k+rank)`, k=60); Stage 2 applies importance/recency/confidence priors. Opt-in; the eval-gated default flip is deferred. |
| **A** | Composite embedding + reembed | Pure `embedding_input()` (content + keywords + tags + context) replaces raw content at the embed call; the query stays raw. Migration `003` adds `embedding_input_version` (column + meta seed). `WriteCommand::Reembed` is the first vector-`UPDATE` path (fail-closed dim, single writer); bounded/idempotent batch scan; `rusty-brain reembed` CLI. |
| **C** | Confidence + contradiction surfacing | Confidence multiplicative dampener (floor 0.5) in both Linear and Rrf; `contested` flag from ACTIVE, namespace-scoped `contradicts` links (inbound/outbound), fail-open. Additive `contested` field (`#[serde(default)]`); `CONTRACT_VERSION` bump. |

## Locked-decision conformance

- `rb-eval` absent from `cargo tree -e no-dev -p rusty-brain` (dev/measurement only).
- `FusionMode::default() == Linear` (test-pinned); `Rrf` opt-in.
- Migration `003` additive, file-discovered, checksummed; passes the fresh-DB reproducibility gate.
- Reembed bounded + idempotent (stamp-skip); fail-closed dim contract preserved.
- No new runtime dependencies (`cargo deny` green).

## Review fixes (two rounds, all verified against code first)

- `update_vector` no longer bumps `updated_at` (re-embed is maintenance-only; matches the no-event invariant).
- `RrfConfig.k` clamped to a positive floor (`MIN_K`) — `k=0` previously sent the rank-0 term to `inf`, which the sanitizer flipped to `0.0` and **inverted** the best candidate.
- `active_contradicts` scoped to namespace on **both** endpoints — a cross-namespace `contradicts` edge could otherwise flag a result `contested` from a memory in another namespace (isolation leak).
- `embedding_input_version` gains `#[serde(default)]` so pre-P5 payloads deserialize.
- Migration `003` drops a redundant `UPDATE`; a stale doc comment corrected.

New regression tests: `k_zero_does_not_invert_or_produce_non_finite_scores`, `cross_namespace_contradiction_does_not_flag`, `deserializes_pre_p5_payload_missing_additive_fields`.

## Test plan

```
cargo test --workspace --all-features ............ 790 passed, 0 failed, 5 ignored (real-model)
cargo clippy --workspace --all-targets --all-features -- -D warnings ... 0 warnings
cargo fmt --all --check .......................... clean
cargo deny check ................................. advisories/bans/licenses/sources ok
cargo test -p rb-eval ............................ regression baselines hold
```

## Known follow-up (deferred, low)

`active_contradicts` does not check the *local* endpoint's `archived_at`, so `get()` on an archived note with an active same-namespace contradictor could still render `[contested]`. Realistic callers (recall/list/context) only pass active ids, so this is cosmetic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Re-embed command to refresh stale memory embeddings (optional limit) with CLI subcommand and summarized/plain or JSON output.
  - Contested memory flag surfaced in human and JSON output (renders as “[contested]”).
  - New RRF ranking mode (opt-in) and confidence-based ranking to influence result ordering.
  - Composite embedding input (keywords/tags/context) to improve embedding quality/idempotence.

* **Documentation**
  - Added evaluation harness and docs for deterministic regression testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->