### PR TITLE
Phase 0: unbreak the product, stop unbackfillable debt (road-to-tens P8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,21 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+  # macOS mirrors the ubuntu clippy+test job: path resolution is platform-
+  # conditional (Library/Caches vs ~/.cache), so the agreement tests must run
+  # on both platforms.
+  clippy-test-macos:
+    name: clippy + test (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Test
+        run: cargo test --workspace
+
   build-local:
     name: build + clippy (local feature)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,21 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+# CI only reads the repo; no job needs write access to anything.
+permissions:
+  contents: read
+
 jobs:
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -24,9 +32,13 @@ jobs:
     name: clippy + test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Test
@@ -39,9 +51,13 @@ jobs:
     name: clippy + test (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Test
@@ -51,9 +67,13 @@ jobs:
     name: build + clippy (local feature)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build with local feature
         run: cargo build -p rusty-brain --features local
       - name: Clippy with local feature
@@ -65,9 +85,13 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check
 
@@ -75,9 +99,13 @@ jobs:
     name: cargo-audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rustsec/audit-check@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -85,9 +113,13 @@ jobs:
     name: build + clippy + test (agent crates)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build agent crates
         run: cargo build -p rb-agents -p rb-hooks -p rb-install
       - name: Clippy agent crates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Jobs opt in to the permissions they need; everything else is denied.
+permissions: {}
+
+jobs:
+  build:
+    name: build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          # Cross-compiled on the arm64 runner: the apple toolchain builds both
+          # arches from one SDK, so we don't depend on Intel runner availability.
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # Required by actions/attest-build-provenance (Sigstore signing).
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      - name: Build release binaries
+        run: cargo build --release --locked --target ${{ matrix.target }} -p rusty-brain -p rb-hooks -p rb-install
+      - name: Package tarball
+        run: |
+          set -euo pipefail
+          archive="rusty-brain-${GITHUB_REF_NAME}-${TARGET}"
+          mkdir -p "dist/${archive}"
+          for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
+            cp "target/${TARGET}/release/${bin}" "dist/${archive}/"
+          done
+          tar -C dist -czf "dist/${archive}.tar.gz" "${archive}"
+        env:
+          TARGET: ${{ matrix.target }}
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tarball-${{ matrix.target }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: tarball-*
+          merge-multiple: true
+      - name: Generate SHA256SUMS
+        run: cd dist && sha256sum -- *.tar.gz > SHA256SUMS
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,14 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
       - name: Build release binaries
@@ -53,10 +56,10 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: dist/*.tar.gz
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: tarball-${{ matrix.target }}
           path: dist/*.tar.gz
@@ -69,7 +72,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           pattern: tarball-*
@@ -77,7 +80,7 @@ jobs:
       - name: Generate SHA256SUMS
         run: cd dist && sha256sum -- *.tar.gz > SHA256SUMS
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           draft: false
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock.orig
 *.db
 *.db-wal
 *.db-shm
+.serena/

--- a/.rusty-brain.toml
+++ b/.rusty-brain.toml
@@ -1,0 +1,3 @@
+# Repo-committed namespace identity (W0.3): every clone of this repository
+# resolves the same memory namespace regardless of its directory name.
+namespace = "rusty-brain"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
 name = "rb-agents"
 version = "0.0.1"
 dependencies = [
+ "rb-config",
  "rb-daemon",
  "rb-embed",
  "rb-proto",
@@ -2495,12 +2496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-config"
+version = "0.0.1"
+dependencies = [
+ "rb-types",
+ "tempfile",
+]
+
+[[package]]
 name = "rb-daemon"
 version = "0.0.1"
 dependencies = [
  "async-trait",
  "chrono",
  "libc",
+ "rb-config",
  "rb-embed",
  "rb-engine",
  "rb-enrich",
@@ -2586,6 +2596,8 @@ dependencies = [
  "assert_cmd",
  "predicates",
  "rb-agents",
+ "rb-config",
+ "rb-daemon",
  "rb-proto",
  "rb-types",
  "serde",
@@ -2871,6 +2883,7 @@ dependencies = [
  "async-trait",
  "clap",
  "predicates",
+ "rb-config",
  "rb-daemon",
  "rb-embed",
  "rb-mcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,9 @@ name = "rb-config"
 version = "0.0.1"
 dependencies = [
  "rb-types",
+ "serde",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "sha2",
  "sqlite-vec",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
 name = "rb-config"
 version = "0.0.1"
 dependencies = [
+ "libc",
  "rb-types",
  "serde",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,7 @@ dependencies = [
  "rb-daemon",
  "rb-proto",
  "rb-types",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 wiremock = "0.6"
 libc = "0.2"
+# Capture-time secret redaction in rb-hooks (W0.5 minimal set; W2.4 expands it).
+regex = "1"
 assert_cmd = "2"
 predicates = "3"
 # Builds a binary owned by another workspace crate from within an integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/rb-types",
+    "crates/rb-config",
     "crates/rb-store",
     "crates/rb-proto",
     "crates/rb-embed",

--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ ANN vector index for larger corpora. See [Roadmap](#roadmap).
 
 ## Quickstart
 
+### Install
+
+Tagged releases ship prebuilt, checksummed tarballs for macOS (Apple Silicon and
+Intel) and Linux x86_64 on the
+[releases page](https://github.com/brianluby/rusty-brain/releases). Each tarball
+contains the three binaries (`rusty-brain`, `rusty-brain-hooks`,
+`rusty-brain-install`); verify it before unpacking:
+
+```bash
+# download the tarball for your platform plus SHA256SUMS from the release, then:
+shasum -a 256 --check --ignore-missing SHA256SUMS      # sha256sum on Linux
+gh attestation verify rusty-brain-*.tar.gz --repo brianluby/rusty-brain  # optional: build provenance
+tar -xzf rusty-brain-*.tar.gz
+# move the binaries somewhere on your PATH
+```
+
+Or build from source:
+
 ### Prerequisites
 
 - Rust **stable** (pinned via `rust-toolchain.toml`). SQLite is bundled (no system

--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ coverage is still being expanded.
 Service configuration is via environment variables (there is no general config file
 for the core service yet). Two small files exist for namespace identity: a
 repo-committed `.rusty-brain.toml` at the git toplevel (`namespace = "..."`) pins a
-project's namespace across clones, and a per-user pin store (`namespace-pins.toml`
+project's namespace across clones — it is read from the blob committed at `HEAD`
+(`git show HEAD:.rusty-brain.toml`), so untracked or uncommitted edits are ignored
+with a warning until committed — and a per-user pin store (`namespace-pins.toml`
 under the user state dir) records `CLAUDE.md` frontmatter overrides accepted via
 `rusty-brain --accept-namespace-override` — unpinned overrides are never silently
 honored.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ honored.
 
 | Variable | Purpose |
 |---|---|
-| `RUSTY_BRAIN_DB` | SQLite database path (default under the user cache dir). |
+| `RUSTY_BRAIN_DB` | SQLite database path (default under the user data dir: `~/Library/Application Support` on macOS, `$XDG_DATA_HOME` or `~/.local/share` on Linux). |
 | `RUSTY_BRAIN_SOCKET` | Unix socket path for the daemon. |
 | `RUSTY_BRAIN_NAMESPACE` | Skip namespace detection and use this namespace (same precedence as the global `--namespace` flag). |
 | `RUSTY_BRAIN_IDLE_TIMEOUT_SECS` | Per-connection request idle timeout for the daemon (default 60; mainly for tests). |

--- a/README.md
+++ b/README.md
@@ -129,15 +129,19 @@ Tagged releases ship prebuilt, checksummed tarballs for macOS (Apple Silicon and
 Intel) and Linux x86_64 on the
 [releases page](https://github.com/brianluby/rusty-brain/releases). Each tarball
 contains the three binaries (`rusty-brain`, `rusty-brain-hooks`,
-`rusty-brain-install`); verify it before unpacking:
+`rusty-brain-install`). One-line install (needs the `gh` CLI; pick your target):
 
 ```bash
-# download the tarball for your platform plus SHA256SUMS from the release, then:
-shasum -a 256 --check --ignore-missing SHA256SUMS      # sha256sum on Linux
-gh attestation verify rusty-brain-*.tar.gz --repo brianluby/rusty-brain  # optional: build provenance
-tar -xzf rusty-brain-*.tar.gz
-# move the binaries somewhere on your PATH
+TARGET=aarch64-apple-darwin   # or x86_64-apple-darwin / x86_64-unknown-linux-gnu
+gh release download --repo brianluby/rusty-brain --pattern "*-${TARGET}.tar.gz" --pattern SHA256SUMS && shasum -a 256 --check --ignore-missing SHA256SUMS && mkdir -p ~/.local/bin && tar -xzf rusty-brain-*-"${TARGET}".tar.gz --strip-components=1 -C ~/.local/bin
 ```
+
+(`sha256sum` on Linux; make sure `~/.local/bin` is on your `PATH`. Optionally verify
+build provenance first: `gh attestation verify rusty-brain-*.tar.gz --repo
+brianluby/rusty-brain`.)
+
+Or manually: download the tarball for your platform plus `SHA256SUMS` from the
+release, check it, and unpack the binaries somewhere on your `PATH`.
 
 Or build from source:
 
@@ -195,9 +199,13 @@ good real-world recall. For meaningful semantic recall, configure a real provide
 | Voyage API | set `VOYAGE_API_KEY` | Remote HTTP embeddings (`voyage-3-lite`, dim 512). |
 | Local ONNX | build `--features local`, then set `RB_EMBED_BACKEND=local` | Downloads `all-MiniLM-L6-v2` (dim 384) on first use via `fastembed`. |
 
-The embedding dimension is fixed at first daemon init and checked fail-closed on
-every startup and read; switching providers to a different dimension against an
-existing database will refuse to run rather than silently corrupt vectors.
+The embedding dimension AND model identity are fixed at first daemon init and checked
+fail-closed on every startup (vector reads are length-checked too); switching
+providers — or models, even at the same dimension — against an existing database
+refuses to run rather than silently mix vector spaces. To accept a deliberate model
+swap, restart with `rusty-brain serve --accept-model-change` (or set
+`RB_ACCEPT_MODEL_CHANGE=1` for auto-started daemons) and re-embed the corpus with
+`rusty-brain reembed`.
 
 ### Wire the MCP server into an agent
 
@@ -225,16 +233,24 @@ coverage is still being expanded.
 
 ## Configuration
 
-All configuration is via environment variables (there is no config file for the core
-service today):
+Service configuration is via environment variables (there is no general config file
+for the core service yet). Two small files exist for namespace identity: a
+repo-committed `.rusty-brain.toml` at the git toplevel (`namespace = "..."`) pins a
+project's namespace across clones, and a per-user pin store (`namespace-pins.toml`
+under the user state dir) records `CLAUDE.md` frontmatter overrides accepted via
+`rusty-brain --accept-namespace-override` — unpinned overrides are never silently
+honored.
 
 | Variable | Purpose |
 |---|---|
 | `RUSTY_BRAIN_DB` | SQLite database path (default under the user cache dir). |
 | `RUSTY_BRAIN_SOCKET` | Unix socket path for the daemon. |
+| `RUSTY_BRAIN_NAMESPACE` | Skip namespace detection and use this namespace (same precedence as the global `--namespace` flag). |
+| `RUSTY_BRAIN_IDLE_TIMEOUT_SECS` | Per-connection request idle timeout for the daemon (default 60; mainly for tests). |
 | `VOYAGE_API_KEY` | Selects the Voyage embedding provider when set. |
 | `RB_EMBED_BACKEND` | `local` forces the local ONNX provider (requires `--features local`). |
 | `RB_LOCAL_MODEL` | Local model name (implies local backend); defaults to `all-MiniLM-L6-v2`. |
+| `RB_ACCEPT_MODEL_CHANGE` | Opt in to an embedding-model swap on an existing DB (flag equivalent: `serve --accept-model-change`); follow with `rusty-brain reembed`. |
 | `RB_ENRICH_BASE_URL`, `RB_ENRICH_MODEL` | Optional LLM enrichment endpoint (off by default; heuristic enrichment is used otherwise). |
 | `RB_JOBS_CONFIG` | Path to an evolution-jobs TOML config for `serve` (jobs are disabled if absent). |
 | `RUST_LOG` | Log verbosity (logs go to stderr; stdout is reserved for results). |

--- a/crates/rb-agents/Cargo.toml
+++ b/crates/rb-agents/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 rb-types = { path = "../rb-types" }
+rb-config = { path = "../rb-config" }
 rb-proto = { path = "../rb-proto" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rb-agents/src/daemon.rs
+++ b/crates/rb-agents/src/daemon.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 // Auto-start env allowlist + override var names are owned by rb-config so the
 // hooks spawner and the CLI spawner can never disagree.
 use rb_config::{DB_ENV, FORWARD_ENV, SOCKET_ENV};
-use rb_proto::Client;
+use rb_proto::{Client, ClientIdentity};
 use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
 
 /// Auto-start parameters. Provided ONLY for `SessionStart`; any other event
@@ -32,14 +32,17 @@ impl DaemonClient {
     /// Connect with the rb-proto handshake inside `timeout`. ANY failure (IO,
     /// timeout, contract-version mismatch) yields `None`. When `auto_start` is
     /// `Some` (SessionStart only) and the first connect fails, spawn a detached
-    /// daemon then retry the connect briefly; otherwise never spawn.
+    /// daemon then retry the connect briefly; otherwise never spawn. `identity`
+    /// is the hook's provenance declaration (source/agent/session), stamped by
+    /// the daemon onto every memory this connection writes.
     pub async fn connect(
         socket: &Path,
         namespace: Namespace,
         timeout: Duration,
         auto_start: Option<AutoStart>,
+        identity: Option<ClientIdentity>,
     ) -> Option<DaemonClient> {
-        if let Some(client) = try_connect(socket, &namespace, timeout).await {
+        if let Some(client) = try_connect(socket, &namespace, timeout, identity.clone()).await {
             return Some(DaemonClient { client, timeout });
         }
         let auto = auto_start?;
@@ -49,7 +52,7 @@ impl DaemonClient {
             return None;
         }
         for _ in 0..50 {
-            if let Some(client) = try_connect(socket, &namespace, timeout).await {
+            if let Some(client) = try_connect(socket, &namespace, timeout, identity.clone()).await {
                 return Some(DaemonClient { client, timeout });
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -58,6 +61,7 @@ impl DaemonClient {
     }
 
     /// Best-effort `remember`. Returns the new id, or `None` on any error/timeout.
+    /// `confidence` is the trust prior in `0.0..=1.0` (hook captures send 0.7).
     pub async fn remember(
         &mut self,
         content: String,
@@ -65,6 +69,7 @@ impl DaemonClient {
         memory_type: MemoryType,
         importance: u8,
         tags: Vec<String>,
+        confidence: f32,
     ) -> Option<MemoryId> {
         let fut = self.client.remember(
             content,
@@ -74,6 +79,7 @@ impl DaemonClient {
             Vec::new(),
             tags,
             Vec::new(),
+            confidence,
         );
         match tokio::time::timeout(self.timeout, fut).await {
             Ok(Ok(id)) => Some(id),
@@ -91,8 +97,18 @@ impl DaemonClient {
 }
 
 /// Connect + handshake within `timeout`; any error or timeout => `None`.
-async fn try_connect(socket: &Path, namespace: &Namespace, timeout: Duration) -> Option<Client> {
-    match tokio::time::timeout(timeout, Client::connect(socket, namespace.clone())).await {
+async fn try_connect(
+    socket: &Path,
+    namespace: &Namespace,
+    timeout: Duration,
+    identity: Option<ClientIdentity>,
+) -> Option<Client> {
+    match tokio::time::timeout(
+        timeout,
+        Client::connect_with_identity(socket, namespace.clone(), identity),
+    )
+    .await
+    {
         Ok(Ok(client)) => Some(client),
         Ok(Err(_)) | Err(_) => None,
     }
@@ -177,6 +193,12 @@ mod tests {
             Namespace::Project("rb-agents-test".to_string()),
             Duration::from_secs(5),
             None,
+            Some(ClientIdentity {
+                agent: Some("claude-code".to_string()),
+                session_id: Some("sess-42".to_string()),
+                source: Some("hook".to_string()),
+                ..Default::default()
+            }),
         )
         .await
         .expect("connect must succeed against a live daemon");
@@ -188,6 +210,7 @@ mod tests {
                 MemoryType::ArchitectureDecision,
                 9,
                 vec!["daemon".to_string()],
+                0.7,
             )
             .await
             .expect("remember must return an id");
@@ -198,10 +221,67 @@ mod tests {
             .await
             .expect("context must return a triple");
         assert!(total >= 1, "the stored memory must be counted");
+        let note = recent
+            .iter()
+            .chain(important.iter())
+            .find(|m| m.id == id)
+            .expect("stored memory must appear in recent or important");
+
+        // W0.5: the handshake identity is stamped onto the write, and the
+        // declared confidence (0.7 for hook captures) is persisted.
+        assert_eq!(note.origin_source.as_deref(), Some("hook"));
+        assert_eq!(note.origin_agent.as_deref(), Some("claude-code"));
+        assert_eq!(note.session_id.as_deref(), Some("sess-42"));
+        assert!((note.confidence - 0.7).abs() < f32::EPSILON);
+        // user/host were not declared: the daemon fell back to its own whoami.
+        assert_eq!(note.origin_user, rb_config::current_user());
+        assert_eq!(note.origin_host, rb_config::current_hostname());
+
+        let _ = shutdown.send(());
+        let _ = handle.await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn old_client_without_identity_gets_whoami_fallback_provenance() {
+        let (_dir, socket, shutdown, handle) = start_daemon().await;
+
+        // identity=None is exactly the pre-W0.5 handshake wire shape.
+        let mut client = DaemonClient::connect(
+            &socket,
+            Namespace::Project("rb-agents-old".to_string()),
+            Duration::from_secs(5),
+            None,
+            None,
+        )
+        .await
+        .expect("old-shape connect must still succeed");
+
+        let id = client
+            .remember(
+                "legacy client write".to_string(),
+                None,
+                MemoryType::Insight,
+                8,
+                vec![],
+                1.0,
+            )
+            .await
+            .expect("remember must return an id");
+
+        let (recent, important, _total) = client.context().await.expect("context");
+        let note = recent
+            .iter()
+            .chain(important.iter())
+            .find(|m| m.id == id)
+            .expect("note present");
+        assert_eq!(note.origin_user, rb_config::current_user());
+        assert_eq!(note.origin_host, rb_config::current_hostname());
+        assert!(note.origin_agent.is_none());
         assert!(
-            !recent.is_empty() || !important.is_empty(),
-            "stored memory must appear in recent or important"
+            note.origin_source.is_none(),
+            "source is client-declared only"
         );
+        assert!(note.session_id.is_none());
 
         let _ = shutdown.send(());
         let _ = handle.await;
@@ -217,6 +297,7 @@ mod tests {
             Namespace::Global,
             Duration::from_millis(200),
             None, // no auto-start: must not spawn, must degrade to None
+            None,
         )
         .await;
         assert!(result.is_none(), "dead socket must degrade to None");

--- a/crates/rb-agents/src/daemon.rs
+++ b/crates/rb-agents/src/daemon.rs
@@ -7,6 +7,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+// Auto-start env allowlist + override var names are owned by rb-config so the
+// hooks spawner and the CLI spawner can never disagree.
+use rb_config::{DB_ENV, FORWARD_ENV, SOCKET_ENV};
 use rb_proto::Client;
 use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
 
@@ -24,24 +27,6 @@ pub struct DaemonClient {
     client: Client,
     timeout: Duration,
 }
-
-/// The minimal set of parent env vars an auto-start daemon child may inherit.
-/// Everything else is cleared before spawn (no parent-env leak into a long-lived
-/// detached process).
-const FORWARD_ENV: &[&str] = &[
-    "VOYAGE_API_KEY",
-    "RB_ENRICH_BASE_URL",
-    "RB_ENRICH_MODEL",
-    "RB_ENRICH_API_KEY",
-    "HOME",
-    "PATH",
-    "XDG_RUNTIME_DIR",
-    "XDG_DATA_HOME",
-    "XDG_CONFIG_HOME",
-];
-
-const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
-const DB_ENV: &str = "RUSTY_BRAIN_DB";
 
 impl DaemonClient {
     /// Connect with the rb-proto handshake inside `timeout`. ANY failure (IO,

--- a/crates/rb-agents/src/lib.rs
+++ b/crates/rb-agents/src/lib.rs
@@ -1,10 +1,11 @@
 //! `rb-agents` — CLI-agnostic spine for the agent hook + install surface.
 //!
 //! Defines the canonical hook event model, the per-CLI `AgentCli` JSON adapter
-//! trait + registry, a strictly fail-open `DaemonClient` over `rb_proto`, a
-//! self-contained namespace detector, and the install-side `AgentInstaller`
-//! contract. NEVER referenced by any core crate: kept out of the default build
-//! closure so the `rusty-brain` binary never links it.
+//! trait + registry, a strictly fail-open `DaemonClient` over `rb_proto`, the
+//! hook-side (non-interactive) namespace shim over `rb_config::namespace`, and
+//! the install-side `AgentInstaller` contract. NEVER referenced by any core
+//! crate: kept out of the default build closure so the `rusty-brain` binary
+//! never links it.
 #![forbid(unsafe_code)]
 
 mod claude_code;

--- a/crates/rb-agents/src/namespace.rs
+++ b/crates/rb-agents/src/namespace.rs
@@ -5,7 +5,9 @@
 //! Hooks are non-interactive: an unpinned `CLAUDE.md` frontmatter `project:`
 //! override is NEVER honored — it logs a `tracing` warning and the git-toplevel
 //! name is used instead (F22). Pins recorded by the CLI's
-//! `--accept-namespace-override` are honored.
+//! `--accept-namespace-override` are honored. Likewise only the
+//! `.rusty-brain.toml` blob committed at `HEAD` counts: a worktree-only or
+//! locally-modified file logs a warning and is never honored.
 //!
 //! Never panics; degrades to `Global`. MUST run OFF the async runtime (reads
 //! files, shells out to git).
@@ -13,20 +15,24 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use rb_config::namespace::{explicit_namespace_from_env, resolve_namespace_in, NamespacePins};
+use rb_config::namespace::{
+    explicit_namespace_from_env, resolve_namespace_in, NamespacePins, RepoConfigDivergenceKind,
+    REPO_CONFIG_FILE,
+};
 use rb_types::Namespace;
 
 use crate::proc::run_git_bounded;
 
-/// Detect the namespace for `cwd`. Reads the pin store, `.rusty-brain.toml`,
-/// and `CLAUDE.md`; invokes git under a 1s bound. Synchronous: call this OFF
-/// the tokio runtime.
+/// Detect the namespace for `cwd`. Reads the pin store, the committed
+/// `.rusty-brain.toml` blob at `HEAD`, and `CLAUDE.md`; invokes git under a 1s
+/// bound. Synchronous: call this OFF the tokio runtime.
 pub fn detect_namespace(cwd: &Path) -> Namespace {
     let res = resolve_namespace_in(
         cwd,
         explicit_namespace_from_env(),
         &NamespacePins::load(),
         git_toplevel,
+        head_repo_config,
     );
     if let Some(o) = &res.unpinned_override {
         tracing::warn!(
@@ -36,6 +42,20 @@ pub fn detect_namespace(cwd: &Path) -> Namespace {
             "ignoring unpinned CLAUDE.md namespace override; run \
              `rusty-brain --accept-namespace-override` in the repo to pin it"
         );
+    }
+    if let Some(d) = &res.repo_config_divergence {
+        match d.kind {
+            RepoConfigDivergenceKind::Untracked => tracing::warn!(
+                toplevel = %d.toplevel.display(),
+                "found {REPO_CONFIG_FILE} but it is not committed at HEAD; \
+                 ignoring — commit it to take effect"
+            ),
+            RepoConfigDivergenceKind::Modified => tracing::warn!(
+                toplevel = %d.toplevel.display(),
+                "{REPO_CONFIG_FILE} differs from the committed version; \
+                 using the committed content"
+            ),
+        }
     }
     res.namespace
 }
@@ -57,6 +77,14 @@ fn git_toplevel(dir: &Path) -> Option<PathBuf> {
     }
 }
 
+/// The committed `.rusty-brain.toml` blob at `HEAD`, via git under a 1s bound;
+/// `None` when not committed, HEAD is unborn, or git hung/failed (fail-open).
+fn head_repo_config(toplevel: &Path) -> Option<String> {
+    let spec = format!("HEAD:{REPO_CONFIG_FILE}");
+    let bytes = run_git_bounded(toplevel, &["show", &spec], Duration::from_secs(1))?;
+    String::from_utf8(bytes).ok()
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -67,11 +95,11 @@ mod tests {
     use std::process::{Command, Stdio};
     use tempfile::TempDir;
 
-    /// `git init` `dir`; false (test skips) when git is unavailable —
-    /// mirroring the `proc.rs` test precedent.
-    fn git_init(dir: &Path) -> bool {
+    /// Run `git <args>` in `dir`; false (test skips) when git is unavailable
+    /// — mirroring the `proc.rs` test precedent.
+    fn git_run(dir: &Path, args: &[&str]) -> bool {
         Command::new("git")
-            .args(["init", "-q"])
+            .args(args)
             .current_dir(dir)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -79,6 +107,19 @@ mod tests {
             .status()
             .map(|s| s.success())
             .unwrap_or(false)
+    }
+
+    /// `git init` with a repo-local identity so commits work everywhere.
+    fn git_init(dir: &Path) -> bool {
+        git_run(dir, &["init", "-q"])
+            && git_run(dir, &["config", "user.email", "test@example.com"])
+            && git_run(dir, &["config", "user.name", "Test"])
+    }
+
+    /// Stage everything and commit.
+    fn git_commit_all(dir: &Path) -> bool {
+        git_run(dir, &["add", "-A"])
+            && git_run(dir, &["commit", "-q", "-m", "init", "--no-gpg-sign"])
     }
 
     #[test]
@@ -124,8 +165,8 @@ mod tests {
 
     #[test]
     fn repo_committed_toml_resolves_identically_across_clone_names() {
-        // (b)+(d): `.rusty-brain.toml` outranks the directory name, so the
-        // same repo under two clone names yields one namespace.
+        // (b)+(d): a COMMITTED `.rusty-brain.toml` outranks the directory
+        // name, so the same repo under two clone names yields one namespace.
         let tmp = TempDir::new().unwrap();
         let base = tmp.path().canonicalize().unwrap();
         let mut seen = Vec::new();
@@ -133,13 +174,49 @@ mod tests {
             let repo = base.join(clone);
             fs::create_dir_all(&repo).unwrap();
             fs::write(repo.join(".rusty-brain.toml"), "namespace = \"one-id\"\n").unwrap();
-            if !git_init(&repo) {
+            if !git_init(&repo) || !git_commit_all(&repo) {
                 return; // git unavailable; skip
             }
             seen.push(detect_namespace(&repo));
         }
         assert_eq!(seen[0], seen[1]);
         assert_eq!(seen[0], Namespace::Project("one-id".to_string()));
+    }
+
+    #[test]
+    fn untracked_toml_is_ignored_and_repo_name_is_used() {
+        // Inverse regression for the namespace-hijack fix: an UNCOMMITTED
+        // `.rusty-brain.toml` dropped into the worktree must not redirect the
+        // hook's namespace — only the blob at HEAD counts.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("host-repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("README.md"), "x\n").unwrap();
+        if !git_init(&repo) || !git_commit_all(&repo) {
+            return; // git unavailable; skip
+        }
+        fs::write(repo.join(".rusty-brain.toml"), "namespace = \"hijacked\"\n").unwrap();
+        assert_eq!(
+            detect_namespace(&repo),
+            Namespace::Project("host-repo".to_string())
+        );
+    }
+
+    #[test]
+    fn unborn_head_with_worktree_toml_degrades_to_repo_name() {
+        // A fresh `git init` repo has no HEAD blob to honor: the worktree
+        // toml is ignored without error and the repo name is used.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("fresh-repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join(".rusty-brain.toml"), "namespace = \"hijacked\"\n").unwrap();
+        if !git_init(&repo) {
+            return; // git unavailable; skip
+        }
+        assert_eq!(
+            detect_namespace(&repo),
+            Namespace::Project("fresh-repo".to_string())
+        );
     }
 
     #[test]

--- a/crates/rb-agents/src/namespace.rs
+++ b/crates/rb-agents/src/namespace.rs
@@ -1,139 +1,43 @@
-//! Self-contained namespace detection (ported from `rusty-brain/src/
-//! namespace_detect.rs`) so the hook binary never links the `rusty-brain`
-//! crate. Resolution order (first non-empty wins): (1) nearest `CLAUDE.md`
-//! frontmatter `project:`, (2) that `CLAUDE.md`'s first `# H1`, (3) git-root dir
-//! name, (4) `cwd` dir name, (5) `Global`. Never panics; degrades to `Global`.
+//! Hook-side namespace resolution: thin shim over [`rb_config::namespace`]
+//! (the single W0.3 implementation), keeping this crate's bounded git
+//! invocation so a wedged git can never hang the agent hook.
 //!
-//! MUST run OFF the async runtime (reads files, shells out to git).
+//! Hooks are non-interactive: an unpinned `CLAUDE.md` frontmatter `project:`
+//! override is NEVER honored — it logs a `tracing` warning and the git-toplevel
+//! name is used instead (F22). Pins recorded by the CLI's
+//! `--accept-namespace-override` are honored.
+//!
+//! Never panics; degrades to `Global`. MUST run OFF the async runtime (reads
+//! files, shells out to git).
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use rb_config::namespace::{explicit_namespace_from_env, resolve_namespace_in, NamespacePins};
 use rb_types::Namespace;
 
 use crate::proc::run_git_bounded;
 
-/// Detect the namespace for `cwd`. Reads `CLAUDE.md`, invokes git. Synchronous:
-/// call this OFF the tokio runtime.
+/// Detect the namespace for `cwd`. Reads the pin store, `.rusty-brain.toml`,
+/// and `CLAUDE.md`; invokes git under a 1s bound. Synchronous: call this OFF
+/// the tokio runtime.
 pub fn detect_namespace(cwd: &Path) -> Namespace {
-    detect_namespace_with(cwd, find_nearest_claude_md, git_toplevel)
-}
-
-/// Pure core, parameterized over the `CLAUDE.md` finder and git-root resolver so
-/// every branch is unit-testable without touching the filesystem or git.
-pub fn detect_namespace_with<C, G>(start: &Path, find_claude_md: C, git_root: G) -> Namespace
-where
-    C: Fn(&Path) -> Option<(PathBuf, String)>,
-    G: Fn(&Path) -> Option<PathBuf>,
-{
-    if let Some((_path, text)) = find_claude_md(start) {
-        if let Some(name) = parse_project_from_claude_md(&text) {
-            return Namespace::Project(name);
-        }
+    let res = resolve_namespace_in(
+        cwd,
+        explicit_namespace_from_env(),
+        &NamespacePins::load(),
+        git_toplevel,
+    );
+    if let Some(o) = &res.unpinned_override {
+        tracing::warn!(
+            claimed = %o.claimed,
+            used = %o.used,
+            toplevel = %o.toplevel.display(),
+            "ignoring unpinned CLAUDE.md namespace override; run \
+             `rusty-brain --accept-namespace-override` in the repo to pin it"
+        );
     }
-    if let Some(name) = git_root(start).as_deref().and_then(dir_name) {
-        return Namespace::Project(name);
-    }
-    if let Some(name) = dir_name(start) {
-        return Namespace::Project(name);
-    }
-    Namespace::Global
-}
-
-/// Extract a non-empty, utf8 final path component. `None` for `/`, empty, or
-/// non-utf8 names — caller then falls through to the next branch.
-fn dir_name(p: &Path) -> Option<String> {
-    p.file_name()
-        .and_then(|n| n.to_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-}
-
-/// Parse a `CLAUDE.md` body: prefer frontmatter `project: NAME`, else first `# H1`.
-///
-/// The H1 scan deliberately skips a leading `---`...`---` YAML frontmatter block
-/// so a `#` comment INSIDE the frontmatter is never misread as the document
-/// title. If the frontmatter has no closing `---`, fall back to scanning the
-/// whole text (preserving prior behavior).
-pub fn parse_project_from_claude_md(text: &str) -> Option<String> {
-    if let Some(name) = project_from_frontmatter(text) {
-        return Some(name);
-    }
-    first_h1_in(frontmatter_aware_lines(text))
-}
-
-/// Collect the lines the H1 scan should consider, skipping a leading
-/// `---`...`---` frontmatter block. With an opening fence but NO closing fence,
-/// preserve prior behavior by scanning the full text (all lines).
-fn frontmatter_aware_lines(text: &str) -> Vec<&str> {
-    let mut lines = text.lines();
-    if lines.clone().next().map(str::trim) != Some("---") {
-        return text.lines().collect();
-    }
-    // Consume the opening fence, then walk to the matching closing fence.
-    lines.next();
-    let mut closed = false;
-    for line in lines.by_ref() {
-        if line.trim() == "---" {
-            closed = true;
-            break;
-        }
-    }
-    if !closed {
-        // No closing fence: behave as before and scan everything.
-        return text.lines().collect();
-    }
-    // Whatever remains after the closing fence is the scannable body.
-    lines.collect()
-}
-
-/// Read `project: NAME` from a leading `---`-delimited frontmatter block.
-fn project_from_frontmatter(text: &str) -> Option<String> {
-    let mut lines = text.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return None;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break;
-        }
-        if let Some(rest) = trimmed.strip_prefix("project:") {
-            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'').trim();
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-            return None;
-        }
-    }
-    None
-}
-
-/// First markdown `# H1` heading text (exactly one leading `#`), trimmed, over
-/// the supplied lines.
-fn first_h1_in<'a>(lines: impl IntoIterator<Item = &'a str>) -> Option<String> {
-    for line in lines {
-        let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("# ") {
-            let heading = rest.trim();
-            if !heading.is_empty() {
-                return Some(heading.to_string());
-            }
-        }
-    }
-    None
-}
-
-/// Walk up from `start`, returning the first `CLAUDE.md`'s `(path, contents)`.
-fn find_nearest_claude_md(start: &Path) -> Option<(PathBuf, String)> {
-    for dir in start.ancestors() {
-        let candidate = dir.join("CLAUDE.md");
-        if let Ok(text) = std::fs::read_to_string(&candidate) {
-            return Some((candidate, text));
-        }
-    }
-    None
+    res.namespace
 }
 
 /// Find the git toplevel for `dir` by invoking git under a 1s bound; `None` if
@@ -159,132 +63,100 @@ mod tests {
     use super::*;
     use rb_types::Namespace;
     use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
+    use std::process::{Command, Stdio};
     use tempfile::TempDir;
 
-    fn no_claude(_: &Path) -> Option<(PathBuf, String)> {
-        None
-    }
-
-    fn no_git(_: &Path) -> Option<PathBuf> {
-        None
-    }
-
-    #[test]
-    fn frontmatter_project_wins_over_h1() {
-        let text = "---\nproject: from-frontmatter\nother: x\n---\n# From Heading\nbody\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("from-frontmatter".to_string())
-        );
+    /// `git init` `dir`; false (test skips) when git is unavailable —
+    /// mirroring the `proc.rs` test precedent.
+    fn git_init(dir: &Path) -> bool {
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
     }
 
     #[test]
-    fn falls_back_to_first_h1_when_no_frontmatter_project() {
-        let text = "---\nother: x\n---\nintro\n#  Heading Name  \n## sub\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("Heading Name".to_string())
-        );
-    }
-
-    #[test]
-    fn empty_text_is_none() {
-        assert_eq!(parse_project_from_claude_md(""), None);
-    }
-
-    #[test]
-    fn h1_inside_frontmatter_is_not_mistaken_for_the_title() {
-        // The frontmatter carries a `#` line (no `project:` key); the real H1 is in
-        // the body. The frontmatter `#` MUST be skipped, not read as the title.
-        let text = "---\n# not-the-title\nfoo: bar\n---\nintro prose\n# real-project\nmore\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("real-project".to_string())
-        );
-    }
-
-    #[test]
-    fn unterminated_frontmatter_falls_back_to_full_scan() {
-        // An opening `---` with no closing fence: preserve prior behavior and scan
-        // the whole text, so a `# H1` anywhere is still found.
-        let text = "---\nfoo: bar\n# only-heading\nbody\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("only-heading".to_string())
-        );
-    }
-
-    #[test]
-    fn branch1_claude_md_frontmatter_project() {
-        let start = Path::new("/home/alice/code/app/src");
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/app/CLAUDE.md"),
-                "---\nproject: cool-app\n---\n# Other\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/app")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        assert_eq!(ns, Namespace::Project("cool-app".to_string()));
-    }
-
-    #[test]
-    fn branch3_git_root_dirname_when_claude_md_useless() {
-        let start = Path::new("/home/alice/code/rusty-brain/crates/rb-agents");
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/rusty-brain/CLAUDE.md"),
-                "just some prose with no heading\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/rusty-brain")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        assert_eq!(ns, Namespace::Project("rusty-brain".to_string()));
-    }
-
-    #[test]
-    fn branch4_cwd_dirname_outside_repo() {
-        let start = Path::new("/home/alice/scratch/notes");
-        let ns = detect_namespace_with(start, no_claude, no_git);
-        assert_eq!(ns, Namespace::Project("notes".to_string()));
-    }
-
-    #[test]
-    fn branch5_global_for_root_dir() {
-        let start = Path::new("/");
-        let ns = detect_namespace_with(start, no_claude, no_git);
-        assert_eq!(ns, Namespace::Global);
-    }
-
-    #[test]
-    fn real_fs_finds_claude_md_three_levels_up_and_uses_frontmatter() {
+    fn walk_stops_at_git_toplevel_f54_regression() {
+        // (a) F54: an ancestor CLAUDE.md OUTSIDE the repo (the ~/CLAUDE.md
+        // scenario) must never name a CLAUDE.md-less repo below it.
         let tmp = TempDir::new().unwrap();
-        let root = tmp.path().to_path_buf();
-        let mut start = root.clone();
-        for i in 0..3 {
-            start = start.join(format!("d{i}"));
-        }
-        fs::create_dir_all(&start).unwrap();
+        // Canonicalize: git reports the physical toplevel (macOS /tmp symlink).
+        let outer = tmp.path().canonicalize().unwrap();
         fs::write(
-            root.join("CLAUDE.md"),
-            "---\nproject: walked-up\n---\n# Ignored\n",
+            outer.join("CLAUDE.md"),
+            "---\nproject: outer-claim\n---\n# Outer Heading\n",
         )
         .unwrap();
-        let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-        assert_eq!(ns, Namespace::Project("walked-up".to_string()));
-        drop(tmp);
+        let repo = outer.join("inner-repo");
+        let nested = repo.join("src").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        if !git_init(&repo) {
+            return; // git unavailable; skip
+        }
+        assert_eq!(
+            detect_namespace(&nested),
+            Namespace::Project("inner-repo".to_string())
+        );
     }
 
     #[test]
-    fn real_fs_no_claude_md_uses_cwd_dirname() {
+    fn hooks_never_honor_unpinned_frontmatter_f22() {
+        // (c) F22: the hook path uses the git-toplevel name even when the
+        // repo's own committed CLAUDE.md claims another project's namespace.
         let tmp = TempDir::new().unwrap();
-        let start = tmp.path().join("standalone");
-        fs::create_dir_all(&start).unwrap();
-        let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-        assert_eq!(ns, Namespace::Project("standalone".to_string()));
-        drop(tmp);
+        let repo = tmp.path().canonicalize().unwrap().join("cloned-repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("CLAUDE.md"), "---\nproject: victim\n---\n").unwrap();
+        if !git_init(&repo) {
+            return; // git unavailable; skip
+        }
+        assert_eq!(
+            detect_namespace(&repo),
+            Namespace::Project("cloned-repo".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_committed_toml_resolves_identically_across_clone_names() {
+        // (b)+(d): `.rusty-brain.toml` outranks the directory name, so the
+        // same repo under two clone names yields one namespace.
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().canonicalize().unwrap();
+        let mut seen = Vec::new();
+        for clone in ["clone-a", "renamed-checkout"] {
+            let repo = base.join(clone);
+            fs::create_dir_all(&repo).unwrap();
+            fs::write(repo.join(".rusty-brain.toml"), "namespace = \"one-id\"\n").unwrap();
+            if !git_init(&repo) {
+                return; // git unavailable; skip
+            }
+            seen.push(detect_namespace(&repo));
+        }
+        assert_eq!(seen[0], seen[1]);
+        assert_eq!(seen[0], Namespace::Project("one-id".to_string()));
+    }
+
+    #[test]
+    fn non_repo_dir_uses_its_own_name_and_ignores_claude_md() {
+        // Frontmatter is repo-scoped: outside a repo it is skipped entirely,
+        // and there is no H1 fallback anywhere.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().canonicalize().unwrap().join("standalone");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("CLAUDE.md"),
+            "---\nproject: nope\n---\n# Nor This\n",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_namespace(&dir),
+            Namespace::Project("standalone".to_string())
+        );
     }
 }

--- a/crates/rb-agents/tests/public_api.rs
+++ b/crates/rb-agents/tests/public_api.rs
@@ -56,8 +56,8 @@ fn daemon_and_autostart_types_are_reexported() {
     // DaemonClient::connect is the entrypoint Parts W reuse; lock its argument
     // shape at compile time by binding the call to an explicitly-typed future.
     // The future is never awaited (no daemon is running): constructing it is
-    // enough to verify the `(&Path, Namespace, Duration, Option<AutoStart>)`
-    // signature against the public re-export.
+    // enough to verify the `(&Path, Namespace, Duration, Option<AutoStart>,
+    // Option<ClientIdentity>)` signature against the public re-export.
     let socket = Path::new("/tmp/rb-agents-public-api.sock");
     let _connect: std::pin::Pin<Box<dyn std::future::Future<Output = Option<DaemonClient>>>> =
         Box::pin(DaemonClient::connect(
@@ -65,6 +65,7 @@ fn daemon_and_autostart_types_are_reexported() {
             rb_types::Namespace::Global,
             Duration::from_millis(1),
             Some(auto.clone()),
+            None,
         ));
 }
 

--- a/crates/rb-agents/tests/public_api.rs
+++ b/crates/rb-agents/tests/public_api.rs
@@ -59,13 +59,16 @@ fn daemon_and_autostart_types_are_reexported() {
     // enough to verify the `(&Path, Namespace, Duration, Option<AutoStart>,
     // Option<ClientIdentity>)` signature against the public re-export.
     let socket = Path::new("/tmp/rb-agents-public-api.sock");
+    // Explicitly typed so the test locks the identity PARAMETER type, not just
+    // the call's arity (a bare `None` would infer whatever connect takes).
+    let identity: Option<rb_proto::ClientIdentity> = None;
     let _connect: std::pin::Pin<Box<dyn std::future::Future<Output = Option<DaemonClient>>>> =
         Box::pin(DaemonClient::connect(
             socket,
             rb_types::Namespace::Global,
             Duration::from_millis(1),
             Some(auto.clone()),
-            None,
+            identity,
         ));
 }
 

--- a/crates/rb-config/Cargo.toml
+++ b/crates/rb-config/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/lib.rs"
 rb-types = { path = "../rb-types" }
 serde = { workspace = true }
 toml = { workspace = true }
+# gethostname(2) for the daemon-side provenance fallback (unix-only in practice).
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rb-config/Cargo.toml
+++ b/crates/rb-config/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rb-config"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "rusty-brain: single source of truth for default paths, config env-var names, and the auto-start env allowlist."
+
+[lib]
+name = "rb_config"
+path = "src/lib.rs"
+
+[dependencies]
+rb-types = { path = "../rb-types" }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-config/Cargo.toml
+++ b/crates/rb-config/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/lib.rs"
 
 [dependencies]
 rb-types = { path = "../rb-types" }
+serde = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -46,6 +46,11 @@ pub const FORWARD_ENV: &[&str] = &[
     "RB_ACCEPT_MODEL_CHANGE",
     // Request idle timeout override; safe to forward (defaulted when unset).
     "RUSTY_BRAIN_IDLE_TIMEOUT_SECS",
+    // Provenance fallback for clients that declare no identity (W0.5):
+    // `current_user()` reads USER/LOGNAME, so an env_clear'd auto-started
+    // daemon would otherwise stamp no origin user.
+    "USER",
+    "LOGNAME",
     // Path resolution inside the child.
     "HOME",
     "PATH",
@@ -161,16 +166,23 @@ pub fn default_db_path() -> Result<PathBuf> {
 /// non-empty wins; unset, empty, or whitespace-only falls back to the default.
 /// Hooks, CLI, and daemon all resolve through this single rule so a malformed
 /// override can never make them disagree (the F03/F12/F49 divergence class).
-fn env_override(name: &str) -> Option<String> {
-    std::env::var(name)
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+/// These are raw filesystem paths, so a non-UTF-8 value is honored as-is when
+/// non-empty (the trim rule only applies where "whitespace" is well-defined,
+/// i.e. valid UTF-8) — `std::env::var` would silently drop it.
+fn env_override(name: &str) -> Option<PathBuf> {
+    let raw = std::env::var_os(name)?;
+    match raw.to_str() {
+        Some(value) if value.trim().is_empty() => None,
+        // Non-UTF-8 (`to_str() == None`) is necessarily non-empty: the empty
+        // string is valid UTF-8, so it lands in the arm above.
+        _ => Some(PathBuf::from(raw)),
+    }
 }
 
 /// Resolve the socket path: `RUSTY_BRAIN_SOCKET` override, else the default.
 pub fn socket_path_from_env() -> Result<PathBuf> {
     match env_override(SOCKET_ENV) {
-        Some(p) => Ok(PathBuf::from(p)),
+        Some(p) => Ok(p),
         None => default_socket_path(),
     }
 }
@@ -178,7 +190,7 @@ pub fn socket_path_from_env() -> Result<PathBuf> {
 /// Resolve the database path: `RUSTY_BRAIN_DB` override, else the default.
 pub fn db_path_from_env() -> Result<PathBuf> {
     match env_override(DB_ENV) {
-        Some(p) => Ok(PathBuf::from(p)),
+        Some(p) => Ok(p),
         None => default_db_path(),
     }
 }
@@ -322,6 +334,18 @@ mod tests {
         assert_eq!(db_path_from_env().unwrap(), default_db_path().unwrap());
     }
 
+    // Overrides are raw filesystem paths: a non-UTF-8 value must be honored
+    // verbatim, not silently dropped (std::env::var would error on it).
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_env_override_is_honored_as_a_path() {
+        use std::os::unix::ffi::OsStrExt as _;
+        let _lock = ENV_LOCK.lock().unwrap();
+        let raw = std::ffi::OsStr::from_bytes(b"/tmp/rb-\xff-override.db");
+        let _g = EnvGuard::set(DB_ENV, std::path::Path::new(raw));
+        assert_eq!(db_path_from_env().unwrap(), PathBuf::from(raw));
+    }
+
     #[test]
     fn xdg_data_home_is_honored_for_db() {
         let _lock = ENV_LOCK.lock().unwrap();
@@ -349,6 +373,16 @@ mod tests {
     #[test]
     fn forward_env_includes_the_idle_timeout_override() {
         assert!(FORWARD_ENV.contains(&IDLE_TIMEOUT_ENV));
+    }
+
+    // W0.5 provenance fallback: the daemon stamps `current_user()` (USER then
+    // LOGNAME) on memories from identity-less clients; an env_clear'd
+    // auto-started daemon must keep seeing those vars or the fallback is lost.
+    #[test]
+    fn forward_env_includes_the_provenance_user_fallback_vars() {
+        for var in ["USER", "LOGNAME"] {
+            assert!(FORWARD_ENV.contains(&var), "FORWARD_ENV must include {var}");
+        }
     }
 
     #[test]

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -13,6 +13,10 @@ pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
 pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
 /// Env var that points at the evolution-jobs TOML config.
 pub const JOBS_CONFIG_ENV: &str = "RB_JOBS_CONFIG";
+/// Env var that opts in to an embedding-model swap (equivalent to the
+/// `--accept-model-change` serve flag; used by auto-start, where no flag can
+/// be passed). Truthy = non-empty and not `0`/`false`.
+pub const ACCEPT_MODEL_CHANGE_ENV: &str = "RB_ACCEPT_MODEL_CHANGE";
 
 /// The exact set of parent env vars an auto-start daemon child may inherit.
 /// Everything else is cleared before spawn (no parent-env leak into a

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -17,6 +17,10 @@ pub const JOBS_CONFIG_ENV: &str = "RB_JOBS_CONFIG";
 /// `--accept-model-change` serve flag; used by auto-start, where no flag can
 /// be passed). Truthy = non-empty and not `0`/`false`.
 pub const ACCEPT_MODEL_CHANGE_ENV: &str = "RB_ACCEPT_MODEL_CHANGE";
+/// Env var that overrides the daemon's per-connection request idle timeout in
+/// whole seconds (default 60). Parse failures fall back to the default; mainly
+/// for tests, which need the idle/reconnect path to run in seconds.
+pub const IDLE_TIMEOUT_ENV: &str = "RUSTY_BRAIN_IDLE_TIMEOUT_SECS";
 
 /// The exact set of parent env vars an auto-start daemon child may inherit.
 /// Everything else is cleared before spawn (no parent-env leak into a
@@ -35,6 +39,8 @@ pub const FORWARD_ENV: &[&str] = &[
     "RB_JOBS_CONFIG",
     // Explicit opt-in to an embedding-model swap (corpus re-embed).
     "RB_ACCEPT_MODEL_CHANGE",
+    // Request idle timeout override; safe to forward (defaulted when unset).
+    "RUSTY_BRAIN_IDLE_TIMEOUT_SECS",
     // Path resolution inside the child.
     "HOME",
     "PATH",
@@ -201,6 +207,13 @@ mod tests {
         for var in ["RB_EMBED_BACKEND", "RB_LOCAL_MODEL", "RB_JOBS_CONFIG"] {
             assert!(FORWARD_ENV.contains(&var), "FORWARD_ENV must include {var}");
         }
+    }
+
+    // W0.1: an auto-started daemon must honor the injected idle timeout, or the
+    // idle/reconnect e2e cannot shrink the 60s default down to test scale.
+    #[test]
+    fn forward_env_includes_the_idle_timeout_override() {
+        assert!(FORWARD_ENV.contains(&IDLE_TIMEOUT_ENV));
     }
 
     #[test]

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -157,6 +157,40 @@ pub fn default_db_path() -> Result<PathBuf> {
     Ok(data_base_dir()?.join("rusty-brain").join("memory.db"))
 }
 
+/// The current OS user, for provenance fallback (W0.5): `USER` then `LOGNAME`,
+/// `None` in a degenerate environment. The daemon stamps this onto memories
+/// written by clients that declared no identity (same-host UDS, so the
+/// daemon's view of the user is the client's user).
+pub fn current_user() -> Option<String> {
+    ["USER", "LOGNAME"]
+        .iter()
+        .find_map(|name| std::env::var(name).ok().filter(|value| !value.is_empty()))
+}
+
+/// The local hostname, for provenance fallback (W0.5). Unix: `gethostname(2)`;
+/// elsewhere (and on any failure) the `HOSTNAME` env var; else `None`.
+pub fn current_hostname() -> Option<String> {
+    #[cfg(unix)]
+    {
+        // _SC_HOST_NAME_MAX is at most 255 on supported platforms; a fixed
+        // 256-byte buffer (incl. NUL) is the conventional portable bound.
+        let mut buf = [0u8; 256];
+        // SAFETY: gethostname writes at most `len` bytes into the provided
+        // buffer and NUL-terminates when it fits; the buffer outlives the call.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::gethostname(buf.as_mut_ptr().cast::<libc::c_char>(), buf.len()) };
+        if rc == 0 {
+            let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+            if let Ok(name) = std::str::from_utf8(&buf[..end]) {
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+    }
+    std::env::var("HOSTNAME").ok().filter(|v| !v.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -185,6 +219,23 @@ mod tests {
                 None => std::env::remove_var(self.name),
             }
         }
+    }
+
+    #[test]
+    fn current_user_reads_user_env_first() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::set("USER", std::path::Path::new("provenance-test-user"));
+        assert_eq!(current_user().as_deref(), Some("provenance-test-user"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_hostname_resolves_on_unix() {
+        let name = current_hostname();
+        assert!(
+            name.as_deref().is_some_and(|n| !n.is_empty()),
+            "gethostname must resolve on unix, got {name:?}"
+        );
     }
 
     #[test]

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -3,12 +3,17 @@
 //! auto-start env allowlist. Every binary (daemon, CLI, hooks) resolves through
 //! this crate so they can never disagree on where the daemon lives.
 
+pub mod namespace;
+
 use std::path::PathBuf;
 
 use rb_types::{Error, Result};
 
 /// Env var that overrides the daemon socket path.
 pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
+/// Env var that overrides namespace detection entirely (same precedence as the
+/// `--namespace` CLI flag: explicit always wins).
+pub const NAMESPACE_ENV: &str = "RUSTY_BRAIN_NAMESPACE";
 /// Env var that overrides the database path.
 pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
 /// Env var that points at the evolution-jobs TOML config.
@@ -108,6 +113,33 @@ fn data_base_dir() -> Result<PathBuf> {
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         Ok(home_dir()?.join(".local").join("share"))
+    }
+}
+
+/// Local mutable state (namespace pins). `~/.local/state` on Linux per XDG;
+/// macOS has no state-dir convention, so it shares the data location.
+pub(crate) fn state_base_dir() -> Result<PathBuf> {
+    if let Some(path) = nonempty_env_path("XDG_STATE_HOME") {
+        return Ok(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(home_dir()?.join("Library").join("Application Support"))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(path) = nonempty_env_path("LOCALAPPDATA") {
+            Ok(path)
+        } else {
+            Ok(home_dir()?.join("AppData").join("Local"))
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Ok(home_dir()?.join(".local").join("state"))
     }
 }
 

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -157,6 +157,32 @@ pub fn default_db_path() -> Result<PathBuf> {
     Ok(data_base_dir()?.join("rusty-brain").join("memory.db"))
 }
 
+/// One env-override rule for every binary: a set var whose trimmed value is
+/// non-empty wins; unset, empty, or whitespace-only falls back to the default.
+/// Hooks, CLI, and daemon all resolve through this single rule so a malformed
+/// override can never make them disagree (the F03/F12/F49 divergence class).
+fn env_override(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+/// Resolve the socket path: `RUSTY_BRAIN_SOCKET` override, else the default.
+pub fn socket_path_from_env() -> Result<PathBuf> {
+    match env_override(SOCKET_ENV) {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => default_socket_path(),
+    }
+}
+
+/// Resolve the database path: `RUSTY_BRAIN_DB` override, else the default.
+pub fn db_path_from_env() -> Result<PathBuf> {
+    match env_override(DB_ENV) {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => default_db_path(),
+    }
+}
+
 /// The current OS user, for provenance fallback (W0.5): `USER` then `LOGNAME`,
 /// `None` in a degenerate environment. The daemon stamps this onto memories
 /// written by clients that declared no identity (same-host UDS, so the
@@ -268,6 +294,32 @@ mod tests {
             p.starts_with(dir.path()),
             "socket must live under XDG_RUNTIME_DIR when set: {p:?}"
         );
+    }
+
+    #[test]
+    fn env_overrides_win_when_set_to_a_real_path() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("override.sock");
+        let db = dir.path().join("override.db");
+        let _g1 = EnvGuard::set(SOCKET_ENV, &sock);
+        let _g2 = EnvGuard::set(DB_ENV, &db);
+        assert_eq!(socket_path_from_env().unwrap(), sock);
+        assert_eq!(db_path_from_env().unwrap(), db);
+    }
+
+    // W0.2: a whitespace-only override is not a path. Every binary must fall
+    // back to the default here, or hooks and CLI resolve different sockets.
+    #[test]
+    fn whitespace_only_env_overrides_fall_back_to_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g1 = EnvGuard::set(SOCKET_ENV, std::path::Path::new("  "));
+        let _g2 = EnvGuard::set(DB_ENV, std::path::Path::new("  "));
+        assert_eq!(
+            socket_path_from_env().unwrap(),
+            default_socket_path().unwrap()
+        );
+        assert_eq!(db_path_from_env().unwrap(), default_db_path().unwrap());
     }
 
     #[test]

--- a/crates/rb-config/src/lib.rs
+++ b/crates/rb-config/src/lib.rs
@@ -1,6 +1,43 @@
+//! `rb_config`: the single source of truth for cross-crate configuration
+//! contracts — default socket/db paths, config-bearing env-var names, and the
+//! auto-start env allowlist. Every binary (daemon, CLI, hooks) resolves through
+//! this crate so they can never disagree on where the daemon lives.
+
 use std::path::PathBuf;
 
 use rb_types::{Error, Result};
+
+/// Env var that overrides the daemon socket path.
+pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
+/// Env var that overrides the database path.
+pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
+/// Env var that points at the evolution-jobs TOML config.
+pub const JOBS_CONFIG_ENV: &str = "RB_JOBS_CONFIG";
+
+/// The exact set of parent env vars an auto-start daemon child may inherit.
+/// Everything else is cleared before spawn (no parent-env leak into a
+/// long-lived detached process). Keep this list minimal — adding a var widens
+/// the leak surface and must fail the allowlist tests in every spawner.
+pub const FORWARD_ENV: &[&str] = &[
+    // Embedding provider selection + credentials.
+    "VOYAGE_API_KEY",
+    "RB_EMBED_BACKEND",
+    "RB_LOCAL_MODEL",
+    // Opt-in LLM enrichment.
+    "RB_ENRICH_BASE_URL",
+    "RB_ENRICH_MODEL",
+    "RB_ENRICH_API_KEY",
+    // Evolution-jobs config file.
+    "RB_JOBS_CONFIG",
+    // Explicit opt-in to an embedding-model swap (corpus re-embed).
+    "RB_ACCEPT_MODEL_CHANGE",
+    // Path resolution inside the child.
+    "HOME",
+    "PATH",
+    "XDG_RUNTIME_DIR",
+    "XDG_DATA_HOME",
+    "XDG_CONFIG_HOME",
+];
 
 fn nonempty_env_path(name: &str) -> Option<PathBuf> {
     std::env::var_os(name)
@@ -138,5 +175,35 @@ mod tests {
             p.starts_with(dir.path()),
             "socket must live under XDG_RUNTIME_DIR when set: {p:?}"
         );
+    }
+
+    #[test]
+    fn xdg_data_home_is_honored_for_db() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set("XDG_DATA_HOME", dir.path());
+        let p = default_db_path().unwrap();
+        assert!(
+            p.starts_with(dir.path()),
+            "db must live under XDG_DATA_HOME when set: {p:?}"
+        );
+    }
+
+    // Regression for the F20 allowlist gap: an auto-started daemon must see the
+    // embedding-backend selection, the local-model choice, and the jobs config —
+    // otherwise it silently degrades to defaults the user never chose.
+    #[test]
+    fn forward_env_includes_the_previously_missing_config_vars() {
+        for var in ["RB_EMBED_BACKEND", "RB_LOCAL_MODEL", "RB_JOBS_CONFIG"] {
+            assert!(FORWARD_ENV.contains(&var), "FORWARD_ENV must include {var}");
+        }
+    }
+
+    #[test]
+    fn forward_env_never_forwards_socket_or_db_overrides() {
+        // Spawners pass the RESOLVED socket/db explicitly; forwarding the raw
+        // override vars too would let a stale parent value shadow them.
+        assert!(!FORWARD_ENV.contains(&SOCKET_ENV));
+        assert!(!FORWARD_ENV.contains(&DB_ENV));
     }
 }

--- a/crates/rb-config/src/namespace.rs
+++ b/crates/rb-config/src/namespace.rs
@@ -1,0 +1,566 @@
+//! Canonical namespace identity (W0.3): the single implementation shared by
+//! the CLI (`rusty-brain`) and the hook spine (`rb-agents`), so two binaries
+//! can never disagree on which namespace a directory maps to.
+//!
+//! Resolution order (first hit wins):
+//!   1. explicit override — `--namespace` flag or [`crate::NAMESPACE_ENV`];
+//!   2. repo-committed [`REPO_CONFIG_FILE`] (`namespace = "..."`) at the git
+//!      toplevel — identity survives cloning under any directory name;
+//!   3. `CLAUDE.md` frontmatter `project:` — nearest file walking from the
+//!      start dir up to and INCLUDING the git toplevel, never past it (F54),
+//!      honored only when it equals the toplevel name or is pinned (F22).
+//!      There is no first-H1 fallback, and outside a git repo this branch is
+//!      skipped entirely (frontmatter is a repo-scoped mechanism);
+//!   4. git-toplevel directory name;
+//!   5. start (cwd) directory name; else `Global`.
+//!
+//! A repo-committed `CLAUDE.md` must not silently claim another project's
+//! namespace: an unpinned differing `project:` is surfaced via
+//! [`NamespaceResolution::unpinned_override`] while the toplevel name is used.
+//! Interactive callers warn and may pin via [`accept_override`]
+//! (known-hosts style, recorded in [`default_pins_path`]); non-interactive
+//! consumers (hooks) log and never honor it.
+//!
+//! Never panics, never fails: every branch degrades to the next and ultimately
+//! to `Namespace::Global`. Resolution shells out to git and reads files — call
+//! it OFF any async runtime.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rb_types::{Error, Namespace, Result};
+use serde::{Deserialize, Serialize};
+
+/// Repo-committed identity file, read from the git toplevel only.
+pub const REPO_CONFIG_FILE: &str = ".rusty-brain.toml";
+
+/// Outcome of resolution: the namespace to use, plus any frontmatter override
+/// that was found but NOT honored (unpinned and differing from the toplevel
+/// name) so callers can warn in their own channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceResolution {
+    pub namespace: Namespace,
+    pub unpinned_override: Option<UnpinnedOverride>,
+}
+
+/// A `CLAUDE.md` frontmatter `project:` that differs from the git-toplevel
+/// name and is not pinned. `namespace` in the enclosing resolution is already
+/// the safe fallback (`used`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpinnedOverride {
+    /// The namespace the frontmatter claims.
+    pub claimed: String,
+    /// The git-toplevel directory name used instead.
+    pub used: String,
+    /// The git toplevel — the directory a pin would be recorded under.
+    pub toplevel: PathBuf,
+}
+
+fn resolved(namespace: Namespace) -> NamespaceResolution {
+    NamespaceResolution {
+        namespace,
+        unpinned_override: None,
+    }
+}
+
+/// Resolve the namespace for the real process: `flag` > env > detection from
+/// the real cwd with the on-disk pin store and real git. Synchronous: call
+/// this OFF any async runtime.
+pub fn resolve_namespace(flag: Option<&str>) -> NamespaceResolution {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let explicit = flag
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(explicit_namespace_from_env);
+    resolve_namespace_in(&cwd, explicit, &NamespacePins::load(), git_toplevel)
+}
+
+/// The explicit namespace from [`crate::NAMESPACE_ENV`], if set non-empty.
+pub fn explicit_namespace_from_env() -> Option<String> {
+    std::env::var(crate::NAMESPACE_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Pure-ish core, parameterized over the git-root resolver (callers supply
+/// their own process bounds) and an in-memory pin set, so every branch is
+/// testable against temp trees without the real state file.
+pub fn resolve_namespace_in<G>(
+    start: &Path,
+    explicit: Option<String>,
+    pins: &NamespacePins,
+    git_root: G,
+) -> NamespaceResolution
+where
+    G: Fn(&Path) -> Option<PathBuf>,
+{
+    // (1) explicit always wins: no detection, nothing to warn about.
+    if let Some(name) = explicit
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        return resolved(Namespace::Project(name));
+    }
+    if let Some(top) = git_root(start).as_deref() {
+        // (2) repo-committed identity: same namespace under any clone name.
+        if let Some(name) = repo_committed_namespace(top) {
+            return resolved(Namespace::Project(name));
+        }
+        // (3) CLAUDE.md frontmatter, bounded at the toplevel, pin-gated.
+        let top_name = dir_name(top);
+        match (frontmatter_project_within(start, top), top_name) {
+            (Some(claimed), Some(used)) if claimed == used => {
+                // Not an override: frontmatter agrees with the toplevel name.
+                return resolved(Namespace::Project(claimed));
+            }
+            (Some(claimed), Some(used)) => {
+                if pins.pinned(top) == Some(claimed.as_str()) {
+                    return resolved(Namespace::Project(claimed));
+                }
+                // Unpinned differing override: fail safe to the toplevel name
+                // (F22) and report it so the caller can warn/pin.
+                return NamespaceResolution {
+                    namespace: Namespace::Project(used.clone()),
+                    unpinned_override: Some(UnpinnedOverride {
+                        claimed,
+                        used,
+                        toplevel: top.to_path_buf(),
+                    }),
+                };
+            }
+            // (4) toplevel directory name.
+            (None, Some(used)) => return resolved(Namespace::Project(used)),
+            // Toplevel has no usable utf8 name (e.g. `/`): fall through.
+            (_, None) => {}
+        }
+    }
+    // (5) start (cwd) directory name; else Global.
+    match dir_name(start) {
+        Some(name) => resolved(Namespace::Project(name)),
+        None => resolved(Namespace::Global),
+    }
+}
+
+/// Extract a non-empty, utf8 final path component. `None` for `/`, empty, or
+/// non-utf8 names — which makes the caller fall through to the next branch.
+fn dir_name(p: &Path) -> Option<String> {
+    p.file_name()
+        .and_then(|n| n.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[derive(Deserialize)]
+struct RepoConfig {
+    namespace: Option<String>,
+}
+
+/// Read `namespace = "..."` from [`REPO_CONFIG_FILE`] at the git toplevel.
+/// Missing file, parse failure, and empty values all degrade to `None`.
+fn repo_committed_namespace(toplevel: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(toplevel.join(REPO_CONFIG_FILE)).ok()?;
+    let cfg: RepoConfig = toml::from_str(&text).ok()?;
+    cfg.namespace
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Nearest `CLAUDE.md` frontmatter `project:` walking `start` up to and
+/// INCLUDING `toplevel`, never past it — an ancestor `CLAUDE.md` outside the
+/// repo must not name it (F54). The nearest `CLAUDE.md` is the governing file:
+/// if it has no usable `project:`, the search ends (no fallback to a higher
+/// file, matching the original nearest-wins behavior).
+fn frontmatter_project_within(start: &Path, toplevel: &Path) -> Option<String> {
+    if !start.starts_with(toplevel) {
+        // Defensive (symlinked cwd vs. git's physical toplevel): the bound
+        // cannot be applied to the walk, so consider only the toplevel itself.
+        let text = std::fs::read_to_string(toplevel.join("CLAUDE.md")).ok()?;
+        return project_from_frontmatter(&text);
+    }
+    for dir in start.ancestors() {
+        if let Ok(text) = std::fs::read_to_string(dir.join("CLAUDE.md")) {
+            return project_from_frontmatter(&text);
+        }
+        if dir == toplevel {
+            break; // bound: never walk past the git toplevel
+        }
+    }
+    None
+}
+
+/// Read `project: NAME` from a leading `---`-delimited frontmatter block.
+/// Lenient hand parser — never panics; `None` when absent or empty. There is
+/// deliberately NO first-H1 fallback (removed in W0.3: prose headings are not
+/// identity).
+pub fn project_from_frontmatter(text: &str) -> Option<String> {
+    let mut lines = text.lines();
+    // Frontmatter must start at the very first line as `---`.
+    if lines.next().map(str::trim) != Some("---") {
+        return None;
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break; // end of frontmatter
+        }
+        if let Some(rest) = trimmed.strip_prefix("project:") {
+            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'').trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+            // Empty value: no override.
+            return None;
+        }
+    }
+    None
+}
+
+/// Find the git toplevel for `dir` by invoking git; `None` if not a repo.
+/// Callers needing a process bound (hooks) supply their own resolver to
+/// [`resolve_namespace_in`].
+pub fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Local pin store: `dir -> namespace` records for accepted `CLAUDE.md`
+/// frontmatter overrides (known-hosts style). Tiny by design: whole-file
+/// read/write of one TOML table.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NamespacePins {
+    #[serde(default)]
+    pins: BTreeMap<String, String>,
+}
+
+impl NamespacePins {
+    /// Load from [`default_pins_path`]; any failure degrades to empty, which
+    /// treats every override as unpinned — the safe direction.
+    pub fn load() -> Self {
+        default_pins_path()
+            .map(|p| Self::load_from(&p))
+            .unwrap_or_default()
+    }
+
+    /// Load from `path`; missing or unparsable degrades to empty.
+    pub fn load_from(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| toml::from_str(&text).ok())
+            .unwrap_or_default()
+    }
+
+    /// The pinned namespace for `dir`, if any.
+    pub fn pinned(&self, dir: &Path) -> Option<&str> {
+        self.pins.get(&pin_key(dir)).map(String::as_str)
+    }
+
+    /// Record (or replace) the pin for `dir`.
+    pub fn insert(&mut self, dir: &Path, namespace: &str) {
+        self.pins.insert(pin_key(dir), namespace.to_string());
+    }
+
+    /// Persist to `path`, creating parent directories.
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| Error::Io(format!("create {}: {e}", parent.display())))?;
+        }
+        let text = toml::to_string_pretty(self).map_err(|e| Error::Serialization(e.to_string()))?;
+        std::fs::write(path, text).map_err(|e| Error::Io(format!("write {}: {e}", path.display())))
+    }
+
+    /// Persist to [`default_pins_path`].
+    pub fn save(&self) -> Result<()> {
+        self.save_to(&default_pins_path()?)
+    }
+}
+
+/// Pin keys are the lossy-utf8 toplevel path; a non-utf8 path simply never
+/// matches its pin and stays in the safe unpinned state.
+fn pin_key(dir: &Path) -> String {
+    dir.to_string_lossy().into_owned()
+}
+
+/// Where pins live: `<state dir>/rusty-brain/namespace-pins.toml`
+/// (`~/.local/state` on Linux; `XDG_STATE_HOME` always wins).
+pub fn default_pins_path() -> Result<PathBuf> {
+    Ok(crate::state_base_dir()?
+        .join("rusty-brain")
+        .join("namespace-pins.toml"))
+}
+
+/// Pin `o` (records `toplevel -> claimed` in the on-disk store) and return the
+/// now-honored namespace. Explicit user consent only — call on
+/// `--accept-namespace-override`.
+pub fn accept_override(o: &UnpinnedOverride) -> Result<Namespace> {
+    let mut pins = NamespacePins::load();
+    pins.insert(&o.toplevel, &o.claimed);
+    pins.save()?;
+    Ok(Namespace::Project(o.claimed.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    fn no_pins() -> NamespacePins {
+        NamespacePins::default()
+    }
+
+    fn no_git(_: &Path) -> Option<PathBuf> {
+        None
+    }
+
+    // --- project_from_frontmatter (pure text parsing) ---
+
+    #[test]
+    fn frontmatter_project_is_parsed_and_trimmed() {
+        let text = "---\nproject:   \"my proj\"  \nother: x\n---\n# Heading\n";
+        assert_eq!(project_from_frontmatter(text), Some("my proj".to_string()));
+    }
+
+    #[test]
+    fn first_h1_is_never_a_namespace() {
+        // W0.3: the H1 fallback is removed — a heading-only CLAUDE.md yields
+        // no override at all.
+        assert_eq!(project_from_frontmatter("# Just A Heading\nbody\n"), None);
+    }
+
+    #[test]
+    fn empty_project_value_and_malformed_frontmatter_are_none() {
+        assert_eq!(project_from_frontmatter("---\nproject:   \n---\n"), None);
+        assert_eq!(project_from_frontmatter("---\nproject\nnonsense\n"), None);
+        assert_eq!(project_from_frontmatter(""), None);
+    }
+
+    // --- resolution order ---
+
+    #[test]
+    fn explicit_beats_everything() {
+        // (e): even with a repo config AND a pinned frontmatter override
+        // available, an explicit namespace short-circuits detection.
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("repo");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(
+            top.join(REPO_CONFIG_FILE),
+            "namespace = \"from-repo-config\"\n",
+        )
+        .unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, Some("explicit".to_string()), &no_pins(), git);
+        assert_eq!(res.namespace, Namespace::Project("explicit".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn env_explicit_beats_detection_via_real_entrypoint() {
+        // (e): the env half of "explicit always wins", through the real
+        // `resolve_namespace` wrapper. Guard the process-global env.
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var(crate::NAMESPACE_ENV, "env-wins");
+        let res = resolve_namespace(None);
+        assert_eq!(res.namespace, Namespace::Project("env-wins".to_string()));
+        // The flag outranks the env var.
+        let res = resolve_namespace(Some("flag-wins"));
+        assert_eq!(res.namespace, Namespace::Project("flag-wins".to_string()));
+        std::env::remove_var(crate::NAMESPACE_ENV);
+    }
+
+    #[test]
+    fn repo_config_beats_directory_name_and_frontmatter() {
+        // (b): `.rusty-brain.toml` outranks both the toplevel dir name and a
+        // CLAUDE.md frontmatter project (even one that would need a pin).
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("some-clone-name");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"canonical\"\n").unwrap();
+        fs::write(top.join("CLAUDE.md"), "---\nproject: pretender\n---\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        assert_eq!(res.namespace, Namespace::Project("canonical".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn same_repo_under_two_clone_names_resolves_identically() {
+        // (d): identity travels with the committed file, not the directory.
+        let tmp = TempDir::new().unwrap();
+        let mut seen = Vec::new();
+        for clone in ["clone-a", "work-checkout-b"] {
+            let top = tmp.path().join(clone);
+            fs::create_dir_all(&top).unwrap();
+            fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"one-project\"\n").unwrap();
+            let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+            seen.push(resolve_namespace_in(&top, None, &no_pins(), git).namespace);
+        }
+        assert_eq!(seen[0], seen[1]);
+        assert_eq!(seen[0], Namespace::Project("one-project".to_string()));
+    }
+
+    #[test]
+    fn malformed_repo_config_degrades_to_next_branch() {
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("repo");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join(REPO_CONFIG_FILE), "namespace = [not toml\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        assert_eq!(res.namespace, Namespace::Project("repo".to_string()));
+    }
+
+    #[test]
+    fn walk_stops_at_git_toplevel_outer_claude_md_is_ignored() {
+        // (a) F54 regression: outer CLAUDE.md above the repo (e.g. ~/CLAUDE.md)
+        // must never name a repo that lacks its own. Both frontmatter and H1
+        // variants stay outside the bound.
+        let tmp = TempDir::new().unwrap();
+        let outer = tmp.path();
+        fs::write(
+            outer.join("CLAUDE.md"),
+            "---\nproject: outer-claim\n---\n# Outer Heading\n",
+        )
+        .unwrap();
+        let top = outer.join("inner-repo");
+        let nested = top.join("src").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&nested, None, &no_pins(), git);
+        assert_eq!(res.namespace, Namespace::Project("inner-repo".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn unpinned_frontmatter_override_is_not_honored() {
+        // (c) F22: a repo-committed CLAUDE.md claiming another project's
+        // namespace falls back to the toplevel name and is reported.
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("malicious-repo");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join("CLAUDE.md"), "---\nproject: victim\n---\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        assert_eq!(
+            res.namespace,
+            Namespace::Project("malicious-repo".to_string())
+        );
+        let o = res.unpinned_override.expect("override must be surfaced");
+        assert_eq!(o.claimed, "victim");
+        assert_eq!(o.used, "malicious-repo");
+        assert_eq!(o.toplevel, top);
+    }
+
+    #[test]
+    fn pinned_frontmatter_override_is_honored() {
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("dir-name");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join("CLAUDE.md"), "---\nproject: real-name\n---\n").unwrap();
+        let mut pins = NamespacePins::default();
+        pins.insert(&top, "real-name");
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &pins, git);
+        assert_eq!(res.namespace, Namespace::Project("real-name".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn pin_for_a_different_value_does_not_cover_a_new_claim() {
+        // A stale pin must not bless a CHANGED frontmatter value.
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("dir-name");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join("CLAUDE.md"), "---\nproject: new-claim\n---\n").unwrap();
+        let mut pins = NamespacePins::default();
+        pins.insert(&top, "old-accepted");
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &pins, git);
+        assert_eq!(res.namespace, Namespace::Project("dir-name".to_string()));
+        assert_eq!(
+            res.unpinned_override.map(|o| o.claimed),
+            Some("new-claim".to_string())
+        );
+    }
+
+    #[test]
+    fn frontmatter_matching_toplevel_name_needs_no_pin() {
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("same-name");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join("CLAUDE.md"), "---\nproject: same-name\n---\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        assert_eq!(res.namespace, Namespace::Project("same-name".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn outside_a_repo_claude_md_is_ignored_and_cwd_name_wins() {
+        // Frontmatter is a repo-scoped mechanism: without a git toplevel there
+        // is no bound, so the branch is skipped entirely.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("plain-dir");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("CLAUDE.md"), "---\nproject: ignored\n---\n").unwrap();
+        let res = resolve_namespace_in(&dir, None, &no_pins(), no_git);
+        assert_eq!(res.namespace, Namespace::Project("plain-dir".to_string()));
+        assert_eq!(res.unpinned_override, None);
+    }
+
+    #[test]
+    fn root_dir_without_repo_degrades_to_global() {
+        let res = resolve_namespace_in(Path::new("/"), None, &no_pins(), no_git);
+        assert_eq!(res.namespace, Namespace::Global);
+    }
+
+    // --- pin store ---
+
+    #[test]
+    fn pins_round_trip_through_the_toml_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state").join("namespace-pins.toml");
+        let mut pins = NamespacePins::default();
+        pins.insert(Path::new("/home/u/code/dir-name"), "real-name");
+        pins.insert(Path::new("/home/u/other"), "second");
+        pins.save_to(&path).unwrap();
+        let loaded = NamespacePins::load_from(&path);
+        assert_eq!(loaded, pins);
+        assert_eq!(
+            loaded.pinned(Path::new("/home/u/code/dir-name")),
+            Some("real-name")
+        );
+        assert_eq!(loaded.pinned(Path::new("/home/u/unknown")), None);
+    }
+
+    #[test]
+    fn missing_or_garbage_pin_file_loads_empty() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("nope.toml");
+        assert_eq!(NamespacePins::load_from(&missing), NamespacePins::default());
+        let garbage = tmp.path().join("bad.toml");
+        fs::write(&garbage, "{{{{ not toml").unwrap();
+        assert_eq!(NamespacePins::load_from(&garbage), NamespacePins::default());
+    }
+}

--- a/crates/rb-config/src/namespace.rs
+++ b/crates/rb-config/src/namespace.rs
@@ -4,8 +4,12 @@
 //!
 //! Resolution order (first hit wins):
 //!   1. explicit override — `--namespace` flag or [`crate::NAMESPACE_ENV`];
-//!   2. repo-committed [`REPO_CONFIG_FILE`] (`namespace = "..."`) at the git
-//!      toplevel — identity survives cloning under any directory name;
+//!   2. repo-committed [`REPO_CONFIG_FILE`] (`namespace = "..."`), read from
+//!      the blob committed at `HEAD` (`git show HEAD:.rusty-brain.toml`), so
+//!      identity survives cloning under any directory name. ONLY the committed
+//!      content counts: an untracked or locally-modified worktree file can
+//!      never redirect the namespace — divergence is surfaced via
+//!      [`NamespaceResolution::repo_config_divergence`] so callers can warn;
 //!   3. `CLAUDE.md` frontmatter `project:` — nearest file walking from the
 //!      start dir up to and INCLUDING the git toplevel, never past it (F54),
 //!      honored only when it equals the toplevel name or is pinned (F22).
@@ -35,13 +39,15 @@ use serde::{Deserialize, Serialize};
 /// Repo-committed identity file, read from the git toplevel only.
 pub const REPO_CONFIG_FILE: &str = ".rusty-brain.toml";
 
-/// Outcome of resolution: the namespace to use, plus any frontmatter override
-/// that was found but NOT honored (unpinned and differing from the toplevel
-/// name) so callers can warn in their own channel.
+/// Outcome of resolution: the namespace to use, plus anything found but NOT
+/// honored — a frontmatter override (unpinned and differing from the toplevel
+/// name) or a diverging worktree [`REPO_CONFIG_FILE`] — so callers can warn
+/// in their own channel.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamespaceResolution {
     pub namespace: Namespace,
     pub unpinned_override: Option<UnpinnedOverride>,
+    pub repo_config_divergence: Option<RepoConfigDivergence>,
 }
 
 /// A `CLAUDE.md` frontmatter `project:` that differs from the git-toplevel
@@ -57,10 +63,40 @@ pub struct UnpinnedOverride {
     pub toplevel: PathBuf,
 }
 
+/// A worktree [`REPO_CONFIG_FILE`] that diverges from the blob committed at
+/// `HEAD`. Only the committed content is ever honored; this is surfaced so
+/// callers can warn in their own channel (CLI stderr / hook tracing), like
+/// [`NamespaceResolution::unpinned_override`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoConfigDivergence {
+    /// The git toplevel whose worktree file diverges.
+    pub toplevel: PathBuf,
+    /// How the worktree file diverges from `HEAD`.
+    pub kind: RepoConfigDivergenceKind,
+}
+
+/// How a worktree [`REPO_CONFIG_FILE`] diverges from `HEAD`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoConfigDivergenceKind {
+    /// No committed counterpart at `HEAD` (untracked file, or `HEAD` is
+    /// unborn): the worktree file is ignored entirely.
+    Untracked,
+    /// Tracked, but the worktree content differs: the committed content wins.
+    Modified,
+}
+
 fn resolved(namespace: Namespace) -> NamespaceResolution {
+    resolved_with(namespace, None)
+}
+
+fn resolved_with(
+    namespace: Namespace,
+    repo_config_divergence: Option<RepoConfigDivergence>,
+) -> NamespaceResolution {
     NamespaceResolution {
         namespace,
         unpinned_override: None,
+        repo_config_divergence,
     }
 }
 
@@ -73,7 +109,13 @@ pub fn resolve_namespace(flag: Option<&str>) -> NamespaceResolution {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .or_else(explicit_namespace_from_env);
-    resolve_namespace_in(&cwd, explicit, &NamespacePins::load(), git_toplevel)
+    resolve_namespace_in(
+        &cwd,
+        explicit,
+        &NamespacePins::load(),
+        git_toplevel,
+        head_repo_config,
+    )
 }
 
 /// The explicit namespace from [`crate::NAMESPACE_ENV`], if set non-empty.
@@ -84,17 +126,20 @@ pub fn explicit_namespace_from_env() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Pure-ish core, parameterized over the git-root resolver (callers supply
-/// their own process bounds) and an in-memory pin set, so every branch is
-/// testable against temp trees without the real state file.
-pub fn resolve_namespace_in<G>(
+/// Pure-ish core, parameterized over the git-root resolver and the committed
+/// [`REPO_CONFIG_FILE`]-at-`HEAD` reader (callers supply their own process
+/// bounds) and an in-memory pin set, so every branch is testable against temp
+/// trees without the real state file.
+pub fn resolve_namespace_in<G, B>(
     start: &Path,
     explicit: Option<String>,
     pins: &NamespacePins,
     git_root: G,
+    head_config: B,
 ) -> NamespaceResolution
 where
     G: Fn(&Path) -> Option<PathBuf>,
+    B: Fn(&Path) -> Option<String>,
 {
     // (1) explicit always wins: no detection, nothing to warn about.
     if let Some(name) = explicit
@@ -103,21 +148,28 @@ where
     {
         return resolved(Namespace::Project(name));
     }
+    // Set when the worktree REPO_CONFIG_FILE diverges from HEAD; carried on
+    // whichever resolution wins so callers can warn in their own channel.
+    let mut divergence = None;
     if let Some(top) = git_root(start).as_deref() {
         // (2) repo-committed identity: same namespace under any clone name.
-        if let Some(name) = repo_committed_namespace(top) {
-            return resolved(Namespace::Project(name));
+        // ONLY the blob at HEAD counts — an untracked or locally-modified
+        // worktree file must never redirect the namespace.
+        let committed = head_config(top);
+        divergence = repo_config_divergence(top, committed.as_deref());
+        if let Some(name) = committed.as_deref().and_then(repo_config_namespace) {
+            return resolved_with(Namespace::Project(name), divergence);
         }
         // (3) CLAUDE.md frontmatter, bounded at the toplevel, pin-gated.
         let top_name = dir_name(top);
         match (frontmatter_project_within(start, top), top_name) {
             (Some(claimed), Some(used)) if claimed == used => {
                 // Not an override: frontmatter agrees with the toplevel name.
-                return resolved(Namespace::Project(claimed));
+                return resolved_with(Namespace::Project(claimed), divergence);
             }
             (Some(claimed), Some(used)) => {
                 if pins.pinned(top) == Some(claimed.as_str()) {
-                    return resolved(Namespace::Project(claimed));
+                    return resolved_with(Namespace::Project(claimed), divergence);
                 }
                 // Unpinned differing override: fail safe to the toplevel name
                 // (F22) and report it so the caller can warn/pin.
@@ -128,18 +180,19 @@ where
                         used,
                         toplevel: top.to_path_buf(),
                     }),
+                    repo_config_divergence: divergence,
                 };
             }
             // (4) toplevel directory name.
-            (None, Some(used)) => return resolved(Namespace::Project(used)),
+            (None, Some(used)) => return resolved_with(Namespace::Project(used), divergence),
             // Toplevel has no usable utf8 name (e.g. `/`): fall through.
             (_, None) => {}
         }
     }
     // (5) start (cwd) directory name; else Global.
     match dir_name(start) {
-        Some(name) => resolved(Namespace::Project(name)),
-        None => resolved(Namespace::Global),
+        Some(name) => resolved_with(Namespace::Project(name), divergence),
+        None => resolved_with(Namespace::Global, divergence),
     }
 }
 
@@ -158,14 +211,53 @@ struct RepoConfig {
     namespace: Option<String>,
 }
 
-/// Read `namespace = "..."` from [`REPO_CONFIG_FILE`] at the git toplevel.
-/// Missing file, parse failure, and empty values all degrade to `None`.
-fn repo_committed_namespace(toplevel: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(toplevel.join(REPO_CONFIG_FILE)).ok()?;
-    let cfg: RepoConfig = toml::from_str(&text).ok()?;
+/// The committed content of [`REPO_CONFIG_FILE`] at `HEAD`, read via
+/// `git -C <toplevel> show HEAD:.rusty-brain.toml` so a worktree-only file can
+/// never redirect the namespace. File not committed at `HEAD`, an unborn
+/// `HEAD` (fresh repo with no commits), and a missing git all degrade to
+/// `None` — "no committed identity". Callers needing a process bound (hooks)
+/// supply their own reader to [`resolve_namespace_in`].
+pub fn head_repo_config(toplevel: &Path) -> Option<String> {
+    let spec = format!("HEAD:{REPO_CONFIG_FILE}");
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(toplevel)
+        .args(["show", &spec])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+/// Parse `namespace = "..."` from committed [`REPO_CONFIG_FILE`] content.
+/// Parse failure and empty values degrade to `None`.
+fn repo_config_namespace(text: &str) -> Option<String> {
+    let cfg: RepoConfig = toml::from_str(text).ok()?;
     cfg.namespace
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+/// Compare the worktree [`REPO_CONFIG_FILE`] (if present) against the
+/// committed blob so callers can warn that only the committed content takes
+/// effect. An absent or unreadable worktree file reports nothing — a locally
+/// DELETED tracked file still resolves from `HEAD`, silently.
+fn repo_config_divergence(
+    toplevel: &Path,
+    committed: Option<&str>,
+) -> Option<RepoConfigDivergence> {
+    let worktree = std::fs::read_to_string(toplevel.join(REPO_CONFIG_FILE)).ok()?;
+    let kind = match committed {
+        None => RepoConfigDivergenceKind::Untracked,
+        Some(blob) if blob != worktree => RepoConfigDivergenceKind::Modified,
+        Some(_) => return None,
+    };
+    Some(RepoConfigDivergence {
+        toplevel: toplevel.to_path_buf(),
+        kind,
+    })
 }
 
 /// Nearest `CLAUDE.md` frontmatter `project:` walking `start` up to and
@@ -321,6 +413,7 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
     use std::fs;
+    use std::process::Stdio;
     use std::sync::Mutex;
     use tempfile::TempDir;
 
@@ -330,6 +423,16 @@ mod tests {
 
     fn no_git(_: &Path) -> Option<PathBuf> {
         None
+    }
+
+    /// No committed [`REPO_CONFIG_FILE`] at HEAD (untracked, unborn HEAD, …).
+    fn no_head_config(_: &Path) -> Option<String> {
+        None
+    }
+
+    /// A committed [`REPO_CONFIG_FILE`] blob with the given content.
+    fn committed(text: &str) -> impl Fn(&Path) -> Option<String> + '_ {
+        move |_| Some(text.to_string())
     }
 
     // --- project_from_frontmatter (pure text parsing) ---
@@ -358,18 +461,19 @@ mod tests {
 
     #[test]
     fn explicit_beats_everything() {
-        // (e): even with a repo config AND a pinned frontmatter override
-        // available, an explicit namespace short-circuits detection.
+        // (e): even with a committed repo config AND a pinned frontmatter
+        // override available, an explicit namespace short-circuits detection.
         let tmp = TempDir::new().unwrap();
         let top = tmp.path().join("repo");
         fs::create_dir_all(&top).unwrap();
-        fs::write(
-            top.join(REPO_CONFIG_FILE),
-            "namespace = \"from-repo-config\"\n",
-        )
-        .unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, Some("explicit".to_string()), &no_pins(), git);
+        let res = resolve_namespace_in(
+            &top,
+            Some("explicit".to_string()),
+            &no_pins(),
+            git,
+            committed("namespace = \"from-repo-config\"\n"),
+        );
         assert_eq!(res.namespace, Namespace::Project("explicit".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
@@ -391,30 +495,43 @@ mod tests {
 
     #[test]
     fn repo_config_beats_directory_name_and_frontmatter() {
-        // (b): `.rusty-brain.toml` outranks both the toplevel dir name and a
-        // CLAUDE.md frontmatter project (even one that would need a pin).
+        // (b): a committed `.rusty-brain.toml` outranks both the toplevel dir
+        // name and a CLAUDE.md frontmatter project (even one needing a pin).
         let tmp = TempDir::new().unwrap();
         let top = tmp.path().join("some-clone-name");
         fs::create_dir_all(&top).unwrap();
-        fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"canonical\"\n").unwrap();
         fs::write(top.join("CLAUDE.md"), "---\nproject: pretender\n---\n").unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        let res = resolve_namespace_in(
+            &top,
+            None,
+            &no_pins(),
+            git,
+            committed("namespace = \"canonical\"\n"),
+        );
         assert_eq!(res.namespace, Namespace::Project("canonical".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
 
     #[test]
     fn same_repo_under_two_clone_names_resolves_identically() {
-        // (d): identity travels with the committed file, not the directory.
+        // (d): identity travels with the committed blob, not the directory.
         let tmp = TempDir::new().unwrap();
         let mut seen = Vec::new();
         for clone in ["clone-a", "work-checkout-b"] {
             let top = tmp.path().join(clone);
             fs::create_dir_all(&top).unwrap();
-            fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"one-project\"\n").unwrap();
             let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-            seen.push(resolve_namespace_in(&top, None, &no_pins(), git).namespace);
+            seen.push(
+                resolve_namespace_in(
+                    &top,
+                    None,
+                    &no_pins(),
+                    git,
+                    committed("namespace = \"one-project\"\n"),
+                )
+                .namespace,
+            );
         }
         assert_eq!(seen[0], seen[1]);
         assert_eq!(seen[0], Namespace::Project("one-project".to_string()));
@@ -425,10 +542,67 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let top = tmp.path().join("repo");
         fs::create_dir_all(&top).unwrap();
-        fs::write(top.join(REPO_CONFIG_FILE), "namespace = [not toml\n").unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        let res = resolve_namespace_in(
+            &top,
+            None,
+            &no_pins(),
+            git,
+            committed("namespace = [not toml\n"),
+        );
         assert_eq!(res.namespace, Namespace::Project("repo".to_string()));
+    }
+
+    #[test]
+    fn untracked_worktree_toml_is_ignored_and_reported() {
+        // INVERSE regression for the namespace-hijack fix: a worktree
+        // `.rusty-brain.toml` with no committed counterpart at HEAD must NOT
+        // redirect the namespace — resolution falls through to the git-root
+        // name, and the divergence is surfaced so callers can warn.
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("host-repo");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git, no_head_config);
+        assert_eq!(res.namespace, Namespace::Project("host-repo".to_string()));
+        let d = res.repo_config_divergence.expect("divergence is surfaced");
+        assert_eq!(d.kind, RepoConfigDivergenceKind::Untracked);
+        assert_eq!(d.toplevel, top);
+    }
+
+    #[test]
+    fn locally_modified_toml_head_blob_wins() {
+        // (c): tracked but locally modified — the committed content is used
+        // and the modification is surfaced.
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("repo");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(top.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(
+            &top,
+            None,
+            &no_pins(),
+            git,
+            committed("namespace = \"canonical\"\n"),
+        );
+        assert_eq!(res.namespace, Namespace::Project("canonical".to_string()));
+        let d = res.repo_config_divergence.expect("divergence is surfaced");
+        assert_eq!(d.kind, RepoConfigDivergenceKind::Modified);
+    }
+
+    #[test]
+    fn worktree_matching_committed_toml_reports_no_divergence() {
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path().join("repo");
+        fs::create_dir_all(&top).unwrap();
+        let text = "namespace = \"canonical\"\n";
+        fs::write(top.join(REPO_CONFIG_FILE), text).unwrap();
+        let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
+        let res = resolve_namespace_in(&top, None, &no_pins(), git, committed(text));
+        assert_eq!(res.namespace, Namespace::Project("canonical".to_string()));
+        assert_eq!(res.repo_config_divergence, None);
     }
 
     #[test]
@@ -447,7 +621,7 @@ mod tests {
         let nested = top.join("src").join("deep");
         fs::create_dir_all(&nested).unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&nested, None, &no_pins(), git);
+        let res = resolve_namespace_in(&nested, None, &no_pins(), git, no_head_config);
         assert_eq!(res.namespace, Namespace::Project("inner-repo".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
@@ -461,7 +635,7 @@ mod tests {
         fs::create_dir_all(&top).unwrap();
         fs::write(top.join("CLAUDE.md"), "---\nproject: victim\n---\n").unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        let res = resolve_namespace_in(&top, None, &no_pins(), git, no_head_config);
         assert_eq!(
             res.namespace,
             Namespace::Project("malicious-repo".to_string())
@@ -481,7 +655,7 @@ mod tests {
         let mut pins = NamespacePins::default();
         pins.insert(&top, "real-name");
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &pins, git);
+        let res = resolve_namespace_in(&top, None, &pins, git, no_head_config);
         assert_eq!(res.namespace, Namespace::Project("real-name".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
@@ -496,7 +670,7 @@ mod tests {
         let mut pins = NamespacePins::default();
         pins.insert(&top, "old-accepted");
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &pins, git);
+        let res = resolve_namespace_in(&top, None, &pins, git, no_head_config);
         assert_eq!(res.namespace, Namespace::Project("dir-name".to_string()));
         assert_eq!(
             res.unpinned_override.map(|o| o.claimed),
@@ -511,7 +685,7 @@ mod tests {
         fs::create_dir_all(&top).unwrap();
         fs::write(top.join("CLAUDE.md"), "---\nproject: same-name\n---\n").unwrap();
         let git = |_: &Path| -> Option<PathBuf> { Some(top.clone()) };
-        let res = resolve_namespace_in(&top, None, &no_pins(), git);
+        let res = resolve_namespace_in(&top, None, &no_pins(), git, no_head_config);
         assert_eq!(res.namespace, Namespace::Project("same-name".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
@@ -524,15 +698,113 @@ mod tests {
         let dir = tmp.path().join("plain-dir");
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("CLAUDE.md"), "---\nproject: ignored\n---\n").unwrap();
-        let res = resolve_namespace_in(&dir, None, &no_pins(), no_git);
+        let res = resolve_namespace_in(&dir, None, &no_pins(), no_git, no_head_config);
         assert_eq!(res.namespace, Namespace::Project("plain-dir".to_string()));
         assert_eq!(res.unpinned_override, None);
     }
 
     #[test]
     fn root_dir_without_repo_degrades_to_global() {
-        let res = resolve_namespace_in(Path::new("/"), None, &no_pins(), no_git);
+        let res = resolve_namespace_in(Path::new("/"), None, &no_pins(), no_git, no_head_config);
         assert_eq!(res.namespace, Namespace::Global);
+    }
+
+    // --- head_repo_config (real git) ---
+
+    /// Run `git <args>` in `dir`; false (test skips) when git is unavailable.
+    fn git_run(dir: &Path, args: &[&str]) -> bool {
+        Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// `git init` with a repo-local identity so commits work everywhere.
+    fn git_init(dir: &Path) -> bool {
+        git_run(dir, &["init", "-q"])
+            && git_run(dir, &["config", "user.email", "test@example.com"])
+            && git_run(dir, &["config", "user.name", "Test"])
+    }
+
+    /// Stage everything and commit.
+    fn git_commit_all(dir: &Path) -> bool {
+        git_run(dir, &["add", "-A"])
+            && git_run(dir, &["commit", "-q", "-m", "init", "--no-gpg-sign"])
+    }
+
+    #[test]
+    fn head_repo_config_reads_the_committed_blob_not_the_worktree() {
+        // (a)+(c) against real git: the blob at HEAD is returned even after a
+        // local (uncommitted) modification to the worktree file.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join(REPO_CONFIG_FILE), "namespace = \"canonical\"\n").unwrap();
+        if !git_init(&repo) || !git_commit_all(&repo) {
+            return; // git unavailable; skip
+        }
+        fs::write(repo.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        assert_eq!(
+            head_repo_config(&repo).as_deref(),
+            Some("namespace = \"canonical\"\n")
+        );
+    }
+
+    #[test]
+    fn head_repo_config_is_none_for_untracked_file() {
+        // (b): a worktree-only file has no blob at HEAD.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("README.md"), "x\n").unwrap();
+        if !git_init(&repo) || !git_commit_all(&repo) {
+            return; // git unavailable; skip
+        }
+        fs::write(repo.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        assert_eq!(head_repo_config(&repo), None);
+    }
+
+    #[test]
+    fn head_repo_config_is_none_for_unborn_head_and_non_repo() {
+        // (d): a fresh `git init` repo has no HEAD to read from — degrade to
+        // "no committed identity", never an error. Same for a plain dir.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("fresh");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        if !git_init(&repo) {
+            return; // git unavailable; skip
+        }
+        assert_eq!(head_repo_config(&repo), None);
+        let plain = tmp.path().join("plain");
+        fs::create_dir_all(&plain).unwrap();
+        assert_eq!(head_repo_config(&plain), None);
+    }
+
+    #[test]
+    fn untracked_toml_falls_through_to_git_root_name_end_to_end() {
+        // The owner-requested inverse regression test against real git: an
+        // untracked `.rusty-brain.toml` claiming another namespace is ignored
+        // and resolution uses the git-root name.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().canonicalize().unwrap().join("host-repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("README.md"), "x\n").unwrap();
+        if !git_init(&repo) || !git_commit_all(&repo) {
+            return; // git unavailable; skip
+        }
+        fs::write(repo.join(REPO_CONFIG_FILE), "namespace = \"hijacked\"\n").unwrap();
+        let res = resolve_namespace_in(&repo, None, &no_pins(), git_toplevel, head_repo_config);
+        assert_eq!(res.namespace, Namespace::Project("host-repo".to_string()));
+        assert_eq!(
+            res.repo_config_divergence.map(|d| d.kind),
+            Some(RepoConfigDivergenceKind::Untracked)
+        );
     }
 
     // --- pin store ---

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 rb-types = { path = "../rb-types" }
+rb-config = { path = "../rb-config" }
 rb-store = { path = "../rb-store" }
 rb-engine = { path = "../rb-engine" }
 rb-embed = { path = "../rb-embed" }

--- a/crates/rb-daemon/src/error_map.rs
+++ b/crates/rb-daemon/src/error_map.rs
@@ -155,12 +155,28 @@ mod tests {
         } else {
             panic!("expected error response");
         }
+
+        // InvalidArgument is validation-class: its message IS the guidance the
+        // client needs (e.g. the content-update rejection) and must pass verbatim.
+        let guidance = "content updates are not supported; create a new memory so \
+                        embeddings stay consistent";
+        let r = error_to_response(Error::InvalidArgument(guidance.into()));
+        if let Response::Error { message, kind } = r {
+            assert_eq!(kind, "invalid_argument");
+            assert_eq!(
+                message,
+                format!("invalid argument: {guidance}"),
+                "validation message must be forwarded verbatim"
+            );
+        } else {
+            panic!("expected error response");
+        }
     }
 
     #[test]
     fn client_safe_errors_pass_through_message() {
         // NotFound, InvalidNamespace, InvalidMemoryType, InvalidLinkType,
-        // and DimensionMismatch are safe to forward verbatim.
+        // DimensionMismatch, and InvalidArgument are safe to forward verbatim.
         let id = MemoryId::new();
         let cases: Vec<Error> = vec![
             Error::NotFound(id),
@@ -171,6 +187,7 @@ mod tests {
                 expected: 512,
                 got: 768,
             },
+            Error::InvalidArgument("importance 0 is out of range 1..=10".into()),
         ];
         for err in cases {
             let display = err.to_string();

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -23,4 +23,4 @@ pub use jobs::{
 pub use rb_config::{default_db_path, default_socket_path};
 pub use server::{Daemon, DaemonConfig};
 pub use shared_embedder::SharedEmbedder;
-pub use store_handle::StoreHandle;
+pub use store_handle::{accept_model_change, StoreHandle};

--- a/crates/rb-daemon/src/lib.rs
+++ b/crates/rb-daemon/src/lib.rs
@@ -9,7 +9,6 @@
 mod change;
 mod error_map;
 mod jobs;
-mod paths;
 mod server;
 mod shared_embedder;
 mod store_handle;
@@ -19,7 +18,9 @@ pub use jobs::{
     run_once, ConsolidationConfig, ImportanceConfig, JobKind, JobSummary, JobsConfig,
     LinkDecayConfig,
 };
-pub use paths::{default_db_path, default_socket_path};
+// Path defaults live in rb-config (the single source of truth shared with the
+// CLI and hooks); re-exported here for existing consumers of the daemon API.
+pub use rb_config::{default_db_path, default_socket_path};
 pub use server::{Daemon, DaemonConfig};
 pub use shared_embedder::SharedEmbedder;
 pub use store_handle::StoreHandle;

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -41,8 +41,10 @@ const REEMBED_MAX_LIMIT: usize = 10_000;
 const MAX_CONNECTIONS: usize = 256;
 /// Idle deadline for the initial handshake read (fail fast on stalled connects).
 const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-/// Idle deadline between consecutive request frames from an established client.
-const REQUEST_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// Default idle deadline between consecutive request frames from an established
+/// client; overridable via `RUSTY_BRAIN_IDLE_TIMEOUT_SECS` (see
+/// [`parse_idle_timeout`]) so the idle/reconnect e2e runs in seconds.
+const DEFAULT_REQUEST_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Static configuration for a daemon instance.
 #[derive(Clone, Debug)]
@@ -63,6 +65,18 @@ pub struct Daemon {
     pidfile_path: PathBuf,
     bind_guard: BindGuard,
     jobs_config: JobsConfig,
+    request_idle_timeout: std::time::Duration,
+}
+
+/// Resolve the request idle timeout from an env value. Fail-safe: absent,
+/// empty, non-numeric, or zero values all use the default — a misconfigured
+/// override must never produce an instantly-dying or never-dying connection.
+fn parse_idle_timeout(value: Option<&str>) -> std::time::Duration {
+    value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&secs| secs > 0)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(DEFAULT_REQUEST_IDLE_TIMEOUT)
 }
 
 impl std::fmt::Debug for Daemon {
@@ -135,6 +149,10 @@ impl Daemon {
             }
         };
 
+        // Read once at bind so every connection of this daemon instance agrees.
+        let request_idle_timeout =
+            parse_idle_timeout(std::env::var(rb_config::IDLE_TIMEOUT_ENV).ok().as_deref());
+
         info!(socket = %config.socket_path.display(), "daemon bound");
         Ok(Self {
             listener,
@@ -145,6 +163,7 @@ impl Daemon {
             pidfile_path,
             bind_guard,
             jobs_config: config.jobs_config,
+            request_idle_timeout,
         })
     }
 
@@ -159,6 +178,7 @@ impl Daemon {
             pidfile_path: _pidfile_path,
             mut bind_guard,
             jobs_config,
+            request_idle_timeout,
         } = self;
         tokio::pin!(shutdown);
         let scheduler = jobs::scheduler::spawn(store.clone(), jobs_config.clone());
@@ -193,8 +213,15 @@ impl Daemon {
                             };
                             conns.spawn(async move {
                                 let _permit = permit; // released when task completes
-                                if let Err(e) =
-                                    handle_connection(stream, store, embedder, enricher, jobs_config).await
+                                if let Err(e) = handle_connection(
+                                    stream,
+                                    store,
+                                    embedder,
+                                    enricher,
+                                    jobs_config,
+                                    request_idle_timeout,
+                                )
+                                .await
                                 {
                                     warn!(error = %e, "connection ended with error");
                                 }
@@ -372,6 +399,7 @@ async fn handle_connection(
     embedder: SharedEmbedder,
     enricher: Option<Arc<dyn Enricher>>,
     jobs_config: JobsConfig,
+    request_idle_timeout: std::time::Duration,
 ) -> Result<()> {
     let mut framed = bounded_framed(stream);
 
@@ -425,7 +453,7 @@ async fn handle_connection(
     };
     loop {
         // Break the loop if the client is idle for too long between requests.
-        let req: Request = match timeout(REQUEST_IDLE_TIMEOUT, read_frame(&mut framed)).await {
+        let req: Request = match timeout(request_idle_timeout, read_frame(&mut framed)).await {
             Ok(Ok(req)) => req,
             Ok(Err(_)) => break, // parse error or clean close
             Err(_) => {
@@ -649,6 +677,37 @@ mod tests {
         );
         let mode = fs::metadata(&socket_dir).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755, "daemon must not chmod caller-owned dirs");
+    }
+
+    #[test]
+    fn parse_idle_timeout_honors_valid_seconds() {
+        assert_eq!(
+            parse_idle_timeout(Some("1")),
+            std::time::Duration::from_secs(1)
+        );
+        assert_eq!(
+            parse_idle_timeout(Some(" 120 ")),
+            std::time::Duration::from_secs(120)
+        );
+    }
+
+    #[test]
+    fn parse_idle_timeout_falls_back_to_default_on_garbage() {
+        // Fail-safe: absent, empty, non-numeric, negative, and zero all default.
+        for bad in [
+            None,
+            Some(""),
+            Some("abc"),
+            Some("-5"),
+            Some("0"),
+            Some("1.5"),
+        ] {
+            assert_eq!(
+                parse_idle_timeout(bad),
+                DEFAULT_REQUEST_IDLE_TIMEOUT,
+                "value {bad:?} must fall back to the default"
+            );
+        }
     }
 
     #[test]

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -95,8 +95,7 @@ impl Daemon {
         let dim = embedder.dim();
 
         if let Some(parent) = config.db_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| Error::Io(format!("create db dir {}: {e}", parent.display())))?;
+            prepare_db_dir(parent)?;
         }
 
         prepare_socket_dir(&config.socket_path)?;
@@ -245,6 +244,22 @@ impl Daemon {
         info!("daemon shut down cleanly");
         Ok(())
     }
+}
+
+/// Create the DB's parent dir private (0700) when the daemon creates it —
+/// parity with the socket dir (W0.5). Unlike the socket dir, an EXISTING dir is
+/// accepted as-is: the daemon only owns dirs it created itself (the default
+/// data dir), while `RUSTY_BRAIN_DB` overrides and tests point into
+/// caller-owned dirs we must not chmod or reject. The DB file itself is always
+/// tightened to 0600 by rb-store at open, so the file stays private either way.
+fn prepare_db_dir(dir: &Path) -> Result<()> {
+    if dir.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(dir)
+        .map_err(|e| Error::Io(format!("create db dir {}: {e}", dir.display())))?;
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+        .map_err(|e| Error::Io(format!("chmod 0700 {}: {e}", dir.display())))
 }
 
 fn prepare_socket_dir(socket_path: &Path) -> Result<()> {
@@ -660,6 +675,24 @@ mod tests {
         let parent = socket.parent().unwrap();
         let mode = fs::metadata(parent).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn prepare_db_dir_creates_missing_dir_private_and_leaves_existing_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let created = dir.path().join("data").join("rusty-brain");
+        prepare_db_dir(&created).unwrap();
+        let mode = fs::metadata(&created).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "daemon-created db dir must be private");
+
+        // An existing caller-owned dir is accepted untouched (the DB file is
+        // still 0600 via rb-store; only daemon-created dirs are tightened).
+        let existing = dir.path().join("caller-owned");
+        fs::create_dir(&existing).unwrap();
+        fs::set_permissions(&existing, fs::Permissions::from_mode(0o755)).unwrap();
+        prepare_db_dir(&existing).unwrap();
+        let mode = fs::metadata(&existing).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "daemon must not chmod caller-owned db dirs");
     }
 
     #[test]

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -111,7 +111,14 @@ impl Daemon {
             .map_err(|e| Error::Io(format!("chmod 0600 {}: {e}", config.socket_path.display())))?;
         bind_guard.mark_socket_bound();
 
-        let store = StoreHandle::start(config.db_path.clone(), dim, config.read_pool_size)?;
+        // Bind the embedder's model identity into every store open so a
+        // same-dim provider swap fails closed instead of mixing vector spaces.
+        let store = StoreHandle::start_with_model(
+            config.db_path.clone(),
+            dim,
+            embedder.model_id().to_string(),
+            config.read_pool_size,
+        )?;
 
         // Build the opt-in LLM enricher once (reqwest client is reused across
         // all connections). Activation requires RB_ENRICH_BASE_URL +

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -391,6 +391,7 @@ async fn probe_live(path: &Path) -> bool {
             let hs = Handshake {
                 contract_version: CONTRACT_VERSION,
                 namespace: rb_types::Namespace::Global,
+                identity: None,
             };
             if write_frame(&mut framed, &hs).await.is_err() {
                 return false;
@@ -457,6 +458,19 @@ async fn handle_connection(
     };
     write_frame(&mut framed, &ack).await?;
 
+    // Connection-scoped provenance (W0.5): client-declared identity with a
+    // daemon-side whoami fallback for user/host (same-host UDS, so the daemon's
+    // view is authoritative when the client stays silent). agent/session/source
+    // are client knowledge only — an old client (no identity) leaves them None.
+    let identity = handshake.identity.unwrap_or_default();
+    let provenance = rb_engine::Provenance {
+        origin_user: identity.user.or_else(rb_config::current_user),
+        origin_host: identity.host.or_else(rb_config::current_hostname),
+        origin_agent: identity.agent,
+        origin_source: identity.source,
+        session_id: identity.session_id,
+    };
+
     let store_for_stream = store.clone();
     let job_store = store.clone();
     let engine = {
@@ -483,7 +497,7 @@ async fn handle_connection(
             stream_changes(&mut framed, &store_for_stream, &namespace).await;
             break;
         }
-        let resp = dispatch(&engine, &job_store, &jobs_config, req).await;
+        let resp = dispatch(&engine, &job_store, &jobs_config, &provenance, req).await;
         write_frame(&mut framed, &resp).await?;
     }
 
@@ -550,6 +564,7 @@ async fn dispatch<P>(
     engine: &MemoryEngine<StoreHandle, P>,
     job_store: &StoreHandle,
     jobs_config: &JobsConfig,
+    provenance: &rb_engine::Provenance,
     req: Request,
 ) -> Response
 where
@@ -567,6 +582,7 @@ where
             keywords,
             tags,
             related_files,
+            confidence,
         } => {
             let input = RememberInput {
                 content,
@@ -576,6 +592,8 @@ where
                 keywords,
                 tags,
                 related_files,
+                confidence,
+                provenance: provenance.clone(),
             };
             match engine.remember(input).await {
                 Ok(id) => Response::Remembered { id },

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -254,6 +254,16 @@ impl Daemon {
 /// tightened to 0600 by rb-store at open, so the file stays private either way.
 fn prepare_db_dir(dir: &Path) -> Result<()> {
     if dir.exists() {
+        // Mirror prepare_socket_dir: a non-directory here would otherwise
+        // surface later as an opaque SQLite open failure.
+        let metadata = fs::metadata(dir)
+            .map_err(|e| Error::Io(format!("stat db dir {}: {e}", dir.display())))?;
+        if !metadata.is_dir() {
+            return Err(Error::Io(format!(
+                "db parent {} is not a directory",
+                dir.display()
+            )));
+        }
         return Ok(());
     }
     fs::create_dir_all(dir)
@@ -711,6 +721,18 @@ mod tests {
         prepare_db_dir(&existing).unwrap();
         let mode = fs::metadata(&existing).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755, "daemon must not chmod caller-owned db dirs");
+    }
+
+    #[test]
+    fn prepare_db_dir_rejects_a_non_directory_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-dir");
+        fs::write(&file, b"x").unwrap();
+        let err = prepare_db_dir(&file).unwrap_err();
+        assert!(
+            err.to_string().contains("is not a directory"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -126,16 +126,38 @@ struct ReadPool {
 }
 
 impl ReadPool {
-    fn open(db_path: &Path, dim: usize, size: usize) -> Result<Self> {
+    fn open(db_path: &Path, dim: usize, model: Option<&str>, size: usize) -> Result<Self> {
         let mut stores = Vec::with_capacity(size);
         for _ in 0..size {
-            stores.push(SqliteStore::open(db_path, dim)?);
+            stores.push(open_store(db_path, dim, model)?);
         }
         Ok(Self {
             permits: Arc::new(Semaphore::new(size)),
             stores: Arc::new(Mutex::new(stores)),
         })
     }
+}
+
+/// Open one store connection, enforcing the embedding-model invariant whenever
+/// a model identity is bound (the daemon path; tests may pass `None`).
+fn open_store(db_path: &Path, dim: usize, model: Option<&str>) -> Result<SqliteStore> {
+    match model {
+        Some(model) => SqliteStore::open_with_model(db_path, dim, model),
+        None => SqliteStore::open(db_path, dim),
+    }
+}
+
+/// Explicit opt-in for an embedding-model swap (`--accept-model-change` /
+/// `RB_ACCEPT_MODEL_CHANGE`): atomically adopt `new_model` and stale every
+/// row's embedding stamp so the reembed machinery converges the corpus. Runs
+/// BEFORE the daemon's model-verified opens; a missing DB is a no-op (a fresh
+/// DB seeds the model at first open). Returns `true` when a swap occurred.
+pub fn accept_model_change(db_path: &Path, embedding_dim: usize, new_model: &str) -> Result<bool> {
+    if !db_path.exists() {
+        return Ok(false);
+    }
+    let store = SqliteStore::open(db_path, embedding_dim)?;
+    store.accept_model_change(new_model)
 }
 
 /// RAII guard that holds a popped `SqliteStore` and pushes it back to the pool
@@ -154,11 +176,38 @@ impl Drop for PoolGuard {
 }
 
 impl StoreHandle {
-    /// Start the writer thread and open the read pool.
+    /// Start the writer thread and open the read pool without binding an
+    /// embedding-model identity (test seam; no model invariant enforced).
     pub fn start(db_path: PathBuf, embedding_dim: usize, read_pool_size: usize) -> Result<Self> {
+        Self::start_inner(db_path, embedding_dim, None, read_pool_size)
+    }
+
+    /// Start the writer thread and open the read pool, enforcing the
+    /// embedding-model invariant on every connection (the daemon path).
+    pub fn start_with_model(
+        db_path: PathBuf,
+        embedding_dim: usize,
+        embedding_model: String,
+        read_pool_size: usize,
+    ) -> Result<Self> {
+        Self::start_inner(
+            db_path,
+            embedding_dim,
+            Some(embedding_model),
+            read_pool_size,
+        )
+    }
+
+    fn start_inner(
+        db_path: PathBuf,
+        embedding_dim: usize,
+        embedding_model: Option<String>,
+        read_pool_size: usize,
+    ) -> Result<Self> {
         let pool = Arc::new(ReadPool::open(
             &db_path,
             embedding_dim,
+            embedding_model.as_deref(),
             read_pool_size.max(1),
         )?);
         let (events, _) = broadcast::channel(BROADCAST_CAPACITY);
@@ -173,6 +222,7 @@ impl StoreHandle {
                 writer_loop(
                     writer_path,
                     embedding_dim,
+                    embedding_model,
                     writer_rx,
                     writer_events,
                     ready_tx,
@@ -468,6 +518,7 @@ fn run_store_op<F>(
     store: &mut Option<SqliteStore>,
     db_path: &Path,
     embedding_dim: usize,
+    embedding_model: Option<&str>,
     op: F,
 ) -> StoreOpReport
 where
@@ -499,7 +550,7 @@ where
             // transaction is closed before the replacement connection is opened.
             drop(store.take());
 
-            match SqliteStore::open(db_path, embedding_dim) {
+            match open_store(db_path, embedding_dim, embedding_model) {
                 Ok(reopened) => {
                     *store = Some(reopened);
                     StoreOpReport {
@@ -533,11 +584,12 @@ fn panic_for_test_store_op(_store: &SqliteStore) -> Result<()> {
 fn writer_loop(
     db_path: PathBuf,
     embedding_dim: usize,
+    embedding_model: Option<String>,
     mut rx: mpsc::Receiver<WriteCommand>,
     events: broadcast::Sender<MemoryChanged>,
     ready_tx: std::sync::mpsc::Sender<Result<()>>,
 ) {
-    let mut store = match SqliteStore::open(&db_path, embedding_dim) {
+    let mut store = match open_store(&db_path, embedding_dim, embedding_model.as_deref()) {
         Ok(store) => {
             let _ = ready_tx.send(Ok(()));
             Some(store)
@@ -557,9 +609,13 @@ fn writer_loop(
             } => {
                 let namespace = note.namespace.clone();
                 let id = note.id.clone();
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.insert_memory(&note, embedding.as_deref())
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.insert_memory(&note, embedding.as_deref()),
+                );
                 let changed = report.result.is_ok();
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
@@ -583,15 +639,19 @@ fn writer_loop(
                 updates,
                 reply,
             } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    match s.get_memory(&id) {
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| match s.get_memory(&id) {
                         Ok(Some(note)) if note.namespace == namespace => {
                             s.update_memory(&id, &updates)
                         }
                         Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
                         Err(e) => Err(e),
-                    }
-                });
+                    },
+                );
                 let changed = report.result.is_ok();
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
@@ -614,13 +674,17 @@ fn writer_loop(
                 id,
                 reply,
             } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    match s.get_memory(&id) {
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| match s.get_memory(&id) {
                         Ok(Some(note)) if note.namespace == namespace => s.archive_memory(&id),
                         Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
                         Err(e) => Err(e),
-                    }
-                });
+                    },
+                );
                 let changed = report.result.is_ok();
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
@@ -639,8 +703,13 @@ fn writer_loop(
                 }
             }
             WriteCommand::AddLink { link, reply } => {
-                let report =
-                    run_store_op(&mut store, &db_path, embedding_dim, |s| s.add_link(&link));
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.add_link(&link),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -648,9 +717,13 @@ fn writer_loop(
                 }
             }
             WriteCommand::RecordAccess { id, reply } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.record_access(&id)
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.record_access(&id),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -659,9 +732,13 @@ fn writer_loop(
             }
             WriteCommand::RecordAccesses { ids, reply } => {
                 // No MemoryChanged event: access tracking is observability-only.
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.record_accesses(&ids)
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.record_accesses(&ids),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -675,9 +752,13 @@ fn writer_loop(
                 strength,
                 reply,
             } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.set_link_strength(&source, &target, link_type, strength)
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.set_link_strength(&source, &target, link_type, strength),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -690,9 +771,13 @@ fn writer_loop(
                 link_type,
                 reply,
             } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.delete_link(&source, &target, link_type)
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.delete_link(&source, &target, link_type),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -705,22 +790,28 @@ fn writer_loop(
                 new,
                 reply,
             } => {
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    // Mirror the Update/Archive arms: verify BOTH memories live in
-                    // the caller's namespace before mutating, so the primitive can
-                    // never merge across namespaces and the Archived event below is
-                    // provably published under `old`'s real namespace. Fail closed
-                    // (NotFound) on a missing or cross-namespace target.
-                    match (s.get_memory(&old), s.get_memory(&new)) {
-                        (Ok(Some(o)), Ok(Some(n)))
-                            if o.namespace == namespace && n.namespace == namespace =>
-                        {
-                            s.supersede(&old, &new)
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| {
+                        // Mirror the Update/Archive arms: verify BOTH memories live in
+                        // the caller's namespace before mutating, so the primitive can
+                        // never merge across namespaces and the Archived event below is
+                        // provably published under `old`'s real namespace. Fail closed
+                        // (NotFound) on a missing or cross-namespace target.
+                        match (s.get_memory(&old), s.get_memory(&new)) {
+                            (Ok(Some(o)), Ok(Some(n)))
+                                if o.namespace == namespace && n.namespace == namespace =>
+                            {
+                                s.supersede(&old, &new)
+                            }
+                            (Err(e), _) | (_, Err(e)) => Err(e),
+                            _ => Err(Error::NotFound(old.clone())),
                         }
-                        (Err(e), _) | (_, Err(e)) => Err(e),
-                        _ => Err(Error::NotFound(old.clone())),
-                    }
-                });
+                    },
+                );
                 let changed = report.result.is_ok();
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
@@ -749,9 +840,13 @@ fn writer_loop(
             } => {
                 // No MemoryChanged event: re-embed only refreshes the vector for
                 // search quality; the note's user-visible content is unchanged.
-                let report = run_store_op(&mut store, &db_path, embedding_dim, |s| {
-                    s.update_vector(&id, &embedding, &model, &input_version)
-                });
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.update_vector(&id, &embedding, &model, &input_version),
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -760,8 +855,13 @@ fn writer_loop(
             }
             #[cfg(test)]
             WriteCommand::PanicForTest { reply } => {
-                let report =
-                    run_store_op(&mut store, &db_path, embedding_dim, panic_for_test_store_op);
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    panic_for_test_store_op,
+                );
                 let writer_usable = report.writer_usable;
                 let _ = reply.send(report.result);
                 if !writer_usable {
@@ -948,6 +1048,52 @@ mod tests {
 
     fn note(ns: &Namespace, body: &str) -> MemoryNote {
         MemoryNote::new(ns.clone(), body.to_string(), MemoryType::Insight, 5)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn start_with_model_refuses_a_swapped_model_then_accept_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+
+        // Seed the DB under one model identity (a real write so rows exist).
+        let handle =
+            StoreHandle::start_with_model(db.clone(), DIM, "deterministic".into(), 1).unwrap();
+        let ns = Namespace::Project("model-swap".to_string());
+        let mut seeded = note(&ns, "seeded under deterministic");
+        seeded.embedding_input_version = "v2-composite".to_string();
+        let id = seeded.id.clone();
+        handle.write(seeded, Some(vec![0.1f32; DIM])).await.unwrap();
+        handle.shutdown().await;
+
+        // A same-dim model swap must fail closed with the remediation hint.
+        let err = StoreHandle::start_with_model(db.clone(), DIM, "voyage-3".into(), 1)
+            .map(|_| ())
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("embedding model changed") && msg.contains("--accept-model-change"),
+            "refusal must carry the hint: {msg}"
+        );
+
+        // Explicit opt-in: swap + stale, then the model-verified start succeeds.
+        let changed = accept_model_change(&db, DIM, "voyage-3").unwrap();
+        assert!(changed, "a real swap reports true");
+        let handle = StoreHandle::start_with_model(db, DIM, "voyage-3".into(), 1).unwrap();
+        let got = handle.get(ns, id).await.unwrap().unwrap();
+        assert_eq!(
+            got.embedding_input_version, "",
+            "accepted swap stales the row to the reembed sentinel"
+        );
+        handle.shutdown().await;
+    }
+
+    #[test]
+    fn accept_model_change_is_a_noop_for_a_missing_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("never-created.db");
+        let changed = accept_model_change(&db, DIM, "voyage-3").unwrap();
+        assert!(!changed, "nothing to accept on a fresh install");
+        assert!(!db.exists(), "the opt-in path must not create the DB");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -101,7 +101,9 @@ async fn full_round_trip_through_client() {
             vec!["sqlite".to_string()],
             vec!["design".to_string()],
             vec!["src/store.rs".to_string()],
-            1.0,
+            // Non-default on purpose: proves confidence round-trips through
+            // wire + store instead of riding the serde default (1.0).
+            0.4,
         )
         .await
         .unwrap();
@@ -111,6 +113,11 @@ async fn full_round_trip_through_client() {
     let note = got.unwrap();
     assert_eq!(note.content, "rusty-brain uses one db and one transaction");
     assert_eq!(note.namespace, ns, "stored under the handshake namespace");
+    assert!(
+        (note.confidence - 0.4).abs() < f32::EPSILON,
+        "confidence must round-trip through wire + store, got {}",
+        note.confidence
+    );
 
     let results = client
         .recall("rusty-brain db transaction".to_string(), None, vec![], 10)

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -101,6 +101,7 @@ async fn full_round_trip_through_client() {
             vec!["sqlite".to_string()],
             vec!["design".to_string()],
             vec!["src/store.rs".to_string()],
+            1.0,
         )
         .await
         .unwrap();
@@ -186,6 +187,7 @@ async fn many_concurrent_clients_no_lost_writes_no_errors() {
                         vec!["concurrent".to_string()],
                         vec![],
                         vec![],
+                        1.0,
                     )
                     .await
                     .unwrap();
@@ -226,6 +228,7 @@ async fn namespace_isolation_enforced_server_side() {
             vec!["alpha".to_string()],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -241,6 +244,7 @@ async fn namespace_isolation_enforced_server_side() {
             vec!["beta".to_string()],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -360,6 +364,7 @@ async fn large_limit_is_clamped_and_does_not_error() {
                 vec![],
                 vec![],
                 vec![],
+                1.0,
             )
             .await
             .unwrap();
@@ -407,6 +412,7 @@ async fn wire_namespace_isolation_cross_namespace_ops_fail_closed() {
             vec![],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -488,6 +494,7 @@ async fn subscribe_streams_only_own_namespace_changes() {
             vec![],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -521,6 +528,7 @@ async fn subscribe_streams_only_own_namespace_changes() {
             vec![],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -536,6 +544,7 @@ async fn subscribe_streams_only_own_namespace_changes() {
             vec![],
             vec![],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -590,6 +599,7 @@ async fn run_job_importance_recalibration_flows_through_client() {
             vec!["evolution".to_string()],
             vec!["jobs".to_string()],
             vec![],
+            1.0,
         )
         .await
         .unwrap();
@@ -639,6 +649,7 @@ async fn reembed_over_the_wire_is_stamp_skip_and_idempotent() {
                 vec![format!("kw{i}")],
                 vec!["reembed".to_string()],
                 vec![],
+                1.0,
             )
             .await
             .unwrap();

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -553,7 +553,9 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         updates: rb_types::MemoryUpdates,
     ) -> rb_types::Result<()> {
         if updates.content.is_some() {
-            return Err(rb_types::Error::Storage(
+            // Validation-class error: error_map forwards the message verbatim so
+            // MCP clients see actionable guidance instead of "internal error".
+            return Err(rb_types::Error::InvalidArgument(
                 "content updates are not supported; create a new memory so embeddings stay consistent"
                     .to_string(),
             ));
@@ -1380,7 +1382,12 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("content updates"));
+        // Must be the validation-class variant: error_map forwards its message
+        // verbatim, so the client sees the guidance instead of "internal error".
+        assert!(matches!(err, rb_types::Error::InvalidArgument(_)));
+        assert!(err
+            .to_string()
+            .contains("content updates are not supported"));
         let note = eng.get(id).await.unwrap().unwrap();
         assert_eq!(note.content, "old body");
     }

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -7,7 +7,8 @@ use rb_search::{FusionMode, RrfConfig, Weights};
 use rb_types::{MemoryId, MemoryNote, MemoryType, Namespace};
 use std::sync::Arc;
 
-/// Input to `remember`. Mirrors the proto `Request::Remember` payload.
+/// Input to `remember`. Mirrors the proto `Request::Remember` payload, plus
+/// the connection-scoped provenance the daemon resolves at handshake (W0.5).
 pub struct RememberInput {
     pub content: String,
     pub context: Option<String>,
@@ -16,6 +17,24 @@ pub struct RememberInput {
     pub keywords: Vec<String>,
     pub tags: Vec<String>,
     pub related_files: Vec<String>,
+    /// Trust prior in `0.0..=1.0`, validated fail-closed (1.0 = full trust,
+    /// the pre-W0.5 hardwired value; hook captures send 0.7).
+    pub confidence: f32,
+    pub provenance: Provenance,
+}
+
+/// Who/where/what produced a write (W0.5): the connection's handshake identity
+/// after the daemon's whoami fallback for user/host. `Default` (all `None`)
+/// matches pre-W0.5 behavior and is what direct engine callers (tests, eval)
+/// use.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Provenance {
+    pub origin_user: Option<String>,
+    pub origin_host: Option<String>,
+    pub origin_agent: Option<String>,
+    /// Producer surface: `hook` | `mcp` | `cli` | `job`.
+    pub origin_source: Option<String>,
+    pub session_id: Option<String>,
 }
 
 /// Policy layer: orchestrates heuristic enrichment + embedding + ranking over a
@@ -124,6 +143,14 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
     /// Store a new memory: heuristic-enrich, embed the content, then write.
     pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
         rb_types::validate_importance(input.importance)?;
+        // Fail-closed confidence range check (mirrors the storage CHECK, but
+        // surfaces as a clean validation error rather than a Storage one).
+        if !input.confidence.is_finite() || !(0.0..=1.0).contains(&input.confidence) {
+            return Err(rb_types::Error::InvalidArgument(format!(
+                "confidence {} out of range 0.0..=1.0",
+                input.confidence
+            )));
+        }
 
         let mut note = MemoryNote::new(
             self.namespace.clone(),
@@ -131,6 +158,12 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             input.memory_type,
             input.importance,
         );
+        note.confidence = input.confidence;
+        note.origin_user = input.provenance.origin_user;
+        note.origin_host = input.provenance.origin_host;
+        note.origin_agent = input.provenance.origin_agent;
+        note.origin_source = input.provenance.origin_source;
+        note.session_id = input.provenance.session_id;
         // Enrichment: opt-in LLM, else heuristic. The enricher only fills fields
         // the caller left empty; an enricher error degrades to the heuristic.
         let enrichment = match &self.enricher {
@@ -627,6 +660,8 @@ mod tests {
             keywords: Vec::new(),
             tags: Vec::new(),
             related_files: Vec::new(),
+            confidence: 1.0,
+            provenance: Provenance::default(),
         }
     }
 
@@ -641,6 +676,43 @@ mod tests {
         assert_eq!(eng.backend().count(), 1);
         let emb = eng.backend().embedding_of(&id).unwrap();
         assert_eq!(emb.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn remember_stores_confidence_and_provenance() {
+        let eng = engine();
+        let mut inp = input("hook capture with provenance", 5);
+        inp.confidence = 0.7;
+        inp.provenance = Provenance {
+            origin_user: Some("alice".into()),
+            origin_host: Some("devbox".into()),
+            origin_agent: Some("claude-code".into()),
+            origin_source: Some("hook".into()),
+            session_id: Some("s-1".into()),
+        };
+        let id = eng.remember(inp).await.unwrap();
+        let note = eng.get(id).await.unwrap().unwrap();
+        assert!((note.confidence - 0.7).abs() < f32::EPSILON);
+        assert_eq!(note.origin_user.as_deref(), Some("alice"));
+        assert_eq!(note.origin_host.as_deref(), Some("devbox"));
+        assert_eq!(note.origin_agent.as_deref(), Some("claude-code"));
+        assert_eq!(note.origin_source.as_deref(), Some("hook"));
+        assert_eq!(note.session_id.as_deref(), Some("s-1"));
+    }
+
+    #[tokio::test]
+    async fn remember_rejects_out_of_range_confidence() {
+        let eng = engine();
+        for bad in [-0.1f32, 1.1, f32::NAN, f32::INFINITY] {
+            let mut inp = input("bad confidence", 5);
+            inp.confidence = bad;
+            let err = eng.remember(inp).await.unwrap_err();
+            assert!(
+                matches!(err, rb_types::Error::InvalidArgument(_)),
+                "confidence {bad} must be InvalidArgument, got {err:?}"
+            );
+        }
+        assert_eq!(eng.backend().count(), 0, "nothing may be written");
     }
 
     #[tokio::test]

--- a/crates/rb-engine/src/lib.rs
+++ b/crates/rb-engine/src/lib.rs
@@ -17,6 +17,6 @@ mod test_support;
 
 pub use backend::MemoryBackend;
 pub use embed_input::{embedding_input, EMBEDDING_INPUT_VERSION};
-pub use engine::{MemoryEngine, RememberInput};
+pub use engine::{MemoryEngine, Provenance, RememberInput};
 pub use enricher::{Enricher, Enrichment};
 pub use linker::{Linker, SimilarityLinker};

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -224,6 +224,8 @@ async fn full_flow_through_public_api() {
             keywords: Vec::new(),
             tags: vec!["concurrency".to_string()],
             related_files: Vec::new(),
+            confidence: 1.0,
+            provenance: Default::default(),
         })
         .await
         .unwrap();

--- a/crates/rb-eval/src/runner.rs
+++ b/crates/rb-eval/src/runner.rs
@@ -104,6 +104,8 @@ async fn ingest<P: EmbeddingProvider>(
                 keywords: m.keywords.clone(),
                 tags: m.tags.clone(),
                 related_files: Vec::new(),
+                confidence: 1.0,
+                provenance: Default::default(),
             })
             .await?;
         // Apply the authored confidence (no-op at the 1.0 default).

--- a/crates/rb-hooks/Cargo.toml
+++ b/crates/rb-hooks/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 rb-agents = { path = "../rb-agents" }
 rb-types = { path = "../rb-types" }
+rb-config = { path = "../rb-config" }
 rb-proto = { path = "../rb-proto" }
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -23,6 +24,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+# Dev-only: the path-agreement tests pin hooks-resolution == daemon-resolution.
+rb-daemon = { path = "../rb-daemon" }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rb-hooks/Cargo.toml
+++ b/crates/rb-hooks/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Minimal capture-time secret redaction (W0.5).
+regex = { workspace = true }
 
 [dev-dependencies]
 # Dev-only: the path-agreement tests pin hooks-resolution == daemon-resolution.

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -12,6 +12,11 @@ use crate::dedup::DedupCache;
 /// Max characters retained from a tool response before head/tail truncation.
 const MAX_RESPONSE_CHARS: usize = 2000;
 
+/// Trust prior for hook-captured memories (W0.5 / F39): automatic captures are
+/// unreviewed observations, not user-asserted facts, so they carry less than
+/// full confidence. Ranking already dampens low-confidence results.
+const HOOK_CONFIDENCE: f32 = 0.7;
+
 const TRUNCATION_MARKER: &str = "[...truncated...]";
 
 /// A `HookResult` that injects no message and always continues.
@@ -169,6 +174,7 @@ pub async fn post_tool_use(
                 memory_type,
                 5,
                 vec!["hook".to_string(), "post-tool-use".to_string()],
+                HOOK_CONFIDENCE,
             )
             .await;
     }
@@ -304,6 +310,7 @@ pub async fn stop(client: Option<&mut DaemonClient>, cwd: &std::path::Path) -> H
                 MemoryType::Reference,
                 4,
                 vec!["hook".to_string(), "session-summary".to_string()],
+                HOOK_CONFIDENCE,
             )
             .await;
     }
@@ -346,6 +353,7 @@ pub async fn pre_compact(
                 MemoryType::ArchitectureDecision,
                 8,
                 vec!["hook".to_string(), "pre-compact".to_string()],
+                HOOK_CONFIDENCE,
             )
             .await;
     }

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -50,10 +50,13 @@ const REDACT_RULES: &[(&str, &str)] = &[
     // Bare bearer tokens outside a header context.
     (r"(?i)\bbearer\s+[A-Za-z0-9._~+/=\-]+", "[REDACTED:bearer]"),
     // key=value / key: value where the key CONTAINS a credential word
-    // (covers GITHUB_TOKEN=..., my_api_key: ..., passwd=...). The key and
-    // separator are kept; only the value is replaced.
+    // (covers GITHUB_TOKEN=..., my_api_key: ..., passwd=...), including
+    // JSON-quoted keys ({"password":"..."}): the optional closing quote before
+    // the separator is matched too, or `extract_response_text`'s serialized
+    // object form would smuggle a structured credential past the rule. The key
+    // and separator are kept; only the value is replaced.
     (
-        r#"(?i)\b([A-Za-z0-9_\-]*(?:password|passwd|secret|token|api[_-]?key|authorization)[A-Za-z0-9_\-]*)(\s*[:=]\s*)("[^"\n]*"|'[^'\n]*'|[^\s"']+)"#,
+        r#"(?i)\b([A-Za-z0-9_\-]*(?:password|passwd|secret|token|api[_-]?key|authorization)[A-Za-z0-9_\-]*)(["']?\s*[:=]\s*)("[^"\n]*"|'[^'\n]*'|[^\s"']+)"#,
         "${1}${2}[REDACTED:credential]",
     ),
 ];
@@ -479,6 +482,26 @@ mod tests {
                 out.contains("[REDACTED:"),
                 "{input:?} must carry a marker: {out}"
             );
+        }
+    }
+
+    #[test]
+    fn redact_catches_credentials_in_serialized_json_tool_responses() {
+        // The exact composition post_tool_use applies to an object-valued
+        // tool_response: serialize via extract_response_text, then redact. A
+        // JSON-quoted key must not slip past the kv rule (the closing quote
+        // sits between the key and the colon).
+        for (response, secret) in [
+            (serde_json::json!({"password": "hunter2"}), "hunter2"),
+            (serde_json::json!({"api_key": "k-123"}), "k-123"),
+            (
+                serde_json::json!({"nested": {"github_token": "ghp_abc"}}),
+                "ghp_abc",
+            ),
+        ] {
+            let out = redact(&extract_response_text(&response));
+            assert!(!out.contains(secret), "{response} leaked: {out}");
+            assert!(out.contains("[REDACTED:credential]"), "{response}: {out}");
         }
     }
 

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -40,8 +40,8 @@ const REDACT_RULES: &[(&str, &str)] = &[
         r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|\z)",
         "[REDACTED:private-key]",
     ),
-    // AWS access key ids.
-    (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED:aws-key]"),
+    // AWS access key ids (AKIA = long-lived, ASIA = STS temporary).
+    (r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b", "[REDACTED:aws-key]"),
     // HTTP Authorization headers (any scheme: Bearer, Basic, token, ...).
     (
         r"(?i)\bauthorization\s*:\s*\S+(?:[ \t]+\S+)?",
@@ -450,6 +450,14 @@ mod tests {
     fn redact_replaces_aws_access_keys() {
         let out = redact("creds: AKIAABCDEFGHIJKLMNOP region us-east-1");
         assert!(!out.contains("AKIAABCDEFGHIJKLMNOP"), "got {out}");
+        assert!(out.contains("[REDACTED:aws-key]"));
+        assert!(out.contains("us-east-1"), "non-secret text survives");
+    }
+
+    #[test]
+    fn redact_replaces_aws_sts_temporary_keys() {
+        let out = redact("creds: ASIAABCDEFGHIJKLMNOP region us-east-1");
+        assert!(!out.contains("ASIAABCDEFGHIJKLMNOP"), "got {out}");
         assert!(out.contains("[REDACTED:aws-key]"));
         assert!(out.contains("us-east-1"), "non-secret text survives");
     }

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -27,6 +27,71 @@ fn continue_only() -> HookResult {
     }
 }
 
+/// Minimal capture-time secret redaction (W0.5; the full benchmarked set is
+/// W2.4). `(pattern, replacement)` pairs applied in order to every external
+/// text the hook persists (tool summaries, tool-response context, pre-compact
+/// snapshots) BEFORE truncation, so a secret split by head/tail truncation can
+/// never survive. Conservative by design: false positives are acceptable,
+/// leaked plaintext secrets are not.
+const REDACT_RULES: &[(&str, &str)] = &[
+    // PEM private-key blocks, including an unterminated block (e.g. a key cut
+    // off mid-response): redact through the END marker or to end-of-text.
+    (
+        r"(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?(?:-----END [A-Z0-9 ]*PRIVATE KEY-----|\z)",
+        "[REDACTED:private-key]",
+    ),
+    // AWS access key ids.
+    (r"\bAKIA[0-9A-Z]{16}\b", "[REDACTED:aws-key]"),
+    // HTTP Authorization headers (any scheme: Bearer, Basic, token, ...).
+    (
+        r"(?i)\bauthorization\s*:\s*\S+(?:[ \t]+\S+)?",
+        "[REDACTED:authorization]",
+    ),
+    // Bare bearer tokens outside a header context.
+    (r"(?i)\bbearer\s+[A-Za-z0-9._~+/=\-]+", "[REDACTED:bearer]"),
+    // key=value / key: value where the key CONTAINS a credential word
+    // (covers GITHUB_TOKEN=..., my_api_key: ..., passwd=...). The key and
+    // separator are kept; only the value is replaced.
+    (
+        r#"(?i)\b([A-Za-z0-9_\-]*(?:password|passwd|secret|token|api[_-]?key|authorization)[A-Za-z0-9_\-]*)(\s*[:=]\s*)("[^"\n]*"|'[^'\n]*'|[^\s"']+)"#,
+        "${1}${2}[REDACTED:credential]",
+    ),
+];
+
+/// Rules compiled once per process. `None` if any pattern fails to compile
+/// (a programmer error, pinned by `all_redaction_rules_compile`).
+static REDACTIONS: std::sync::OnceLock<Option<Vec<(regex::Regex, &'static str)>>> =
+    std::sync::OnceLock::new();
+
+fn redactions() -> Option<&'static [(regex::Regex, &'static str)]> {
+    REDACTIONS
+        .get_or_init(|| {
+            REDACT_RULES
+                .iter()
+                .map(|(pattern, replacement)| {
+                    regex::Regex::new(pattern).ok().map(|re| (re, *replacement))
+                })
+                .collect()
+        })
+        .as_deref()
+}
+
+/// Replace recognizable secrets in `text` with `[REDACTED:kind]` markers.
+/// Fail-closed: if the rule set is unavailable, the WHOLE text is replaced —
+/// a hook capture is best-effort and must never persist a known-shape secret.
+fn redact(text: &str) -> String {
+    let Some(rules) = redactions() else {
+        return "[REDACTED:unavailable]".to_string();
+    };
+    let mut out = text.to_string();
+    for (re, replacement) in rules {
+        if let std::borrow::Cow::Owned(replaced) = re.replace_all(&out, *replacement) {
+            out = replaced;
+        }
+    }
+    out
+}
+
 /// Normalize a CLI-reported tool name to its canonical capitalized form.
 ///
 /// Each CLI names the same handful of mutations differently, so this single
@@ -153,13 +218,15 @@ pub async fn post_tool_use(
     if !is_mutation_tool(tool_name) {
         return continue_only();
     }
-    let summary = summarize_post_tool_use(tool_name, tool_input);
+    // Redact BEFORE dedup so the recorded key matches the stored summary, and
+    // BEFORE truncation so a secret can never be split around the marker.
+    let summary = redact(&summarize_post_tool_use(tool_name, tool_input));
     if dedup.is_duplicate(tool_name, &summary) {
         return continue_only();
     }
 
     let memory_type = classify_tool(tool_name);
-    let raw = extract_response_text(tool_response);
+    let raw = redact(&extract_response_text(tool_response));
     let context = if raw.trim().is_empty() {
         None
     } else {
@@ -348,7 +415,7 @@ pub async fn pre_compact(
     if let Some(client) = client {
         let _ = client
             .remember(
-                format!("Pre-compaction decision snapshot: {}", text.trim()),
+                format!("Pre-compaction decision snapshot: {}", redact(text.trim())),
                 None,
                 MemoryType::ArchitectureDecision,
                 8,
@@ -364,6 +431,103 @@ pub async fn pre_compact(
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
+
+    #[test]
+    fn all_redaction_rules_compile() {
+        // The fail-closed posture in `redact` ("[REDACTED:unavailable]" for the
+        // whole text) must never trigger in a shipped build: every static
+        // pattern compiles.
+        assert!(
+            redactions().is_some_and(|rules| rules.len() == REDACT_RULES.len()),
+            "every redaction rule must compile"
+        );
+    }
+
+    #[test]
+    fn redact_replaces_aws_access_keys() {
+        let out = redact("creds: AKIAABCDEFGHIJKLMNOP region us-east-1");
+        assert!(!out.contains("AKIAABCDEFGHIJKLMNOP"), "got {out}");
+        assert!(out.contains("[REDACTED:aws-key]"));
+        assert!(out.contains("us-east-1"), "non-secret text survives");
+    }
+
+    #[test]
+    fn redact_replaces_authorization_headers_and_bearer_tokens() {
+        let out = redact("curl -H 'Authorization: Bearer sk-live-deadbeef' https://x");
+        assert!(!out.contains("sk-live-deadbeef"), "got {out}");
+        assert!(out.contains("[REDACTED:"));
+
+        let out = redact("sent bearer abc.def-ghi to the api");
+        assert!(!out.contains("abc.def-ghi"), "got {out}");
+        assert!(out.contains("[REDACTED:bearer]"));
+    }
+
+    #[test]
+    fn redact_replaces_credential_key_value_pairs() {
+        for (input, secret) in [
+            ("password=hunter2", "hunter2"),
+            ("passwd: swordfish", "swordfish"),
+            ("export GITHUB_TOKEN=ghp_abc123", "ghp_abc123"),
+            ("api_key: \"k-123 456\"", "k-123 456"),
+            ("API-KEY='q w e'", "q w e"),
+            ("my_secret = ssshhh", "ssshhh"),
+            ("authorization=basic-xyz", "basic-xyz"),
+        ] {
+            let out = redact(input);
+            assert!(!out.contains(secret), "{input:?} leaked: {out}");
+            assert!(
+                out.contains("[REDACTED:"),
+                "{input:?} must carry a marker: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn redact_replaces_pem_blocks_even_unterminated() {
+        let pem =
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIfakekeymaterial\n-----END RSA PRIVATE KEY-----";
+        let out = redact(&format!("before\n{pem}\nafter"));
+        assert!(!out.contains("MIIfakekeymaterial"), "got {out}");
+        assert!(out.contains("[REDACTED:private-key]"));
+        assert!(out.contains("before") && out.contains("after"));
+
+        // A block truncated before its END marker (the exact shape head/tail
+        // truncation could produce upstream) is redacted to end-of-text.
+        let cut = "log line\n-----BEGIN PRIVATE KEY-----\nMIIcutshort";
+        let out = redact(cut);
+        assert!(!out.contains("MIIcutshort"), "got {out}");
+        assert!(out.contains("[REDACTED:private-key]"));
+    }
+
+    #[test]
+    fn redact_leaves_ordinary_text_untouched() {
+        let text = "Edited /src/main.rs; cargo test passed with 42 tests";
+        assert_eq!(redact(text), text);
+    }
+
+    #[tokio::test]
+    async fn post_tool_use_redacts_summary_before_dedup_and_store() {
+        // A Bash command carrying a secret: the canonical summary (which is
+        // both stored and used as the dedup key) must be the REDACTED form.
+        let tmp = tempfile::tempdir().unwrap();
+        let dedup = DedupCache::at(tmp.path().join("d.json"));
+        let result = post_tool_use(
+            None,
+            &dedup,
+            "Bash",
+            &serde_json::json!({"command": "export AWS_SECRET_KEY=AKIAABCDEFGHIJKLMNOP"}),
+            &serde_json::json!("ok"),
+        )
+        .await;
+        assert!(result.continue_execution);
+        assert!(
+            dedup.is_duplicate(
+                "Bash",
+                "Ran command: export AWS_SECRET_KEY=[REDACTED:credential]"
+            ),
+            "the redacted summary is the recorded canonical form"
+        );
+    }
 
     #[test]
     fn mutation_tools_are_recognized() {

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -125,11 +125,21 @@ fn run() -> serde_json::Value {
         }
     };
 
+    // Provenance identity (W0.5): every hook write declares source=hook plus
+    // the driving agent CLI and the event's session id; the daemon stamps these
+    // onto the stored memories (user/host fall back to daemon-side whoami).
+    let identity = rb_proto::ClientIdentity {
+        agent: Some(cli.id().as_str().to_string()),
+        session_id: ctx.session_id.clone(),
+        source: Some("hook".to_string()),
+        ..Default::default()
+    };
+
     let result = runtime.block_on(async {
         // Overall timeout guards the whole connect+capture phase.
         match tokio::time::timeout(
             OVERALL_TIMEOUT,
-            capture_phase(&socket, &namespace, auto_start, &dedup, &ctx),
+            capture_phase(&socket, &namespace, auto_start, identity, &dedup, &ctx),
         )
         .await
         {
@@ -149,11 +159,18 @@ async fn capture_phase(
     socket: &std::path::Path,
     namespace: &rb_types::Namespace,
     auto_start: Option<AutoStart>,
+    identity: rb_proto::ClientIdentity,
     dedup: &DedupCache,
     ctx: &rb_agents::HookContext,
 ) -> HookResult {
-    let mut client =
-        DaemonClient::connect(socket, namespace.clone(), CONNECT_TIMEOUT, auto_start).await;
+    let mut client = DaemonClient::connect(
+        socket,
+        namespace.clone(),
+        CONNECT_TIMEOUT,
+        auto_start,
+        Some(identity),
+    )
+    .await;
     dispatch::dispatch(client.as_mut(), dedup, ctx).await
 }
 

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -182,25 +182,16 @@ fn continue_result() -> HookResult {
 }
 
 /// Resolve the daemon socket path: `RUSTY_BRAIN_SOCKET` override, else the
-/// rb-config default shared with the daemon and CLI.
+/// rb-config default. Delegates so hooks, CLI, and daemon share ONE override
+/// rule and can never resolve different sockets (F03/F12/F49).
 fn socket_path() -> rb_types::Result<std::path::PathBuf> {
-    if let Some(p) = std::env::var_os(rb_config::SOCKET_ENV) {
-        if !p.is_empty() {
-            return Ok(std::path::PathBuf::from(p));
-        }
-    }
-    rb_config::default_socket_path()
+    rb_config::socket_path_from_env()
 }
 
 /// Resolve the daemon db path: `RUSTY_BRAIN_DB` override, else the rb-config
-/// default shared with the daemon and CLI.
+/// default. Same single-rule delegation as [`socket_path`].
 fn db_path() -> rb_types::Result<std::path::PathBuf> {
-    if let Some(p) = std::env::var_os(rb_config::DB_ENV) {
-        if !p.is_empty() {
-            return Ok(std::path::PathBuf::from(p));
-        }
-    }
-    rb_config::default_db_path()
+    rb_config::db_path_from_env()
 }
 
 /// Resolve the `rusty-brain` DAEMON binary for auto-start.
@@ -336,6 +327,26 @@ mod tests {
 
         assert_eq!(socket_path().unwrap(), sock);
         assert_eq!(db_path().unwrap(), db);
+    }
+
+    // A whitespace-only override is not a path: hooks must fall back to the
+    // daemon default exactly like the CLI does (both delegate to rb-config),
+    // not treat " " as a real socket — the W0.2 divergence class.
+    #[test]
+    fn whitespace_only_overrides_agree_with_daemon_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g1 = EnvGuard::set("RUSTY_BRAIN_SOCKET", std::path::Path::new("  "));
+        let _g2 = EnvGuard::set("RUSTY_BRAIN_DB", std::path::Path::new("  "));
+        assert_eq!(
+            socket_path().unwrap(),
+            rb_daemon::default_socket_path().unwrap(),
+            "whitespace socket override must fall back to the daemon default"
+        );
+        assert_eq!(
+            db_path().unwrap(),
+            rb_daemon::default_db_path().unwrap(),
+            "whitespace db override must fall back to the daemon default"
+        );
     }
 
     #[test]

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -83,12 +83,31 @@ fn run() -> serde_json::Value {
     // reads files). detect_namespace never panics; degrades to Global.
     let namespace = detect_namespace(&ctx.cwd);
 
+    // Resolve daemon paths through rb-config (one truth with daemon + CLI). In
+    // a degenerate environment (no HOME/XDG at all) the socket is unresolvable:
+    // fail open with no daemon work rather than guessing a divergent path.
+    let socket = match socket_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("socket path unresolvable (fail-open): {e}");
+            return cli.render_output(&continue_result());
+        }
+    };
+
     // Only SessionStart may auto-start the daemon. Other events never spawn.
+    // An unresolvable db path only disables auto-start; connecting to an
+    // already-running daemon at `socket` still works.
     let auto_start = match &ctx.event {
-        HookEvent::SessionStart { .. } => Some(AutoStart {
-            self_exe: daemon_bin(),
-            db: db_path(),
-        }),
+        HookEvent::SessionStart { .. } => match db_path() {
+            Ok(db) => Some(AutoStart {
+                self_exe: daemon_bin(),
+                db,
+            }),
+            Err(e) => {
+                tracing::warn!("db path unresolvable; auto-start disabled (fail-open): {e}");
+                None
+            }
+        },
         _ => None,
     };
 
@@ -110,7 +129,7 @@ fn run() -> serde_json::Value {
         // Overall timeout guards the whole connect+capture phase.
         match tokio::time::timeout(
             OVERALL_TIMEOUT,
-            capture_phase(&namespace, auto_start, &dedup, &ctx),
+            capture_phase(&socket, &namespace, auto_start, &dedup, &ctx),
         )
         .await
         {
@@ -127,14 +146,14 @@ fn run() -> serde_json::Value {
 
 /// Connect (best-effort) and dispatch the event to its capture flow.
 async fn capture_phase(
+    socket: &std::path::Path,
     namespace: &rb_types::Namespace,
     auto_start: Option<AutoStart>,
     dedup: &DedupCache,
     ctx: &rb_agents::HookContext,
 ) -> HookResult {
-    let socket = socket_path();
     let mut client =
-        DaemonClient::connect(&socket, namespace.clone(), CONNECT_TIMEOUT, auto_start).await;
+        DaemonClient::connect(socket, namespace.clone(), CONNECT_TIMEOUT, auto_start).await;
     dispatch::dispatch(client.as_mut(), dedup, ctx).await
 }
 
@@ -145,47 +164,26 @@ fn continue_result() -> HookResult {
     }
 }
 
-/// Resolve the daemon socket path from `RUSTY_BRAIN_SOCKET`, else a temp default.
-fn socket_path() -> std::path::PathBuf {
-    if let Some(p) = std::env::var_os("RUSTY_BRAIN_SOCKET") {
+/// Resolve the daemon socket path: `RUSTY_BRAIN_SOCKET` override, else the
+/// rb-config default shared with the daemon and CLI.
+fn socket_path() -> rb_types::Result<std::path::PathBuf> {
+    if let Some(p) = std::env::var_os(rb_config::SOCKET_ENV) {
         if !p.is_empty() {
-            return std::path::PathBuf::from(p);
+            return Ok(std::path::PathBuf::from(p));
         }
     }
-    default_runtime_dir().join("rusty-brain").join("sock")
+    rb_config::default_socket_path()
 }
 
-/// Resolve the daemon db path from `RUSTY_BRAIN_DB`, else a data-dir default.
-fn db_path() -> std::path::PathBuf {
-    if let Some(p) = std::env::var_os("RUSTY_BRAIN_DB") {
+/// Resolve the daemon db path: `RUSTY_BRAIN_DB` override, else the rb-config
+/// default shared with the daemon and CLI.
+fn db_path() -> rb_types::Result<std::path::PathBuf> {
+    if let Some(p) = std::env::var_os(rb_config::DB_ENV) {
         if !p.is_empty() {
-            return std::path::PathBuf::from(p);
+            return Ok(std::path::PathBuf::from(p));
         }
     }
-    default_data_dir().join("rusty-brain").join("memory.db")
-}
-
-fn default_runtime_dir() -> std::path::PathBuf {
-    if let Some(d) = std::env::var_os("XDG_RUNTIME_DIR") {
-        if !d.is_empty() {
-            return std::path::PathBuf::from(d);
-        }
-    }
-    std::env::temp_dir()
-}
-
-fn default_data_dir() -> std::path::PathBuf {
-    if let Some(d) = std::env::var_os("XDG_DATA_HOME") {
-        if !d.is_empty() {
-            return std::path::PathBuf::from(d);
-        }
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        if !home.is_empty() {
-            return std::path::PathBuf::from(home).join(".local").join("share");
-        }
-    }
-    std::env::temp_dir()
+    rb_config::default_db_path()
 }
 
 /// Resolve the `rusty-brain` DAEMON binary for auto-start.
@@ -215,6 +213,113 @@ const DAEMON_BIN_NAME: &str = "rusty-brain";
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-mutating tests (process-global env; see rb-config tests).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(name: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::remove_var(name);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
+    /// Clear the `RUSTY_BRAIN_*` overrides so the default-resolution path runs.
+    fn without_overrides() -> [EnvGuard; 2] {
+        [
+            EnvGuard::remove("RUSTY_BRAIN_SOCKET"),
+            EnvGuard::remove("RUSTY_BRAIN_DB"),
+        ]
+    }
+
+    // F03/F12/F49 regression: the hooks binary and the daemon MUST resolve the
+    // same default socket/db paths, or capture writes to a daemon the CLI never
+    // reads. rb_daemon re-exports rb-config, so these pin hooks == daemon.
+    #[test]
+    fn hook_default_paths_agree_with_daemon_when_xdg_vars_are_set() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _overrides = without_overrides();
+        let runtime = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        let _g1 = EnvGuard::set("XDG_RUNTIME_DIR", runtime.path());
+        let _g2 = EnvGuard::set("XDG_DATA_HOME", data.path());
+
+        assert_eq!(
+            socket_path().unwrap(),
+            rb_daemon::default_socket_path().unwrap(),
+            "hooks and daemon must agree on the socket path"
+        );
+        assert_eq!(
+            db_path().unwrap(),
+            rb_daemon::default_db_path().unwrap(),
+            "hooks and daemon must agree on the db path"
+        );
+    }
+
+    #[test]
+    fn hook_default_paths_agree_with_daemon_when_xdg_vars_are_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _overrides = without_overrides();
+        let home = tempfile::tempdir().unwrap();
+        let _g1 = EnvGuard::remove("XDG_RUNTIME_DIR");
+        let _g2 = EnvGuard::remove("XDG_CACHE_HOME");
+        let _g3 = EnvGuard::remove("XDG_DATA_HOME");
+        let _g4 = EnvGuard::set("HOME", home.path());
+
+        let socket = socket_path().unwrap();
+        let db = db_path().unwrap();
+        assert_eq!(
+            socket,
+            rb_daemon::default_socket_path().unwrap(),
+            "hooks and daemon must agree on the socket path"
+        );
+        assert_eq!(
+            db,
+            rb_daemon::default_db_path().unwrap(),
+            "hooks and daemon must agree on the db path"
+        );
+        // Both live under HOME-derived platform dirs, never a temp dir.
+        assert!(
+            socket.starts_with(home.path()),
+            "socket under HOME: {socket:?}"
+        );
+        assert!(db.starts_with(home.path()), "db under HOME: {db:?}");
+    }
+
+    #[test]
+    fn explicit_env_overrides_win_over_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("override.sock");
+        let db = dir.path().join("override.db");
+        let _g1 = EnvGuard::set("RUSTY_BRAIN_SOCKET", &sock);
+        let _g2 = EnvGuard::set("RUSTY_BRAIN_DB", &db);
+
+        assert_eq!(socket_path().unwrap(), sock);
+        assert_eq!(db_path().unwrap(), db);
+    }
 
     #[test]
     fn daemon_bin_resolves_to_the_daemon_not_the_hooks_binary() {

--- a/crates/rb-hooks/tests/integration.rs
+++ b/crates/rb-hooks/tests/integration.rs
@@ -100,22 +100,37 @@ use rb_types::MemoryId;
 use tokio::net::{UnixListener, UnixStream};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
+/// What the mock daemon observed from the hook: the handshake identity and
+/// the first Remember's payload (W0.5 provenance + confidence assertions).
+#[derive(Debug, Default, Clone)]
+struct Observed {
+    saw_remember: bool,
+    identity_source: Option<String>,
+    identity_agent: Option<String>,
+    confidence: Option<f32>,
+}
+
 // Accept one connection, handshake-ack, and answer the first Remember with a
-// canned id. Signals back via the channel that a Remember was observed.
-async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Sender<bool>) {
+// canned id. Signals back via the channel what was observed.
+async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Sender<Observed>) {
+    let mut observed = Observed::default();
     let Ok((stream, _addr)) = listener.accept().await else {
-        let _ = tx.send(false);
+        let _ = tx.send(observed);
         return;
     };
     let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
         Framed::new(stream, LengthDelimitedCodec::new());
-    let _hs: Handshake = match read_frame(&mut framed).await {
+    let hs: Handshake = match read_frame(&mut framed).await {
         Ok(h) => h,
         Err(_) => {
-            let _ = tx.send(false);
+            let _ = tx.send(observed);
             return;
         }
     };
+    if let Some(identity) = hs.identity {
+        observed.identity_source = identity.source;
+        observed.identity_agent = identity.agent;
+    }
     let _ = write_frame(
         &mut framed,
         &HandshakeAck {
@@ -125,11 +140,11 @@ async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Se
         },
     )
     .await;
-    let mut saw_remember = false;
     while let Ok(req) = read_frame::<_, Request>(&mut framed).await {
         let resp = match req {
-            Request::Remember { .. } => {
-                saw_remember = true;
+            Request::Remember { confidence, .. } => {
+                observed.saw_remember = true;
+                observed.confidence = Some(confidence);
                 Response::Remembered {
                     id: MemoryId::new(),
                 }
@@ -150,7 +165,7 @@ async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Se
             break;
         }
     }
-    let _ = tx.send(saw_remember);
+    let _ = tx.send(observed);
 }
 
 #[test]
@@ -159,7 +174,7 @@ fn post_tool_use_against_live_daemon_remembers() {
     let socket = dir.path().join("live.sock");
     let socket_str = socket.to_string_lossy().to_string();
 
-    let (tx, rx) = std::sync::mpsc::channel::<bool>();
+    let (tx, rx) = std::sync::mpsc::channel::<Observed>();
     let socket_for_thread = socket.clone();
     let server = std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -168,11 +183,11 @@ fn post_tool_use_against_live_daemon_remembers() {
             .expect("rt");
         rt.block_on(async move {
             let listener = UnixListener::bind(&socket_for_thread).expect("bind");
-            let (otx, orx) = tokio::sync::oneshot::channel::<bool>();
+            let (otx, orx) = tokio::sync::oneshot::channel::<Observed>();
             let accept = tokio::spawn(serve_one_remember(listener, otx));
-            let saw = orx.await.unwrap_or(false);
+            let observed = orx.await.unwrap_or_default();
             let _ = accept.await;
-            let _ = tx.send(saw);
+            let _ = tx.send(observed);
         });
     });
 
@@ -201,10 +216,22 @@ fn post_tool_use_against_live_daemon_remembers() {
     let output = child.wait_with_output().expect("wait for output");
     assert!(output.status.success(), "must exit 0");
 
-    let saw_remember = rx
+    let observed = rx
         .recv_timeout(std::time::Duration::from_secs(10))
-        .unwrap_or(false);
-    assert!(saw_remember, "the daemon should have observed a Remember");
+        .unwrap_or_default();
+    assert!(
+        observed.saw_remember,
+        "the daemon should have observed a Remember"
+    );
+    // W0.5: a hook-written memory declares source=hook + the driving agent on
+    // the handshake identity, and carries confidence 0.7 on the Remember.
+    assert_eq!(observed.identity_source.as_deref(), Some("hook"));
+    assert_eq!(observed.identity_agent.as_deref(), Some("claude-code"));
+    let confidence = observed.confidence.expect("Remember carries confidence");
+    assert!(
+        (confidence - 0.7).abs() < f32::EPSILON,
+        "hook captures must send confidence 0.7, got {confidence}"
+    );
     let _ = server.join();
     let _: PathBuf = socket; // keep tempdir alive until here
 }

--- a/crates/rb-hooks/tests/integration.rs
+++ b/crates/rb-hooks/tests/integration.rs
@@ -108,6 +108,8 @@ struct Observed {
     identity_source: Option<String>,
     identity_agent: Option<String>,
     confidence: Option<f32>,
+    content: Option<String>,
+    context: Option<String>,
 }
 
 // Accept one connection, handshake-ack, and answer the first Remember with a
@@ -142,9 +144,16 @@ async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Se
     .await;
     while let Ok(req) = read_frame::<_, Request>(&mut framed).await {
         let resp = match req {
-            Request::Remember { confidence, .. } => {
+            Request::Remember {
+                confidence,
+                content,
+                context,
+                ..
+            } => {
                 observed.saw_remember = true;
                 observed.confidence = Some(confidence);
+                observed.content = Some(content);
+                observed.context = context;
                 Response::Remembered {
                     id: MemoryId::new(),
                 }
@@ -168,8 +177,11 @@ async fn serve_one_remember(listener: UnixListener, tx: tokio::sync::oneshot::Se
     let _ = tx.send(observed);
 }
 
-#[test]
-fn post_tool_use_against_live_daemon_remembers() {
+/// Run the hooks binary against an in-process mock daemon, feeding `stdin`,
+/// and return what the daemon observed. The dedup cache is isolated to a fresh
+/// tempdir so a previously-persisted entry within the 60s TTL cannot suppress
+/// the Remember under test as a duplicate.
+fn observe_against_mock_daemon(stdin: &str) -> Observed {
     let dir = tempfile::tempdir().unwrap();
     let socket = dir.path().join("live.sock");
     let socket_str = socket.to_string_lossy().to_string();
@@ -194,10 +206,6 @@ fn post_tool_use_against_live_daemon_remembers() {
     // Give the listener a moment to bind.
     std::thread::sleep(std::time::Duration::from_millis(200));
 
-    // Isolate the dedup cache to this tempdir so a previously-persisted entry from
-    // an earlier run within the 60s TTL cannot suppress this observation as a
-    // duplicate (which would skip the Remember the test asserts on).
-    let stdin = r#"{"hook_event_name":"PostToolUse","cwd":"/tmp","session_id":"s1","tool_name":"Edit","tool_input":{"file_path":"/src/uniqueW9.rs"},"tool_response":"ok"}"#;
     let mut child = hooks_command()
         .args(["--agent", "claude-code"])
         .env("RUSTY_BRAIN_SOCKET", &socket_str)
@@ -219,6 +227,15 @@ fn post_tool_use_against_live_daemon_remembers() {
     let observed = rx
         .recv_timeout(std::time::Duration::from_secs(10))
         .unwrap_or_default();
+    let _ = server.join();
+    let _: PathBuf = socket; // keep tempdir alive until here
+    observed
+}
+
+#[test]
+fn post_tool_use_against_live_daemon_remembers() {
+    let stdin = r#"{"hook_event_name":"PostToolUse","cwd":"/tmp","session_id":"s1","tool_name":"Edit","tool_input":{"file_path":"/src/uniqueW9.rs"},"tool_response":"ok"}"#;
+    let observed = observe_against_mock_daemon(stdin);
     assert!(
         observed.saw_remember,
         "the daemon should have observed a Remember"
@@ -232,6 +249,45 @@ fn post_tool_use_against_live_daemon_remembers() {
         (confidence - 0.7).abs() < f32::EPSILON,
         "hook captures must send confidence 0.7, got {confidence}"
     );
-    let _ = server.join();
-    let _: PathBuf = socket; // keep tempdir alive until here
+}
+
+#[test]
+fn planted_secrets_in_tool_response_never_reach_the_remember_payload() {
+    // W0.5 minimal redaction: a tool response carrying every supported secret
+    // shape must arrive at the daemon with markers instead of plaintext.
+    let stdin = concat!(
+        r#"{"hook_event_name":"PostToolUse","cwd":"/tmp","session_id":"s1","#,
+        r#""tool_name":"Bash","tool_input":{"command":"deploy --password=hunter2"},"#,
+        r#""tool_response":"key AKIAABCDEFGHIJKLMNOP\nAuthorization: Bearer sk-live-deadbeef\n"#,
+        r#"GITHUB_TOKEN=ghp_secret123\n-----BEGIN RSA PRIVATE KEY-----\nMIIfakekeymaterial\n"#,
+        r#"-----END RSA PRIVATE KEY-----\ndone"}"#
+    );
+    let observed = observe_against_mock_daemon(stdin);
+    assert!(observed.saw_remember, "the Remember must reach the daemon");
+
+    let payload = format!(
+        "{}\n{}",
+        observed.content.as_deref().unwrap_or_default(),
+        observed.context.as_deref().unwrap_or_default()
+    );
+    for secret in [
+        "hunter2",
+        "AKIAABCDEFGHIJKLMNOP",
+        "sk-live-deadbeef",
+        "ghp_secret123",
+        "MIIfakekeymaterial",
+    ] {
+        assert!(
+            !payload.contains(secret),
+            "planted secret {secret:?} leaked into the remember payload: {payload}"
+        );
+    }
+    assert!(
+        payload.contains("[REDACTED:"),
+        "redaction markers must be present: {payload}"
+    );
+    assert!(
+        payload.contains("done"),
+        "non-secret response text must survive: {payload}"
+    );
 }

--- a/crates/rb-install/src/installers/claude_code.rs
+++ b/crates/rb-install/src/installers/claude_code.rs
@@ -30,14 +30,14 @@ impl AgentInstaller for ClaudeCodeInstaller {
             InstallScope::Project(root) => root.join(".claude").join("settings.json"),
             InstallScope::Global => home_join(".claude")?.join("settings.json"),
         };
-        // Claude Code: its own event names, tool event `PostToolUse`, EXEC form
-        // (it supports a separate `args` array).
+        // Claude Code: its own event names, tool event `PostToolUse`. The
+        // documented hooks schema takes `command` as ONE shell string (no `args`
+        // field — verified against a recorded real settings.json, F50).
         let merge = hooks_block(
             &hooks_bin.to_string_lossy(),
             AgentId::ClaudeCode.as_str(),
             &CLAUDE_EVENTS,
             "PostToolUse",
-            true,
         );
         Ok(HookFragment { config_path, merge })
     }
@@ -74,14 +74,21 @@ mod tests {
             let group = &arr[0];
             assert_eq!(group.get(SENTINEL).unwrap(), &serde_json::json!(true));
             let inner = group.get("hooks").unwrap().as_array().unwrap();
-            // EXEC form: `command` is the raw binary path; flags live in `args`.
-            let cmd = inner[0].get("command").unwrap().as_str().unwrap();
-            assert_eq!(cmd, "/usr/local/bin/rusty-brain-hooks");
-            assert_eq!(
-                inner[0].get("args").unwrap(),
-                &serde_json::json!(["--agent", "claude-code"])
+            // Documented shape: exactly {type, command}; the flag lives inside
+            // the single shell string, never in a separate `args` array.
+            let entry = inner[0].as_object().unwrap();
+            let keys: Vec<&str> = entry.keys().map(String::as_str).collect();
+            assert_eq!(keys, ["command", "type"], "no args key, no unknown keys");
+            assert_eq!(entry.get("type").unwrap(), &serde_json::json!("command"));
+            let cmd = entry.get("command").unwrap().as_str().unwrap();
+            assert!(
+                cmd.contains("/usr/local/bin/rusty-brain-hooks"),
+                "command must reference the hooks binary path; got {cmd}"
             );
-            assert_eq!(inner[0].get(SENTINEL).unwrap(), &serde_json::json!(true));
+            assert!(
+                cmd.ends_with("--agent claude-code"),
+                "command must pass the claude-code agent id; got {cmd}"
+            );
         }
         // PostToolUse carries a matcher; the others do not.
         let post = hooks.get("PostToolUse").unwrap().as_array().unwrap();

--- a/crates/rb-install/src/installers/codex.rs
+++ b/crates/rb-install/src/installers/codex.rs
@@ -31,14 +31,13 @@ impl AgentInstaller for CodexInstaller {
             InstallScope::Global => home_join(".codex")?.join("hooks.json"),
         };
         // Codex: SessionStart/PostToolUse/Stop/PreCompact event names, tool event
-        // `PostToolUse`, INLINE form (Codex has no `args` field — the `--agent`
-        // flag must live inside the single command string).
+        // `PostToolUse`. Like every CLI, no `args` field — the `--agent` flag
+        // must live inside the single command string.
         let merge = hooks_block(
             &hooks_bin.to_string_lossy(),
             AgentId::Codex.as_str(),
             &CODEX_EVENTS,
             "PostToolUse",
-            false,
         );
         Ok(HookFragment { config_path, merge })
     }
@@ -65,7 +64,7 @@ mod tests {
             .unwrap();
         assert_eq!(frag.config_path, PathBuf::from("/tmp/c/.codex/hooks.json"));
         let hooks = frag.merge.get("hooks").unwrap();
-        // Codex uses Claude's event names — but the command form differs.
+        // Codex uses Claude's event names (and the same single-string command form).
         for event in ["SessionStart", "PostToolUse", "Stop", "PreCompact"] {
             assert!(
                 hooks.get(event).is_some(),
@@ -79,9 +78,8 @@ mod tests {
         assert!(stop[0].get("matcher").is_none());
 
         let entry = post[0].get("hooks").unwrap().as_array().unwrap()[0].clone();
-        // INLINE form: one shell string with the binary SHELL-QUOTED (the exact
-        // quoting is verified in `installers::tests`); there is NO separate `args`
-        // key.
+        // One shell string with the binary SHELL-QUOTED (the exact quoting is
+        // verified in `installers::tests`); there is NO separate `args` key.
         let cmd = entry.get("command").unwrap().as_str().unwrap();
         assert!(
             cmd.contains("/bin/rusty-brain-hooks"),

--- a/crates/rb-install/src/installers/gemini.rs
+++ b/crates/rb-install/src/installers/gemini.rs
@@ -31,14 +31,13 @@ impl AgentInstaller for GeminiInstaller {
             InstallScope::Global => home_join(".gemini")?.join("settings.json"),
         };
         // Gemini: its own event names (SessionStart/AfterTool/SessionEnd/
-        // PreCompress), tool event `AfterTool`, INLINE form (Gemini has no `args`
-        // field — the `--agent` flag must live inside the single command string).
+        // PreCompress), tool event `AfterTool`. Like every CLI, no `args` field —
+        // the `--agent` flag must live inside the single command string.
         let merge = hooks_block(
             &hooks_bin.to_string_lossy(),
             AgentId::Gemini.as_str(),
             &GEMINI_EVENTS,
             "AfterTool",
-            false,
         );
         Ok(HookFragment { config_path, merge })
     }
@@ -91,9 +90,8 @@ mod tests {
             .as_array()
             .unwrap()[0]
             .clone();
-        // INLINE form: one shell string with the binary SHELL-QUOTED (the exact
-        // quoting is verified in `installers::tests`); there is NO separate `args`
-        // key.
+        // One shell string with the binary SHELL-QUOTED (the exact quoting is
+        // verified in `installers::tests`); there is NO separate `args` key.
         let cmd = entry.get("command").unwrap().as_str().unwrap();
         assert!(
             cmd.contains("/bin/rusty-brain-hooks"),

--- a/crates/rb-install/src/installers/mod.rs
+++ b/crates/rb-install/src/installers/mod.rs
@@ -40,44 +40,32 @@ pub(crate) const GEMINI_EVENTS: [&str; 4] =
 /// Codex's hook event names. The tool event is `PostToolUse`.
 pub(crate) const CODEX_EVENTS: [&str; 4] = ["SessionStart", "PostToolUse", "Stop", "PreCompact"];
 
-/// Build one command-hook entry, tagged with the sentinel marker, in the form
-/// required by the target CLI.
+/// Build one command-hook entry in the documented shape shared by all three
+/// CLIs: `{"type": "command", "command": "<single shell string>"}`.
 ///
-/// Two command forms exist because the CLIs differ in whether they support a
-/// separate `args` array:
+/// `command` is ONE shell-interpreted string — none of the CLIs honor a
+/// separate `args` array (Claude Code's documented hooks schema has no `args`
+/// field, verified against a recorded real `settings.json`; an `args` array
+/// would be silently dropped and run `rusty-brain-hooks` WITHOUT `--agent`).
+/// The binary path is SHELL-QUOTED via [`shell_quote`] so spaces AND
+/// metacharacters survive the CLI's shell re-tokenization, followed by
+/// `--agent <id>`.
 ///
-/// - `exec_args == true` (Claude Code): EXEC form — `command` is the raw binary
-///   path (its own JSON string) and the flags live in a separate `args` array.
-///   A shell-form string would be re-tokenized by the shell, splitting a binary
-///   path that contains spaces (common in macOS/Windows home dirs) mid-path and
-///   failing to launch.
-/// - `exec_args == false` (Gemini, Codex): INLINE form — these CLIs have **no**
-///   `args` field, so a separate `args` array is silently dropped (which would
-///   run `rusty-brain-hooks` WITHOUT `--agent`). The whole invocation is one
-///   shell string: the binary path SHELL-QUOTED via [`shell_quote`] (so spaces
-///   AND metacharacters survive the CLI's shell re-tokenization) followed by
-///   `--agent <id>`. No `args` key is emitted.
-fn command_entry(hooks_bin: &str, agent_id: &str, exec_args: bool) -> serde_json::Value {
-    if exec_args {
-        serde_json::json!({
-            "type": "command",
-            "command": hooks_bin,
-            "args": ["--agent", agent_id],
-            SENTINEL: true,
-        })
-    } else {
-        serde_json::json!({
-            "type": "command",
-            "command": format!("{} --agent {agent_id}", shell_quote(hooks_bin)),
-            SENTINEL: true,
-        })
-    }
+/// No keys beyond the documented `type`/`command` are emitted — the sentinel
+/// marker lives on the enclosing matcher group (see [`command_group`]), which
+/// is wholly ours, so uninstall scoping is preserved without putting an
+/// unknown key inside the entry the CLI validates.
+fn command_entry(hooks_bin: &str, agent_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "command",
+        "command": format!("{} --agent {agent_id}", shell_quote(hooks_bin)),
+    })
 }
 
-/// Quote a binary path for the INLINE-form `command` string so it survives the
+/// Quote a binary path for the single-string `command` so it survives the
 /// target CLI's shell re-tokenization intact.
 ///
-/// The INLINE form (Gemini, Codex) embeds the path in a single shell string that
+/// The `command` string embeds the path in a single shell string that
 /// the CLI runs through a shell. A naive double-quote wrap tolerates spaces but
 /// still lets a POSIX shell expand `$`, backticks, and embedded quotes inside the
 /// path — a correctness hole and, because the string is persisted to user config
@@ -103,17 +91,17 @@ fn shell_quote(path: &str) -> String {
 }
 
 /// Build one matcher-group for `event`, wrapping the [`command_entry`] for this
-/// CLI. The group carries the sentinel marker; the tool event (`tool_event`)
-/// additionally carries `"matcher": "*"`, while the non-tool events omit it to
-/// match each CLI's schema.
+/// CLI. The group carries the sentinel marker (it is created wholly by us, so
+/// stripping the group removes exactly our entries); the tool event
+/// (`tool_event`) additionally carries `"matcher": "*"`, while the non-tool
+/// events omit it to match each CLI's schema.
 pub(crate) fn command_group(
     hooks_bin: &str,
     agent_id: &str,
     event: &str,
     tool_event: &str,
-    exec_args: bool,
 ) -> serde_json::Value {
-    let entry = command_entry(hooks_bin, agent_id, exec_args);
+    let entry = command_entry(hooks_bin, agent_id);
     if event == tool_event {
         serde_json::json!({
             "matcher": "*",
@@ -131,23 +119,20 @@ pub(crate) fn command_group(
 /// Build the full `{ "hooks": { <event>: [group], ... } }` block for a CLI whose
 /// config nests hooks under a top-level `hooks` key (Claude Code, Gemini, Codex).
 ///
-/// `events` is that CLI's native event-name set, `tool_event` is the member of
-/// `events` that gets the `"matcher": "*"` group, and `exec_args` selects the
-/// EXEC (`true`) vs INLINE (`false`) command form (see [`command_entry`]).
+/// `events` is that CLI's native event-name set and `tool_event` is the member
+/// of `events` that gets the `"matcher": "*"` group (see [`command_entry`] for
+/// the shared single-shell-string command form).
 pub(crate) fn hooks_block(
     hooks_bin: &str,
     agent_id: &str,
     events: &[&str],
     tool_event: &str,
-    exec_args: bool,
 ) -> serde_json::Value {
     let mut hooks = serde_json::Map::new();
     for event in events {
         hooks.insert(
             (*event).to_string(),
-            serde_json::Value::Array(vec![command_group(
-                hooks_bin, agent_id, event, tool_event, exec_args,
-            )]),
+            serde_json::Value::Array(vec![command_group(hooks_bin, agent_id, event, tool_event)]),
         );
     }
     serde_json::json!({ "hooks": serde_json::Value::Object(hooks) })
@@ -175,37 +160,49 @@ mod tests {
     }
 
     #[test]
-    fn exec_form_keeps_raw_path_and_separate_args() {
-        // EXEC form (Claude Code): the raw path is its own JSON string and flags
-        // live in a separate `args` array — never re-tokenized, never quoted.
-        let entry = command_entry(
-            "/Users/jo bloggs/.local/bin/rusty-brain-hooks",
-            "claude-code",
-            true,
-        );
+    fn entry_has_exactly_the_documented_keys() {
+        // Documented hook-entry shape for every CLI: {"type": "command",
+        // "command": "<shell string>"} — no `args` array (it would be silently
+        // dropped) and no unknown keys (the sentinel lives on the group, not in
+        // the entry the CLI validates).
+        let entry = command_entry("/bin/rusty-brain-hooks", "claude-code");
+        let keys: Vec<&str> = entry
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
         assert_eq!(
-            command_of(&entry),
-            "/Users/jo bloggs/.local/bin/rusty-brain-hooks"
+            keys,
+            ["command", "type"],
+            "exactly type+command, nothing else"
         );
-        assert_eq!(
-            entry.get("args").unwrap(),
-            &serde_json::json!(["--agent", "claude-code"])
-        );
+        assert_eq!(entry.get("type").unwrap(), &serde_json::json!("command"));
+        assert!(command_of(&entry).ends_with("--agent claude-code"));
     }
 
     #[test]
-    fn inline_form_has_no_args_array() {
-        // INLINE form (Gemini/Codex): a separate `args` array would be dropped, so
-        // the flag must be inside the single command string and no `args` emitted.
-        let entry = command_entry("/bin/rusty-brain-hooks", "gemini", false);
-        assert!(entry.get("args").is_none());
-        assert!(command_of(&entry).ends_with("--agent gemini"));
+    fn group_carries_sentinel_for_uninstall_scoping() {
+        // The matcher group is created wholly by us, so the sentinel marker on
+        // the group (not the entry) is what uninstall strips.
+        let group = command_group(
+            "/bin/rusty-brain-hooks",
+            "claude-code",
+            "Stop",
+            "PostToolUse",
+        );
+        assert_eq!(group.get(SENTINEL).unwrap(), &serde_json::json!(true));
+        let inner = group.get("hooks").unwrap().as_array().unwrap();
+        assert!(
+            inner[0].get(SENTINEL).is_none(),
+            "entry must stay documented-shape"
+        );
     }
 
     #[cfg(not(windows))]
     #[test]
-    fn inline_clean_path_is_single_quoted_posix() {
-        let entry = command_entry("/usr/local/bin/rusty-brain-hooks", "gemini", false);
+    fn clean_path_is_single_quoted_posix() {
+        let entry = command_entry("/usr/local/bin/rusty-brain-hooks", "gemini");
         assert_eq!(
             command_of(&entry),
             "'/usr/local/bin/rusty-brain-hooks' --agent gemini"
@@ -214,12 +211,8 @@ mod tests {
 
     #[cfg(not(windows))]
     #[test]
-    fn inline_path_with_space_is_quoted_posix() {
-        let entry = command_entry(
-            "/Users/jo bloggs/.local/bin/rusty-brain-hooks",
-            "codex",
-            false,
-        );
+    fn path_with_space_is_quoted_posix() {
+        let entry = command_entry("/Users/jo bloggs/.local/bin/rusty-brain-hooks", "codex");
         assert_eq!(
             command_of(&entry),
             "'/Users/jo bloggs/.local/bin/rusty-brain-hooks' --agent codex"
@@ -228,12 +221,12 @@ mod tests {
 
     #[cfg(not(windows))]
     #[test]
-    fn inline_path_metacharacters_are_neutralized_posix() {
+    fn path_metacharacters_are_neutralized_posix() {
         // `$(...)`, backticks, and an embedded single quote must NOT survive as
         // live shell syntax. Single-quote wrapping makes everything literal except
         // the embedded single quote, which is closed/escaped/reopened as `'\''`.
         let nasty = "/opt/$(rm -rf ~)/`whoami`/r'b/hooks";
-        let entry = command_entry(nasty, "gemini", false);
+        let entry = command_entry(nasty, "gemini");
         assert_eq!(
             command_of(&entry),
             "'/opt/$(rm -rf ~)/`whoami`/r'\\''b/hooks' --agent gemini"
@@ -271,12 +264,8 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn inline_path_is_double_quoted_on_windows() {
-        let entry = command_entry(
-            r"C:\Program Files\rb\rusty-brain-hooks.exe",
-            "gemini",
-            false,
-        );
+    fn path_is_double_quoted_on_windows() {
+        let entry = command_entry(r"C:\Program Files\rb\rusty-brain-hooks.exe", "gemini");
         assert_eq!(
             command_of(&entry),
             "\"C:\\Program Files\\rb\\rusty-brain-hooks.exe\" --agent gemini"

--- a/crates/rb-install/tests/claude_code_fixture.rs
+++ b/crates/rb-install/tests/claude_code_fixture.rs
@@ -1,0 +1,212 @@
+//! W0.7 (F50): recorded-fixture verification of the Claude Code hook form.
+//!
+//! `fixtures/claude_code_settings.json` is a realistic pre-existing user
+//! `settings.json` recorded from a real Claude Code installation shape: other
+//! hooks (with matchers and a `timeout`), a `permissions` block, `env`,
+//! `statusLine`. The documented hooks schema takes `command` as ONE
+//! shell-interpreted string — there is no `args` field — so these tests pin:
+//! (a) install preserves every unrelated entry and emits only documented-shape
+//! entries, (b) uninstall restores the fixture semantically, and (c) the
+//! emitted command string round-trips through real shell parsing back to our
+//! binary + flags.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::path::Path;
+
+use rb_agents::install::{AgentInstaller, InstallScope, SENTINEL};
+use rb_install::installers::ClaudeCodeInstaller;
+use rb_install::uninstall::uninstall_file;
+use rb_install::writer::merge_into_file;
+
+/// The four Claude Code events the installer writes (mirrors `CLAUDE_EVENTS`).
+const OUR_EVENTS: [&str; 4] = ["SessionStart", "PostToolUse", "Stop", "PreCompact"];
+
+/// Parse the recorded fixture.
+fn fixture() -> serde_json::Value {
+    serde_json::from_str(include_str!("fixtures/claude_code_settings.json"))
+        .expect("fixture must be valid JSON")
+}
+
+/// Materialize the fixture at `<project>/.claude/settings.json` and return the
+/// settings path.
+fn write_fixture(project: &Path) -> std::path::PathBuf {
+    let dir = project.join(".claude");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("settings.json");
+    std::fs::write(&path, include_str!("fixtures/claude_code_settings.json")).unwrap();
+    path
+}
+
+/// Install our Claude Code fragment for `hooks_bin` into the fixture on disk;
+/// returns the settings path and the merged value.
+fn install_into_fixture(
+    project: &Path,
+    hooks_bin: &Path,
+) -> (std::path::PathBuf, serde_json::Value) {
+    let path = write_fixture(project);
+    let frag = ClaudeCodeInstaller
+        .hook_fragment(hooks_bin, &InstallScope::Project(project.to_path_buf()))
+        .unwrap();
+    assert_eq!(
+        frag.config_path, path,
+        "fragment must target the fixture file"
+    );
+    let merged = merge_into_file(&path, &frag.merge).unwrap();
+    (path, merged)
+}
+
+/// Split an event's groups into (user's, ours) by the group-level sentinel.
+fn split_groups(
+    merged: &serde_json::Value,
+    event: &str,
+) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+    let groups = merged
+        .get("hooks")
+        .unwrap()
+        .get(event)
+        .unwrap()
+        .as_array()
+        .unwrap();
+    groups
+        .iter()
+        .cloned()
+        .partition(|g| g.get(SENTINEL).is_none())
+}
+
+/// True if any object anywhere in `value` carries an `args` key.
+fn contains_args_key(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.contains_key("args") || map.values().any(contains_args_key)
+        }
+        serde_json::Value::Array(items) => items.iter().any(contains_args_key),
+        _ => false,
+    }
+}
+
+#[test]
+fn install_preserves_user_settings_and_emits_documented_shape() {
+    let original = fixture();
+    let dir = tempfile::tempdir().unwrap();
+    let (_path, merged) =
+        install_into_fixture(dir.path(), Path::new("/usr/local/bin/rusty-brain-hooks"));
+
+    // Unrelated top-level entries survive byte-for-byte semantically.
+    for key in ["model", "permissions", "env", "statusLine", "theme"] {
+        assert_eq!(
+            merged.get(key),
+            original.get(key),
+            "user `{key}` entry must survive install unchanged"
+        );
+    }
+    // PreToolUse is not an event we install — the user's groups are untouched.
+    assert_eq!(
+        merged.get("hooks").unwrap().get("PreToolUse"),
+        original.get("hooks").unwrap().get("PreToolUse"),
+        "user PreToolUse hooks must survive install unchanged"
+    );
+
+    for event in OUR_EVENTS {
+        let (user_groups, our_groups) = split_groups(&merged, event);
+        // The user's pre-existing groups for this event survive unchanged.
+        let original_groups = original
+            .get("hooks")
+            .unwrap()
+            .get(event)
+            .and_then(|v| v.as_array().cloned())
+            .unwrap_or_default();
+        assert_eq!(
+            user_groups, original_groups,
+            "user {event} groups must survive install unchanged"
+        );
+        // Exactly one group of ours, with exactly one documented-shape entry:
+        // {"type": "command", "command": "<shell string>"} — no `args` key, no
+        // unknown keys (the sentinel lives on the group only).
+        assert_eq!(our_groups.len(), 1, "exactly one of our groups for {event}");
+        let inner = our_groups[0].get("hooks").unwrap().as_array().unwrap();
+        assert_eq!(inner.len(), 1);
+        let entry = inner[0].as_object().unwrap();
+        let keys: Vec<&str> = entry.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            ["command", "type"],
+            "{event} entry must have exactly the documented keys"
+        );
+        assert_eq!(entry.get("type").unwrap(), &serde_json::json!("command"));
+        let cmd = entry.get("command").unwrap().as_str().unwrap();
+        assert!(
+            cmd.contains("rusty-brain-hooks") && cmd.ends_with("--agent claude-code"),
+            "{event} command must be one shell string carrying the agent flag; got {cmd}"
+        );
+    }
+
+    // The documented schema has no `args` field anywhere; neither the fixture
+    // nor our injected entries may introduce one.
+    assert!(
+        !contains_args_key(&merged),
+        "no `args` key anywhere after install"
+    );
+}
+
+#[test]
+fn uninstall_restores_fixture_semantically() {
+    let original = fixture();
+    let dir = tempfile::tempdir().unwrap();
+    let (path, merged) =
+        install_into_fixture(dir.path(), Path::new("/usr/local/bin/rusty-brain-hooks"));
+    assert_ne!(merged, original, "install must have changed the settings");
+
+    uninstall_file(&path).unwrap();
+    let after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        after, original,
+        "uninstall must restore the recorded fixture semantically"
+    );
+}
+
+/// Strongest form check: a real `/bin/sh` parses the emitted `command` string
+/// back to OUR binary (its path containing a space and a single quote) plus
+/// exactly `--agent claude-code` — precedent: `shell_quote_roundtrips_through_sh`
+/// in `installers::tests`.
+#[cfg(unix)]
+#[test]
+fn emitted_command_round_trips_through_shell_to_binary_and_flags() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().unwrap();
+    let bin_dir = dir.path().join("jo bloggs's tools");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let hooks_bin = bin_dir.join("rusty-brain-hooks");
+    // Stand-in binary that prints each argv element on its own line.
+    std::fs::write(&hooks_bin, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n").unwrap();
+    std::fs::set_permissions(&hooks_bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let frag = ClaudeCodeInstaller
+        .hook_fragment(&hooks_bin, &InstallScope::Project(dir.path().to_path_buf()))
+        .unwrap();
+    let (_, our_groups) = split_groups(&frag.merge, "PostToolUse");
+    let cmd = our_groups[0].get("hooks").unwrap().as_array().unwrap()[0]
+        .get("command")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Claude Code runs `command` through a shell; do exactly that.
+    let out = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&cmd)
+        .output()
+        .expect("run the emitted command through /bin/sh");
+    assert!(
+        out.status.success(),
+        "shell must reach the binary despite space+quote in its path; cmd={cmd:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "--agent\nclaude-code\n",
+        "the binary must receive exactly the agent flag arguments"
+    );
+}

--- a/crates/rb-install/tests/e2e.rs
+++ b/crates/rb-install/tests/e2e.rs
@@ -145,12 +145,9 @@ async fn install_capture_uninstall_round_trip() {
     // --- fixture project -----------------------------------------------------
     let proj_dir = tempfile::tempdir_in(std::env::temp_dir()).unwrap();
     let project = proj_dir.path().to_path_buf();
-    // Mark the project so namespace detection resolves to a stable Project name.
-    std::fs::write(
-        project.join("CLAUDE.md"),
-        "---\nproject: rb-e2e-fixture\n---\n# rb-e2e-fixture\n",
-    )
-    .unwrap();
+    // Pin the namespace explicitly (env on the hook invocation below): the
+    // fixture dir is not a git repo, and since W0.3 hooks never honor unpinned
+    // CLAUDE.md frontmatter, so the env override is the stable identity here.
     let namespace = Namespace::Project("rb-e2e-fixture".to_string());
 
     // --- in-process daemon ---------------------------------------------------
@@ -217,6 +214,9 @@ async fn install_capture_uninstall_round_trip() {
         .args(["--agent", "claude-code"])
         .env("RUSTY_BRAIN_SOCKET", &daemon.socket)
         .env("RUSTY_BRAIN_DB", &daemon.db)
+        // Explicit namespace (W0.3 rule 1) so capture and the recall below
+        // agree on identity without a git repo in the fixture.
+        .env("RUSTY_BRAIN_NAMESPACE", "rb-e2e-fixture")
         // Isolate the dedup cache to the fixture tempdir so this test never reads
         // or writes the real ~/.cache and a prior run cannot suppress this edit as
         // a duplicate (mirrors crates/rb-hooks/tests/integration.rs).

--- a/crates/rb-install/tests/fixtures/claude_code_settings.json
+++ b/crates/rb-install/tests/fixtures/claude_code_settings.json
@@ -1,0 +1,77 @@
+{
+  "model": "claude-opus-4-1",
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run test:*)",
+      "Read(~/.zshrc)"
+    ],
+    "deny": [
+      "Bash(curl:*)",
+      "Read(./.env)"
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/protect-files.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx prettier --write \"$CLAUDE_PROJECT_DIR\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks activate --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay /System/Library/Sounds/Glass.aiff"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  },
+  "theme": "dark"
+}

--- a/crates/rb-mcp/src/change_buffer.rs
+++ b/crates/rb-mcp/src/change_buffer.rs
@@ -5,6 +5,18 @@
 
 use rb_types::MemoryChanged;
 use std::collections::VecDeque;
+use std::time::Instant;
+
+/// Health of the background daemon subscriber feeding this ring, surfaced in
+/// `poll_changes` so a consumer can tell a quiet corpus (connected, no events)
+/// from a deaf one (disconnected — events may be happening unseen).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriberStatus {
+    /// A live subscription is streaming into the ring.
+    Connected,
+    /// No live subscription since `since` (including "never connected yet").
+    Disconnected { since: Instant },
+}
 
 /// A bounded ring of buffered change events with a since-last-drain dropped
 /// counter. Cheap to clone via `Arc<Mutex<ChangeBuffer>>` at the call site.
@@ -15,6 +27,9 @@ pub struct ChangeBuffer {
     /// Events dropped (evicted on overflow, or reported by broadcast `Lagged`)
     /// since the last `drain`. Reset to 0 by `drain`.
     dropped: u64,
+    /// Subscriber health. Starts `Disconnected` (fail closed: a ring nobody
+    /// feeds must read as deaf, not quiet) until the subscriber reports in.
+    status: SubscriberStatus,
 }
 
 /// The result of draining the ring: up to `max` events plus the number of
@@ -32,7 +47,32 @@ impl ChangeBuffer {
             events: VecDeque::new(),
             capacity: capacity.max(1),
             dropped: 0,
+            status: SubscriberStatus::Disconnected {
+                since: Instant::now(),
+            },
         }
+    }
+
+    /// Mark the feeding subscriber as live (called on each successful
+    /// resubscribe).
+    pub fn set_connected(&mut self) {
+        self.status = SubscriberStatus::Connected;
+    }
+
+    /// Mark the feeding subscriber as down. Idempotent: repeated failed
+    /// reconnect attempts keep the ORIGINAL disconnect instant so the reported
+    /// outage duration stays truthful.
+    pub fn set_disconnected(&mut self) {
+        if !matches!(self.status, SubscriberStatus::Disconnected { .. }) {
+            self.status = SubscriberStatus::Disconnected {
+                since: Instant::now(),
+            };
+        }
+    }
+
+    /// Current subscriber health.
+    pub fn subscriber_status(&self) -> SubscriberStatus {
+        self.status
     }
 
     /// Push one event, evicting (and counting) the oldest if at capacity.
@@ -145,6 +185,40 @@ mod tests {
         let next = b.drain(10);
         assert_eq!(next.dropped, 0);
         assert!(next.events.is_empty());
+    }
+
+    #[test]
+    fn subscriber_status_starts_disconnected_and_tracks_transitions() {
+        let mut b = ChangeBuffer::new(4);
+        // Fail closed: until the subscriber reports in, the ring is deaf.
+        assert!(matches!(
+            b.subscriber_status(),
+            SubscriberStatus::Disconnected { .. }
+        ));
+        b.set_connected();
+        assert_eq!(b.subscriber_status(), SubscriberStatus::Connected);
+        b.set_disconnected();
+        assert!(matches!(
+            b.subscriber_status(),
+            SubscriberStatus::Disconnected { .. }
+        ));
+    }
+
+    #[test]
+    fn repeated_disconnects_keep_the_original_since_instant() {
+        let mut b = ChangeBuffer::new(4);
+        b.set_connected();
+        b.set_disconnected();
+        let SubscriberStatus::Disconnected { since: first } = b.subscriber_status() else {
+            panic!("expected disconnected");
+        };
+        // A later redundant set_disconnected (failed reconnect attempt) must not
+        // reset the outage clock.
+        b.set_disconnected();
+        let SubscriberStatus::Disconnected { since: second } = b.subscriber_status() else {
+            panic!("expected disconnected");
+        };
+        assert_eq!(first, second, "outage start must be preserved");
     }
 
     #[test]

--- a/crates/rb-mcp/src/lib.rs
+++ b/crates/rb-mcp/src/lib.rs
@@ -13,7 +13,7 @@ pub mod server;
 pub mod tools;
 pub mod transport;
 
-pub use change_buffer::{ChangeBuffer, Drained};
+pub use change_buffer::{ChangeBuffer, Drained, SubscriberStatus};
 pub use jsonrpc::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 pub use proxy::{build_request, response_to_content, DaemonProxy};
 pub use server::handle_request;

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -128,6 +128,9 @@ pub fn build_request(name: &str, args: &Value) -> Result<Request, ToolError> {
                 keywords: Vec::new(),
                 tags: opt_string_vec(args, "tags")?,
                 related_files: Vec::new(),
+                // MCP-tool writes keep full trust (W0.5: only hook captures
+                // declare a lower prior).
+                confidence: 1.0,
             })
         }
         "recall" => Ok(Request::Recall {

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -236,6 +236,16 @@ mod tests {
                 Request::Graph { .. } => Response::GraphResult {
                     memories: vec![note()],
                 },
+                // Mirrors the daemon: the engine rejects content updates with
+                // InvalidArgument and error_map forwards the message verbatim.
+                Request::Update { ref updates, .. } if updates.content.is_some() => {
+                    Response::Error {
+                        kind: "invalid_argument".into(),
+                        message: "invalid argument: content updates are not supported; \
+                                  create a new memory so embeddings stay consistent"
+                            .into(),
+                    }
+                }
                 Request::Update { .. } => Response::Updated,
                 Request::Delete { .. } => Response::Deleted,
                 Request::Context => Response::ContextResult {
@@ -385,6 +395,35 @@ mod tests {
             result["isError"],
             json!(true),
             "daemon error -> isError result"
+        );
+        // The transport itself stays successful (result, not error).
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_call_update_with_content_surfaces_guidance_not_internal_error() {
+        // F55: a content update must come back as an isError tool result whose
+        // text carries the actionable guidance, not an opaque internal fault.
+        let mut proxy = fake();
+        let r = req(
+            "tools/call",
+            Some(8),
+            json!({ "name": "update", "arguments": {
+                "id": MemoryId::new().to_string(),
+                "content": "rewritten body"
+            } }),
+        );
+        let resp = handle_request(r, &mut proxy).await.unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["isError"], json!(true));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("content updates are not supported"),
+            "guidance must reach the client verbatim: {text}"
+        );
+        assert!(
+            !text.contains("internal error"),
+            "rejection must be distinguishable from a real fault: {text}"
         );
         // The transport itself stays successful (result, not error).
         assert!(resp.error.is_none());

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -1,6 +1,6 @@
 //! MCP method dispatch: one decoded JSON-RPC request -> optional response.
 
-use crate::change_buffer::ChangeBuffer;
+use crate::change_buffer::{ChangeBuffer, SubscriberStatus};
 use crate::jsonrpc::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, INTERNAL_ERROR, INVALID_PARAMS, METHOD_NOT_FOUND,
 };
@@ -155,18 +155,42 @@ async fn handle_poll_changes(
     };
 
     let Some(buffer) = buffer else {
-        // No background subscriber is running: nothing to drain, but this is not
-        // an error — the client can keep polling.
-        let content = json!({ "events": [], "dropped": 0 });
+        // No background subscriber is running (plain stdio mode): nothing to
+        // drain, but this is not an error — the client can keep polling. Report
+        // disconnected so "no events" is never mistaken for a quiet corpus.
+        let content = json!({
+            "events": [],
+            "dropped": 0,
+            "subscriber": { "status": "disconnected" }
+        });
         return JsonRpcResponse::success(id, tool_result(content, false));
     };
 
-    let drained = {
+    // Drain and snapshot health under one lock so they describe the same moment.
+    let (drained, status) = {
         let mut guard = buffer.lock().await;
-        guard.drain(max)
+        let drained = guard.drain(max);
+        (drained, guard.subscriber_status())
     };
-    let content = json!({ "events": drained.events, "dropped": drained.dropped });
+    let content = json!({
+        "events": drained.events,
+        "dropped": drained.dropped,
+        "subscriber": subscriber_json(status),
+    });
     JsonRpcResponse::success(id, tool_result(content, false))
+}
+
+/// Render subscriber health for the `poll_changes` payload. `for_secs` bounds
+/// how long changes may have gone unseen, so the model can tell "quiet"
+/// (connected, no events) from "deaf" (disconnected — events may be missing).
+fn subscriber_json(status: SubscriberStatus) -> Value {
+    match status {
+        SubscriberStatus::Connected => json!({ "status": "connected" }),
+        SubscriberStatus::Disconnected { since } => json!({
+            "status": "disconnected",
+            "for_secs": since.elapsed().as_secs(),
+        }),
+    }
 }
 
 /// Wrap a JSON payload as an MCP tool result (a single JSON text content item).
@@ -469,6 +493,8 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(text).unwrap();
         assert_eq!(payload["events"].as_array().unwrap().len(), 1);
         assert_eq!(payload["dropped"], 2);
+        // A fresh buffer with no subscriber report reads as deaf, not quiet.
+        assert_eq!(payload["subscriber"]["status"], "disconnected");
         assert_ne!(result["isError"], json!(true));
 
         // A second poll returns nothing new and zero drops (the ring was drained).
@@ -487,5 +513,73 @@ mod tests {
         let payload2: serde_json::Value = serde_json::from_str(&text2).unwrap();
         assert_eq!(payload2["events"].as_array().unwrap().len(), 0);
         assert_eq!(payload2["dropped"], 0);
+    }
+
+    // F57: the model must be able to distinguish "quiet" (connected, nothing
+    // happened) from "deaf" (subscriber down, events possibly missed).
+    #[tokio::test]
+    async fn poll_changes_reports_subscriber_health_transitions() {
+        use crate::change_buffer::ChangeBuffer;
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let mut proxy = fake();
+        let buffer = Arc::new(Mutex::new(ChangeBuffer::new(16)));
+
+        let poll = |id: i64| {
+            req(
+                "tools/call",
+                Some(id),
+                json!({ "name": "poll_changes", "arguments": {} }),
+            )
+        };
+        let payload_of = |resp: crate::jsonrpc::JsonRpcResponse| {
+            let text = resp.result.unwrap()["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            serde_json::from_str::<serde_json::Value>(&text).unwrap()
+        };
+
+        // Connected: status alone, no outage duration.
+        buffer.lock().await.set_connected();
+        let resp = handle_request_with_buffer(poll(30), &mut proxy, &buffer)
+            .await
+            .unwrap();
+        let payload = payload_of(resp);
+        assert_eq!(payload["subscriber"]["status"], "connected");
+        assert!(payload["subscriber"].get("for_secs").is_none());
+
+        // Disconnected: carries how long the subscriber has been down.
+        buffer.lock().await.set_disconnected();
+        let resp = handle_request_with_buffer(poll(31), &mut proxy, &buffer)
+            .await
+            .unwrap();
+        let payload = payload_of(resp);
+        assert_eq!(payload["subscriber"]["status"], "disconnected");
+        assert!(
+            payload["subscriber"]["for_secs"].is_u64(),
+            "outage duration must be reported: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_changes_without_buffer_reports_disconnected() {
+        // Plain stdio mode never runs a subscriber; "no events" must not read
+        // as a healthy quiet stream.
+        let mut proxy = fake();
+        let r = req(
+            "tools/call",
+            Some(32),
+            json!({ "name": "poll_changes", "arguments": {} }),
+        );
+        let resp = handle_request(r, &mut proxy).await.unwrap();
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let payload: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(payload["subscriber"]["status"], "disconnected");
+        assert_eq!(payload["events"].as_array().unwrap().len(), 0);
     }
 }

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -145,9 +145,11 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ToolDef {
             name: "poll_changes",
             description: "Drain buffered change notifications for the current \
-                          namespace since the last poll. Returns up to `max` events \
-                          plus a count of events dropped (the buffer is bounded and \
-                          lossy under heavy write load).",
+                          namespace since the last poll. Returns up to `max` events, \
+                          a count of events dropped (the buffer is bounded and lossy \
+                          under heavy write load), and the subscriber health: status \
+                          'disconnected' means events may be missed, not that \
+                          nothing changed.",
             input_schema: json!({
                 "type": "object",
                 "properties": {

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -110,7 +110,11 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                 "type": "object",
                 "properties": {
                     "id": { "type": "string", "description": "Memory id (UUID)." },
-                    "content": { "type": "string" },
+                    "content": { "type": "string",
+                                 "description": "Content updates are not supported yet — \
+                                                 delete and re-remember instead (keeps \
+                                                 embeddings consistent). Sending content \
+                                                 returns a validation error." },
                     "summary": { "type": "string" },
                     "importance": { "type": "integer", "minimum": 1, "maximum": 10 },
                     "tags": { "type": "array", "items": { "type": "string" } },
@@ -246,6 +250,28 @@ mod tests {
                 "remember should accept optional {opt}"
             );
         }
+    }
+
+    #[test]
+    fn update_content_property_documents_the_limitation() {
+        // F55: the schema must not advertise a bare `content` property — the
+        // engine rejects content updates, so the description has to say so and
+        // point at the workaround (delete + re-remember).
+        let t = tool_definitions()
+            .into_iter()
+            .find(|t| t.name == "update")
+            .unwrap();
+        let desc = t.input_schema["properties"]["content"]["description"]
+            .as_str()
+            .expect("update.content needs a description documenting the limitation");
+        assert!(
+            desc.contains("not supported"),
+            "description must state the limitation: {desc}"
+        );
+        assert!(
+            desc.contains("delete and re-remember"),
+            "description must point at the workaround: {desc}"
+        );
     }
 
     #[test]

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -105,16 +105,16 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         },
         ToolDef {
             name: "update",
-            description: "Apply a partial update to a memory (only provided fields change).",
+            description: "Apply a partial update to a memory (only provided fields change). \
+                          Content cannot be updated — delete and re-remember so embeddings \
+                          stay consistent.",
+            // `content` is deliberately ABSENT from the schema: the runtime
+            // rejects it, and schema-driven clients would keep generating it.
+            // Re-introduce alongside W3.1 update-as-supersede.
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "id": { "type": "string", "description": "Memory id (UUID)." },
-                    "content": { "type": "string",
-                                 "description": "Content updates are not supported yet — \
-                                                 delete and re-remember instead (keeps \
-                                                 embeddings consistent). Sending content \
-                                                 returns a validation error." },
                     "summary": { "type": "string" },
                     "importance": { "type": "integer", "minimum": 1, "maximum": 10 },
                     "tags": { "type": "array", "items": { "type": "string" } },
@@ -255,24 +255,29 @@ mod tests {
     }
 
     #[test]
-    fn update_content_property_documents_the_limitation() {
-        // F55: the schema must not advertise a bare `content` property — the
-        // engine rejects content updates, so the description has to say so and
-        // point at the workaround (delete + re-remember).
+    fn update_schema_omits_content_and_description_carries_the_guidance() {
+        // F55: the schema must not advertise a `content` property at all — the
+        // engine rejects content updates, and schema-driven clients generate
+        // whatever the schema offers. The tool DESCRIPTION carries the
+        // limitation and the workaround (delete + re-remember) instead.
         let t = tool_definitions()
             .into_iter()
             .find(|t| t.name == "update")
             .unwrap();
-        let desc = t.input_schema["properties"]["content"]["description"]
-            .as_str()
-            .expect("update.content needs a description documenting the limitation");
+        let props = t.input_schema["properties"].as_object().unwrap();
         assert!(
-            desc.contains("not supported"),
-            "description must state the limitation: {desc}"
+            !props.contains_key("content"),
+            "update schema must not advertise content: {props:?}"
         );
         assert!(
-            desc.contains("delete and re-remember"),
-            "description must point at the workaround: {desc}"
+            t.description.contains("Content cannot be updated"),
+            "description must state the limitation: {}",
+            t.description
+        );
+        assert!(
+            t.description.contains("delete and re-remember"),
+            "description must point at the workaround: {}",
+            t.description
         );
     }
 

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -31,8 +31,20 @@ pub enum SubscribeItem {
 impl Client {
     /// Connect to the daemon socket, perform the versioned handshake, and verify
     /// the daemon speaks `CONTRACT_VERSION`. Fails closed on any version drift or
-    /// a non-ok ack.
+    /// a non-ok ack. Sends no identity; provenance-aware callers use
+    /// [`connect_with_identity`](Self::connect_with_identity).
     pub async fn connect(socket_path: &Path, namespace: Namespace) -> Result<Client> {
+        Self::connect_with_identity(socket_path, namespace, None).await
+    }
+
+    /// [`connect`](Self::connect) carrying an optional client identity on the
+    /// handshake (W0.5): the daemon stamps it as provenance on every memory this
+    /// connection writes. `None` matches the pre-W0.5 wire shape exactly.
+    pub async fn connect_with_identity(
+        socket_path: &Path,
+        namespace: Namespace,
+        identity: Option<crate::ClientIdentity>,
+    ) -> Result<Client> {
         let stream = UnixStream::connect(socket_path)
             .await
             .map_err(|e| Error::from_io(&e))?;
@@ -41,6 +53,7 @@ impl Client {
         let handshake = Handshake {
             contract_version: CONTRACT_VERSION,
             namespace,
+            identity,
         };
         write_frame(&mut framed, &handshake).await?;
 
@@ -130,7 +143,8 @@ impl Client {
         }
     }
 
-    /// Store a new memory; returns its id.
+    /// Store a new memory; returns its id. `confidence` is the trust prior in
+    /// `0.0..=1.0` (1.0 = today's full-trust default; hook captures send 0.7).
     #[allow(clippy::too_many_arguments)]
     pub async fn remember(
         &mut self,
@@ -141,6 +155,7 @@ impl Client {
         keywords: Vec<String>,
         tags: Vec<String>,
         related_files: Vec<String>,
+        confidence: f32,
     ) -> Result<MemoryId> {
         let resp = self
             .request(Request::Remember {
@@ -151,6 +166,7 @@ impl Client {
                 keywords,
                 tags,
                 related_files,
+                confidence,
             })
             .await?;
         match resp {
@@ -378,6 +394,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connect_with_identity_carries_identity_on_the_handshake() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        // Inline responder that captures the handshake identity for assertion.
+        let server = tokio::spawn(async move {
+            let (stream, _addr) = listener.accept().await.unwrap();
+            let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
+                Framed::new(stream, LengthDelimitedCodec::new());
+            let hs: Handshake = read_frame(&mut framed).await.unwrap();
+            write_frame(
+                &mut framed,
+                &HandshakeAck {
+                    contract_version: CONTRACT_VERSION,
+                    ok: true,
+                    message: None,
+                },
+            )
+            .await
+            .unwrap();
+            hs.identity
+        });
+
+        let identity = crate::ClientIdentity {
+            agent: Some("claude-code".into()),
+            session_id: Some("s-7".into()),
+            source: Some("hook".into()),
+            ..Default::default()
+        };
+        let _client =
+            Client::connect_with_identity(&path, Namespace::Global, Some(identity.clone()))
+                .await
+                .unwrap();
+        let got = server.await.unwrap();
+        assert_eq!(got, Some(identity), "identity must reach the daemon");
+    }
+
+    #[tokio::test]
     async fn connect_rejects_contract_version_mismatch() {
         let (_dir, path) = socket_path();
         let listener = UnixListener::bind(&path).unwrap();
@@ -527,6 +580,7 @@ mod wrapper_tests {
                 vec!["k".into()],
                 vec!["t".into()],
                 vec![],
+                1.0,
             )
             .await
             .unwrap();

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -61,11 +61,27 @@ impl Client {
         Ok(Client { framed })
     }
 
+    /// Send one request frame WITHOUT reading the response. Split from
+    /// [`request`](Self::request) so retrying callers can distinguish the two
+    /// failure phases: a SEND failure means the daemon never received the frame
+    /// (a Unix-socket write fails immediately once the peer has closed), so a
+    /// retry on a fresh connection is safe for any op; a RECV failure after a
+    /// successful send means the daemon may have executed the request and only
+    /// the response was lost, so only idempotent ops may be retried.
+    pub async fn send_request(&mut self, req: &Request) -> Result<()> {
+        write_frame(&mut self.framed, req).await
+    }
+
+    /// Read one response frame for a request previously sent with
+    /// [`send_request`](Self::send_request).
+    pub async fn recv_response(&mut self) -> Result<Response> {
+        read_frame(&mut self.framed).await
+    }
+
     /// Send one request and read one response.
     pub async fn request(&mut self, req: Request) -> Result<Response> {
-        write_frame(&mut self.framed, &req).await?;
-        let resp: Response = read_frame(&mut self.framed).await?;
-        Ok(resp)
+        self.send_request(&req).await?;
+        self.recv_response().await
     }
 
     /// Open a live change-notification stream on this connection. After this
@@ -333,6 +349,26 @@ mod tests {
             .unwrap();
         let resp = client.request(Request::Ping).await.unwrap();
         match resp {
+            Response::Pong { contract_version } => {
+                assert_eq!(contract_version, CONTRACT_VERSION);
+            }
+            other => panic!("expected Pong, got {other:?}"),
+        }
+        server.await.unwrap();
+    }
+
+    // The split send/recv phases must compose to the same round trip as
+    // `request` — they exist so retrying callers can tell a dead-on-send
+    // connection from a lost response.
+    #[tokio::test]
+    async fn send_request_then_recv_response_round_trips() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let server = tokio::spawn(run_responder(listener, CONTRACT_VERSION, true));
+
+        let mut client = Client::connect(&path, Namespace::Global).await.unwrap();
+        client.send_request(&Request::Ping).await.unwrap();
+        match client.recv_response().await.unwrap() {
             Response::Pong { contract_version } => {
                 assert_eq!(contract_version, CONTRACT_VERSION);
             }

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -144,7 +144,9 @@ impl Client {
     }
 
     /// Store a new memory; returns its id. `confidence` is the trust prior in
-    /// `0.0..=1.0` (1.0 = today's full-trust default; hook captures send 0.7).
+    /// `0.0..=1.0` (1.0 = today's full-trust default; hook captures send 0.7);
+    /// a non-finite or out-of-range value is rejected client-side with
+    /// [`Error::InvalidArgument`] before anything touches the wire.
     #[allow(clippy::too_many_arguments)]
     pub async fn remember(
         &mut self,
@@ -157,6 +159,13 @@ impl Client {
         related_files: Vec<String>,
         confidence: f32,
     ) -> Result<MemoryId> {
+        // Mirrors the engine-side check so a bad value fails fast and with the
+        // same error class the daemon would round-trip back.
+        if !confidence.is_finite() || !(0.0..=1.0).contains(&confidence) {
+            return Err(Error::InvalidArgument(format!(
+                "confidence {confidence} out of range 0.0..=1.0"
+            )));
+        }
         let resp = self
             .request(Request::Remember {
                 content,
@@ -618,6 +627,38 @@ mod wrapper_tests {
         let (rs, rc, rk) = c.reembed(Some(10)).await.unwrap();
         assert_eq!((rs, rc, rk), (6, 5, 1));
 
+        drop(c);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn remember_rejects_invalid_confidence_before_any_io() {
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        // `serve` answers ANY Remember with Remembered, so an Err here can only
+        // come from the client-side validation: the frame never hit the wire.
+        let server = tokio::spawn(serve(listener, MemoryId::new()));
+
+        let mut c = connect(&path).await;
+        for bad in [f32::NAN, 1.5] {
+            let err = c
+                .remember(
+                    "body".into(),
+                    None,
+                    MemoryType::Insight,
+                    5,
+                    vec![],
+                    vec![],
+                    vec![],
+                    bad,
+                )
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, Error::InvalidArgument(_)),
+                "confidence {bad} must be InvalidArgument, got {err:?}"
+            );
+        }
         drop(c);
         server.await.unwrap();
     }

--- a/crates/rb-proto/src/frame.rs
+++ b/crates/rb-proto/src/frame.rs
@@ -81,6 +81,7 @@ mod tests {
         let hs = Handshake {
             contract_version: CONTRACT_VERSION,
             namespace: Namespace::Project("rusty-brain".into()),
+            identity: None,
         };
         write_frame(&mut client, &hs).await.unwrap();
 

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -14,4 +14,4 @@ pub use client::{Client, SubscribeItem};
 pub use codec::{bounded_codec, bounded_framed, MAX_FRAME_BYTES};
 pub use error::{error_to_response, response_error_to_error};
 pub use frame::{read_frame, write_frame};
-pub use messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
+pub use messages::{ClientIdentity, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -18,6 +18,31 @@ pub const CONTRACT_VERSION: u32 = 2;
 pub struct Handshake {
     pub contract_version: u32,
     pub namespace: Namespace,
+    /// Optional client-declared identity (W0.5). Additive + `#[serde(default)]`
+    /// — an old client omits it (`None`) and an old daemon ignores it (serde
+    /// tolerates unknown fields), so NO contract-version bump is needed.
+    #[serde(default)]
+    pub identity: Option<ClientIdentity>,
+}
+
+/// Who/where/what is on the other end of a connection, declared by the client
+/// at handshake and stamped onto every memory it writes. All fields optional:
+/// the daemon falls back to its own whoami for `user`/`host` (same-host UDS),
+/// while `agent`/`session_id`/`source` are client-knowledge only.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientIdentity {
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,
+    /// The agent CLI driving the write (e.g. `claude-code`), when known.
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Producer surface, declared per binary: `hook` | `mcp` | `cli`.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 /// Daemon reply to a `Handshake`.
@@ -40,6 +65,11 @@ pub enum Request {
         keywords: Vec<String>,
         tags: Vec<String>,
         related_files: Vec<String>,
+        /// Trust prior in `0.0..=1.0` (W0.5 / F39 producer down-payment).
+        /// `#[serde(default)]` to 1.0 so old clients keep today's behavior;
+        /// hook captures send 0.7. Range-validated by the engine.
+        #[serde(default = "default_confidence")]
+        confidence: f32,
     },
     Recall {
         query: String,
@@ -83,6 +113,12 @@ pub enum Request {
     /// The stream is scoped to the connection's handshake namespace, filtered
     /// server-side.
     Subscribe,
+}
+
+/// Serde default for `Request::Remember::confidence`: full trust, the
+/// pre-W0.5 hardwired value.
+fn default_confidence() -> f32 {
+    1.0
 }
 
 /// One response per request. Internally tagged on `result`.
@@ -166,11 +202,96 @@ mod tests {
         let hs = Handshake {
             contract_version: CONTRACT_VERSION,
             namespace: Namespace::Project("rusty-brain".into()),
+            identity: None,
         };
         let json = serde_json::to_string(&hs).unwrap();
         let back: Handshake = serde_json::from_str(&json).unwrap();
         assert_eq!(back.contract_version, CONTRACT_VERSION);
         assert_eq!(back.namespace, Namespace::Project("rusty-brain".into()));
+        assert!(back.identity.is_none());
+    }
+
+    #[test]
+    fn handshake_identity_round_trips() {
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Global,
+            identity: Some(ClientIdentity {
+                user: Some("alice".into()),
+                host: Some("devbox".into()),
+                agent: Some("claude-code".into()),
+                session_id: Some("s-1".into()),
+                source: Some("hook".into()),
+            }),
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        let back: Handshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.identity, hs.identity);
+    }
+
+    #[test]
+    fn old_client_handshake_without_identity_deserializes() {
+        // A pre-W0.5 client sends exactly {contract_version, namespace}; the
+        // daemon must accept it with identity == None (no CONTRACT_VERSION bump:
+        // the field is additive and serde-default).
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Global,
+            identity: None,
+        };
+        let mut value = serde_json::to_value(&hs).unwrap();
+        value.as_object_mut().unwrap().remove("identity");
+        let back: Handshake = serde_json::from_value(value).unwrap();
+        assert!(back.identity.is_none());
+    }
+
+    #[test]
+    fn old_daemon_tolerates_identity_field_on_the_wire() {
+        // The reverse direction: a new client's handshake (with identity) must
+        // still deserialize under a decoder that doesn't know the field — serde
+        // ignores unknown fields by default, which this pins for Handshake.
+        #[derive(serde::Deserialize)]
+        struct OldHandshake {
+            contract_version: u32,
+            #[allow(dead_code)]
+            namespace: Namespace,
+        }
+        let hs = Handshake {
+            contract_version: CONTRACT_VERSION,
+            namespace: Namespace::Global,
+            identity: Some(ClientIdentity {
+                source: Some("cli".into()),
+                ..Default::default()
+            }),
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        let back: OldHandshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.contract_version, CONTRACT_VERSION);
+    }
+
+    #[test]
+    fn remember_without_confidence_defaults_to_full_trust() {
+        // Pre-W0.5 Remember payloads carry no confidence: serde must default it
+        // to 1.0 (today's hardwired value), keeping old clients byte-compatible.
+        let req = Request::Remember {
+            content: "c".into(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance: 5,
+            keywords: vec![],
+            tags: vec![],
+            related_files: vec![],
+            confidence: 0.3,
+        };
+        let mut value = serde_json::to_value(&req).unwrap();
+        value.as_object_mut().unwrap().remove("confidence");
+        let back: Request = serde_json::from_value(value).unwrap();
+        match back {
+            Request::Remember { confidence, .. } => {
+                assert!((confidence - 1.0).abs() < f32::EPSILON);
+            }
+            other => panic!("expected Remember, got {other:?}"),
+        }
     }
 
     #[test]
@@ -197,6 +318,7 @@ mod tests {
                 keywords: vec!["k".into()],
                 tags: vec!["t".into()],
                 related_files: vec!["src/lib.rs".into()],
+                confidence: 0.7,
             },
             Request::Recall {
                 query: "q".into(),

--- a/crates/rb-proto/tests/public_api.rs
+++ b/crates/rb-proto/tests/public_api.rs
@@ -1,26 +1,44 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use rb_proto::{
-    error_to_response, read_frame, response_error_to_error, write_frame, Client, Handshake,
-    HandshakeAck, Request, Response, CONTRACT_VERSION,
+    error_to_response, read_frame, response_error_to_error, write_frame, Client, ClientIdentity,
+    Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
 };
-use rb_types::{Error, MemoryId, Namespace};
+use rb_types::{Error, MemoryId, MemoryType, Namespace};
 
 #[test]
 fn public_surface_is_reachable_and_stable() {
     // Constants and messages. v2 = P5 Feature C (additive `contested`).
     assert_eq!(CONTRACT_VERSION, 2);
+    // W0.5 additions are public surface: the handshake identity struct and the
+    // Remember confidence field are constructed literally to lock their shape.
+    let identity = ClientIdentity {
+        user: Some("u".into()),
+        host: Some("h".into()),
+        agent: Some("claude-code".into()),
+        session_id: Some("s-1".into()),
+        source: Some("cli".into()),
+    };
     let _hs = Handshake {
         contract_version: CONTRACT_VERSION,
         namespace: Namespace::Global,
-        identity: None,
+        identity: Some(identity),
     };
     let _ack = HandshakeAck {
         contract_version: CONTRACT_VERSION,
         ok: true,
         message: None,
     };
-    let _req = Request::Ping;
+    let _req = Request::Remember {
+        content: "c".into(),
+        context: None,
+        memory_type: MemoryType::Insight,
+        importance: 5,
+        keywords: vec![],
+        tags: vec![],
+        related_files: vec![],
+        confidence: 0.7,
+    };
 
     // Error mapping helpers, round-tripping through the wire form.
     let resp = error_to_response(&Error::NotFound(MemoryId::new()));

--- a/crates/rb-proto/tests/public_api.rs
+++ b/crates/rb-proto/tests/public_api.rs
@@ -13,6 +13,7 @@ fn public_surface_is_reachable_and_stable() {
     let _hs = Handshake {
         contract_version: CONTRACT_VERSION,
         namespace: Namespace::Global,
+        identity: None,
     };
     let _ack = HandshakeAck {
         contract_version: CONTRACT_VERSION,

--- a/crates/rb-store/Cargo.toml
+++ b/crates/rb-store/Cargo.toml
@@ -19,6 +19,8 @@ include_dir = { workspace = true }
 sha2 = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+# site_id (meta key) seeding: one uuid v4 per database, generated at init.
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rb-store/migrations/004_provenance.sql
+++ b/crates/rb-store/migrations/004_provenance.sql
@@ -1,0 +1,31 @@
+-- 004_provenance.sql
+-- W0.5: provenance columns + durable oplog (the unbackfillable migration).
+--
+-- Provenance: who/where/what wrote each memory. All five columns are nullable
+-- with NO default and NO backfill UPDATE — an UPDATE here would fire the
+-- `mem_au` trigger and rewrite the FTS index for every existing row. Old rows
+-- keep NULL provenance (decoded as `None`); only writes from now on carry it.
+-- ALTER ... ADD COLUMN is metadata-only in SQLite (no row rewrite, no trigger),
+-- and the FTS triggers reference fixed column lists, so this is trigger-safe.
+ALTER TABLE memories ADD COLUMN origin_user   TEXT;
+ALTER TABLE memories ADD COLUMN origin_host   TEXT;
+ALTER TABLE memories ADD COLUMN origin_agent  TEXT;
+ALTER TABLE memories ADD COLUMN origin_source TEXT;   -- hook|mcp|cli|job
+ALTER TABLE memories ADD COLUMN session_id    TEXT;
+
+-- Durable operation log: one row per mutation, appended IN THE SAME
+-- TRANSACTION as the mutation itself, from day one. `seq` is the site-local
+-- monotonic order; `site_id` (meta key, uuid v4 seeded in code at init)
+-- disambiguates rows once logs from multiple machines merge (team mode).
+-- `details` is a small JSON payload (e.g. link type) or empty.
+CREATE TABLE memory_oplog (
+  seq       INTEGER PRIMARY KEY AUTOINCREMENT,
+  site_id   TEXT NOT NULL,
+  op        TEXT NOT NULL,            -- insert|update|archive|supersede|link
+  memory_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  at        INTEGER NOT NULL,         -- unix seconds
+  details   TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX idx_oplog_ns_seq ON memory_oplog(namespace, seq);

--- a/crates/rb-store/src/migrations.rs
+++ b/crates/rb-store/src/migrations.rs
@@ -169,6 +169,20 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
     apply_all(conn, &migs)
 }
 
+/// Test-only: apply the real, file-discovered migrations up to and including
+/// `max_version`, recording checksums as the runner does. Used to build a
+/// populated "old schema" fixture and then prove a later migration applies
+/// cleanly on top of real rows.
+#[cfg(test)]
+pub(crate) fn run_migrations_up_to(conn: &rusqlite::Connection, max_version: i64) -> Result<()> {
+    ensure_migrations_table(conn)?;
+    let migs: Vec<Migration> = discover()?
+        .into_iter()
+        .filter(|m| m.version <= max_version)
+        .collect();
+    apply_all(conn, &migs)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic)]

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -163,29 +163,54 @@ impl SqliteStore {
         embedding_model: Option<&str>,
     ) -> Result<Self> {
         register_vec()?;
+        // The DB file holds captured memory text: owner-only (0600), parity with
+        // the daemon socket. Pre-create a missing file at 0600 so it is never
+        // observable at the umask-derived default (Connection::open would create
+        // it 0644 and leave a read window until the chmod below). Then chmod
+        // fail-closed on every open — tightening a loose pre-W0.5 DB — including
+        // any leftover `-wal`/`-shm` siblings: SQLite copies the main file's
+        // mode only when it CREATES a sibling, so a 0644 WAL surviving an
+        // unclean shutdown would otherwise keep collecting memory content at
+        // 0644 for the daemon's whole lifetime.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
+                .open(path)
+                .map_err(|e| {
+                    io_err(std::io::Error::other(format!(
+                        "create 0600 {}: {e}",
+                        path.display()
+                    )))
+                })?;
+            for sibling in ["", "-wal", "-shm"] {
+                let mut os = path.as_os_str().to_os_string();
+                os.push(sibling);
+                let p = std::path::PathBuf::from(os);
+                match std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o600)) {
+                    Ok(()) => {}
+                    // Absent siblings are the common case; only NotFound passes.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        return Err(io_err(std::io::Error::other(format!(
+                            "chmod 0600 {}: {e}",
+                            p.display()
+                        ))))
+                    }
+                }
+            }
+        }
         let conn = rusqlite::Connection::open(path).map_err(|e| {
             io_err(std::io::Error::other(format!(
                 "open {}: {e}",
                 path.display()
             )))
         })?;
-        // The DB file holds captured memory text: owner-only (0600), parity with
-        // the daemon socket. Applied fail-closed on every open so a pre-W0.5 DB
-        // is tightened too. SQLite's unix VFS creates `-wal`/`-shm` siblings
-        // copying the main file's mode, and they appear only at first write —
-        // after this chmod — so they inherit 0600.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
-                |e| {
-                    io_err(std::io::Error::other(format!(
-                        "chmod 0600 {}: {e}",
-                        path.display()
-                    )))
-                },
-            )?;
-        }
         Self::init(conn, embedding_dim, embedding_model)
     }
 
@@ -382,19 +407,54 @@ impl SqliteStore {
         link_type: rb_types::LinkType,
         strength: f32,
     ) -> Result<()> {
+        // Transaction: the UPDATE and its oplog row commit (or roll back)
+        // together — link strength is durable graph state replay must reproduce.
         self.conn
-            .execute(
-                "UPDATE memory_links SET strength = ?1
-                 WHERE source_id = ?2 AND target_id = ?3 AND link_type = ?4",
-                rusqlite::params![
-                    strength as f64,
-                    source.to_string(),
-                    target.to_string(),
-                    link_type.as_str(),
-                ],
-            )
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            let affected = self
+                .conn
+                .execute(
+                    "UPDATE memory_links SET strength = ?1
+                     WHERE source_id = ?2 AND target_id = ?3 AND link_type = ?4",
+                    rusqlite::params![
+                        strength as f64,
+                        source.to_string(),
+                        target.to_string(),
+                        link_type.as_str(),
+                    ],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected > 0 {
+                let details = serde_json::json!({
+                    "type": link_type.as_str(),
+                    "target": target.to_string(),
+                    "strength": strength,
+                })
+                .to_string();
+                append_oplog(
+                    &self.conn,
+                    &self.site_id,
+                    "set_link_strength",
+                    source,
+                    &details,
+                )?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     /// Set the `confidence` of a single memory. Validates the `0.0..=1.0` range
@@ -407,13 +467,37 @@ impl SqliteStore {
                 "confidence {confidence} out of range 0.0..=1.0"
             )));
         }
+        // Transaction: the UPDATE and its oplog row commit (or roll back)
+        // together — confidence is durable ranking state replay must reproduce.
         self.conn
-            .execute(
-                "UPDATE memories SET confidence = ?1 WHERE memory_id = ?2",
-                rusqlite::params![confidence as f64, id.to_string()],
-            )
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            let affected = self
+                .conn
+                .execute(
+                    "UPDATE memories SET confidence = ?1 WHERE memory_id = ?2",
+                    rusqlite::params![confidence as f64, id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected > 0 {
+                let details = serde_json::json!({ "confidence": confidence }).to_string();
+                append_oplog(&self.conn, &self.site_id, "set_confidence", id, &details)?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     /// Read a value from the key/value `meta` table (e.g. the
@@ -421,17 +505,7 @@ impl SqliteStore {
     /// key is absent. A small read helper for invariant checks and the migration
     /// reproducibility gate.
     pub fn meta_value(&self, key: &str) -> Result<Option<String>> {
-        self.conn
-            .query_row(
-                "SELECT value FROM meta WHERE key = ?1",
-                rusqlite::params![key],
-                |r| r.get::<_, String>(0),
-            )
-            .map(Some)
-            .or_else(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => Ok(None),
-                other => Err(Error::Storage(other.to_string())),
-            })
+        meta_value(&self.conn, key)
     }
 
     /// Delete a single link edge identified by its full PK. A missing edge is a
@@ -442,14 +516,42 @@ impl SqliteStore {
         target: &MemoryId,
         link_type: rb_types::LinkType,
     ) -> Result<()> {
+        // Transaction: the DELETE and its oplog row commit (or roll back)
+        // together — a pruned edge must be reproducible from the log.
         self.conn
-            .execute(
-                "DELETE FROM memory_links
-                 WHERE source_id = ?1 AND target_id = ?2 AND link_type = ?3",
-                rusqlite::params![source.to_string(), target.to_string(), link_type.as_str(),],
-            )
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            let affected = self
+                .conn
+                .execute(
+                    "DELETE FROM memory_links
+                     WHERE source_id = ?1 AND target_id = ?2 AND link_type = ?3",
+                    rusqlite::params![source.to_string(), target.to_string(), link_type.as_str(),],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected > 0 {
+                let details = serde_json::json!({
+                    "type": link_type.as_str(),
+                    "target": target.to_string(),
+                })
+                .to_string();
+                append_oplog(&self.conn, &self.site_id, "unlink", source, &details)?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     /// Find active memories in `ns` whose stored vector is near-identical to the
@@ -3928,6 +4030,70 @@ mod oplog_tests {
     }
 
     #[test]
+    fn set_confidence_appends_oplog_only_on_real_change() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let n = node(&store, "to score");
+        store.set_confidence(&MemoryId::new(), 0.5).unwrap(); // missing no-op
+        store.set_confidence(&n.id, 0.4).unwrap();
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 2, "insert + exactly one set_confidence");
+        assert_eq!(rows[1].0, "set_confidence");
+        assert_eq!(rows[1].1, n.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(&rows[1].4).unwrap();
+        let logged = details["confidence"].as_f64().unwrap();
+        assert!(
+            (logged - 0.4).abs() < 1e-6,
+            "confidence in details: {logged}"
+        );
+    }
+
+    #[test]
+    fn set_link_strength_and_delete_link_append_oplog_with_edge_details() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a");
+        let b = node(&store, "b");
+        store
+            .add_link(&MemoryLink {
+                source_id: a.id.clone(),
+                target_id: b.id.clone(),
+                link_type: LinkType::Extends,
+                strength: 0.9,
+                reason: "a extends b".into(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+        store
+            .set_link_strength(&a.id, &b.id, LinkType::Extends, 0.5)
+            .unwrap();
+        // Missing-edge ops stay silent no-ops (decay is best-effort): no rows.
+        store
+            .set_link_strength(&a.id, &b.id, LinkType::Contradicts, 0.5)
+            .unwrap();
+        store
+            .delete_link(&a.id, &b.id, LinkType::Contradicts)
+            .unwrap();
+        store.delete_link(&a.id, &b.id, LinkType::Extends).unwrap();
+
+        let rows = oplog_rows(&store);
+        assert_eq!(
+            rows.len(),
+            5,
+            "two inserts + link + set_link_strength + unlink"
+        );
+        assert_eq!(rows[3].0, "set_link_strength");
+        assert_eq!(rows[3].1, a.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(&rows[3].4).unwrap();
+        assert_eq!(details["type"], "extends");
+        assert_eq!(details["target"], b.id.to_string());
+        assert!((details["strength"].as_f64().unwrap() - 0.5).abs() < 1e-6);
+        assert_eq!(rows[4].0, "unlink");
+        assert_eq!(rows[4].1, a.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(&rows[4].4).unwrap();
+        assert_eq!(details["type"], "extends");
+        assert_eq!(details["target"], b.id.to_string());
+    }
+
+    #[test]
     fn failed_insert_rolls_back_memory_and_oplog_together() {
         let store = SqliteStore::open_in_memory(8).unwrap();
         // A link to a missing target violates the FK AFTER both the memories row
@@ -4104,5 +4270,32 @@ mod db_perms_tests {
         std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
         drop(SqliteStore::open(&db, 8).unwrap());
         assert_eq!(mode_of(&db), 0o600, "open must tighten a loose pre-W0.5 DB");
+    }
+
+    #[test]
+    fn reopen_tightens_a_pre_existing_loose_wal_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("loose-wal.db");
+        drop(SqliteStore::open(&db, 8).unwrap());
+        // An unclean daemon death leaves the -wal behind (it is only removed on
+        // a clean close); a pre-W0.5 install left it 0644 and SQLite reuses the
+        // file as-is on reopen, so open must tighten it too.
+        let wal = dir.path().join("loose-wal.db-wal");
+        std::fs::write(&wal, b"").unwrap();
+        std::fs::set_permissions(&wal, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let store = SqliteStore::open(&db, 8).unwrap();
+        let n = MemoryNote::new(
+            Namespace::Project("perm".into()),
+            "wal probe".into(),
+            MemoryType::Insight,
+            5,
+        );
+        store.insert_memory(&n, None).unwrap();
+        assert!(wal.exists(), "-wal must exist after a write");
+        assert_eq!(
+            mode_of(&wal),
+            0o600,
+            "open must tighten a loose pre-existing -wal"
+        );
     }
 }

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -109,6 +109,9 @@ pub struct SqliteStore {
     /// Embedding dimension configured at open; used to fail-close dimension mismatches
     /// before touching the DB.
     pub(crate) embedding_dim: usize,
+    /// This database's `meta.site_id` (uuid v4, seeded at init), stamped on every
+    /// oplog row so logs from multiple machines stay distinguishable after a merge.
+    pub(crate) site_id: String,
 }
 
 impl std::fmt::Debug for SqliteStore {
@@ -166,6 +169,23 @@ impl SqliteStore {
                 path.display()
             )))
         })?;
+        // The DB file holds captured memory text: owner-only (0600), parity with
+        // the daemon socket. Applied fail-closed on every open so a pre-W0.5 DB
+        // is tightened too. SQLite's unix VFS creates `-wal`/`-shm` siblings
+        // copying the main file's mode, and they appear only at first write —
+        // after this chmod — so they inherit 0600.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(
+                |e| {
+                    io_err(std::io::Error::other(format!(
+                        "chmod 0600 {}: {e}",
+                        path.display()
+                    )))
+                },
+            )?;
+        }
         Self::init(conn, embedding_dim, embedding_model)
     }
 
@@ -219,11 +239,19 @@ impl SqliteStore {
         if let Some(model) = embedding_model {
             seed_or_verify_model(&conn, model)?;
         }
+        let site_id = seed_or_get_site_id(&conn)?;
 
         Ok(Self {
             conn,
             embedding_dim,
+            site_id,
         })
+    }
+
+    /// This database's `meta.site_id` (uuid v4, seeded at init), stamped on
+    /// every `memory_oplog` row.
+    pub fn site_id(&self) -> &str {
+        &self.site_id
     }
 
     /// Explicit opt-in for an embedding-model swap: atomically point
@@ -752,6 +780,50 @@ fn seed_or_verify_model(conn: &rusqlite::Connection, embedding_model: &str) -> R
     Ok(())
 }
 
+/// Seed `meta.site_id` (uuid v4) on first init, or read it back on re-open.
+/// `INSERT OR IGNORE` + re-read: two connections racing the first open both
+/// end up with the single stored value.
+fn seed_or_get_site_id(conn: &rusqlite::Connection) -> Result<String> {
+    if let Some(existing) = meta_value(conn, "site_id")? {
+        return Ok(existing);
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES ('site_id', ?1)",
+        rusqlite::params![uuid::Uuid::new_v4().to_string()],
+    )
+    .map_err(storage_err)?;
+    meta_value(conn, "site_id")?
+        .ok_or_else(|| Error::Storage("meta.site_id missing after seed".to_string()))
+}
+
+/// Append one `memory_oplog` row for a mutation on `memory_id`, resolving the
+/// namespace from the memories row (already written within the same
+/// transaction for inserts). MUST be called inside the mutation's transaction
+/// so the log row commits — or rolls back — with the mutation itself. Callers
+/// gate on the mutation having actually changed a row, so the SELECT always
+/// resolves; `details` is a small JSON payload (e.g. link type) or empty.
+fn append_oplog(
+    conn: &rusqlite::Connection,
+    site_id: &str,
+    op: &str,
+    memory_id: &MemoryId,
+    details: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO memory_oplog (site_id, op, memory_id, namespace, at, details)
+         SELECT ?1, ?2, ?3, namespace, ?4, ?5 FROM memories WHERE memory_id = ?3",
+        rusqlite::params![
+            site_id,
+            op,
+            memory_id.to_string(),
+            chrono::Utc::now().timestamp(),
+            details
+        ],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Private codec helpers
 // ---------------------------------------------------------------------------
@@ -887,6 +959,10 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
         row.get::<_, i64>(c)
             .map_err(|e| Error::Storage(e.to_string()))
     };
+    let go = |c: &str| -> Result<Option<String>> {
+        row.get::<_, Option<String>>(c)
+            .map_err(|e| Error::Storage(e.to_string()))
+    };
     // TODO(P1): batch link loading (avoid N+1 load_links per row in list/get_memory).
     let links = load_links(conn, &id)?;
     Ok(MemoryNote {
@@ -932,6 +1008,13 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
         // from `memory_links` after ranking; it is never stored, so loads default
         // it to false.
         contested: false,
+        // Provenance (W0.5): nullable by-name decode; rows written before the
+        // 004 migration carry NULL and surface as `None`.
+        origin_user: go("origin_user")?,
+        origin_host: go("origin_host")?,
+        origin_agent: go("origin_agent")?,
+        origin_source: go("origin_source")?,
+        session_id: go("session_id")?,
     })
 }
 
@@ -974,10 +1057,11 @@ impl Store for SqliteStore {
                         memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model, embedding_input_version
+                        superseded_by, embedding_model, embedding_input_version,
+                        origin_user, origin_host, origin_agent, origin_source, session_id
                      ) VALUES (
                         ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                        ?13, ?14, ?15, ?16, ?17, ?18, ?19
+                        ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
                      )",
                     rusqlite::params![
                         note.id.to_string(),
@@ -999,9 +1083,18 @@ impl Store for SqliteStore {
                         note.superseded_by.as_ref().map(|id| id.to_string()),
                         note.embedding_model,
                         note.embedding_input_version,
+                        note.origin_user,
+                        note.origin_host,
+                        note.origin_agent,
+                        note.origin_source,
+                        note.session_id,
                     ],
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
+
+            // One oplog row per mutation: links carried on the note ride along
+            // with this single `insert` op (they are part of the same write).
+            append_oplog(&self.conn, &self.site_id, "insert", &note.id, "")?;
 
             if let Some(emb) = embedding {
                 self.conn
@@ -1055,7 +1148,8 @@ impl Store for SqliteStore {
                 "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model, embedding_input_version
+                        superseded_by, embedding_model, embedding_input_version,
+                        origin_user, origin_host, origin_agent, origin_source, session_id
                  FROM memories WHERE memory_id = ?1",
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -1250,7 +1344,8 @@ impl Store for SqliteStore {
                 "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model, embedding_input_version
+                        superseded_by, embedding_model, embedding_input_version,
+                        origin_user, origin_host, origin_agent, origin_source, session_id
                  FROM memories
                  WHERE namespace = ?1
                    AND archived_at IS NULL
@@ -1340,45 +1435,116 @@ impl Store for SqliteStore {
             id_pos
         );
 
-        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+        // Transaction: the UPDATE and its oplog row commit (or roll back) together.
         self.conn
-            .execute(&sql, refs.as_slice())
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+            let affected = self
+                .conn
+                .execute(&sql, refs.as_slice())
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            // Oplog only on a real change: 0 rows means the id does not exist
+            // (a missing-id update stays an Ok no-op and logs nothing).
+            if affected > 0 {
+                append_oplog(&self.conn, &self.site_id, "update", id, "")?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     fn archive_memory(&self, id: &MemoryId) -> Result<()> {
+        // Transaction: the archive and its oplog row commit (or roll back) together.
         self.conn
-            .execute(
-                "UPDATE memories
-                 SET archived_at = ?1, updated_at = ?1
-                 WHERE memory_id = ?2 AND archived_at IS NULL",
-                rusqlite::params![chrono::Utc::now().timestamp(), id.to_string()],
-            )
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            let affected = self
+                .conn
+                .execute(
+                    "UPDATE memories
+                     SET archived_at = ?1, updated_at = ?1
+                     WHERE memory_id = ?2 AND archived_at IS NULL",
+                    rusqlite::params![chrono::Utc::now().timestamp(), id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            // Missing or already-archived ids are Ok no-ops and log nothing.
+            if affected > 0 {
+                append_oplog(&self.conn, &self.site_id, "archive", id, "")?;
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     fn add_link(&self, link: &MemoryLink) -> Result<()> {
+        // Transaction: the link INSERT and its oplog row commit (or roll back)
+        // together (an FK failure on a missing endpoint rolls back both).
         self.conn
-            .execute(
-                "INSERT INTO memory_links
-                    (source_id, target_id, link_type, strength, base_strength, reason, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                rusqlite::params![
-                    link.source_id.to_string(),
-                    link.target_id.to_string(),
-                    link.link_type.as_str(),
-                    link.strength as f64,
-                    // Baseline equals the created strength; decay never mutates
-                    // it, so the pass stays idempotent.
-                    link.strength as f64,
-                    link.reason,
-                    link.created_at.timestamp(),
-                ],
-            )
+            .execute_batch("BEGIN IMMEDIATE;")
             .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+
+        let result = (|| -> Result<()> {
+            self.conn
+                .execute(
+                    "INSERT INTO memory_links
+                        (source_id, target_id, link_type, strength, base_strength, reason, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    rusqlite::params![
+                        link.source_id.to_string(),
+                        link.target_id.to_string(),
+                        link.link_type.as_str(),
+                        link.strength as f64,
+                        // Baseline equals the created strength; decay never mutates
+                        // it, so the pass stays idempotent.
+                        link.strength as f64,
+                        link.reason,
+                        link.created_at.timestamp(),
+                    ],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let details = serde_json::json!({
+                "type": link.link_type.as_str(),
+                "target": link.target_id.to_string(),
+            })
+            .to_string();
+            append_oplog(&self.conn, &self.site_id, "link", &link.source_id, &details)
+        })();
+
+        match result {
+            Ok(()) => self
+                .conn
+                .execute_batch("COMMIT;")
+                .map_err(|e| Error::Storage(e.to_string())),
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     fn record_access(&self, id: &MemoryId) -> Result<()> {
@@ -1456,7 +1622,10 @@ impl Store for SqliteStore {
                     rusqlite::params![now, old.to_string()],
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
-            Ok(())
+            // One `supersede` oplog row covers the whole compound mutation
+            // (pointer + archive); the replacement id rides in `details`.
+            let details = serde_json::json!({ "new": new.to_string() }).to_string();
+            append_oplog(&self.conn, &self.site_id, "supersede", old, &details)
         })();
 
         match result {
@@ -1482,7 +1651,8 @@ impl Store for SqliteStore {
             "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                     keywords, tags, context, memory_type, importance, confidence,
                     related_files, access_count, last_accessed_at, archived_at,
-                    superseded_by, embedding_model, embedding_input_version
+                    superseded_by, embedding_model, embedding_input_version,
+                    origin_user, origin_host, origin_agent, origin_source, session_id
              FROM memories
              WHERE namespace = ?1 AND memory_id IN ({})",
             placeholders.join(", ")
@@ -1608,7 +1778,8 @@ impl Store for SqliteStore {
                 "SELECT memory_id, namespace, created_at, updated_at, content, summary,
                         keywords, tags, context, memory_type, importance, confidence,
                         related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model, embedding_input_version
+                        superseded_by, embedding_model, embedding_input_version,
+                        origin_user, origin_host, origin_agent, origin_source, session_id
                  FROM memories
                  WHERE archived_at IS NULL
                    AND (embedding_model <> ?1 OR embedding_input_version <> ?2)
@@ -3599,5 +3770,339 @@ mod contradiction_tests {
             in_other.is_empty(),
             "neither endpoint is flagged from either namespace's view"
         );
+    }
+}
+
+#[cfg(test)]
+mod oplog_tests {
+    use super::*;
+    use rb_types::{LinkType, MemoryLink, MemoryNote, MemoryType, MemoryUpdates, Namespace};
+
+    fn node(store: &SqliteStore, c: &str) -> MemoryNote {
+        let n = MemoryNote::new(
+            Namespace::Project("oplog".into()),
+            c.to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        store.insert_memory(&n, None).unwrap();
+        n
+    }
+
+    /// All `(op, memory_id, namespace, site_id, details)` rows in seq order.
+    fn oplog_rows(store: &SqliteStore) -> Vec<(String, String, String, String, String)> {
+        let mut stmt = store
+            .conn
+            .prepare(
+                "SELECT op, memory_id, namespace, site_id, details
+                 FROM memory_oplog ORDER BY seq",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                ))
+            })
+            .unwrap();
+        rows.map(|r| r.unwrap()).collect()
+    }
+
+    #[test]
+    fn site_id_is_seeded_as_uuid_and_stable_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("site.db");
+        let first = SqliteStore::open(&db, 8).unwrap().site_id().to_string();
+        assert_eq!(first.len(), 36, "site_id is a uuid: {first}");
+        let second = SqliteStore::open(&db, 8).unwrap().site_id().to_string();
+        assert_eq!(first, second, "site_id must survive reopen");
+    }
+
+    #[test]
+    fn insert_appends_one_oplog_row_with_namespace_and_site_id() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let n = node(&store, "first");
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 1);
+        let (op, mid, ns, site, details) = &rows[0];
+        assert_eq!(op, "insert");
+        assert_eq!(mid, &n.id.to_string());
+        assert_eq!(ns, &n.namespace.as_db_string());
+        assert_eq!(site, store.site_id());
+        assert_eq!(
+            store.meta_value("site_id").unwrap().as_deref(),
+            Some(store.site_id()),
+            "cached site_id must equal the meta seed"
+        );
+        assert_eq!(details, "");
+    }
+
+    #[test]
+    fn update_appends_oplog_only_on_real_change() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let n = node(&store, "to update");
+
+        // All-None update: true no-op, no oplog row.
+        store
+            .update_memory(&n.id, &MemoryUpdates::default())
+            .unwrap();
+        // Missing-id update: Ok no-op, no oplog row.
+        store
+            .update_memory(
+                &MemoryId::new(),
+                &MemoryUpdates {
+                    summary: Some("s".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(oplog_rows(&store).len(), 1, "only the insert is logged");
+
+        store
+            .update_memory(
+                &n.id,
+                &MemoryUpdates {
+                    summary: Some("new summary".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].0, "update");
+        assert_eq!(rows[1].1, n.id.to_string());
+    }
+
+    #[test]
+    fn archive_appends_oplog_once_and_rearchive_logs_nothing() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let n = node(&store, "to archive");
+        store.archive_memory(&n.id).unwrap();
+        store.archive_memory(&n.id).unwrap(); // idempotent no-op
+        store.archive_memory(&MemoryId::new()).unwrap(); // missing no-op
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 2, "insert + exactly one archive");
+        assert_eq!(rows[1].0, "archive");
+    }
+
+    #[test]
+    fn supersede_appends_oplog_with_replacement_id_in_details() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let old = node(&store, "old");
+        let new = node(&store, "new");
+        store.supersede(&old.id, &new.id).unwrap();
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 3, "two inserts + one supersede");
+        assert_eq!(rows[2].0, "supersede");
+        assert_eq!(rows[2].1, old.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(&rows[2].4).unwrap();
+        assert_eq!(details["new"], new.id.to_string());
+    }
+
+    #[test]
+    fn add_link_appends_oplog_with_type_and_target_in_details() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a");
+        let b = node(&store, "b");
+        store
+            .add_link(&MemoryLink {
+                source_id: a.id.clone(),
+                target_id: b.id.clone(),
+                link_type: LinkType::Extends,
+                strength: 0.9,
+                reason: "a extends b".into(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 3, "two inserts + one link");
+        assert_eq!(rows[2].0, "link");
+        assert_eq!(rows[2].1, a.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(&rows[2].4).unwrap();
+        assert_eq!(details["type"], "extends");
+        assert_eq!(details["target"], b.id.to_string());
+    }
+
+    #[test]
+    fn failed_insert_rolls_back_memory_and_oplog_together() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        // A link to a missing target violates the FK AFTER both the memories row
+        // and the oplog row were written inside the transaction: everything must
+        // roll back together.
+        let mut n = MemoryNote::new(
+            Namespace::Project("oplog".into()),
+            "doomed".into(),
+            MemoryType::Insight,
+            5,
+        );
+        n.links = vec![MemoryLink {
+            source_id: n.id.clone(),
+            target_id: MemoryId::new(), // does not exist
+            link_type: LinkType::References,
+            strength: 0.5,
+            reason: String::new(),
+            created_at: n.created_at,
+        }];
+        assert!(store.insert_memory(&n, None).is_err());
+
+        let memories: i64 = store
+            .conn
+            .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(memories, 0, "memories insert rolled back");
+        assert!(
+            oplog_rows(&store).is_empty(),
+            "oplog row must roll back with the failed mutation"
+        );
+    }
+
+    #[test]
+    fn failed_add_link_rolls_back_oplog() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "a");
+        let err = store.add_link(&MemoryLink {
+            source_id: a.id.clone(),
+            target_id: MemoryId::new(), // missing target: FK failure
+            link_type: LinkType::References,
+            strength: 0.5,
+            reason: String::new(),
+            created_at: chrono::Utc::now(),
+        });
+        assert!(err.is_err());
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 1, "only the insert is logged; no link row");
+    }
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+
+    #[test]
+    fn provenance_fields_round_trip_through_insert_and_get() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let mut n = MemoryNote::new(
+            Namespace::Project("prov".into()),
+            "with provenance".into(),
+            MemoryType::Insight,
+            5,
+        );
+        n.origin_user = Some("alice".into());
+        n.origin_host = Some("devbox".into());
+        n.origin_agent = Some("claude-code".into());
+        n.origin_source = Some("hook".into());
+        n.session_id = Some("s-123".into());
+        store.insert_memory(&n, None).unwrap();
+
+        let got = store.get_memory(&n.id).unwrap().unwrap();
+        assert_eq!(got.origin_user.as_deref(), Some("alice"));
+        assert_eq!(got.origin_host.as_deref(), Some("devbox"));
+        assert_eq!(got.origin_agent.as_deref(), Some("claude-code"));
+        assert_eq!(got.origin_source.as_deref(), Some("hook"));
+        assert_eq!(got.session_id.as_deref(), Some("s-123"));
+
+        // The list projection decodes them too (same by-name path, explicit
+        // column list).
+        let listed = store.list(&n.namespace, None, 10).unwrap();
+        assert_eq!(listed[0].origin_source.as_deref(), Some("hook"));
+        // And get_many.
+        let many = store.get_many(&n.namespace, &[n.id.clone()]).unwrap();
+        assert_eq!(many[0].session_id.as_deref(), Some("s-123"));
+    }
+
+    #[test]
+    fn migration_004_applies_on_populated_pre_provenance_db() {
+        // Build a REAL 003-schema DB (file-discovered migrations 001..003 only),
+        // populate it, then open through SqliteStore (which applies 004). Old
+        // rows must decode with `None` provenance and the FTS index must be
+        // untouched (no backfill UPDATE may churn it).
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("old.db");
+        {
+            let conn = rusqlite::Connection::open(&db).unwrap();
+            crate::migrations::run_migrations_up_to(&conn, 3).unwrap();
+            conn.execute(
+                "INSERT INTO memories (memory_id, namespace, created_at, updated_at, content, \
+                 summary, keywords, tags, memory_type, importance, confidence, embedding_model) \
+                 VALUES ('00000000-0000-4000-8000-000000000001','project:legacy',0,0,\
+                 'pre-provenance row','s','[]','[]','insight',5,1.0,'')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let store = SqliteStore::open(&db, 8).unwrap();
+        let id: MemoryId = "00000000-0000-4000-8000-000000000001".parse().unwrap();
+        let got = store.get_memory(&id).unwrap().unwrap();
+        assert_eq!(got.content, "pre-provenance row");
+        assert!(got.origin_user.is_none(), "old rows keep NULL provenance");
+        assert!(got.origin_host.is_none());
+        assert!(got.origin_agent.is_none());
+        assert!(got.origin_source.is_none());
+        assert!(got.session_id.is_none());
+
+        // FTS still matches the old row: 004 ran no UPDATE, so the mem_au
+        // trigger never fired and the index is exactly the insert-time one.
+        let hits = store
+            .keyword_search(&got.namespace, "pre-provenance", 10)
+            .unwrap();
+        assert!(hits.contains(&id), "FTS untouched by the migration");
+
+        // The oplog table now exists and new mutations log into it.
+        store.archive_memory(&id).unwrap();
+        let ops: i64 = store
+            .conn
+            .query_row("SELECT COUNT(*) FROM memory_oplog", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(ops, 1, "post-migration mutation appends to the oplog");
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod db_perms_tests {
+    use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(path: &std::path::Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn db_file_is_0600_after_create_and_wal_inherits() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("perm.db");
+        let store = SqliteStore::open(&db, 8).unwrap();
+        assert_eq!(mode_of(&db), 0o600, "db file must be owner-only");
+
+        // Force a write so the -wal sibling exists; SQLite creates it copying
+        // the main file's (already-tightened) mode.
+        let n = MemoryNote::new(
+            Namespace::Project("perm".into()),
+            "perm probe".into(),
+            MemoryType::Insight,
+            5,
+        );
+        store.insert_memory(&n, None).unwrap();
+        let wal = dir.path().join("perm.db-wal");
+        if wal.exists() {
+            assert_eq!(mode_of(&wal), 0o600, "-wal must inherit owner-only");
+        }
+    }
+
+    #[test]
+    fn reopen_tightens_a_pre_existing_loose_db_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("loose.db");
+        drop(SqliteStore::open(&db, 8).unwrap());
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
+        drop(SqliteStore::open(&db, 8).unwrap());
+        assert_eq!(mode_of(&db), 0o600, "open must tighten a loose pre-W0.5 DB");
     }
 }

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -1194,8 +1194,6 @@ impl Store for SqliteStore {
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
 
-            // One oplog row per mutation: links carried on the note ride along
-            // with this single `insert` op (they are part of the same write).
             append_oplog(&self.conn, &self.site_id, "insert", &note.id, "")?;
 
             if let Some(emb) = embedding {
@@ -1226,6 +1224,15 @@ impl Store for SqliteStore {
                         ],
                     )
                     .map_err(|e| Error::Storage(e.to_string()))?;
+                // One `link` oplog row per edge, same shape as `add_link`'s:
+                // a replay consumer could not reconstruct edges from the bare
+                // `insert` row alone.
+                let details = serde_json::json!({
+                    "type": link.link_type.as_str(),
+                    "target": link.target_id.to_string(),
+                })
+                .to_string();
+                append_oplog(&self.conn, &self.site_id, "link", &link.source_id, &details)?;
             }
             Ok(())
         })();
@@ -3941,6 +3948,40 @@ mod oplog_tests {
             "cached site_id must equal the meta seed"
         );
         assert_eq!(details, "");
+    }
+
+    #[test]
+    fn insert_with_links_appends_one_link_oplog_row_per_edge() {
+        // Links carried on the note must each produce a `link` oplog row (same
+        // shape as add_link's), or a replay consumer cannot reconstruct edges.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let target = node(&store, "target");
+        let mut n = MemoryNote::new(
+            Namespace::Project("oplog".into()),
+            "linked at insert".to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        n.links.push(MemoryLink {
+            source_id: n.id.clone(),
+            target_id: target.id.clone(),
+            link_type: LinkType::Extends,
+            strength: 0.8,
+            reason: "carried on the note".into(),
+            created_at: chrono::Utc::now(),
+        });
+        store.insert_memory(&n, None).unwrap();
+
+        let rows = oplog_rows(&store);
+        assert_eq!(rows.len(), 3, "target insert + insert + one link row");
+        assert_eq!(rows[1].0, "insert");
+        assert_eq!(rows[1].1, n.id.to_string());
+        let (op, mid, _, _, details) = &rows[2];
+        assert_eq!(op, "link");
+        assert_eq!(mid, &n.id.to_string());
+        let details: serde_json::Value = serde_json::from_str(details).unwrap();
+        assert_eq!(details["type"], "extends");
+        assert_eq!(details["target"], target.id.to_string());
     }
 
     #[test]

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -133,7 +133,32 @@ impl SqliteStore {
     /// Registers sqlite-vec, enables WAL + foreign keys, runs migrations,
     /// creates the dynamic-dim `memory_vectors` table, and enforces the
     /// embedding-dimension invariant fail-closed.
+    ///
+    /// The embedding-MODEL invariant is NOT enforced here (no model is bound);
+    /// any path that serves a real embedding provider must open via
+    /// [`SqliteStore::open_with_model`] so a same-dim provider swap cannot
+    /// silently mix vector spaces.
     pub fn open(path: &Path, embedding_dim: usize) -> Result<Self> {
+        Self::open_inner(path, embedding_dim, None)
+    }
+
+    /// Open (or create) a store at `path`, enforcing BOTH embedding invariants:
+    /// the dimension and the model identity. Seeds `meta.embedding_model` on
+    /// first init; fails closed when the stored model differs from
+    /// `embedding_model` (remediation: [`SqliteStore::accept_model_change`]).
+    pub fn open_with_model(
+        path: &Path,
+        embedding_dim: usize,
+        embedding_model: &str,
+    ) -> Result<Self> {
+        Self::open_inner(path, embedding_dim, Some(embedding_model))
+    }
+
+    fn open_inner(
+        path: &Path,
+        embedding_dim: usize,
+        embedding_model: Option<&str>,
+    ) -> Result<Self> {
         register_vec()?;
         let conn = rusqlite::Connection::open(path).map_err(|e| {
             io_err(std::io::Error::other(format!(
@@ -141,18 +166,23 @@ impl SqliteStore {
                 path.display()
             )))
         })?;
-        Self::init(conn, embedding_dim)
+        Self::init(conn, embedding_dim, embedding_model)
     }
 
     /// Open an ephemeral in-memory store with the given embedding dimension.
     pub fn open_in_memory(embedding_dim: usize) -> Result<Self> {
         register_vec()?;
         let conn = rusqlite::Connection::open_in_memory().map_err(storage_err)?;
-        Self::init(conn, embedding_dim)
+        Self::init(conn, embedding_dim, None)
     }
 
-    /// Shared init path: pragmas, migrations, vectors table, dim invariant.
-    fn init(conn: rusqlite::Connection, embedding_dim: usize) -> Result<Self> {
+    /// Shared init path: pragmas, migrations, vectors table, dim invariant,
+    /// and (when a model is bound) the model-identity invariant.
+    fn init(
+        conn: rusqlite::Connection,
+        embedding_dim: usize,
+        embedding_model: Option<&str>,
+    ) -> Result<Self> {
         // A zero-dimension embedding produces a malformed `float[0]` vec0 column.
         // Reject it up front rather than letting SQLite fail cryptically later.
         if embedding_dim == 0 {
@@ -186,11 +216,63 @@ impl SqliteStore {
         .map_err(storage_err)?;
 
         seed_or_verify_dim(&conn, embedding_dim)?;
+        if let Some(model) = embedding_model {
+            seed_or_verify_model(&conn, model)?;
+        }
 
         Ok(Self {
             conn,
             embedding_dim,
         })
+    }
+
+    /// Explicit opt-in for an embedding-model swap: atomically point
+    /// `meta.embedding_model` at `new_model` and stale every row's
+    /// `embedding_input_version` to the `''` sentinel so the existing reembed
+    /// machinery converges the corpus onto the new vector space.
+    ///
+    /// Returns `true` when a swap occurred (rows were staled). Idempotent:
+    /// `false` when `new_model` is already current, or when no model was
+    /// recorded yet (legacy/fresh DB — it is seeded without staling, because
+    /// the per-row `embedding_model` stamps already drive reembed there).
+    pub fn accept_model_change(&self, new_model: &str) -> Result<bool> {
+        self.conn
+            .execute_batch("BEGIN IMMEDIATE;")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let result = (|| -> Result<bool> {
+            let stored = meta_value(&self.conn, "embedding_model")?;
+            if stored.as_deref() == Some(new_model) {
+                return Ok(false);
+            }
+            let swapping = stored.is_some();
+            self.conn
+                .execute(
+                    "INSERT INTO meta (key, value) VALUES ('embedding_model', ?1)
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    rusqlite::params![new_model],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if swapping {
+                self.conn
+                    .execute("UPDATE memories SET embedding_input_version = ''", [])
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            }
+            Ok(swapping)
+        })();
+
+        match result {
+            Ok(changed) => {
+                self.conn
+                    .execute_batch("COMMIT;")
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                Ok(changed)
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e)
+            }
+        }
     }
 
     /// Fold the WAL back into the main database file and truncate it to zero.
@@ -603,20 +685,24 @@ fn register_vec() -> Result<()> {
     outcome.clone().map_err(Error::Storage)
 }
 
+/// Read one `meta` value; `None` when the key was never seeded.
+fn meta_value(conn: &rusqlite::Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM meta WHERE key = ?1",
+        rusqlite::params![key],
+        |r| r.get::<_, String>(0),
+    )
+    .map(Some)
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(storage_err(other)),
+    })
+}
+
 /// Seed `meta.embedding_dim` on first init, or verify it matches on re-open.
 /// Fails closed with `Error::DimensionMismatch` on disagreement.
 fn seed_or_verify_dim(conn: &rusqlite::Connection, embedding_dim: usize) -> Result<()> {
-    let existing: Option<String> = conn
-        .query_row(
-            "SELECT value FROM meta WHERE key='embedding_dim'",
-            [],
-            |r| r.get::<_, String>(0),
-        )
-        .map(Some)
-        .or_else(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => Ok(None),
-            other => Err(storage_err(other)),
-        })?;
+    let existing = meta_value(conn, "embedding_dim")?;
 
     match existing {
         Some(v) => {
@@ -634,6 +720,31 @@ fn seed_or_verify_dim(conn: &rusqlite::Connection, embedding_dim: usize) -> Resu
             conn.execute(
                 "INSERT INTO meta (key, value) VALUES ('embedding_dim', ?1)",
                 rusqlite::params![embedding_dim.to_string()],
+            )
+            .map_err(storage_err)?;
+        }
+    }
+    Ok(())
+}
+
+/// Seed `meta.embedding_model` on first init (or on the first open of a DB
+/// created before the key existed), or verify it matches on re-open. A
+/// same-dim provider swap would silently mix vector spaces, so this fails
+/// closed with the explicit remediation.
+fn seed_or_verify_model(conn: &rusqlite::Connection, embedding_model: &str) -> Result<()> {
+    match meta_value(conn, "embedding_model")? {
+        Some(stored) => {
+            if stored != embedding_model {
+                return Err(Error::Storage(format!(
+                    "embedding model changed (stored: {stored}, configured: {embedding_model}); \
+                     run with --accept-model-change to mark the corpus for re-embedding"
+                )));
+            }
+        }
+        None => {
+            conn.execute(
+                "INSERT INTO meta (key, value) VALUES ('embedding_model', ?1)",
+                rusqlite::params![embedding_model],
             )
             .map_err(storage_err)?;
         }
@@ -1683,6 +1794,146 @@ mod tests {
             }
             other => panic!("expected DimensionMismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn open_with_model_seeds_then_reopens_with_same_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let _s = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+        }
+        let s2 = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+        let model: String = s2
+            .conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='embedding_model'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            model, "deterministic",
+            "embedding_model seeded at first init"
+        );
+    }
+
+    #[test]
+    fn open_with_a_different_model_refuses_with_remediation_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        // Deterministic-seeded DB; a same-dim provider swap must fail closed.
+        {
+            let _s = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+        }
+        let err = SqliteStore::open_with_model(&path, 8, "voyage-3").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("embedding model changed"),
+            "refusal names the invariant: {msg}"
+        );
+        assert!(
+            msg.contains("stored: deterministic") && msg.contains("configured: voyage-3"),
+            "refusal names both models: {msg}"
+        );
+        assert!(
+            msg.contains("--accept-model-change"),
+            "refusal carries the remediation hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn open_with_model_seeds_model_on_a_db_created_without_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        // Legacy shape: DB created without a bound model (no meta key).
+        {
+            let _s = SqliteStore::open(&path, 8).unwrap();
+        }
+        // First model-bound open adopts the configured model.
+        let _s = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+        // ...and a later swap is then refused.
+        let err = SqliteStore::open_with_model(&path, 8, "other-model").unwrap_err();
+        assert!(err.to_string().contains("embedding model changed"), "{err}");
+    }
+
+    #[test]
+    fn accept_model_change_swaps_model_and_stales_every_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        let ns = Namespace::Project("model-swap".to_string());
+
+        {
+            let store = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+            let mut note =
+                MemoryNote::new(ns.clone(), "stale me".to_string(), MemoryType::Insight, 5);
+            note.embedding_model = "deterministic".to_string();
+            note.embedding_input_version = "v2-composite".to_string();
+            store.insert_memory(&note, Some(&[0.1f32; 8])).unwrap();
+        }
+
+        // The model-bound open refuses; the opt-in path uses the unbound open.
+        let store = SqliteStore::open(&path, 8).unwrap();
+        let changed = store.accept_model_change("voyage-3").unwrap();
+        assert!(changed, "a real swap reports true");
+
+        let model: String = store
+            .conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='embedding_model'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "voyage-3", "meta points at the new model");
+
+        let stale: i64 = store
+            .conn
+            .query_row(
+                "SELECT count(*) FROM memories WHERE embedding_input_version = ''",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let total: i64 = store
+            .conn
+            .query_row("SELECT count(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(stale, total, "every row carries the reembed sentinel");
+        drop(store);
+
+        // The accepted model now opens cleanly.
+        let _reopened = SqliteStore::open_with_model(&path, 8, "voyage-3").unwrap();
+    }
+
+    #[test]
+    fn accept_model_change_with_current_model_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        let ns = Namespace::Project("model-noop".to_string());
+
+        let store = SqliteStore::open_with_model(&path, 8, "deterministic").unwrap();
+        let mut note = MemoryNote::new(ns, "keep stamp".to_string(), MemoryType::Insight, 5);
+        note.embedding_model = "deterministic".to_string();
+        note.embedding_input_version = "v2-composite".to_string();
+        store.insert_memory(&note, Some(&[0.1f32; 8])).unwrap();
+
+        // Same model (e.g. a lingering RB_ACCEPT_MODEL_CHANGE on every restart):
+        // no swap, and crucially no corpus-wide re-stale.
+        let changed = store.accept_model_change("deterministic").unwrap();
+        assert!(!changed, "accepting the current model is a no-op");
+        let version: String = store
+            .conn
+            .query_row(
+                "SELECT embedding_input_version FROM memories LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, "v2-composite", "stamps survive a no-op accept");
     }
 
     #[test]

--- a/crates/rb-types/src/memory.rs
+++ b/crates/rb-types/src/memory.rs
@@ -41,6 +41,22 @@ pub struct MemoryNote {
     /// `#[serde(default)]` so older payloads (and clients) default to `false`.
     #[serde(default)]
     pub contested: bool,
+    /// Provenance (W0.5): who/where/what wrote this memory. All optional and
+    /// `#[serde(default)]` (the `contested` precedent): rows written before the
+    /// 004 migration — and payloads from older clients — carry `None`.
+    /// `origin_user`/`origin_host` are filled daemon-side (whoami fallback);
+    /// `origin_agent`/`session_id` come from the client's handshake identity.
+    #[serde(default)]
+    pub origin_user: Option<String>,
+    #[serde(default)]
+    pub origin_host: Option<String>,
+    #[serde(default)]
+    pub origin_agent: Option<String>,
+    /// Producer surface that declared the write: `hook` | `mcp` | `cli` | `job`.
+    #[serde(default)]
+    pub origin_source: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 impl MemoryNote {
@@ -76,6 +92,11 @@ impl MemoryNote {
             embedding_input_version: String::new(),
             links: Vec::new(),
             contested: false,
+            origin_user: None,
+            origin_host: None,
+            origin_agent: None,
+            origin_source: None,
+            session_id: None,
         }
     }
 }
@@ -158,6 +179,30 @@ mod tests {
         let json = serde_json::to_string(&m).unwrap();
         let back: MemoryNote = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn deserializes_pre_w05_payload_missing_provenance_fields() {
+        // A pre-W0.5 MemoryNote JSON lacks the five provenance fields; they must
+        // deserialize to `None` (serde defaults), keeping old payloads valid.
+        let m = sample();
+        let mut value = serde_json::to_value(&m).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        for key in [
+            "origin_user",
+            "origin_host",
+            "origin_agent",
+            "origin_source",
+            "session_id",
+        ] {
+            obj.remove(key);
+        }
+        let back: MemoryNote = serde_json::from_value(value).unwrap();
+        assert!(back.origin_user.is_none());
+        assert!(back.origin_host.is_none());
+        assert!(back.origin_agent.is_none());
+        assert!(back.origin_source.is_none());
+        assert!(back.session_id.is_none());
     }
 
     #[test]

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -22,6 +22,7 @@ local = ["rb-embed/local"]
 
 [dependencies]
 rb-types = { path = "../rb-types" }
+rb-config = { path = "../rb-config" }
 rb-proto = { path = "../rb-proto" }
 rb-daemon = { path = "../rb-daemon" }
 rb-embed = { path = "../rb-embed" }

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -31,6 +31,13 @@ pub enum Command {
         /// all jobs disabled).
         #[arg(long = "jobs-config", env = "RB_JOBS_CONFIG")]
         jobs_config: Option<String>,
+
+        /// Accept a changed embedding model: adopt the configured model and
+        /// mark the whole corpus for re-embedding (run `rusty-brain reembed`
+        /// until changed=0). Without this, a model swap refuses to start.
+        /// Env equivalent (for auto-start): `RB_ACCEPT_MODEL_CHANGE`.
+        #[arg(long = "accept-model-change")]
+        accept_model_change: bool,
     },
 
     /// Run the MCP (Model Context Protocol) stdio server for agents.
@@ -176,9 +183,25 @@ mod tests {
     fn serve_accepts_jobs_config_flag() {
         let cli = Cli::parse_from(["rusty-brain", "serve", "--jobs-config", "/tmp/jobs.toml"]);
         match cli.command {
-            Command::Serve { jobs_config } => {
+            Command::Serve {
+                jobs_config,
+                accept_model_change,
+            } => {
                 assert_eq!(jobs_config.as_deref(), Some("/tmp/jobs.toml"));
+                assert!(!accept_model_change, "opt-in flag defaults to off");
             }
+            other => panic!("expected Serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serve_accepts_the_accept_model_change_flag() {
+        let cli = Cli::parse_from(["rusty-brain", "serve", "--accept-model-change"]);
+        match cli.command {
+            Command::Serve {
+                accept_model_change,
+                ..
+            } => assert!(accept_model_change),
             other => panic!("expected Serve, got {other:?}"),
         }
     }

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -19,6 +19,17 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Use this namespace instead of detecting one (env equivalent:
+    /// `RUSTY_BRAIN_NAMESPACE`; explicit always wins).
+    #[arg(long, global = true)]
+    pub namespace: Option<String>,
+
+    /// Accept and pin this repo's `CLAUDE.md` frontmatter `project:` namespace
+    /// override (recorded per-directory in the local pin store; later runs
+    /// honor it without warning).
+    #[arg(long, global = true)]
+    pub accept_namespace_override: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -154,6 +165,22 @@ mod tests {
         let cli = Cli::parse_from(["rusty-brain", "--json", "subscribe"]);
         assert!(cli.json, "--json is a global flag and applies to subscribe");
         assert!(matches!(cli.command, Command::Subscribe));
+    }
+
+    #[test]
+    fn namespace_flag_is_global_and_defaults_off() {
+        let cli = Cli::parse_from(["rusty-brain", "status"]);
+        assert_eq!(cli.namespace, None);
+        assert!(!cli.accept_namespace_override);
+        // Global: accepted after the subcommand too.
+        let cli = Cli::parse_from(["rusty-brain", "status", "--namespace", "my-proj"]);
+        assert_eq!(cli.namespace.as_deref(), Some("my-proj"));
+    }
+
+    #[test]
+    fn accept_namespace_override_flag_parses() {
+        let cli = Cli::parse_from(["rusty-brain", "--accept-namespace-override", "status"]);
+        assert!(cli.accept_namespace_override);
     }
 
     #[test]

--- a/crates/rusty-brain/src/client.rs
+++ b/crates/rusty-brain/src/client.rs
@@ -4,7 +4,7 @@
 // forwards the identical set; adding a var there widens the leak surface and
 // must fail `daemon_command_forwards_only_allowlisted_vars`.
 use rb_config::FORWARD_ENV;
-use rb_proto::Client;
+use rb_proto::{Client, ClientIdentity};
 use rb_types::{Error, Namespace, Result};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -53,20 +53,34 @@ where
     Err(last_err.unwrap_or_else(|| Error::Io("connect failed".into())))
 }
 
+/// Build this binary's provenance identity (W0.5): `source` is the producer
+/// surface (`cli` | `mcp`); user/host are left for the daemon's whoami
+/// fallback (same host, same user over the UDS).
+pub fn client_identity(source: &str) -> ClientIdentity {
+    ClientIdentity {
+        source: Some(source.to_string()),
+        ..Default::default()
+    }
+}
+
 /// Connect to the daemon at `socket_path` for `namespace`, auto-starting a
 /// detached `rusty-brain serve` child if the socket is not yet accepting.
+/// `identity` (see [`client_identity`]) is stamped as provenance on every
+/// memory the connection writes.
 pub async fn connect_or_start(
     socket_path: &Path,
     db_path: &Path,
     namespace: Namespace,
     self_exe: PathBuf,
+    identity: Option<ClientIdentity>,
 ) -> Result<Client> {
     let sock = socket_path.to_path_buf();
     let ns = namespace.clone();
     let connect = || {
         let sock = sock.clone();
         let ns = ns.clone();
-        async move { Client::connect(&sock, ns).await }
+        let identity = identity.clone();
+        async move { Client::connect_with_identity(&sock, ns, identity).await }
     };
     let spawn_sock = socket_path.to_path_buf();
     let spawn_db = db_path.to_path_buf();

--- a/crates/rusty-brain/src/client.rs
+++ b/crates/rusty-brain/src/client.rs
@@ -1,5 +1,9 @@
 //! Client connection with daemon auto-start and bounded backoff retry.
 
+// The auto-start allowlist is owned by rb-config so every spawner (CLI, hooks)
+// forwards the identical set; adding a var there widens the leak surface and
+// must fail `daemon_command_forwards_only_allowlisted_vars`.
+use rb_config::FORWARD_ENV;
 use rb_proto::Client;
 use rb_types::{Error, Namespace, Result};
 use std::future::Future;
@@ -83,21 +87,6 @@ fn spawn_daemon(self_exe: &Path, socket_path: &Path, db_path: &Path) -> Result<(
     let mut cmd = daemon_command(self_exe, socket_path, db_path);
     cmd.spawn().map(|_child| ()).map_err(|e| Error::from_io(&e))
 }
-
-/// The exact set of parent vars the auto-start child may inherit. Everything
-/// else is cleared. Keep this list minimal — adding a var widens the leak
-/// surface and must fail `daemon_command_forwards_only_allowlisted_vars`.
-const FORWARD_ENV: &[&str] = &[
-    "VOYAGE_API_KEY",
-    "RB_ENRICH_BASE_URL",
-    "RB_ENRICH_MODEL",
-    "RB_ENRICH_API_KEY",
-    "HOME",
-    "PATH",
-    "XDG_RUNTIME_DIR",
-    "XDG_DATA_HOME",
-    "XDG_CONFIG_HOME",
-];
 
 fn daemon_command(self_exe: &Path, socket_path: &Path, db_path: &Path) -> Command {
     daemon_command_with(self_exe, socket_path, db_path, |key| {

--- a/crates/rusty-brain/src/main.rs
+++ b/crates/rusty-brain/src/main.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use rusty_brain::cli::Cli;
 use rusty_brain::logging::init_logging;
-use rusty_brain::namespace_detect::detect_namespace;
+use rusty_brain::namespace_detect::resolve_for_cli;
 use rusty_brain::run::run;
 use std::process::ExitCode;
 
@@ -15,7 +15,9 @@ fn main() -> ExitCode {
     // Resolve the namespace synchronously BEFORE the runtime exists: detection
     // shells out to git and reads `CLAUDE.md`, which must not run on a tokio
     // worker thread (P1 should-fix). It never fails (degrades to Global).
-    let namespace = detect_namespace();
+    // `--namespace` short-circuits detection; `--accept-namespace-override`
+    // pins an unpinned CLAUDE.md frontmatter override (W0.3).
+    let namespace = resolve_for_cli(cli.namespace.as_deref(), cli.accept_namespace_override);
 
     let runtime = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
@@ -37,15 +39,15 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
-    use rusty_brain::namespace_detect::detect_namespace;
+    use rusty_brain::namespace_detect::resolve_for_cli;
 
     #[test]
-    fn detect_namespace_runs_without_a_tokio_runtime() {
-        // This test has NO #[tokio::test] and no runtime: detection must be a
+    fn namespace_resolution_runs_without_a_tokio_runtime() {
+        // This test has NO #[tokio::test] and no runtime: resolution must be a
         // plain synchronous call. It does spawn a `git` subprocess (no network)
         // and read files, which is exactly why it must run BEFORE block_on and
         // never on a tokio worker thread. A clean return here (it never fails;
         // it degrades to Global) proves it is runtime-free.
-        let _ns = detect_namespace();
+        let _ns = resolve_for_cli(None, false);
     }
 }

--- a/crates/rusty-brain/src/mcp.rs
+++ b/crates/rusty-brain/src/mcp.rs
@@ -165,7 +165,7 @@ impl DaemonProxy for ClientProxy {
     // including Remember. A RECV failure after a successful send is ambiguous
     // for mutating ops (the daemon may have committed and only the response was
     // lost), so only read-only ops are retried; mutating ops return the error
-    // but the connection is rebuilt so the NEXT call succeeds.
+    // and the NEXT call rebuilds the connection lazily.
     async fn call(&mut self, request: Request) -> rb_types::Result<Response> {
         let failure = {
             let client = self.ensure_connected().await?;
@@ -183,10 +183,11 @@ impl DaemonProxy for ClientProxy {
             CallFailure::Recv(_) => retry_safe_after_send(&request),
         };
         if !retryable {
-            // Best-effort eager reconnect so the next call starts healthy.
-            if let Err(e) = self.reconnect().await {
-                tracing::warn!(error = %e, "mcp proxy reconnect after ambiguous failure failed");
-            }
+            // Surface the ambiguous failure immediately. An eager reconnect
+            // here can block ~20s (backoff attempts x auto-start retries) while
+            // serial stdio dispatch stalls every other tool call — and buys
+            // nothing: `self.client` is None, so the next call reconnects
+            // lazily via `ensure_connected`.
             return Err(failure.into_error());
         }
 

--- a/crates/rusty-brain/src/mcp.rs
+++ b/crates/rusty-brain/src/mcp.rs
@@ -3,36 +3,204 @@
 //! The namespace is resolved OFF the async runtime in `main.rs` (same as the
 //! CLI path) and threaded into `run_mcp`. stdout carries ONLY JSON-RPC frames;
 //! tracing goes to stderr.
+//!
+//! Transport resilience (W0.1): the daemon closes idle connections (60s
+//! default), which is routine for an MCP session, so both the request proxy and
+//! the background change subscriber reconnect instead of dying with the first
+//! broken connection.
 
 use crate::client::connect_or_start;
 use async_trait::async_trait;
 use rb_mcp::{serve_stdio_with_buffer, ChangeBuffer, DaemonProxy};
 use rb_proto::{Client, Request, Response, SubscribeItem};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::BufReader;
 use tokio::sync::Mutex;
 
-/// Adapts the daemon `rb_proto::Client` to the adapter's `DaemonProxy` seam.
+/// Sleeps between successive proxy reconnect attempts: one immediate attempt,
+/// then one retry per entry. `connect_or_start` already retries auto-start
+/// internally; this outer schedule only covers a daemon slow to die or rebind.
+const RECONNECT_BACKOFF: [Duration; 3] = [
+    Duration::from_millis(100),
+    Duration::from_millis(300),
+    Duration::from_millis(900),
+];
+
+/// Subscriber reconnect backoff: capped exponential, reset to the initial value
+/// on each successful resubscribe.
+const SUBSCRIBE_BACKOFF_INITIAL: Duration = Duration::from_millis(500);
+const SUBSCRIBE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Adapts the daemon `rb_proto::Client` to the adapter's `DaemonProxy` seam,
+/// reconnecting (with auto-start) when the connection has died between calls.
 pub struct ClientProxy {
-    client: Client,
+    /// `None` after a transport failure; rebuilt lazily by the next call.
+    client: Option<Client>,
+    socket_path: PathBuf,
+    db_path: PathBuf,
+    namespace: rb_types::Namespace,
+    self_exe: PathBuf,
+}
+
+/// Which phase of a request round-trip failed. See the retry rule on
+/// [`ClientProxy::call`].
+enum CallFailure {
+    Send(rb_types::Error),
+    Recv(rb_types::Error),
+}
+
+impl CallFailure {
+    fn into_error(self) -> rb_types::Error {
+        match self {
+            CallFailure::Send(e) | CallFailure::Recv(e) => e,
+        }
+    }
+}
+
+/// One send+recv round trip with the failure phase preserved.
+async fn attempt_call(
+    client: &mut Client,
+    request: &Request,
+) -> std::result::Result<Response, CallFailure> {
+    client
+        .send_request(request)
+        .await
+        .map_err(CallFailure::Send)?;
+    client.recv_response().await.map_err(CallFailure::Recv)
+}
+
+/// Whether `request` is safe to retry after a SUCCESSFUL send with a lost
+/// response: only ops the daemon cannot have mutated state for. `Remember`
+/// creates a new row per execution and is the canonical non-retryable case;
+/// `Update`/`Delete`/`RunJob`/`Reembed` are conservatively excluded too.
+fn retry_safe_after_send(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::Ping
+            | Request::Recall { .. }
+            | Request::Get { .. }
+            | Request::List { .. }
+            | Request::Graph { .. }
+            | Request::Context
+    )
 }
 
 impl ClientProxy {
-    /// Wrap a connected daemon client.
-    pub fn new(client: Client) -> Self {
-        Self { client }
+    /// Wrap a connected daemon client plus everything needed to reconnect.
+    pub fn new(
+        client: Client,
+        socket_path: PathBuf,
+        db_path: PathBuf,
+        namespace: rb_types::Namespace,
+        self_exe: PathBuf,
+    ) -> Self {
+        Self {
+            client: Some(client),
+            socket_path,
+            db_path,
+            namespace,
+            self_exe,
+        }
+    }
+
+    /// Drop any dead client and rebuild the connection (auto-starting the
+    /// daemon if needed), backing off per [`RECONNECT_BACKOFF`].
+    async fn reconnect(&mut self) -> rb_types::Result<()> {
+        self.client = None;
+        let mut last_err: Option<rb_types::Error> = None;
+        for (attempt, backoff) in std::iter::once(None)
+            .chain(RECONNECT_BACKOFF.iter().map(Some))
+            .enumerate()
+        {
+            if let Some(backoff) = backoff {
+                tokio::time::sleep(*backoff).await;
+            }
+            match connect_or_start(
+                &self.socket_path,
+                &self.db_path,
+                self.namespace.clone(),
+                self.self_exe.clone(),
+            )
+            .await
+            {
+                Ok(client) => {
+                    self.client = Some(client);
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, attempt, "mcp proxy reconnect attempt failed");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| rb_types::Error::Io("reconnect failed".into())))
+    }
+
+    /// Borrow the live client, reconnecting first if a previous failure (or a
+    /// non-retryable lost-response) left the proxy without one.
+    async fn ensure_connected(&mut self) -> rb_types::Result<&mut Client> {
+        if self.client.is_none() {
+            self.reconnect().await?;
+        }
+        self.client
+            .as_mut()
+            .ok_or_else(|| rb_types::Error::Io("not connected".into()))
     }
 }
 
 #[async_trait]
 impl DaemonProxy for ClientProxy {
+    // The adapter already built a well-formed Request; forward it verbatim via
+    // the raw send/recv methods (not the typed wrappers) so the daemon's
+    // Response::Error stays a Response (surfaced as an isError tool result),
+    // and only transport failures become Err.
+    //
+    // RETRY RULE (see rb_proto::Client::send_request / recv_response): a SEND
+    // failure means the daemon never received the frame — Unix-socket writes
+    // fail immediately once the peer has closed, which is exactly the daemon's
+    // idle-timeout case — so one reconnect+retry is safe for EVERY op,
+    // including Remember. A RECV failure after a successful send is ambiguous
+    // for mutating ops (the daemon may have committed and only the response was
+    // lost), so only read-only ops are retried; mutating ops return the error
+    // but the connection is rebuilt so the NEXT call succeeds.
     async fn call(&mut self, request: Request) -> rb_types::Result<Response> {
-        // The adapter already built a well-formed Request; forward it verbatim
-        // via the raw `request` method (not the typed wrappers) so the daemon's
-        // Response::Error stays a Response (surfaced as an isError tool result),
-        // and only transport failures become Err.
-        self.client.request(request).await
+        let failure = {
+            let client = self.ensure_connected().await?;
+            match attempt_call(client, &request).await {
+                Ok(resp) => return Ok(resp),
+                Err(f) => f,
+            }
+        };
+
+        // The connection is dead either way; never reuse a broken stream.
+        self.client = None;
+
+        let retryable = match &failure {
+            CallFailure::Send(_) => true,
+            CallFailure::Recv(_) => retry_safe_after_send(&request),
+        };
+        if !retryable {
+            // Best-effort eager reconnect so the next call starts healthy.
+            if let Err(e) = self.reconnect().await {
+                tracing::warn!(error = %e, "mcp proxy reconnect after ambiguous failure failed");
+            }
+            return Err(failure.into_error());
+        }
+
+        tracing::warn!(
+            error = %failure.into_error(),
+            "mcp proxy connection dead; reconnecting and retrying once"
+        );
+        let client = self.ensure_connected().await?;
+        match attempt_call(client, &request).await {
+            Ok(resp) => Ok(resp),
+            Err(f) => {
+                self.client = None;
+                Err(f.into_error())
+            }
+        }
     }
 }
 
@@ -56,18 +224,26 @@ pub async fn run_mcp(
     // Bounded ring shared between the background subscriber and poll_changes.
     let buffer = Arc::new(Mutex::new(ChangeBuffer::new(1024)));
 
-    // Background subscriber on a dedicated, read-only connection. If it cannot
-    // connect or subscribe, poll_changes simply returns empty — the adapter must
-    // still serve tools, so a subscriber failure is logged, not fatal.
+    // Background subscriber on a dedicated, read-only connection. It reconnects
+    // with capped backoff for the adapter's lifetime; while down, poll_changes
+    // reports `subscriber.status = "disconnected"` instead of going silently
+    // deaf. A subscriber outage is never fatal to tool serving.
     let sub_buffer = Arc::clone(&buffer);
     let sub_socket = socket_path.to_path_buf();
     let sub_db = db_path.to_path_buf();
     let sub_ns = namespace.clone();
+    let sub_exe = self_exe.clone();
     tokio::spawn(async move {
-        run_subscriber(&sub_socket, &sub_db, sub_ns, self_exe, sub_buffer).await;
+        run_subscriber(&sub_socket, &sub_db, sub_ns, sub_exe, sub_buffer).await;
     });
 
-    let proxy = ClientProxy::new(client);
+    let proxy = ClientProxy::new(
+        client,
+        socket_path.to_path_buf(),
+        db_path.to_path_buf(),
+        namespace,
+        self_exe,
+    );
     let stdin = BufReader::new(tokio::io::stdin());
     let stdout = tokio::io::stdout();
     serve_stdio_with_buffer(stdin, stdout, proxy, buffer)
@@ -76,10 +252,11 @@ pub async fn run_mcp(
     Ok(())
 }
 
-/// Background loop: open a subscriber connection and push namespace-scoped change
-/// events into the shared ring until the stream closes. Best-effort: connection
-/// or stream errors end the loop quietly (logged to stderr), leaving poll_changes
-/// to return whatever was already buffered.
+/// Background loop: keep a subscriber connection alive for the adapter's
+/// lifetime, pushing namespace-scoped change events into the shared ring.
+/// Connect/subscribe/stream failures mark the buffer disconnected and retry
+/// with capped exponential backoff (reset on each successful resubscribe);
+/// the task ends only with the runtime.
 async fn run_subscriber(
     socket_path: &Path,
     db_path: &Path,
@@ -87,17 +264,46 @@ async fn run_subscriber(
     self_exe: std::path::PathBuf,
     buffer: Arc<Mutex<ChangeBuffer>>,
 ) {
-    let mut client = match connect_or_start(socket_path, db_path, namespace, self_exe).await {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(error = %e, "mcp change subscriber could not connect; poll_changes will be empty");
-            return;
+    let mut backoff = SUBSCRIBE_BACKOFF_INITIAL;
+    loop {
+        match connect_and_subscribe(socket_path, db_path, namespace.clone(), self_exe.clone()).await
+        {
+            Ok(mut client) => {
+                buffer.lock().await.set_connected();
+                backoff = SUBSCRIBE_BACKOFF_INITIAL;
+                pump_changes(&mut client, &buffer).await;
+                buffer.lock().await.set_disconnected();
+            }
+            Err(e) => {
+                buffer.lock().await.set_disconnected();
+                tracing::warn!(
+                    error = %e,
+                    retry_in = ?backoff,
+                    "mcp change subscriber connect/subscribe failed"
+                );
+            }
         }
-    };
-    if let Err(e) = client.subscribe().await {
-        tracing::warn!(error = %e, "mcp change subscriber could not subscribe; poll_changes will be empty");
-        return;
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(SUBSCRIBE_BACKOFF_MAX);
     }
+}
+
+/// Open a fresh connection (auto-starting the daemon if needed) and switch it
+/// into the change stream.
+async fn connect_and_subscribe(
+    socket_path: &Path,
+    db_path: &Path,
+    namespace: rb_types::Namespace,
+    self_exe: std::path::PathBuf,
+) -> rb_types::Result<Client> {
+    let mut client = connect_or_start(socket_path, db_path, namespace, self_exe).await?;
+    client.subscribe().await?;
+    Ok(client)
+}
+
+/// Drain the live stream into the ring until it errors (daemon restart or
+/// shutdown); the caller handles reconnect.
+async fn pump_changes(client: &mut Client, buffer: &Arc<Mutex<ChangeBuffer>>) {
     loop {
         match client.recv_change().await {
             Ok(SubscribeItem::Change(evt)) => {
@@ -119,16 +325,69 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
 
-    // The proxy is a thin newtype over rb_proto::Client; there is no offline way
-    // to construct a connected Client without a daemon, so behavior is proven in
-    // the daemon-backed e2e (Task 18). Here we only assert the type implements
-    // the rb_mcp::DaemonProxy trait (a compile-time guarantee via this fn).
+    // The proxy is a thin wrapper over rb_proto::Client; there is no offline way
+    // to construct a connected Client without a daemon, so reconnect behavior is
+    // proven in the daemon-backed e2e (tests/mcp_e2e.rs). Here we only assert
+    // the type implements the rb_mcp::DaemonProxy trait (a compile-time
+    // guarantee via this fn).
     fn _assert_impls_daemon_proxy<T: rb_mcp::DaemonProxy>() {}
 
     #[test]
     fn client_proxy_implements_daemon_proxy() {
         // If ClientProxy did not implement DaemonProxy this would not compile.
         let _ = _assert_impls_daemon_proxy::<ClientProxy>;
+    }
+
+    // The retry rule's idempotency split: read-only ops may be retried after a
+    // lost response; anything that writes (or streams) must not be, because the
+    // daemon may already have executed it.
+    #[test]
+    fn lost_response_retry_is_limited_to_read_only_ops() {
+        let id = rb_types::MemoryId::new;
+        for req in [
+            Request::Ping,
+            Request::Recall {
+                query: "q".into(),
+                memory_type: None,
+                tags: vec![],
+                limit: 5,
+            },
+            Request::Get { id: id() },
+            Request::List {
+                min_importance: None,
+                limit: 10,
+            },
+            Request::Graph { id: id(), depth: 2 },
+            Request::Context,
+        ] {
+            assert!(retry_safe_after_send(&req), "read-only must retry: {req:?}");
+        }
+        for req in [
+            Request::Remember {
+                content: "c".into(),
+                context: None,
+                memory_type: rb_types::MemoryType::Insight,
+                importance: 5,
+                keywords: vec![],
+                tags: vec![],
+                related_files: vec![],
+            },
+            Request::Update {
+                id: id(),
+                updates: Default::default(),
+            },
+            Request::Delete { id: id() },
+            Request::Subscribe,
+            Request::RunJob {
+                job: rb_types::JobKind::LinkDecay,
+            },
+            Request::Reembed { limit: None },
+        ] {
+            assert!(
+                !retry_safe_after_send(&req),
+                "mutating/streaming must not retry: {req:?}"
+            );
+        }
     }
 
     // Compile-time guard: run_mcp must accept a pre-resolved Namespace (threaded

--- a/crates/rusty-brain/src/mcp.rs
+++ b/crates/rusty-brain/src/mcp.rs
@@ -122,6 +122,7 @@ impl ClientProxy {
                 &self.db_path,
                 self.namespace.clone(),
                 self.self_exe.clone(),
+                Some(crate::client::client_identity("mcp")),
             )
             .await
             {
@@ -217,9 +218,15 @@ pub async fn run_mcp(
 ) -> anyhow::Result<()> {
     let self_exe =
         std::env::current_exe().map_err(|e| anyhow::anyhow!("locating own executable: {e}"))?;
-    let client = connect_or_start(socket_path, db_path, namespace.clone(), self_exe.clone())
-        .await
-        .map_err(|e| anyhow::anyhow!("connecting to daemon: {e}"))?;
+    let client = connect_or_start(
+        socket_path,
+        db_path,
+        namespace.clone(),
+        self_exe.clone(),
+        Some(crate::client::client_identity("mcp")),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("connecting to daemon: {e}"))?;
 
     // Bounded ring shared between the background subscriber and poll_changes.
     let buffer = Arc::new(Mutex::new(ChangeBuffer::new(1024)));
@@ -296,7 +303,14 @@ async fn connect_and_subscribe(
     namespace: rb_types::Namespace,
     self_exe: std::path::PathBuf,
 ) -> rb_types::Result<Client> {
-    let mut client = connect_or_start(socket_path, db_path, namespace, self_exe).await?;
+    let mut client = connect_or_start(
+        socket_path,
+        db_path,
+        namespace,
+        self_exe,
+        Some(crate::client::client_identity("mcp")),
+    )
+    .await?;
     client.subscribe().await?;
     Ok(client)
 }
@@ -371,6 +385,7 @@ mod tests {
                 keywords: vec![],
                 tags: vec![],
                 related_files: vec![],
+                confidence: 1.0,
             },
             Request::Update {
                 id: id(),

--- a/crates/rusty-brain/src/namespace_detect.rs
+++ b/crates/rusty-brain/src/namespace_detect.rs
@@ -2,13 +2,18 @@
 //! (the single W0.3 implementation). The CLI is the interactive consumer: an
 //! unpinned `CLAUDE.md` frontmatter `project:` override warns on stderr and
 //! falls back to the git-toplevel name unless `--accept-namespace-override`
-//! pins it (known-hosts style).
+//! pins it (known-hosts style). A worktree `.rusty-brain.toml` that diverges
+//! from the blob committed at `HEAD` likewise warns on stderr — only the
+//! committed content is ever honored.
 //!
 //! Resolution MUST run off the async runtime (it shells out to git and reads
 //! files); `main.rs` computes it before `block_on`. Never panics, never fails:
 //! degrades branch by branch to `Namespace::Global`.
 
-use rb_config::namespace::{accept_override, resolve_namespace, NamespaceResolution};
+use rb_config::namespace::{
+    accept_override, resolve_namespace, NamespaceResolution, RepoConfigDivergenceKind,
+    REPO_CONFIG_FILE,
+};
 use rb_types::Namespace;
 
 /// Resolve for the CLI: `--namespace` flag > `RUSTY_BRAIN_NAMESPACE` env >
@@ -18,7 +23,22 @@ pub fn resolve_for_cli(flag: Option<&str>, accept: bool) -> Namespace {
     let NamespaceResolution {
         namespace,
         unpinned_override,
+        repo_config_divergence,
     } = resolve_namespace(flag);
+    if let Some(d) = &repo_config_divergence {
+        match d.kind {
+            RepoConfigDivergenceKind::Untracked => eprintln!(
+                "WARNING: found {REPO_CONFIG_FILE} in {} but it is not committed at HEAD; \
+                 ignoring — commit it to take effect",
+                d.toplevel.display()
+            ),
+            RepoConfigDivergenceKind::Modified => eprintln!(
+                "WARNING: {REPO_CONFIG_FILE} in {} differs from the committed version; \
+                 using the committed content",
+                d.toplevel.display()
+            ),
+        }
+    }
     let Some(o) = unpinned_override else {
         return namespace;
     };
@@ -84,17 +104,20 @@ mod tests {
     // End-to-end resolution against real temp trees and real git, exercised
     // through the shared rb-config implementation this shim delegates to.
     mod fs_walk {
-        use rb_config::namespace::{git_toplevel, resolve_namespace_in, NamespacePins};
+        use rb_config::namespace::{
+            git_toplevel, head_repo_config, resolve_namespace_in, NamespacePins,
+        };
         use rb_types::Namespace;
         use std::fs;
         use std::path::Path;
         use std::process::{Command, Stdio};
         use tempfile::TempDir;
 
-        /// `git init` `dir`; false (test skips) when git is unavailable.
-        fn git_init(dir: &Path) -> bool {
+        /// Run `git <args>` in `dir`; false (test skips) when git is
+        /// unavailable.
+        fn git_run(dir: &Path, args: &[&str]) -> bool {
             Command::new("git")
-                .args(["init", "-q"])
+                .args(args)
                 .current_dir(dir)
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
@@ -104,8 +127,28 @@ mod tests {
                 .unwrap_or(false)
         }
 
+        /// `git init` with a repo-local identity so commits work everywhere.
+        fn git_init(dir: &Path) -> bool {
+            git_run(dir, &["init", "-q"])
+                && git_run(dir, &["config", "user.email", "test@example.com"])
+                && git_run(dir, &["config", "user.name", "Test"])
+        }
+
+        /// Stage everything and commit.
+        fn git_commit_all(dir: &Path) -> bool {
+            git_run(dir, &["add", "-A"])
+                && git_run(dir, &["commit", "-q", "-m", "init", "--no-gpg-sign"])
+        }
+
         fn resolve(start: &Path) -> Namespace {
-            resolve_namespace_in(start, None, &NamespacePins::default(), git_toplevel).namespace
+            resolve_namespace_in(
+                start,
+                None,
+                &NamespacePins::default(),
+                git_toplevel,
+                head_repo_config,
+            )
+            .namespace
         }
 
         #[test]
@@ -134,7 +177,7 @@ mod tests {
 
         #[test]
         fn repo_committed_toml_wins_over_directory_name() {
-            // (b)+(d): identity travels with `.rusty-brain.toml`.
+            // (b)+(d): identity travels with the COMMITTED `.rusty-brain.toml`.
             let tmp = TempDir::new().unwrap();
             let repo = tmp.path().canonicalize().unwrap().join("any-clone-name");
             fs::create_dir_all(&repo).unwrap();
@@ -143,10 +186,26 @@ mod tests {
                 "namespace = \"pinned-id\"\n",
             )
             .unwrap();
-            if !git_init(&repo) {
+            if !git_init(&repo) || !git_commit_all(&repo) {
                 return; // git unavailable; skip
             }
             assert_eq!(resolve(&repo), Namespace::Project("pinned-id".to_string()));
+        }
+
+        #[test]
+        fn untracked_toml_is_ignored_and_repo_name_is_used() {
+            // Inverse regression for the namespace-hijack fix: a worktree
+            // `.rusty-brain.toml` with no committed counterpart at HEAD must
+            // not redirect the CLI's namespace.
+            let tmp = TempDir::new().unwrap();
+            let repo = tmp.path().canonicalize().unwrap().join("host-repo");
+            fs::create_dir_all(&repo).unwrap();
+            fs::write(repo.join("README.md"), "x\n").unwrap();
+            if !git_init(&repo) || !git_commit_all(&repo) {
+                return; // git unavailable; skip
+            }
+            fs::write(repo.join(".rusty-brain.toml"), "namespace = \"hijacked\"\n").unwrap();
+            assert_eq!(resolve(&repo), Namespace::Project("host-repo".to_string()));
         }
 
         #[test]

--- a/crates/rusty-brain/src/namespace_detect.rs
+++ b/crates/rusty-brain/src/namespace_detect.rs
@@ -1,142 +1,63 @@
-//! Client-side namespace detection (P2): `CLAUDE.md` frontmatter/H1, then git
-//! root, then cwd, then `Global`.
-//!
-//! Pure core is parameterized over a "find nearest `CLAUDE.md`" closure and a
-//! "git root" closure so every branch is unit-testable without touching the real
-//! filesystem or shelling out to git. Never panics, never fails: degrades to the
-//! next branch and ultimately to `Namespace::Global`.
+//! Client-side namespace resolution: thin shim over [`rb_config::namespace`]
+//! (the single W0.3 implementation). The CLI is the interactive consumer: an
+//! unpinned `CLAUDE.md` frontmatter `project:` override warns on stderr and
+//! falls back to the git-toplevel name unless `--accept-namespace-override`
+//! pins it (known-hosts style).
 //!
 //! Resolution MUST run off the async runtime (it shells out to git and reads
-//! files); `main.rs` computes it before `block_on`.
+//! files); `main.rs` computes it before `block_on`. Never panics, never fails:
+//! degrades branch by branch to `Namespace::Global`.
 
+use rb_config::namespace::{accept_override, resolve_namespace, NamespaceResolution};
 use rb_types::Namespace;
-use std::path::{Path, PathBuf};
-use std::process::Command;
 
-/// Detect the namespace for the real process. Reads the real cwd, searches for a
-/// `CLAUDE.md`, and invokes git. Synchronous: call this OFF the tokio runtime.
+/// Resolve for the CLI: `--namespace` flag > `RUSTY_BRAIN_NAMESPACE` env >
+/// detection. `accept` records the pin for an unpinned frontmatter override
+/// (explicit user consent). Synchronous: call this OFF the tokio runtime.
+pub fn resolve_for_cli(flag: Option<&str>, accept: bool) -> Namespace {
+    let NamespaceResolution {
+        namespace,
+        unpinned_override,
+    } = resolve_namespace(flag);
+    let Some(o) = unpinned_override else {
+        return namespace;
+    };
+    if accept {
+        return match accept_override(&o) {
+            Ok(ns) => {
+                eprintln!(
+                    "pinned namespace override for {}: `{}`",
+                    o.toplevel.display(),
+                    o.claimed
+                );
+                ns
+            }
+            // The user consented explicitly: honor the override for this run
+            // even if persisting the pin failed.
+            Err(e) => {
+                eprintln!(
+                    "warning: could not record namespace pin ({e}); using `{}` for this run only",
+                    o.claimed
+                );
+                Namespace::Project(o.claimed)
+            }
+        };
+    }
+    eprintln!(
+        "WARNING: CLAUDE.md in {} claims namespace `{}`, but this repository is `{}`.\n\
+         Using `{}`. If `{}` is intentional, re-run with --accept-namespace-override to pin it.",
+        o.toplevel.display(),
+        o.claimed,
+        o.used,
+        o.used,
+        o.claimed
+    );
+    namespace
+}
+
+/// Compat entry point (original P2 API): plain detection, no flags.
 pub fn detect_namespace() -> Namespace {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    detect_namespace_with(&cwd, find_nearest_claude_md, git_toplevel)
-}
-
-/// Pure core. `find_claude_md` returns the nearest `CLAUDE.md`'s `(path, text)`
-/// (searching from `start` upward); `git_root` returns the git toplevel.
-///
-/// Order (first non-empty wins): (1) `CLAUDE.md` frontmatter `project:`,
-/// (2) `CLAUDE.md` first `# H1`, (3) git-root dir name, (4) `start` dir name,
-/// (5) `Global`.
-pub fn detect_namespace_with<C, G>(start: &Path, find_claude_md: C, git_root: G) -> Namespace
-where
-    C: Fn(&Path) -> Option<(PathBuf, String)>,
-    G: Fn(&Path) -> Option<PathBuf>,
-{
-    // (1)+(2): nearest CLAUDE.md -> frontmatter project, else first H1.
-    if let Some((_path, text)) = find_claude_md(start) {
-        if let Some(name) = parse_project_from_claude_md(&text) {
-            return Namespace::Project(name);
-        }
-    }
-    // (3): git-root directory name.
-    if let Some(name) = git_root(start).as_deref().and_then(dir_name) {
-        return Namespace::Project(name);
-    }
-    // (4): start (cwd) directory name.
-    if let Some(name) = dir_name(start) {
-        return Namespace::Project(name);
-    }
-    // (5): nothing usable.
-    Namespace::Global
-}
-
-/// Extract a non-empty, utf8 final path component. `None` for `/`, empty, or
-/// non-utf8 names — which makes the caller fall through to the next branch.
-fn dir_name(p: &Path) -> Option<String> {
-    p.file_name()
-        .and_then(|n| n.to_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-}
-
-/// Pure: parse a `CLAUDE.md` body for a project name. Prefer YAML-frontmatter
-/// `project: NAME` (leading `---` ... `---` block); else the first `# H1`.
-/// Lenient hand parser — never panics; returns `None` if neither is present.
-pub fn parse_project_from_claude_md(text: &str) -> Option<String> {
-    if let Some(name) = project_from_frontmatter(text) {
-        return Some(name);
-    }
-    first_h1(text)
-}
-
-/// Read `project: NAME` from a leading `---`-delimited frontmatter block.
-fn project_from_frontmatter(text: &str) -> Option<String> {
-    let mut lines = text.lines();
-    // Frontmatter must start at the very first line as `---`.
-    if lines.next().map(str::trim) != Some("---") {
-        return None;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break; // end of frontmatter
-        }
-        if let Some(rest) = trimmed.strip_prefix("project:") {
-            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'').trim();
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-            // Empty value: stop scanning frontmatter; defer to H1.
-            return None;
-        }
-    }
-    None
-}
-
-/// First markdown `# H1` heading text (exactly one leading `#`), trimmed.
-fn first_h1(text: &str) -> Option<String> {
-    for line in text.lines() {
-        let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix("# ") {
-            let heading = rest.trim();
-            if !heading.is_empty() {
-                return Some(heading.to_string());
-            }
-        }
-    }
-    None
-}
-
-/// Walk up from `start` to the filesystem root, returning the first
-/// `CLAUDE.md`'s `(path, contents)`. `None` if none found or unreadable.
-fn find_nearest_claude_md(start: &Path) -> Option<(PathBuf, String)> {
-    for dir in start.ancestors() {
-        let candidate = dir.join("CLAUDE.md");
-        if let Ok(text) = std::fs::read_to_string(&candidate) {
-            return Some((candidate, text));
-        }
-    }
-    None
-}
-
-/// Find the git toplevel for `dir` by invoking git; `None` if not a repo.
-fn git_toplevel(dir: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let path = String::from_utf8(output.stdout).ok()?;
-    let trimmed = path.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(trimmed))
-    }
+    resolve_for_cli(None, false)
 }
 
 #[cfg(test)]
@@ -144,243 +65,105 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
     use rb_types::Namespace;
-    use std::path::{Path, PathBuf};
-
-    // --- parse_project_from_claude_md (pure text parsing) ---
 
     #[test]
-    fn frontmatter_project_wins_over_h1() {
-        let text = "---\nproject: from-frontmatter\nother: x\n---\n# From Heading\nbody\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("from-frontmatter".to_string())
-        );
+    fn explicit_flag_beats_everything() {
+        // (e): the flag short-circuits detection entirely — no fs, no git, no
+        // warning path.
+        let ns = resolve_for_cli(Some("forced-name"), false);
+        assert_eq!(ns, Namespace::Project("forced-name".to_string()));
     }
 
     #[test]
-    fn frontmatter_project_with_quotes_and_spaces_is_trimmed() {
-        let text = "---\nproject:   \"my proj\"  \n---\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("my proj".to_string())
-        );
+    fn blank_flag_falls_back_to_detection() {
+        // A whitespace-only flag is not an explicit namespace.
+        let ns = resolve_for_cli(Some("   "), false);
+        assert_ne!(ns, Namespace::Project("   ".to_string()));
     }
 
-    #[test]
-    fn falls_back_to_first_h1_when_no_frontmatter_project() {
-        let text = "---\nother: x\n---\nintro\n#  Heading Name  \n## sub\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("Heading Name".to_string())
-        );
-    }
-
-    #[test]
-    fn h1_used_when_no_frontmatter_at_all() {
-        let text = "# Just A Heading\nbody\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("Just A Heading".to_string())
-        );
-    }
-
-    #[test]
-    fn malformed_frontmatter_never_panics_and_degrades() {
-        // Unterminated frontmatter, no project key, no h1 -> None.
-        let text = "---\nproject\nnonsense: : :\n";
-        assert_eq!(parse_project_from_claude_md(text), None);
-    }
-
-    #[test]
-    fn empty_project_value_is_ignored() {
-        // project: with empty value must not yield an empty namespace.
-        let text = "---\nproject:   \n---\n# Heading\n";
-        assert_eq!(
-            parse_project_from_claude_md(text),
-            Some("Heading".to_string())
-        );
-    }
-
-    #[test]
-    fn empty_text_is_none() {
-        assert_eq!(parse_project_from_claude_md(""), None);
-    }
-
-    // --- detect_namespace_with (3-arg pure core) ---
-
-    fn no_claude(_: &Path) -> Option<(PathBuf, String)> {
-        None
-    }
-
-    #[test]
-    fn branch1_claude_md_frontmatter_project() {
-        let start = Path::new("/home/alice/code/app/src");
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/app/CLAUDE.md"),
-                "---\nproject: cool-app\n---\n# Other\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/app")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        assert_eq!(ns, Namespace::Project("cool-app".to_string()));
-    }
-
-    #[test]
-    fn branch2_claude_md_h1_heading() {
-        let start = Path::new("/home/alice/code/app/src");
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/app/CLAUDE.md"),
-                "# Heading Project\nbody\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/app")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        assert_eq!(ns, Namespace::Project("Heading Project".to_string()));
-    }
-
-    #[test]
-    fn branch3_git_root_dirname_when_claude_md_useless() {
-        let start = Path::new("/home/alice/code/rusty-brain/crates/rusty-brain");
-        // CLAUDE.md exists but has neither project nor h1 -> skip to git root.
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/rusty-brain/CLAUDE.md"),
-                "just some prose with no heading\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/rusty-brain")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        assert_eq!(ns, Namespace::Project("rusty-brain".to_string()));
-    }
-
-    #[test]
-    fn branch4_cwd_dirname_outside_repo() {
-        let start = Path::new("/home/alice/scratch/notes");
-        let git_root = |_: &Path| -> Option<PathBuf> { None };
-        let ns = detect_namespace_with(start, no_claude, git_root);
-        assert_eq!(ns, Namespace::Project("notes".to_string()));
-    }
-
-    #[test]
-    fn branch5_global_for_root_dir() {
-        let start = Path::new("/");
-        let git_root = |_: &Path| -> Option<PathBuf> { None };
-        let ns = detect_namespace_with(start, no_claude, git_root);
-        assert_eq!(ns, Namespace::Global);
-    }
-
-    #[test]
-    fn non_utf8_git_root_dirname_degrades_to_cwd_then_global() {
-        // git root has a non-utf8 final component; start is "/" so we end at Global.
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-        let mut bytes = b"/tmp/".to_vec();
-        bytes.extend_from_slice(&[0x66, 0x80, 0x6f]); // "f\x80o" invalid utf8
-        let bad = PathBuf::from(OsString::from_vec(bytes));
-        let start = Path::new("/");
-        let git_root = move |_: &Path| -> Option<PathBuf> { Some(bad.clone()) };
-        let ns = detect_namespace_with(start, no_claude, git_root);
-        // git-root name is non-utf8 -> None; start "/" has no name -> Global.
-        assert_eq!(ns, Namespace::Global);
-    }
-
-    #[test]
-    fn empty_frontmatter_project_skips_to_git_root() {
-        let start = Path::new("/home/alice/code/app/src");
-        let find_claude = |_: &Path| -> Option<(PathBuf, String)> {
-            Some((
-                PathBuf::from("/home/alice/code/app/CLAUDE.md"),
-                "---\nproject:   \n---\n".to_string(),
-            ))
-        };
-        let git_root =
-            |_: &Path| -> Option<PathBuf> { Some(PathBuf::from("/home/alice/code/app")) };
-        let ns = detect_namespace_with(start, find_claude, git_root);
-        // empty project + no h1 -> git root name.
-        assert_eq!(ns, Namespace::Project("app".to_string()));
-    }
-
+    // End-to-end resolution against real temp trees and real git, exercised
+    // through the shared rb-config implementation this shim delegates to.
     mod fs_walk {
-        #![allow(clippy::unwrap_used, clippy::expect_used)]
-        use super::super::{detect_namespace_with, find_nearest_claude_md};
+        use rb_config::namespace::{git_toplevel, resolve_namespace_in, NamespacePins};
         use rb_types::Namespace;
         use std::fs;
         use std::path::Path;
+        use std::process::{Command, Stdio};
         use tempfile::TempDir;
 
-        // Build start dir + write a CLAUDE.md `levels` directories above it.
-        fn tree_with_claude(levels: usize, body: &str) -> (TempDir, std::path::PathBuf) {
+        /// `git init` `dir`; false (test skips) when git is unavailable.
+        fn git_init(dir: &Path) -> bool {
+            Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(dir)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        }
+
+        fn resolve(start: &Path) -> Namespace {
+            resolve_namespace_in(start, None, &NamespacePins::default(), git_toplevel).namespace
+        }
+
+        #[test]
+        fn walk_stops_at_git_toplevel_f54_regression() {
+            // (a) F54: outer CLAUDE.md (the ~/CLAUDE.md scenario) + inner
+            // CLAUDE.md-less repo -> the repo's own name, never the outer file.
             let tmp = TempDir::new().unwrap();
-            let root = tmp.path().to_path_buf();
-            let mut start = root.clone();
-            for i in 0..levels {
-                start = start.join(format!("d{i}"));
+            // Canonicalize: git reports the physical toplevel (macOS /tmp).
+            let outer = tmp.path().canonicalize().unwrap();
+            fs::write(
+                outer.join("CLAUDE.md"),
+                "---\nproject: outer-claim\n---\n# Outer Heading\n",
+            )
+            .unwrap();
+            let repo = outer.join("inner-repo");
+            let nested = repo.join("src");
+            fs::create_dir_all(&nested).unwrap();
+            if !git_init(&repo) {
+                return; // git unavailable; skip
             }
-            fs::create_dir_all(&start).unwrap();
-            fs::write(root.join("CLAUDE.md"), body).unwrap();
-            (tmp, start)
-        }
-
-        fn no_git(_: &Path) -> Option<std::path::PathBuf> {
-            None
+            assert_eq!(
+                resolve(&nested),
+                Namespace::Project("inner-repo".to_string())
+            );
         }
 
         #[test]
-        fn finds_claude_md_three_levels_up_and_uses_frontmatter() {
-            let (tmp, start) = tree_with_claude(3, "---\nproject: walked-up\n---\n# Ignored\n");
-            let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-            assert_eq!(ns, Namespace::Project("walked-up".to_string()));
-            drop(tmp);
-        }
-
-        #[test]
-        fn uses_h1_from_real_file_when_no_frontmatter() {
-            let (tmp, start) = tree_with_claude(2, "# Real Heading\nbody\n");
-            let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-            assert_eq!(ns, Namespace::Project("Real Heading".to_string()));
-            drop(tmp);
-        }
-
-        #[test]
-        fn nearest_claude_md_wins_over_higher_one() {
+        fn repo_committed_toml_wins_over_directory_name() {
+            // (b)+(d): identity travels with `.rusty-brain.toml`.
             let tmp = TempDir::new().unwrap();
-            let root = tmp.path().to_path_buf();
-            let mid = root.join("mid");
-            let leaf = mid.join("leaf");
-            fs::create_dir_all(&leaf).unwrap();
-            fs::write(root.join("CLAUDE.md"), "---\nproject: outer\n---\n").unwrap();
-            fs::write(mid.join("CLAUDE.md"), "---\nproject: inner\n---\n").unwrap();
-            let ns = detect_namespace_with(&leaf, find_nearest_claude_md, no_git);
-            assert_eq!(ns, Namespace::Project("inner".to_string()));
-            drop(tmp);
+            let repo = tmp.path().canonicalize().unwrap().join("any-clone-name");
+            fs::create_dir_all(&repo).unwrap();
+            fs::write(
+                repo.join(".rusty-brain.toml"),
+                "namespace = \"pinned-id\"\n",
+            )
+            .unwrap();
+            if !git_init(&repo) {
+                return; // git unavailable; skip
+            }
+            assert_eq!(resolve(&repo), Namespace::Project("pinned-id".to_string()));
         }
 
         #[test]
-        fn malformed_claude_md_degrades_to_cwd_dirname() {
-            // CLAUDE.md present but no project + no h1 -> cwd dir name (no git).
+        fn malicious_repo_frontmatter_is_not_honored_unpinned() {
+            // (c) F22: a cloned repo's own CLAUDE.md cannot claim another
+            // project's namespace without an explicit pin.
             let tmp = TempDir::new().unwrap();
-            let root = tmp.path().to_path_buf();
-            let start = root.join("my-project-dir");
-            fs::create_dir_all(&start).unwrap();
-            fs::write(root.join("CLAUDE.md"), "---\nbroken\n").unwrap();
-            let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-            assert_eq!(ns, Namespace::Project("my-project-dir".to_string()));
-            drop(tmp);
-        }
-
-        #[test]
-        fn no_claude_md_anywhere_uses_cwd_dirname() {
-            let tmp = TempDir::new().unwrap();
-            let start = tmp.path().join("standalone");
-            fs::create_dir_all(&start).unwrap();
-            let ns = detect_namespace_with(&start, find_nearest_claude_md, no_git);
-            assert_eq!(ns, Namespace::Project("standalone".to_string()));
-            drop(tmp);
+            let repo = tmp.path().canonicalize().unwrap().join("cloned-repo");
+            fs::create_dir_all(&repo).unwrap();
+            fs::write(repo.join("CLAUDE.md"), "---\nproject: victim\n---\n").unwrap();
+            if !git_init(&repo) {
+                return; // git unavailable; skip
+            }
+            assert_eq!(
+                resolve(&repo),
+                Namespace::Project("cloned-repo".to_string())
+            );
         }
     }
 }

--- a/crates/rusty-brain/src/paths.rs
+++ b/crates/rusty-brain/src/paths.rs
@@ -2,27 +2,23 @@
 
 use std::path::PathBuf;
 
-/// Env var that overrides the daemon socket path.
-pub const SOCKET_ENV: &str = "RUSTY_BRAIN_SOCKET";
-/// Env var that overrides the database path.
-pub const DB_ENV: &str = "RUSTY_BRAIN_DB";
+// Env-var names are owned by rb-config (shared with the daemon and hooks);
+// re-exported so existing `crate::paths::*` consumers keep working.
+pub use rb_config::{DB_ENV, JOBS_CONFIG_ENV, SOCKET_ENV};
 
-/// Env var that points at the evolution-jobs TOML config.
-pub const JOBS_CONFIG_ENV: &str = "RB_JOBS_CONFIG";
-
-/// Resolve the socket path: explicit override wins, else the daemon default.
+/// Resolve the socket path: explicit override wins, else the shared default.
 pub fn resolve_socket_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
     match override_value.filter(|p| !p.trim().is_empty()) {
         Some(p) => Ok(PathBuf::from(p)),
-        None => rb_daemon::default_socket_path(),
+        None => rb_config::default_socket_path(),
     }
 }
 
-/// Resolve the database path: explicit override wins, else the daemon default.
+/// Resolve the database path: explicit override wins, else the shared default.
 pub fn resolve_db_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
     match override_value.filter(|p| !p.trim().is_empty()) {
         Some(p) => Ok(PathBuf::from(p)),
-        None => rb_daemon::default_db_path(),
+        None => rb_config::default_db_path(),
     }
 }
 

--- a/crates/rusty-brain/src/paths.rs
+++ b/crates/rusty-brain/src/paths.rs
@@ -6,21 +6,10 @@ use std::path::PathBuf;
 // re-exported so existing `crate::paths::*` consumers keep working.
 pub use rb_config::{DB_ENV, JOBS_CONFIG_ENV, SOCKET_ENV};
 
-/// Resolve the socket path: explicit override wins, else the shared default.
-pub fn resolve_socket_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
-    match override_value.filter(|p| !p.trim().is_empty()) {
-        Some(p) => Ok(PathBuf::from(p)),
-        None => rb_config::default_socket_path(),
-    }
-}
-
-/// Resolve the database path: explicit override wins, else the shared default.
-pub fn resolve_db_path(override_value: Option<String>) -> rb_types::Result<PathBuf> {
-    match override_value.filter(|p| !p.trim().is_empty()) {
-        Some(p) => Ok(PathBuf::from(p)),
-        None => rb_config::default_db_path(),
-    }
-}
+// Env-override composition (one trim/non-empty rule for hooks, CLI, and
+// daemon) is owned by rb-config; re-exported so `crate::paths::*` callers keep
+// working and the CLI can never drift from the hooks' resolution.
+pub use rb_config::{db_path_from_env, socket_path_from_env};
 
 /// Resolve the jobs-config path: explicit override wins, else the env value,
 /// else `None` (meaning: load the all-disabled default). Blank strings are
@@ -35,57 +24,15 @@ pub fn resolve_jobs_config_path(
         .map(PathBuf::from)
 }
 
-/// Read the socket path from the environment (override) or fall back to default.
-pub fn socket_path_from_env() -> rb_types::Result<PathBuf> {
-    resolve_socket_path(std::env::var(SOCKET_ENV).ok())
-}
-
-/// Read the db path from the environment (override) or fall back to default.
-pub fn db_path_from_env() -> rb_types::Result<PathBuf> {
-    resolve_db_path(std::env::var(DB_ENV).ok())
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
     use std::path::PathBuf;
 
-    #[test]
-    fn socket_path_prefers_override() {
-        let got = resolve_socket_path(Some("/tmp/rb-test.sock".to_string())).unwrap();
-        assert_eq!(got, PathBuf::from("/tmp/rb-test.sock"));
-    }
-
-    #[test]
-    fn socket_path_falls_back_to_default_when_no_override() {
-        let got = resolve_socket_path(None).unwrap();
-        assert_eq!(got.file_name().unwrap(), "sock");
-    }
-
-    #[test]
-    fn socket_path_falls_back_to_default_when_override_is_empty() {
-        let got = resolve_socket_path(Some("  ".to_string())).unwrap();
-        assert_eq!(got.file_name().unwrap(), "sock");
-    }
-
-    #[test]
-    fn db_path_prefers_override() {
-        let got = resolve_db_path(Some("/tmp/rb-test.db".to_string())).unwrap();
-        assert_eq!(got, PathBuf::from("/tmp/rb-test.db"));
-    }
-
-    #[test]
-    fn db_path_falls_back_to_default_when_no_override() {
-        let got = resolve_db_path(None).unwrap();
-        assert_eq!(got.extension().unwrap(), "db");
-    }
-
-    #[test]
-    fn db_path_falls_back_to_default_when_override_is_empty() {
-        let got = resolve_db_path(Some("".to_string())).unwrap();
-        assert_eq!(got.extension().unwrap(), "db");
-    }
+    // The socket/db override-vs-default rule is pinned in rb-config's own tests
+    // (including the whitespace-only case); only the jobs-config composition
+    // lives here.
 
     #[test]
     fn jobs_config_prefers_override_then_env_then_none() {

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -20,7 +20,10 @@ pub async fn run(cli: Cli, namespace: rb_types::Namespace) -> anyhow::Result<()>
     let db_path = paths::db_path_from_env().context("resolving daemon database path")?;
 
     match cli.command {
-        Command::Serve { jobs_config } => {
+        Command::Serve {
+            jobs_config,
+            accept_model_change,
+        } => {
             let jobs_config_path = paths::resolve_jobs_config_path(
                 jobs_config,
                 std::env::var(paths::JOBS_CONFIG_ENV).ok(),
@@ -28,9 +31,16 @@ pub async fn run(cli: Cli, namespace: rb_types::Namespace) -> anyhow::Result<()>
             let shutdown = async {
                 let _ = tokio::signal::ctrl_c().await;
             };
-            serve::run_serve(socket_path, db_path, 4, jobs_config_path, shutdown)
-                .await
-                .context("daemon failed")?;
+            serve::run_serve(
+                socket_path,
+                db_path,
+                4,
+                jobs_config_path,
+                accept_model_change,
+                shutdown,
+            )
+            .await
+            .context("daemon failed")?;
             Ok(())
         }
         Command::Mcp => crate::mcp::run_mcp(&socket_path, &db_path, namespace)

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -60,9 +60,15 @@ async fn run_client(
     db_path: &std::path::Path,
 ) -> anyhow::Result<()> {
     let self_exe = std::env::current_exe().context("locating own executable")?;
-    let mut client = client::connect_or_start(socket_path, db_path, namespace, self_exe)
-        .await
-        .context("connecting to daemon")?;
+    let mut client = client::connect_or_start(
+        socket_path,
+        db_path,
+        namespace,
+        self_exe,
+        Some(client::client_identity("cli")),
+    )
+    .await
+    .context("connecting to daemon")?;
 
     match command {
         Command::Serve { .. } => anyhow::bail!("internal: serve must be handled before run_client"),
@@ -83,6 +89,7 @@ async fn run_client(
                     Vec::new(),
                     tags,
                     Vec::new(),
+                    1.0,
                 )
                 .await
                 .context("remember failed")?;
@@ -264,7 +271,7 @@ mod tests {
 
         let ns = Namespace::Project("injected".to_string());
         let started = Instant::now();
-        let result = crate::client::connect_or_start(&sock, &db, ns, self_exe).await;
+        let result = crate::client::connect_or_start(&sock, &db, ns, self_exe, None).await;
         let elapsed = started.elapsed();
 
         // Returns an Err quickly (no 50-retry backoff, no daemon spawn).

--- a/crates/rusty-brain/src/serve.rs
+++ b/crates/rusty-brain/src/serve.rs
@@ -34,6 +34,24 @@ pub fn select_provider_kind(api_key: Option<String>, local_requested: bool) -> P
     }
 }
 
+/// Read the `RB_ACCEPT_MODEL_CHANGE` opt-in from the environment (the
+/// auto-start path, where no flag can be passed).
+fn accept_model_change_from_env() -> bool {
+    env_truthy(std::env::var(rb_config::ACCEPT_MODEL_CHANGE_ENV).ok())
+}
+
+/// Pure core for env-flag parsing: truthy = present, non-empty, and not
+/// `0`/`false` (case-insensitive). Injected value so tests never mutate
+/// process-global env.
+fn env_truthy(value: Option<String>) -> bool {
+    value
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
 /// Read whether the local backend was requested via the environment.
 /// True when `RB_EMBED_BACKEND=local` (case-insensitive) or `RB_LOCAL_MODEL`
 /// is set to a non-empty value.
@@ -52,22 +70,28 @@ fn local_requested_from_env() -> bool {
 /// Run the daemon at the given paths until `shutdown` resolves.
 /// Picks the embedding provider from the environment (`RB_EMBED_BACKEND` /
 /// `RB_LOCAL_MODEL` for local, `VOYAGE_API_KEY` for Voyage).
+/// `accept_model_change` (the `--accept-model-change` flag, OR-ed with
+/// `RB_ACCEPT_MODEL_CHANGE` for auto-start) opts in to an embedding-model
+/// swap; without it a swap fails closed at bind.
 pub async fn run_serve(
     socket_path: PathBuf,
     db_path: PathBuf,
     read_pool_size: usize,
     jobs_config_path: Option<PathBuf>,
+    accept_model_change: bool,
     shutdown: impl std::future::Future<Output = ()>,
 ) -> Result<()> {
     let jobs_config = rb_daemon::JobsConfig::load(jobs_config_path.as_deref())?;
     let api_key = std::env::var("VOYAGE_API_KEY").ok();
     let kind = select_provider_kind(api_key, local_requested_from_env());
+    let accept = accept_model_change || accept_model_change_from_env();
     run_with_kind(
         kind,
         socket_path,
         db_path,
         read_pool_size,
         jobs_config,
+        accept,
         shutdown,
     )
     .await
@@ -81,6 +105,7 @@ async fn run_with_kind(
     db_path: PathBuf,
     read_pool_size: usize,
     jobs_config: rb_daemon::JobsConfig,
+    accept_model_change: bool,
     shutdown: impl std::future::Future<Output = ()>,
 ) -> Result<()> {
     match kind {
@@ -104,13 +129,21 @@ async fn run_with_kind(
                     read_pool_size,
                     jobs_config,
                     embedder,
+                    accept_model_change,
                     shutdown,
                 )
                 .await
             }
             #[cfg(not(feature = "local"))]
             {
-                let _ = (socket_path, db_path, read_pool_size, jobs_config, shutdown);
+                let _ = (
+                    socket_path,
+                    db_path,
+                    read_pool_size,
+                    jobs_config,
+                    accept_model_change,
+                    shutdown,
+                );
                 Err(rb_types::Error::Embedding(
                     "local embedding backend requested but this binary was built \
                      without the `local` feature; rebuild with `--features local`"
@@ -126,6 +159,7 @@ async fn run_with_kind(
                 read_pool_size,
                 jobs_config,
                 embedder,
+                accept_model_change,
                 shutdown,
             )
             .await
@@ -143,6 +177,7 @@ async fn run_with_kind(
                 read_pool_size,
                 jobs_config,
                 embedder,
+                accept_model_change,
                 shutdown,
             )
             .await
@@ -157,11 +192,25 @@ async fn run_with_embedder<P>(
     read_pool_size: usize,
     jobs_config: rb_daemon::JobsConfig,
     embedder: P,
+    accept_model_change: bool,
     shutdown: impl std::future::Future<Output = ()>,
 ) -> Result<()>
 where
     P: EmbeddingProvider + 'static,
 {
+    // Explicit opt-in to an embedding-model swap, BEFORE bind so the daemon's
+    // model-verified opens then succeed. A no-op when nothing changed.
+    if accept_model_change {
+        let changed =
+            rb_daemon::accept_model_change(&db_path, embedder.dim(), embedder.model_id())?;
+        if changed {
+            tracing::info!(
+                model = embedder.model_id(),
+                "accepted embedding model change; corpus marked for re-embed \
+                 (run `rusty-brain reembed` until changed=0)"
+            );
+        }
+    }
     let config = DaemonConfig {
         socket_path,
         db_path,
@@ -176,6 +225,17 @@ where
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
+
+    #[test]
+    fn env_truthy_accepts_set_values_and_rejects_off_values() {
+        for v in ["1", "true", "TRUE", "yes"] {
+            assert!(env_truthy(Some(v.to_string())), "{v:?} must opt in");
+        }
+        for v in ["", "  ", "0", "false", "FALSE"] {
+            assert!(!env_truthy(Some(v.to_string())), "{v:?} must not opt in");
+        }
+        assert!(!env_truthy(None), "absent var must not opt in");
+    }
 
     #[test]
     fn selects_voyage_when_key_present_and_local_not_requested() {
@@ -230,6 +290,7 @@ mod tests {
             db,
             4,
             rb_daemon::JobsConfig::default(),
+            false,
             std::future::ready(()),
         )
         .await

--- a/crates/rusty-brain/tests/mcp_e2e.rs
+++ b/crates/rusty-brain/tests/mcp_e2e.rs
@@ -11,9 +11,9 @@
 use assert_cmd::cargo::cargo_bin;
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Hard upper bound on waiting for any single response. Daemon auto-start +
 /// offline embedding is sub-second locally; this just prevents a wedged adapter
@@ -87,6 +87,44 @@ fn read_until_id(rx: &Receiver<Value>, id: i64) -> Value {
             }
         }
     }
+}
+
+/// Issue one `poll_changes` and return the parsed payload JSON.
+fn poll_changes(stdin: &mut ChildStdin, rx: &Receiver<Value>, id: i64) -> Value {
+    send(
+        stdin,
+        &json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{
+            "name":"poll_changes","arguments":{}
+        }}),
+    );
+    let resp = read_until_id(rx, id);
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("poll_changes tool text");
+    serde_json::from_str(text).expect("poll_changes payload is JSON")
+}
+
+/// Poll until the subscriber status equals `want`, returning the matching
+/// payload. Panics (with the last payload) if `deadline` passes first.
+fn wait_for_subscriber_status(
+    stdin: &mut ChildStdin,
+    rx: &Receiver<Value>,
+    next_id: &mut i64,
+    want: &str,
+    deadline: Duration,
+) -> Value {
+    let end = Instant::now() + deadline;
+    let mut last = Value::Null;
+    while Instant::now() < end {
+        let id = *next_id;
+        *next_id += 1;
+        last = poll_changes(stdin, rx, id);
+        if last["subscriber"]["status"] == want {
+            return last;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("subscriber never reached status {want:?}; last payload: {last}");
 }
 
 #[test]
@@ -188,5 +226,214 @@ fn mcp_remember_then_recall_round_trips() {
 
     // Close stdin so the adapter shuts down; the Reap guard kills/reaps the mcp
     // child regardless. The detached daemon grandchild times out on its own.
+    drop(stdin);
+}
+
+// W0.1 (F01/F11/F48): the daemon closes idle connections; with the timeout
+// injected down to 1s, a call after a 2s gap proves the proxy reconnects
+// instead of failing every subsequent tool call.
+#[test]
+fn mcp_call_succeeds_after_daemon_idle_timeout() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+
+    // RUSTY_BRAIN_IDLE_TIMEOUT_SECS is on FORWARD_ENV, so the auto-started
+    // daemon inherits the 1s idle timeout.
+    let mut child = Command::new(&exe)
+        .arg("mcp")
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env("RUSTY_BRAIN_IDLE_TIMEOUT_SECS", "1")
+        .env_remove("VOYAGE_API_KEY") // force offline DeterministicProvider
+        .env("RUST_LOG", "warn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mcp adapter");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let _reap = Reap(child);
+    let rx = spawn_line_reader(stdout);
+
+    send(
+        &mut stdin,
+        &json!({"jsonrpc":"2.0","id":1,"method":"initialize",
+                "params":{"protocolVersion":"2024-11-05"}}),
+    );
+    read_until_id(&rx, 1);
+
+    send(
+        &mut stdin,
+        &json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+            "name":"remember",
+            "arguments":{ "content":"idle survivors reconnect", "importance":7 }
+        }}),
+    );
+    let remembered = read_until_id(&rx, 2);
+    assert_ne!(
+        remembered["result"]["isError"],
+        json!(true),
+        "remember failed: {remembered}"
+    );
+
+    // Exceed the injected idle timeout so the daemon closes the proxy's
+    // connection between request frames.
+    std::thread::sleep(Duration::from_secs(2));
+
+    send(
+        &mut stdin,
+        &json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
+            "name":"recall",
+            "arguments":{ "query":"idle survivors", "limit":10 }
+        }}),
+    );
+    let recalled = read_until_id(&rx, 3);
+    assert_ne!(
+        recalled["result"]["isError"],
+        json!(true),
+        "recall after idle must succeed via reconnect: {recalled}"
+    );
+    let recall_text = recalled["result"]["content"][0]["text"]
+        .as_str()
+        .expect("recall tool text");
+    assert!(
+        recall_text.contains("idle survivors reconnect"),
+        "recalled content missing after reconnect; got: {recall_text}"
+    );
+
+    drop(stdin);
+}
+
+// W0.1 (F57): kill the daemon under a live adapter. The change subscriber must
+// report `disconnected` while down, reconnect with backoff (auto-starting a
+// fresh daemon), report `connected` again, and then deliver change events for
+// new writes — proving poll_changes distinguishes "quiet" from "deaf" and
+// recovers without an adapter restart.
+#[test]
+fn subscriber_recovers_after_daemon_restart_and_reports_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+
+    let mut child = Command::new(&exe)
+        .arg("mcp")
+        .env("RUSTY_BRAIN_SOCKET", &socket)
+        .env("RUSTY_BRAIN_DB", &db)
+        .env_remove("VOYAGE_API_KEY") // force offline DeterministicProvider
+        .env("RUST_LOG", "warn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mcp adapter");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let _reap = Reap(child);
+    let rx = spawn_line_reader(stdout);
+    let mut next_id = 100i64;
+
+    send(
+        &mut stdin,
+        &json!({"jsonrpc":"2.0","id":1,"method":"initialize",
+                "params":{"protocolVersion":"2024-11-05"}}),
+    );
+    read_until_id(&rx, 1);
+
+    // The subscriber connects in the background; wait until it reports in
+    // BEFORE writing, so the change event below cannot race the subscription.
+    wait_for_subscriber_status(
+        &mut stdin,
+        &rx,
+        &mut next_id,
+        "connected",
+        Duration::from_secs(10),
+    );
+
+    // SIGKILL the auto-started daemon via its pidfile (written next to the
+    // socket by the daemon's BindGuard).
+    let pidfile = socket.with_extension("pid");
+    let pid = std::fs::read_to_string(&pidfile)
+        .expect("daemon pidfile")
+        .trim()
+        .to_string();
+    let killed = Command::new("kill")
+        .args(["-9", &pid])
+        .status()
+        .expect("run kill");
+    assert!(killed.success(), "kill -9 {pid} failed");
+
+    // The subscriber notices the dead stream and sits in its >=500ms backoff
+    // window with the buffer marked disconnected (50ms polls cannot miss it).
+    let down = wait_for_subscriber_status(
+        &mut stdin,
+        &rx,
+        &mut next_id,
+        "disconnected",
+        Duration::from_secs(5),
+    );
+    assert!(
+        down["subscriber"]["for_secs"].is_u64(),
+        "disconnected status must carry an outage duration: {down}"
+    );
+
+    // The reconnect loop auto-starts a fresh daemon and resubscribes.
+    wait_for_subscriber_status(
+        &mut stdin,
+        &rx,
+        &mut next_id,
+        "connected",
+        Duration::from_secs(10),
+    );
+
+    // A write through the proxy (whose own connection also died with the old
+    // daemon) must succeed and produce a change event in the recovered stream.
+    send(
+        &mut stdin,
+        &json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+            "name":"remember",
+            "arguments":{ "content":"post-restart write", "importance":6 }
+        }}),
+    );
+    let remembered = read_until_id(&rx, 2);
+    assert_ne!(
+        remembered["result"]["isError"],
+        json!(true),
+        "remember after daemon restart failed: {remembered}"
+    );
+    let remembered_id = {
+        let text = remembered["result"]["content"][0]["text"]
+            .as_str()
+            .expect("remember tool text");
+        let payload: Value = serde_json::from_str(text).unwrap();
+        payload["id"].as_str().expect("remember id").to_string()
+    };
+
+    // The event for the post-restart write must arrive through poll_changes.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let id = next_id;
+        next_id += 1;
+        let payload = poll_changes(&mut stdin, &rx, id);
+        let found = payload["events"]
+            .as_array()
+            .expect("events array")
+            .iter()
+            .any(|e| e["id"] == json!(remembered_id.as_str()) && e["kind"] == json!("Created"));
+        if found {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "change event for {remembered_id} never arrived; last payload: {payload}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
     drop(stdin);
 }

--- a/crates/rusty-brain/tests/mcp_e2e.rs
+++ b/crates/rusty-brain/tests/mcp_e2e.rs
@@ -68,11 +68,12 @@ fn spawn_line_reader(stdout: std::process::ChildStdout) -> Receiver<Value> {
 }
 
 /// Receive response frames until one with the given `id` is found, bounded by
-/// `RESPONSE_TIMEOUT` so a deadlock cannot hang CI. Panics on timeout or stream
-/// end before the match.
-fn read_until_id(rx: &Receiver<Value>, id: i64) -> Value {
+/// `timeout` so a deadlock cannot hang CI. Panics on timeout or stream end
+/// before the match. One-shot call sites pass `RESPONSE_TIMEOUT`; loops with
+/// their own deadline pass the remaining budget instead.
+fn read_until_id(rx: &Receiver<Value>, id: i64, timeout: Duration) -> Value {
     loop {
-        match rx.recv_timeout(RESPONSE_TIMEOUT) {
+        match rx.recv_timeout(timeout) {
             Ok(value) => {
                 if value.get("id").and_then(Value::as_i64) == Some(id) {
                     return value;
@@ -80,7 +81,7 @@ fn read_until_id(rx: &Receiver<Value>, id: i64) -> Value {
                 // Otherwise a notification/frame we don't expect; ignore.
             }
             Err(RecvTimeoutError::Timeout) => {
-                panic!("timed out after {RESPONSE_TIMEOUT:?} waiting for response id {id}")
+                panic!("timed out after {timeout:?} waiting for response id {id}")
             }
             Err(RecvTimeoutError::Disconnected) => {
                 panic!("stream ended before response id {id} arrived")
@@ -89,15 +90,16 @@ fn read_until_id(rx: &Receiver<Value>, id: i64) -> Value {
     }
 }
 
-/// Issue one `poll_changes` and return the parsed payload JSON.
-fn poll_changes(stdin: &mut ChildStdin, rx: &Receiver<Value>, id: i64) -> Value {
+/// Issue one `poll_changes` and return the parsed payload JSON, waiting up to
+/// `timeout` for the response.
+fn poll_changes(stdin: &mut ChildStdin, rx: &Receiver<Value>, id: i64, timeout: Duration) -> Value {
     send(
         stdin,
         &json!({"jsonrpc":"2.0","id":id,"method":"tools/call","params":{
             "name":"poll_changes","arguments":{}
         }}),
     );
-    let resp = read_until_id(rx, id);
+    let resp = read_until_id(rx, id, timeout);
     let text = resp["result"]["content"][0]["text"]
         .as_str()
         .expect("poll_changes tool text");
@@ -118,7 +120,11 @@ fn wait_for_subscriber_status(
     while Instant::now() < end {
         let id = *next_id;
         *next_id += 1;
-        last = poll_changes(stdin, rx, id);
+        // Cap each poll's read at the caller's REMAINING budget so the whole
+        // wait honors `deadline` instead of stretching to a fresh
+        // RESPONSE_TIMEOUT on the final iteration.
+        let remaining = end.saturating_duration_since(Instant::now());
+        last = poll_changes(stdin, rx, id, remaining.min(RESPONSE_TIMEOUT));
         if last["subscriber"]["status"] == want {
             return last;
         }
@@ -161,7 +167,7 @@ fn mcp_remember_then_recall_round_trips() {
         &json!({"jsonrpc":"2.0","id":1,"method":"initialize",
                 "params":{"protocolVersion":"2024-11-05"}}),
     );
-    let init = read_until_id(&rx, 1);
+    let init = read_until_id(&rx, 1, RESPONSE_TIMEOUT);
     assert_eq!(init["result"]["serverInfo"]["name"], "rusty-brain");
     assert_eq!(
         init["result"]["serverInfo"]["contractVersion"],
@@ -186,7 +192,7 @@ fn mcp_remember_then_recall_round_trips() {
             }
         }}),
     );
-    let remembered = read_until_id(&rx, 2);
+    let remembered = read_until_id(&rx, 2, RESPONSE_TIMEOUT);
     assert_ne!(
         remembered["result"]["isError"],
         json!(true),
@@ -210,7 +216,7 @@ fn mcp_remember_then_recall_round_trips() {
             "arguments":{ "query":"one database transaction", "limit":10 }
         }}),
     );
-    let recalled = read_until_id(&rx, 3);
+    let recalled = read_until_id(&rx, 3, RESPONSE_TIMEOUT);
     assert_ne!(
         recalled["result"]["isError"],
         json!(true),
@@ -264,7 +270,7 @@ fn mcp_call_succeeds_after_daemon_idle_timeout() {
         &json!({"jsonrpc":"2.0","id":1,"method":"initialize",
                 "params":{"protocolVersion":"2024-11-05"}}),
     );
-    read_until_id(&rx, 1);
+    read_until_id(&rx, 1, RESPONSE_TIMEOUT);
 
     send(
         &mut stdin,
@@ -273,7 +279,7 @@ fn mcp_call_succeeds_after_daemon_idle_timeout() {
             "arguments":{ "content":"idle survivors reconnect", "importance":7 }
         }}),
     );
-    let remembered = read_until_id(&rx, 2);
+    let remembered = read_until_id(&rx, 2, RESPONSE_TIMEOUT);
     assert_ne!(
         remembered["result"]["isError"],
         json!(true),
@@ -291,7 +297,7 @@ fn mcp_call_succeeds_after_daemon_idle_timeout() {
             "arguments":{ "query":"idle survivors", "limit":10 }
         }}),
     );
-    let recalled = read_until_id(&rx, 3);
+    let recalled = read_until_id(&rx, 3, RESPONSE_TIMEOUT);
     assert_ne!(
         recalled["result"]["isError"],
         json!(true),
@@ -343,7 +349,7 @@ fn subscriber_recovers_after_daemon_restart_and_reports_status() {
         &json!({"jsonrpc":"2.0","id":1,"method":"initialize",
                 "params":{"protocolVersion":"2024-11-05"}}),
     );
-    read_until_id(&rx, 1);
+    read_until_id(&rx, 1, RESPONSE_TIMEOUT);
 
     // The subscriber connects in the background; wait until it reports in
     // BEFORE writing, so the change event below cannot race the subscription.
@@ -400,7 +406,7 @@ fn subscriber_recovers_after_daemon_restart_and_reports_status() {
             "arguments":{ "content":"post-restart write", "importance":6 }
         }}),
     );
-    let remembered = read_until_id(&rx, 2);
+    let remembered = read_until_id(&rx, 2, RESPONSE_TIMEOUT);
     assert_ne!(
         remembered["result"]["isError"],
         json!(true),
@@ -419,7 +425,7 @@ fn subscriber_recovers_after_daemon_restart_and_reports_status() {
     loop {
         let id = next_id;
         next_id += 1;
-        let payload = poll_changes(&mut stdin, &rx, id);
+        let payload = poll_changes(&mut stdin, &rx, id, RESPONSE_TIMEOUT);
         let found = payload["events"]
             .as_array()
             .expect("events array")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,34 +251,62 @@ flowchart TD
 ```
 
 The CLI and hooks resolve the current namespace off the async runtime before any work
-begins: they look for a project marker (a `CLAUDE.md` with a `project:` front-matter
-key or first H1), then the git top-level directory name, then the working directory,
-falling back to `global`. Detection shells out to git and reads files, so it runs
-synchronously off the runtime to respect the "no blocking I/O on async workers" rule.
+begins, through one shared implementation (`rb-config`), first hit wins:
+
+1. an explicit `--namespace` flag or `RUSTY_BRAIN_NAMESPACE` env override;
+2. a repo-committed `.rusty-brain.toml` (`namespace = "..."`) at the git toplevel —
+   identity survives cloning under any directory name;
+3. a `CLAUDE.md` front-matter `project:` key, walking from the working directory up to
+   and *including* the git toplevel, never past it (there is no first-H1 fallback). A
+   `project:` that differs from the toplevel name is never silently trusted: the CLI
+   warns and uses it only once pinned via `--accept-namespace-override` (known-hosts
+   style); hooks never honor an unpinned override — they log it and fall back — so a
+   malicious repo's own `CLAUDE.md` cannot claim another project's namespace;
+4. the git top-level directory name;
+5. the working directory name; else `global`.
+
+Detection shells out to git and reads files, so it runs synchronously off the runtime
+to respect the "no blocking I/O on async workers" rule.
 
 ## Storage layout
 
 A single SQLite file holds everything, opened in WAL mode:
 
 - **`memories`** — the note rows (content, enrichment, type, importance, confidence,
-  timestamps, archive/supersede state, and the embedding model + composition-version
-  stamps).
+  timestamps, archive/supersede state, the embedding model + composition-version
+  stamps, and provenance: `origin_user`, `origin_host`, `origin_agent`,
+  `origin_source`, `session_id` — nullable, never backfilled, so pre-provenance rows
+  keep `NULL`).
 - **`memory_vectors`** — a `sqlite-vec` virtual table of embeddings, one per memory.
 - **`memory_links`** — directed edges between memories (e.g. `references`,
   `contradicts`) with a decaying strength.
+- **`memory_oplog`** — a durable operation log: one row per mutation (insert, update,
+  archive, supersede, link/unlink, confidence and link-strength changes), appended in
+  the same transaction as the mutation itself, ordered by a site-local monotonic `seq`
+  and stamped with this database's `site_id`.
 - **full-text index** — an FTS5 index over content for keyword search.
-- **`meta`** — invariants seeded at init, including the embedding dimension and the
-  current embedding composition version.
+- **`meta`** — invariants seeded at init: the embedding dimension, the embedding model
+  identity, the current embedding composition version, and the `site_id` (uuid v4)
+  stamped onto oplog rows.
 
 Migrations are individual `NNN_*.sql` files discovered at build time, checksummed, and
 applied transactionally. A CI test builds a brand-new database from the committed SQL
 and runs every query path against it, so the schema the code expects and the schema the
 migrations produce cannot silently diverge.
 
-The embedding dimension is the load-bearing invariant: it is seeded on first init and
-verified on every startup, and every vector read is length-checked. A provider whose
-dimension disagrees with the stored value makes the daemon refuse to start rather than
-write mismatched vectors.
+Two open-time invariants are load-bearing and fail closed. The embedding dimension is
+seeded on first init and verified on every startup, and every vector read is
+length-checked: a provider whose dimension disagrees with the stored value makes the
+daemon refuse to start rather than write mismatched vectors. The embedding model
+identity (`meta.embedding_model`) is the second: a same-dimension provider swap also
+refuses to start — mixed vector spaces must be impossible — unless explicitly accepted
+via `serve --accept-model-change` (or `RB_ACCEPT_MODEL_CHANGE=1` for auto-started
+daemons) followed by a corpus `reembed`.
+
+The database file holds captured memory text, so it gets the same posture as the
+daemon socket: the file is created `0600` and tightened fail-closed on every open
+(including leftover `-wal`/`-shm` siblings from an unclean shutdown), and the daemon
+creates the data directory `0700` when it creates it.
 
 ## What is intentionally out of scope (for now)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,8 +254,11 @@ The CLI and hooks resolve the current namespace off the async runtime before any
 begins, through one shared implementation (`rb-config`), first hit wins:
 
 1. an explicit `--namespace` flag or `RUSTY_BRAIN_NAMESPACE` env override;
-2. a repo-committed `.rusty-brain.toml` (`namespace = "..."`) at the git toplevel —
-   identity survives cloning under any directory name;
+2. a repo-committed `.rusty-brain.toml` (`namespace = "..."`), read from the blob
+   committed at `HEAD` (`git show HEAD:.rusty-brain.toml`) — identity survives cloning
+   under any directory name, and only the committed content counts: an untracked or
+   locally-modified worktree file cannot redirect the namespace and is ignored with a
+   warning (commit it to take effect);
 3. a `CLAUDE.md` front-matter `project:` key, walking from the working directory up to
    and *including* the git toplevel, never past it (there is no first-H1 fallback). A
    `project:` that differs from the toplevel name is never silently trusted: the CLI

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -124,7 +124,7 @@ Target: teamfit →9.5+, security →9.5+. Design first: **P8 spec** precedes 5a
 
 ### Phase 5a — Team substrate
 - **W5a.1** Handshake identity finalized (consumes the W0.5 field; shape pinned by spike S2 so the contract bumps once); token auth (or mTLS/SSH-tunnel per S2).
-- **W5a.2** Oplog replay API: `Pull since seq` / `Push batch`, idempotent apply over the existing UUID + tombstone + supersede primitives; per-site seq tracking.
+- **W5a.2** Oplog replay API: `Pull since seq` / `Push batch`, idempotent apply over the existing UUID + tombstone + supersede primitives; per-site seq tracking; the hub assigns its own hub-local seq on ingest and preserves the origin (site_id, seq) as explicit columns — the local seq from migration 004 is a per-site cursor, never a cross-site identity (schema lands with 5a, additive migration).
 - **W5a.3** Transport genericization: `Client<S>`, listener seam (codec/framing already stream-generic; sized at ~a day).
 - **W5a.4** Protocol evolution policy doc: additive serde-default fields never bump CONTRACT_VERSION; breaking changes bump it and the hub supports N and N−1 for one release; CI handshakes an N−1 fixture client.
 - **Gate:** two daemons on two machines exchange a promoted memory, with replay after restart; N−1 client fixture connects.

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -145,7 +145,7 @@ Target: teamfit →9.5+, security →9.5+. Design first: **P8 spec** precedes 5a
 
 ## 9. Spike register (time-boxed, before committing the dependent phase)
 
-- **S1 (before the Phase 0 gate is finalized, 1 day):** prove `claude -p` fires SessionStart/PostToolUse/SessionEnd hooks headlessly with an API key in CI. If not, the nightly tier becomes fixture-only and real-CC checks stay a per-phase manual ritual — W3.5's design depends on this answer.
+- **S1 (answered on knowledge 2026-06-12; empirical CI run still owed):** `claude -p` (headless/print mode) does fire lifecycle hooks — SessionStart, PostToolUse, Stop/SessionEnd — so the nightly real-CC smoke tier and W3.5's A/B eval design are viable. Two operational consequences: (a) unprompted MCP tool calls stall on permission prompts in non-interactive mode unless allowlisted — `permissions.allow` entries for `mcp__rusty-brain__*` (W3.2) are a hard prerequisite for any headless eval arm that expects model-initiated remember/recall; (b) the nightly job needs an API-key secret and a small spend budget. Remaining to close S1: one recorded CI run on a macOS runner proving the hook events arrive (lands with gate tier (b), see Phase-0 carryover debt).
 - **S2 (during Phase 2, 1–2 days):** hub auth design note — token vs mTLS vs SSH tunnel — pinning the handshake identity field shape so the wire contract bumps once.
 - **S3 (retired):** vec0 `distance_metric=cosine` support confirmed in vendored sqlite-vec 0.1.9; rebuild mechanics folded into W1.1 as open-time code.
 

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -1,0 +1,248 @@
+# rusty-brain — Road to Tens: Uplevel Roadmap
+
+- **Status:** Proposed (synthesized from the 2026-06-11 intensive review + adversarial plan critique)
+- **Date:** 2026-06-11
+- **Author:** Brian Luby (plan drafted with Claude, critiqued by a 6-agent panel against the 57-finding review digest)
+- **Baseline scores (2026-06-11 review, adversarially verified):** architecture 6.5 · correctness 6 · security 6 · retrieval 4.5 · teamfit 4 · claudecode 3
+- **References:** review findings digest (F01–F57, archived from the 2026-06-11 review run); `docs/specs/2026-06-02-rusty-brain-p7-apm-distribution.md`; `docs/specs/2026-06-02-rusty-brain-p6-llm-evolution.md`
+
+---
+
+## 1. Operating principles
+
+1. **Stop unbackfillable debt first.** Every memory written before provenance columns exist is anonymous forever; every memory written under a heuristic namespace needs a rename later; every secret captured before redaction persists until purged. These land in Phase 0, before standing dogfood capture begins.
+2. **Measure before changing.** The real-embedding eval corpus is captured *before* retrieval semantics change, so every fix lands with before/after numbers instead of assumptions.
+3. **Validation-bound, not code-bound.** P0–P5 were built in ~4 days of agentic development (275 commits, May 31–Jun 3) — with zero end-to-end validation, which is why claudecode sits at 3. Code workstreams remain days-each at that velocity; **phase elapsed time is gated by validation**: CI stabilization, macOS runners, API budget for Voyage/Claude in CI, fresh-machine installs, and (in Phase 5) a multi-week human pilot. Expect 1–3 weeks per phase 0–4, and 6–10 weeks for Phase 5a–5c combined.
+4. **Phases are gate checkpoints, not serial work batches.** See §12 for the parallel tracks and the short serial spine that actually constrains ordering.
+5. **Every phase has a falsifiable gate.** A gate is a test or drill that can fail, not a review ritual.
+
+---
+
+## 2. What "10" means per dimension
+
+Each clause is tagged with its owning workstream; clauses with no owner appear in the Phase 6 closure table (§10) as accepted gaps. Unowned criteria are the failure mode this section exists to prevent.
+
+- **Architecture 10** — cross-crate contracts (paths, env allowlist, timeouts) defined once with agreement tests [W0.2]; config file replaces env-var sprawl [W0.2]; transport survives idle/restart [W0.1] and version skew per a written protocol-evolution policy [W5a.4]; perf budgeted in CI: recall p95 < 150 ms and remember p95 < 100 ms at 10k memories on the CI runner [W4.2]; ANN decision made from measured data [W4.2]; zero advertised-but-unreachable features [W2.2, W4.4]; observability: `status` reports writer health, WAL size, corpus stats, subscriber state [W1.6, W4.3]; signed release artifacts with a one-line install [W0.6]; documented platform policy [§15].
+- **Correctness 10** — no known data-misroute or data-loss paths [W0.2, W0.3]; RAII transactions, writer recovers from Err-path COMMIT failures, daemon never zombies [W1.6]; degraded keyword-only recall when embeddings are down [W1.6]; fault-injection suite: kill mid-write, disk full, API outage [W4.3]; idle/reconnect e2e with injectable timeouts [W0.1]; every migration tested against populated prior-version DB fixtures [W1.1 ground rule]; macOS in the CI matrix [W0.2]; embedding-model identity is an open-time invariant [W0.2].
+- **Security 10** — DB 0600/dir 0700 parity with the socket [W0.5]; capture-time secret redaction benchmarked against external leak corpora, plus retroactive `scrub` [W0.5 minimal, W2.4 full]; injected memory framed as untrusted data with an injection drill that must pass [W2.5]; provenance + trust tiers in schema and ranking [W0.5, W2.2, W5c.1]; peer-credential check; admin ops gated [W2.6]; written threat model [W2.6]; scheduled fuzzing of the frame decoder, FTS escaping, and hook JSON parsing [W4.3]; signed releases with provenance attestation [W0.6]; cargo-deny/audit stay green (already true — claimed credit).
+- **Retrieval 10** — true cosine metric, declared in DDL, thresholds recalibrated in distance units [W1.1]; tokenized FTS (AND-of-terms, tokenizer chosen from eval evidence) [W1.2]; score floor with a model-legible empty state [W1.3]; queries embedded as queries [W1.4]; graph signal = real hop distance [W1.5]; vectors pruned on archive/supersede, KNN partitioned by namespace [W1.7]; recall issues zero writer ops [W1.8]; importance recalibration respects author intent [W1.9]; write-time near-dup suppression [W3.1]; RRF/confidence/contested all reachable [W2.2]; eval: ≥200-memory corpus, ≥50 graded golden queries, a held-out query set, and a ≥5k-distractor variant, gating CI at recall@5 ≥ 0.8 / MRR ≥ 0.7 on both [W1.0, W4.1]; hybrid demonstrably beats BM25-only and vector-only on the held-out set [W4.1].
+- **Teamfit 10** — provenance on every memory [W0.5]; namespace = repo-committed declared identity [W0.3]; durable sequence-numbered oplog with cursor replay [W0.5 schema, W2.7 consumers, W5a.2 replication]; shipped team mode: authenticated hub, promote/curation workflow, per-author trust weighting, conflict surfacing [Phase 5]; data-lifecycle ops: backup/restore, hard-delete purge that cascades to vectors/FTS/oplog, retention policy [W5b.3]; one-command teammate onboarding (snapshot + oplog tail) [W5b.4]; validated by a 2+ user / 2+ machine pilot including restore, purge, mid-pilot onboarding, and poisoning drills [Phase 5c gate].
+- **Claudecode 10** — out-of-the-box capture→idle→recall on clean macOS+Linux from a signed artifact [Phase 0 gate]; three-channel elicitation (deterministic UserPromptSubmit injection, CLAUDE.md policy fragment/skill, trigger-condition tool descriptions + MCP instructions) with a measured elicitation scorecard [W3.2]; capture produces decision-grade memories — one summary per session via SessionEnd, zero per-event memories [W3.1]; SessionStart injection source-aware and budgeted ≤ 600 tokens [W3.3]; recall rendered as compact markdown with age and contested markers [W3.3]; token-accounting CI test: tools/list ≤ 900 + instructions ≤ 150 + injection ≤ 600 tokens [W3.3]; native distribution: plugin, committed `.mcp.json`, project settings template, `permissions.allow` entries [W3.6]; A/B outcome eval (memory-on vs memory-off vs CLAUDE.md-only) wins on success/turns within token budget, with stale-memory harm cases enumerated [W3.5].
+
+---
+
+## 3. Phase 0 — Stop the bleeding (unbreak + unbackfillable debt + install story)
+
+Target: claudecode 3→6, correctness +1, teamfit +1. Everything here either unblocks end-to-end use or stops debt that cannot be backfilled later.
+
+- **W0.1 Transport resilience.** Reconnect-with-backoff in `ClientProxy::call` and the change-subscriber loop (or connection-per-call — decide by measuring reconnect cost); `REQUEST_IDLE_TIMEOUT` (`rb-daemon/src/server.rs:45`) becomes env-injectable so the idle test runs in seconds; subscriber staleness surfaced in `poll_changes` output. *(F01/F11/F48, F57)*
+- **W0.2 One config truth + corpus integrity.** Single-source path defaults and FORWARD_ENV: keep `rb-daemon/src/paths.rs` as canonical (rb-hooks already transitively depends on rb-daemon) or extract `rb-config`; delete the copies in `rb-hooks/src/main.rs` (paths), `rb-agents/src/daemon.rs` and `rusty-brain/src/client.rs:90-100` (FORWARD_ENV — it exists in **three** places); **add `RB_EMBED_BACKEND`, `RB_LOCAL_MODEL`, `RB_JOBS_CONFIG`** to the allowlist; agreement test pinning hooks==CLI==daemon resolution; add a macOS CI runner. Introduce `~/.config/rusty-brain/config.toml` (+ repo-committed `.rusty-brain.toml`, which W0.3 needs anyway) so the env allowlist shrinks to secrets and XDG/HOME — retiring the F20 bug *class*, not just the instance. **Seed and verify `embedding_model` in `meta` alongside `embedding_dim`; fail closed on mismatch with a `reembed` remediation hint** — mixed vector spaces must be impossible before dogfood capture starts. *(F03/F12/F49, F20, F10)*
+- **W0.3 Canonical namespace identity.** Resolution order becomes: repo-committed `.rusty-brain.toml` > `--namespace` flag / env > git-toplevel name > cwd; the CLAUDE.md ancestor walk is bounded at the git toplevel and **demoted to legacy compat**. The `project:` frontmatter override is no longer silently trusted: interactive use warns and pins the override on first use per directory (SSH known-hosts style); non-interactive hooks fall back to the git-root name and log the unconfirmed override — a malicious repo's own CLAUDE.md must not silently claim another project's namespace. Apply identically in `rusty-brain/src/namespace_detect.rs` and `rb-agents/src/namespace.rs` (or unify them); ship a one-time namespace-rename helper for existing rows. Test: the F22 clone-a-malicious-repo scenario, plus same repo cloned under two different directory names on two hosts resolves the identical namespace string. *(F04/F13/F54, F22, F40)*
+- **W0.4 MCP `update` tool honesty.** Add a validation-class variant to `rb_types::Error` (none exists today — the engine returns `Error::Storage`, which `error_map` masks); the content-update rejection returns it message-verbatim with a leak-prevention test; the tool schema documents the limitation. (W3.1's update-as-supersede may later lift the limitation — wording should not preclude that.) *(F55)*
+- **W0.5 Provenance + oplog migration (the unbackfillable one).** Additive migration: `origin_user`, `origin_host`, `origin_agent`, `origin_source` (hook|mcp|cli|job), `session_id` on memories; a durable `memory_oplog` table (monotonic seq, site_id) appended **in the same transaction** as every mutation from day one; optional serde-default identity field on the Handshake (one CONTRACT_VERSION bump, coordinated with any other Phase 0 protocol change); hook-written memories get `confidence < 1.0`. Constraints that keep it clean: **no backfill UPDATE on memories** (the `mem_au` trigger would rewrite FTS for every row); old rows keep NULL provenance; new columns decoded by name in `row_to_note` with serde defaults per the `contested` precedent. Also in this phase: **DB file 0600 / dir 0700 at creation** (two-line fix, parity with the socket), and a **minimal redaction pattern set** (bearer tokens, `key=value`, AWS-style keys, PEM blocks) in hook capture — full benchmarked redaction comes in W2.4. *(F38, F41, F43, F23, F24-minimal, F39-partial)*
+- **W0.6 Distribution v0.** cargo-dist (or a release.yml) producing signed, checksummed macOS+Linux binaries on tag, with provenance attestation; one-line install documented in README. The Phase 0 gate installs from this artifact, not a source build. *(prereq for every later gate; claudecode/architecture 10 criteria)*
+- **W0.7 Claude Code hook-form verification.** Record a real Claude Code `settings.json` + hook-event fixture set; assert the installer's emitted hook config round-trips against it; if the separate-`args` form is not honored by current Claude Code, switch to the shell-quoted single-string form already used for Gemini/Codex. *(F50 — contested between review verifier and critique panel; resolve empirically, the fixture is needed regardless)*
+
+**Phase 0 gate (three tiers, replacing "fresh macOS machine" as a manual ritual):**
+(a) **per-PR CI**: path-agreement tests + fixture-driven hook lifecycle e2e on ubuntu *and* macos runners, idle test with injected short timeout; (b) **nightly, allowed-to-fail with alerting**: real Claude Code headless (`claude -p`) smoke on macOS with an API-key secret — capture → idle → recall reaches **one** daemon and **one** 0600 DB; (c) **once per phase**: scripted fresh-machine checklist (`scripts/verify-fresh-install.sh`) using the W0.6 artifact. Plus: a hook-written memory carries author/source/seq/confidence; planted fake secret yields zero plaintext grep hits in the DB; two clones of the same repo resolve the same namespace.
+
+---
+
+## 4. Phase 1 — Measure, then fix retrieval semantics + hard robustness
+
+Target: retrieval 4.5→7, correctness →8. **Ground rule:** every retrieval-semantics workstream lands with a re-captured `baselines.json` in the same commit, with a one-line justification of which metric moved and why (the compile-time include at `rb-eval/src/runner.rs:52` hard-gates CI otherwise).
+
+- **W1.0 Real-embedding eval corpus FIRST.** Extend rb-eval's existing real-model mode to record/replay real Voyage vectors as committed fixtures, keyed on `(model_id, input_kind, text)` (W1.4-proof); ≥200 memories, ≥50 graded golden queries + a held-out set; per-channel (FTS/vector/graph) hit-contribution counters in the daemon; capture the pre-Phase-1 baseline (measurement only — CI gating thresholds come in W4.1). Corpus authoring is content work that starts during Phase 0. *(F35)*
+- **W1.1 Cosine metric — open-time code rebuild, not a SQL migration.** The vec0 table is created in code at open with a runtime dim, and vec0 implements no `xRename`, so the rebuild is: in `SqliteStore::init` after `run_migrations`, if `meta.vector_metric != 'cosine'`, then in one `BEGIN IMMEDIATE`: stash `memory_id, embedding` to a plain table via vec0 fullscan, `DROP` the virtual table, recreate with `distance_metric=cosine` (supported by vendored sqlite-vec 0.1.9; vectors are unchanged bytes — no re-embed), re-insert, set the meta marker. Sequence it in the **writer's** open path before the read pool spins up (single-flight by construction; avoids busy_timeout failures on large corpora). Recalibrate thresholds **in distance units** (linker 0.6 under L2 ≈ cos 0.82 → choose cosine-distance ≈ 0.18 for parity; consolidation 0.95 similarity re-derived); one-shot revalidation pass re-scores existing similarity-produced links and drops/flags those below the recalibrated threshold. Tests: an L2-vs-cosine distinguishing test using non-unit vectors inserted via the store API, and migration tests against **committed populated previous-schema DB fixtures**. *(F02/F14/F28)*
+- **W1.2 FTS tokenization.** Per-token escaping, AND of quoted tokens (+ trailing prefix match where useful); tokenizer decision (unicode61 vs porter) made from W1.0 eval evidence and recorded; injection tests retained; the README quickstart query becomes a test. *(F09/F18/F29)*
+- **W1.3 Score floor + empty state.** Recall may return fewer than limit or nothing; below-floor/empty results return a compact model-legible empty state (`{results: [], hint: "no stored memories match"}`); SessionStart injects zero tokens on an empty corpus (first-session scenario tested in the W3.4 harness). *(F30)*
+- **W1.4 Query-kind embeddings.** `EmbedKind { Query, Document }` on the provider trait (all five impls update); Voyage uses `input_type="query"` for recall. **DeterministicProvider MUST ignore the kind** (test: `embed_query == embed_document` for identical text) to preserve persisted corpora and the eval baselines. If the composite-doc asymmetry is changed on the document side, bump `EMBEDDING_INPUT_VERSION` and converge via the existing stale-stamp reembed scan; a query-side-only change needs no migration. *(F36)*
+- **W1.5 Real graph hops.** `graph_neighbors` returns `(MemoryId, hops)` via `SELECT node, MIN(d) ... GROUP BY node ORDER BY MIN(d)` (the CTE already computes depth; the UNION currently dedups `(node, d)` pairs, so MIN-GROUP-BY is required, not just exposing `d`); ripple through `MemoryBackend`, rb-eval's backend, and `build_signals`; re-capture baselines. *(F06/F15/F31)*
+- **W1.6 Writer robustness, named mechanisms.** (a) rb-store: convert `insert_memory`/`supersede`/`update_vector` to RAII via `Transaction::new_unchecked(conn, Immediate)` with drop-rollback — covers failed COMMITs; (b) store_handle: after a completed-with-Err op, if `!is_autocommit` (exposed via SqliteStore), drop+reopen via the existing panic-path machinery; (c) writer death raises an internal shutdown signal raced in `Server::run`'s existing `select!` — no more zombie daemons that pong Ping while every write fails; (d) recall degrades to keyword+graph when the embedder errors, flagged in the response. *(F07/F16, F17, F19)*
+- **W1.7 Vector hygiene + namespace partitioning.** Archive/supersede delete the `memory_vectors` row in the same transaction; one-shot cleanup migration prunes vectors for already-archived rows; recreate the vec0 table with a `namespace` **partition key** (supported by sqlite-vec 0.1.9) so KNN scopes per namespace and the 4096 cap applies to live, in-namespace candidates — fold into the W1.1 rebuild so the virtual table is rebuilt once. Test: a namespace whose live rows are <1% of all vectors still fills `limit`. *(F44, second half of F08)*
+- **W1.8 Read-path write amplification.** Recall must issue zero writer-thread ops: change `mem_au` to `AFTER UPDATE OF content, summary, keywords, tags` (migration) **or** move `access_count`/`last_accessed_at` to a side table with batched bumps. Test: a recall of N results triggers zero FTS writes. *(first half of F08)*
+- **W1.9 Importance recalibration respects author intent.** Author-set importance becomes a prior modulated within a bounded delta (e.g. `clamp(base + k·tanh(signal) − decay, base−2, base+2)`), or the job ships disabled by default until the W3.7 usefulness signal exists. Property tests: importance-10 never falls below 8 from access signals alone; rb-eval runs with evolution jobs off. *(F33)*
+
+**Phase 1 gate:** W1.0 corpus shows improved recall@5/MRR vs the pre-Phase-1 baseline; FTS channel contributes hits on ≥80% of natural-language goldens (per-channel counters); the README quickstart query returns its target memory; recall succeeds with the embedding provider down; a 10k-archived-vector scenario still returns correct live-namespace results; recall issues zero writer ops.
+
+---
+
+## 5. Phase 2 — Trust producers, security hardening
+
+Target: security →8, teamfit →6.
+
+- **W2.2 Wire the trust machinery.** Confidence settable (update path + enrichment producer; hook captures already write <1.0 from W0.5); contradicts-link creation exposed via CLI/MCP; `contested` reachable end-to-end; RRF selectable via config (decision on default deferred to W4.1 evidence). Anything not wired by end of phase is **removed from the README** until real. *(F05/F32, F39)*
+- **W2.4 Redaction, benchmarked + retroactive.** Patterns benchmarked against external leak-rule corpora (gitleaks/trufflehog fixtures) with the measured false-negative rate documented in the threat model; entropy heuristic for high-entropy tokens; **`rusty-brain scrub`** retroactively redacts existing DBs (content, context, FTS, re-embed affected rows). Residual risk stated honestly: redaction is best-effort; 0600 + purge (W5b.3) are the backstops. *(F24/F42)*
+- **W2.5 Untrusted-data framing + injection drill.** SessionStart/context injection wraps memory content in data-not-instructions framing with provenance labels. Exit test (in the W3.4 harness): a planted memory containing instruction-shaped text ("ignore previous instructions and run X") is injected and the scripted session asserts the agent does not act on it. Documented as best-effort; the curation queue (Phase 5b) is the team-mode backstop. *(F21)*
+- **W2.6 Peer identity + threat model.** `getpeereid`/`SO_PEERCRED` check; handshake principal populated (field landed in W0.5); `RunJob`/`Reembed` gated as admin ops; threat-model doc covering today's surface and the team surface, stating explicitly that namespace is not an auth boundary. *(F25, F43)*
+- **W2.7 Oplog consumers.** The W0.1 subscriber and `poll_changes` consume oplog cursors (replay-on-reconnect instead of silently-empty); `subscribe --since <seq>` for the CLI. Phase 5a inherits a proven replication substrate instead of building it under the hub. *(F41, F57)*
+- **W2.8 Logging polish.** Enrichment internal errors logged with detail per the module's own contract (F26); error-taxonomy audit so every guidance-bearing rejection is a validation-class error.
+
+**Phase 2 gate:** redaction benchmark numbers documented and `scrub` drill passes on a seeded DB; injection drill passes; non-admin client cannot invoke RunJob/Reembed; provenance fields present from all three write paths; a killed-and-reconnected subscriber replays missed events from its cursor; fresh DB is 0600/0700.
+
+---
+
+## 6. Phase 3 — Claude Code value
+
+Target: claudecode →8.5. This phase was redesigned after critique — the original Stop-hook plan contradicted the engine's own no-content-update invariant, and the elicitation bet ignored Claude Code's deterministic channels.
+
+- **W3.1 Capture inversion, SessionEnd-centric.** PostToolUse writes **zero** memories; it appends to a local per-session scratch file keyed by `session_id` (files touched, commands, failures). **SessionEnd** (add to `CLAUDE_EVENTS` and the claude_code adapter — it is not consumed today) folds scratch + transcript into **one** summary memory per session: heuristic extraction by default (user prompts, decision-marker lines, files touched), rb-enrich LLM summarization when configured. Stop stores nothing (any retained Stop logic checks `stop_hook_active`). PreCompact switches from `custom_instructions` (empty on auto-compact — it effectively never fires today) to reading `transcript_path` and extracting decision-markers. Incremental summaries use **update-as-supersede** (new note + supersede link — reuses the existing atomic supersede, preserves the embedding-consistency invariant). Write-time near-dup suppression via the existing `near_duplicates()`. Decision-grade bar: ≥80% of a 50-memory sample per release passes a written rubric ("states a decision, constraint, or outcome a future session would act on"), human-graded. *(F34, F51)*
+- **W3.2 Three-channel elicitation (ranked).** (a) **Deterministic recall**: a UserPromptSubmit hook (the event reaches the adapter today and is dropped as `Other`) runs recall on the user's prompt and injects top-k under a token budget via `additionalContext` — recall stops depending on the model electing to call a tool; (b) **policy**: the installer optionally appends a 4–6 line memory-policy block to project CLAUDE.md, and/or ships a skill; (c) **tool surface**: trigger-condition descriptions ("Use when the user states a decision, preference, or constraint…") + MCP `instructions` (cheap; currently omitted from initialize). Installer adds `permissions.allow` entries for `mcp__rusty-brain__*` — without allowlisting, every unprompted call stalls on an approval prompt. Channel ranking validated by the W3.5 transcript metrics. **Elicitation scorecard**: K≥10 scripted sessions where the user states a decision with no mention of memory; pass = remember fires in ≥70%, recall-before-work in ≥50%; tracked per release. *(F52)*
+- **W3.3 Token economy.** Projection implemented **exclusively in rb-mcp's `response_to_content`** (the wire Response and CLI `--json` keep the full shape — no CONTRACT_VERSION bump; rb-eval is unaffected). Render recall/list/context as markdown, one line per result: `N. [type, imp 8, 3d ago] summary-or-first-200-chars (id 1a2b3c)` + `⚠ contested` marker; age is decision-critical and was missing from the draft's 7-field projection; score bucketed or omitted; full JSON only as optional structuredContent. SessionStart injection is **source-aware** (full digest on `startup`; nothing on `resume`; constraints-only after `compact`), budget ≤600 tokens / ≤10 items, preferring constraint + architecture_decision at importance ≥8, with the W2.5 framing and a "use recall for older decisions" pointer. Default MCP toolset shrinks to remember/recall/get/context (+update); poll_changes/graph/delete/list behind `RB_MCP_FULL_TOOLSET`. **Token-accounting CI test**: tokenize the actual tools/list + instructions + injection payloads; fail above 900/150/600. *(F53, F56)*
+- **W3.4 Fixture harness.** Recorded real Claude Code settings.json + hook payloads (started in W0.7) expanded to full session-lifecycle coverage on macOS + Linux; the empty-corpus first-session scenario; the W2.5 injection drill lives here.
+- **W3.5 A/B outcome eval (nightly, not per-PR).** ≥10 scenario pairs run headless via `claude -p` with hooks+MCP installed: session 1 plants a decision/constraint; session 2 (fresh context, same namespace) performs a task where it matters. Arms: memory-on, memory-off, **CLAUDE.md-only** (the native baseline — this is the value-over-native proof F56 demands). Judge: deterministic assertion on output/diff where possible, LLM judge otherwise; N runs per scenario for stochasticity; report task success, turns-to-completion, token cost, and **memory-induced errors (stale/wrong memory acted on) enumerated, not averaged away**. Memory-on must win on success/turns within token budget. *(F56)*
+- **W3.6 Native distribution.** Claude Code plugin (hooks + MCP config + memory skill + `/rb:remember`, `/rb:recall`) publishable via a marketplace repo; committed `.mcp.json` + project `.claude/settings.json` template for zero-effort team rollout on clone; `rusty-brain install` becomes a thin wrapper preferring native channels; execute the existing **P7 APM spec** as the cross-harness channel; document enterprise managed-settings interactions (org policy can disable hooks/MCP — a Phase 5 rollout dependency).
+- **W3.7 Usefulness signal.** `memory_feedback` MCP tool (helpful/wrong/stale) as the confidence producer W2.2 needs and the non-circular input W5c trust weighting needs — `access_count` counts "returned", not "useful". *(F37)*
+
+**Phase 3 gate:** a 40-turn simulated session produces ≤5 memories (vs ~40 today); elicitation scorecard passes; token-accounting test green; W3.5 nightly eval: memory-on beats memory-off AND CLAUDE.md-only on the scenario set; decision-grade rubric ≥80% on the sampled corpus. **Begin recruiting Phase 5 pilot users now.**
+
+---
+
+## 7. Phase 4 — Prove it: eval gates, perf, fuzz
+
+Target: retrieval →9, architecture →9, security →9.
+
+- **W4.1 Eval gating.** Promote W1.0 measurements to CI gates: recall@5 ≥ 0.8 / MRR ≥ 0.7 on the authored corpus **and** the ≥5k-distractor variant (golden queries inside hook-capture-shaped noise); the held-out query set (never used during weight tuning) gates CI; baseline comparisons (BM25-only / vector-only / hybrid / RRF) reported on the held-out set; RRF default decision from this evidence.
+- **W4.2 Perf budgets.** Criterion benches + e2e latency: recall p95 < 150 ms, remember p95 < 100 ms at 10k memories on the CI runner, gated; 100k-memory load test informational; empirical brute-force-KNN ceiling documented; ANN trigger point decided from data. (W1.7/W1.8 already removed the known pathologies — benches measure honest numbers, not artifacts.)
+- **W4.3 Fault injection, soak, fuzz.** Concurrent-client soak; kill −9 mid-write; disk full; embedding-API outage (proves W1.6 degraded mode); cargo-fuzz targets for the frame decoder, FTS escaping, and hook JSON parsing — short per-PR, long nightly, **scheduled** (a posture, not an event).
+- **W4.4 Docs truth pass.** Every README/ARCHITECTURE claim mapped to a reachable production path; `status` surface verified to report writer health, WAL size, corpus stats, subscriber state.
+
+**Phase 4 gate:** all eval and perf gates green in CI; fault-injection suite green; fuzz corpus running on schedule with zero outstanding crashes; docs-truth audit clean.
+
+---
+
+## 8. Phase 5 — Team mode (split: 5a substrate, 5b hub, 5c trust & pilot)
+
+Target: teamfit →9.5+, security →9.5+. Design first: **P8 spec** precedes 5a. Shape (endorsed independently by the review, the critique panel, and the clean-room plan): **curated central hub with explicit promote semantics over the oplog — not live multi-master sync.** The supersede/conflict semantics and writer guards assume a single coordinator; keep that assumption and team mode is an extension, not a rewrite.
+
+### Phase 5a — Team substrate
+- **W5a.1** Handshake identity finalized (consumes the W0.5 field; shape pinned by spike S2 so the contract bumps once); token auth (or mTLS/SSH-tunnel per S2).
+- **W5a.2** Oplog replay API: `Pull since seq` / `Push batch`, idempotent apply over the existing UUID + tombstone + supersede primitives; per-site seq tracking.
+- **W5a.3** Transport genericization: `Client<S>`, listener seam (codec/framing already stream-generic; sized at ~a day).
+- **W5a.4** Protocol evolution policy doc: additive serde-default fields never bump CONTRACT_VERSION; breaking changes bump it and the hub supports N and N−1 for one release; CI handshakes an N−1 fixture client.
+- **Gate:** two daemons on two machines exchange a promoted memory, with replay after restart; N−1 client fixture connects.
+
+### Phase 5b — Hub + promote
+- **W5b.1** Shared central daemon over the authenticated transport; local daemon remains the private store; explicit `promote` of curated memories to the team namespace, pull of team changes.
+- **W5b.2** Curation queue: promoted memories reviewable before they enter teammates' injection paths (the team-mode injection backstop).
+- **W5b.3** Data-lifecycle ops: `rusty-brain backup`/`restore` (SQLite online-backup API); `purge <id|--author|--pattern>` hard-delete cascading memories+vectors+FTS+oplog (oplog entry redacted to a content-free tombstone), propagated hub→spokes; retention policy config. A shared brain with no backup and no way to excise a secret or a departed teammate's data fails any review.
+- **W5b.4** Onboarding bootstrap: initial snapshot fetch + oplog tail from the snapshot's seq; one-command `rusty-brain join <hub>`.
+- **Gate:** 3-machine smoke with curation queue; restore drill; purge drill (planted secret provably absent from DB, FTS, vectors, and oplog afterward).
+
+### Phase 5c — Trust & pilot
+- **W5c.1** Per-author trust weighting in ranking (fed by W3.7 feedback + provenance); cross-author contradiction surfacing; provenance-aware curation CLI.
+- **W5c.2** Pilot: 2+ real users, 2+ machines, 2 weeks; a third user onboards mid-pilot and reaches recall parity within minutes (measured); poisoning drill: a planted malicious memory is contained by framing + curation + trust.
+- **Gate:** pilot completes with all drills passed and teammates' curated memories recalled with correct attribution; network kill mid-sync re-converges with zero duplicates and zero lost acked writes (DB diff after replay).
+
+---
+
+## 9. Spike register (time-boxed, before committing the dependent phase)
+
+- **S1 (before the Phase 0 gate is finalized, 1 day):** prove `claude -p` fires SessionStart/PostToolUse/SessionEnd hooks headlessly with an API key in CI. If not, the nightly tier becomes fixture-only and real-CC checks stay a per-phase manual ritual — W3.5's design depends on this answer.
+- **S2 (during Phase 2, 1–2 days):** hub auth design note — token vs mTLS vs SSH tunnel — pinning the handshake identity field shape so the wire contract bumps once.
+- **S3 (retired):** vec0 `distance_metric=cosine` support confirmed in vendored sqlite-vec 0.1.9; rebuild mechanics folded into W1.1 as open-time code.
+
+---
+
+## 10. Phase 6 — Last mile to 10 (closure table)
+
+Run the full review battery (see §13) and close the residue. Every "what 10 means" clause must by now map to a shipped workstream or appear below as an accepted, stated gap:
+
+| Dimension | Residual clause | Owner / resolution |
+|---|---|---|
+| architecture | version-skew survival | W5a.4 (policy + N−1 CI fixture) |
+| architecture | Windows | accepted gap, documented (§15): WSL2 path; revisit when W5a.3 TCP lands |
+| correctness | upgrade-path coverage for *every* future migration | standing rule from W1.1: populated prior-version fixtures, enforced in review checklist |
+| security | continuous fuzzing + signed releases | W4.3 + W0.6 (verify both still on schedule) |
+| retrieval | multilingual | accepted gap (§15) |
+| teamfit | GDPR-grade deletion semantics beyond purge | accepted gap unless pilot demands it; documented in threat model |
+| claudecode | sustained elicitation + outcome wins across releases | W3.2 scorecard + W3.5 A/B tracked per release, regression = release blocker |
+
+**Final gate:** all six dimensions ≥9.5 on a fresh full review **plus** external evidence: pilot metrics, the A/B outcome results, and at least one fresh-eyes install by someone who has never used the tool.
+
+---
+
+## 11. Dogfood-data lifecycle through the migrations
+
+Pre-provenance, pre-redaction, pre-cosine memories accumulate during Phases 0–2. Policy: cosine rebuild migrates vectors automatically (W1.1); namespace rename helper re-scopes rows (W0.3); `scrub` (W2.4) is run before any DB is shared; **no local store is promoted or joined to a hub until scrubbed** — enforced as a check in `rusty-brain join`/`promote` (pre-redaction rows carry no `redaction_pass` stamp). Anonymous (NULL-provenance) rows are never auto-promoted.
+
+---
+
+## 12. Parallel tracks & the serial spine
+
+Phases are gate checkpoints; with one developer orchestrating agents, run as tracks:
+
+- **Track A — transport/robustness:** W0.1, W0.4, W1.6
+- **Track B — retrieval:** W1.0 corpus authoring (starts during Phase 0) → W1.1 → W1.2–W1.5, W1.7–W1.9
+- **Track C — capture/claudecode:** W0.7 → W2.4 → W3.1–W3.7
+- **Track D — quick wins, landable any time:** DB perms (in W0.5), W2.5 framing, W2.6 threat-model doc, W2.8 logging
+
+**The spine that must stay ordered:** W0.2 paths → everything e2e; W0.5 provenance/oplog → W2.2/W2.7 → Phase 5; W1.0 → W1.1 → threshold recalibration → W4.1 gating; W3.1 capture quality → W3.5 eval (a corpus worth searching) → Phase 5 sharing.
+
+---
+
+## 13. CI & cadence policy
+
+- **Test tiers:** per-PR = unit + agreement + fixture e2e with injected short timeouts (minutes; any test >60 s wall-clock must justify per-PR placement); nightly = soak, fault injection, 10k/100k benches, real-Claude-Code smoke (allowed-to-fail with alerting), long fuzz, W3.5 A/B; per-phase = manual fresh-machine checklist.
+- **Review cadence:** dimension-scoped re-reviews at each phase boundary (Phase 1 → retrieval+correctness agents only, etc.); the **full** intensive review at the Phase 2 and Phase 4 boundaries and pre-pilot. Phase 3+ scorecards must include external evidence (pilot metrics, A/B results, fresh-eyes installs) — self-grading against a known rubric overfits to the reviewer.
+- **Baseline discipline:** retrieval changes land with re-captured baselines + justification in the same commit (§4 ground rule).
+- **Contract-version policy:** additive serde-default fields: no bump. W0.5 (Handshake identity) and any Phase 0 protocol change share **one** bump. Breaking changes thereafter follow W5a.4.
+
+---
+
+## 14. Score trajectory (honest, sums to the title)
+
+| Phase | arch | corr | sec | retr | team | cc |
+|---|---|---|---|---|---|---|
+| baseline | 6.5 | 6 | 6 | 4.5 | 4 | 3 |
+| P0 | 7 | 7 | 6.5 | 4.5 | 5 | 6 |
+| P1 | 7.5 | 8 | 6.5 | 7 | 5 | 6.5 |
+| P2 | 8 | 8 | 8 | 7.5 | 6 | 7 |
+| P3 | 8 | 8 | 8.5 | 8 | 6.5 | 8.5 |
+| P4 | 9 | 9 | 9 | 9 | 6.5 | 9 |
+| P5a–c | 9.5 | 9.5 | 9.5 | 9.5 | 9.5 | 9.5 |
+| P6 | 10* | 10* | 10* | 10* | 10* | 10* |
+
+\* "10" = every exit criterion in §2 demonstrably met or explicitly accepted-and-documented in §10's table. A 10 with stated non-goals is honest; a 10 by omission is not.
+
+---
+
+## 15. Deliberate non-goals (beyond 10 for this product)
+
+- **Multilingual retrieval** — dev-team memories are English/code-dominant; unicode61 handles incidental non-English.
+- **Windows tier-1** — out of scope for v1; WSL2 documented as the supported path; revisit when the team-mode TCP transport removes the UDS blocker.
+- **At-rest encryption** — 0600 + OS full-disk encryption is the documented posture.
+- **Live multi-master sync (CRDTs)** — hub-and-spoke with promote semantics chosen deliberately (§8); revisit only with pilot evidence that curation is the bottleneck.
+
+---
+
+## 16. Traceability appendix — finding → workstream
+
+| Finding | Workstream(s) | | Finding | Workstream(s) |
+|---|---|---|---|---|
+| F01/F11/F48 idle-death | W0.1 | | F30 junk default recall | W1.3 (+W1.0 evidence) |
+| F02/F14/F28 L2-vs-cosine | W1.1 | | F31 (=F06) | W1.5 |
+| F03/F12/F49 path split-brain | W0.2 | | F32 (=F05) | W2.2 |
+| F04/F13/F54 namespace hijack | W0.3 | | F33 importance job | W1.9 (+W3.7) |
+| F05 unreachable features | W2.2, W4.4 | | F34 low-info capture | W3.1 |
+| F06/F15 graph_hops | W1.5 | | F35 eval blindness | W1.0, W4.1 |
+| F07/F16 COMMIT poison | W1.6 | | F36 query input_type | W1.4 |
+| F08 recall-as-write + residue | W1.8, W1.7 | | F37 no usefulness signal | W3.7 |
+| F09/F18/F29 phrase-only FTS | W1.2 | | F38 zero provenance | W0.5 |
+| F10 model identity | W0.2 | | F39 no trust producers | W0.5, W2.2 |
+| F17 zombie daemon | W1.6(c) | | F40 namespace not a team key | W0.3 |
+| F19 recall hard-fail | W1.6(d) | | F41 no durable change log | W0.5, W2.7, W5a.2 |
+| F20 env allowlist | W0.2 | | F42 capture leak engine | W0.5-min, W2.4 |
+| F21 injection-via-memory | W2.5, W5b.2 | | F43 no identity slot | W0.5, W2.6, W5a.1 |
+| F22 frontmatter attack | W0.3 | | F44 KNN cliff | W1.7 |
+| F23 world-readable DB | W0.5 | | F45/F47 (positive/sequencing) | adopted in §8 shape |
+| F24 verbatim secrets | W0.5-min, W2.4 | | F46 transport coupling | W5a.3 |
+| F25 no peer-cred | W2.6 | | F50 installer hook form | W0.7 |
+| F26 enrichment logging | W2.8 | | F51 noise-dominant capture | W3.1 |
+| F27 (positive) | — | | F52 no elicitation | W3.2 |
+| | | | F53 token economy | W3.3 |
+| | | | F55 update tool lies | W0.4 (+W3.1 supersede) |
+| | | | F56 value-over-native unproven | W3.5 (CLAUDE.md-only arm), W3.6 |
+| | | | F57 dead subscriber | W0.1, W2.7 |
+
+Every confirmed finding has an owner; F27/F45/F47 are positives that shaped the design rather than work items.

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -46,6 +46,13 @@ Target: claudecode 3→6, correctness +1, teamfit +1. Everything here either unb
 **Phase 0 gate (three tiers, replacing "fresh macOS machine" as a manual ritual):**
 (a) **per-PR CI**: path-agreement tests + fixture-driven hook lifecycle e2e on ubuntu *and* macos runners, idle test with injected short timeout; (b) **nightly, allowed-to-fail with alerting**: real Claude Code headless (`claude -p`) smoke on macOS with an API-key secret — capture → idle → recall reaches **one** daemon and **one** 0600 DB; (c) **once per phase**: scripted fresh-machine checklist (`scripts/verify-fresh-install.sh`) using the W0.6 artifact. Plus: a hook-written memory carries author/source/seq/confidence; planted fake secret yields zero plaintext grep hits in the DB; two clones of the same repo resolve the same namespace.
 
+**Phase-0 carryover debt (recorded deferrals — must land before/with early Phase 1):**
+
+- **W0.2 config file.** `~/.config/rusty-brain/config.toml` was not introduced; the env allowlist grew to 13 entries (the three specified vars plus `RB_ACCEPT_MODEL_CHANGE` and `RUSTY_BRAIN_IDLE_TIMEOUT_SECS`) instead of shrinking to secrets + XDG/HOME. The F20 bug *class* (config reaching a foreground daemon but not auto-started ones) stays open — only known instances are fixed, and every new daemon knob must remember to extend `FORWARD_ENV` until the config file lands.
+- **W0.3 namespace-rename helper.** The one-time wire op + `rusty-brain namespace rename` was deferred. §11's dogfood-data lifecycle depends on it: memories captured before a repo pins identity via `.rusty-brain.toml` land under the heuristic directory-name namespace and cannot be re-scoped until it ships — land it pre-dogfood.
+- **W0.7 hook-event fixtures.** Only the real Claude Code `settings.json` was recorded; real hook-event payload fixtures (PostToolUse/SessionStart/Stop/PreCompact as Claude Code actually emits them) are still missing — rb-hooks integration tests run on hand-authored payloads. W3.4 and gate tier (a)'s "fixture-driven hook lifecycle e2e" assume the full set.
+- **Gate tiers (b)/(c).** The nightly real-Claude-Code smoke workflow does not exist (blocked on the S1 spike: prove `claude -p` fires hooks headlessly), and the planted-secret check is asserted at the wire (Remember payload), not by grepping a DB file.
+
 ---
 
 ## 4. Phase 1 — Measure, then fix retrieval semantics + hard robustness

--- a/scripts/verify-fresh-install.sh
+++ b/scripts/verify-fresh-install.sh
@@ -89,10 +89,19 @@ done
 # SHORT socket path (default cache-dir sockets can exceed the 104-byte macOS
 # sun_path limit under a temp HOME). The DB stays on default resolution so the
 # real path + permission code runs.
+#
+# Hermetic: unset every config-bearing var the auto-started daemon could
+# inherit — the rb_config::FORWARD_ENV allowlist (crates/rb-config/src/lib.rs)
+# minus HOME/PATH/XDG_* — plus the path/namespace overrides, BEFORE re-exporting
+# our own. A developer's VOYAGE_API_KEY or RB_* settings must not leak into the
+# fresh-machine simulation.
 export HOME="$WORKDIR/home"
 mkdir -p "$HOME"
 unset XDG_RUNTIME_DIR XDG_CACHE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_STATE_HOME
-unset RUSTY_BRAIN_DB RUSTY_BRAIN_NAMESPACE VOYAGE_API_KEY RB_EMBED_BACKEND RB_LOCAL_MODEL
+unset VOYAGE_API_KEY RB_EMBED_BACKEND RB_LOCAL_MODEL \
+      RB_ENRICH_BASE_URL RB_ENRICH_MODEL RB_ENRICH_API_KEY \
+      RB_JOBS_CONFIG RB_ACCEPT_MODEL_CHANGE RUSTY_BRAIN_IDLE_TIMEOUT_SECS
+unset RUSTY_BRAIN_DB RUSTY_BRAIN_SOCKET RUSTY_BRAIN_NAMESPACE
 export RUSTY_BRAIN_SOCKET="$WORKDIR/rb/sock"
 export PATH="$BIN_DIR:$PATH"
 cd "$HOME"
@@ -116,15 +125,19 @@ DB_COUNT="$(find "$HOME" -name memory.db | wc -l | tr -d ' ')"
 DB="$(find "$HOME" -name memory.db)"
 MODE="$(mode_of "$DB")"
 [ "$MODE" = "600" ] || { echo "db must be 0600, got $MODE ($DB)" >&2; exit 1; }
+# Grep only the siblings that exist: under `set -euo pipefail`, grep's exit 2
+# on a missing $DB-wal would fail the marker gate spuriously.
+FILES=("$DB")
 for sibling in "$DB-wal" "$DB-shm"; do
   if [ -e "$sibling" ]; then
     MODE="$(mode_of "$sibling")"
     [ "$MODE" = "600" ] || { echo "${sibling##*/} must be 0600, got $MODE" >&2; exit 1; }
+    FILES+=("$sibling")
   fi
 done
-grep -a "REDACTED:credential" "$DB" "$DB-wal" 2>/dev/null | grep -q . \
+grep -aq "REDACTED:credential" "${FILES[@]}" \
   || { echo "hook capture did not land in the DB (no redaction marker found)" >&2; exit 1; }
-if grep -a "$PLANTED" "$DB" "$DB-wal" 2>/dev/null | grep -q .; then
+if grep -aq "$PLANTED" "${FILES[@]}"; then
   echo "planted secret found in plaintext in the DB" >&2
   exit 1
 fi

--- a/scripts/verify-fresh-install.sh
+++ b/scripts/verify-fresh-install.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Phase 0 gate tier (c): scripted fresh-machine checklist (plan §3, W0.6).
+#
+# Consumes a W0.6 release artifact, installs it into an isolated prefix with a
+# fresh HOME, and proves the out-of-the-box loop:
+#   checksum-verified install -> auto-started daemon -> remember -> recall,
+# against ONE daemon and ONE owner-only (0600) database. Also plants a fake
+# secret through the real hook capture path and greps the raw DB + WAL for it:
+# zero plaintext hits, while the redaction marker must be present.
+#
+# Usage:
+#   scripts/verify-fresh-install.sh --tag v0.2.0      # download from the GitHub release (needs gh)
+#   scripts/verify-fresh-install.sh --tarball PATH    # use a local artifact (checksum skipped
+#                                                     # unless SHA256SUMS sits next to it)
+set -euo pipefail
+
+usage() { sed -n '2,16p' "$0"; exit 2; }
+
+TAG=""
+TARBALL=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tag) TAG="${2:?--tag needs a value}"; shift 2 ;;
+    --tarball) TARBALL="${2:?--tarball needs a value}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[ -n "$TAG" ] || [ -n "$TARBALL" ] || usage
+
+REPO="brianluby/rusty-brain"
+SENTINEL="fresh-install gate sentinel $(date +%s)"
+PLANTED="gate-planted-secret-3f9c2b"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) TARGET="aarch64-apple-darwin" ;;
+  Darwin-x86_64) TARGET="x86_64-apple-darwin" ;;
+  Linux-x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+  *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+# Portable octal-mode and sha256 helpers (macOS vs GNU).
+mode_of() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"; }
+sha_check() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum --check --ignore-missing SHA256SUMS
+  else shasum -a 256 --check --ignore-missing SHA256SUMS; fi
+}
+
+WORKDIR="$(mktemp -d)"
+DAEMON_PID=""
+cleanup() {
+  status=$?
+  if [ -n "$DAEMON_PID" ] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if [ "$status" -eq 0 ]; then
+    rm -rf "$WORKDIR"
+    echo "PASS: fresh-install checklist"
+  else
+    echo "FAIL: fresh-install checklist (workdir kept: $WORKDIR)" >&2
+  fi
+}
+trap cleanup EXIT
+
+# 1. Fetch + verify + unpack the artifact.
+cd "$WORKDIR"
+if [ -n "$TAG" ]; then
+  gh release download "$TAG" --repo "$REPO" \
+    --pattern "*-${TARGET}.tar.gz" --pattern SHA256SUMS
+  sha_check
+  TARBALL="$(ls rusty-brain-*-"${TARGET}".tar.gz)"
+else
+  TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+  if [ -f "$(dirname "$TARBALL")/SHA256SUMS" ]; then
+    cp "$(dirname "$TARBALL")/SHA256SUMS" .
+    cp "$TARBALL" .
+    sha_check
+  else
+    echo "note: no SHA256SUMS next to the tarball; checksum skipped (local mode)"
+  fi
+fi
+BIN_DIR="$WORKDIR/bin"
+mkdir -p "$BIN_DIR"
+tar -xzf "$TARBALL" --strip-components=1 -C "$BIN_DIR"
+for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
+  [ -x "$BIN_DIR/$bin" ] || { echo "missing binary in tarball: $bin" >&2; exit 1; }
+done
+
+# 2. Fresh-machine environment: empty HOME, no XDG dirs, no overrides except a
+# SHORT socket path (default cache-dir sockets can exceed the 104-byte macOS
+# sun_path limit under a temp HOME). The DB stays on default resolution so the
+# real path + permission code runs.
+export HOME="$WORKDIR/home"
+mkdir -p "$HOME"
+unset XDG_RUNTIME_DIR XDG_CACHE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_STATE_HOME
+unset RUSTY_BRAIN_DB RUSTY_BRAIN_NAMESPACE VOYAGE_API_KEY RB_EMBED_BACKEND RB_LOCAL_MODEL
+export RUSTY_BRAIN_SOCKET="$WORKDIR/rb/sock"
+export PATH="$BIN_DIR:$PATH"
+cd "$HOME"
+
+# 3. First client command auto-starts the daemon (the path a fresh user hits).
+rusty-brain remember "$SENTINEL" --type insight --importance 7
+rusty-brain status >/dev/null
+
+# 4. Recall round-trips the sentinel.
+rusty-brain recall "gate sentinel" | grep -F "fresh-install gate sentinel" >/dev/null \
+  || { echo "recall did not return the sentinel" >&2; exit 1; }
+
+# 5. Plant a fake secret through the REAL hook capture path; the daemon must
+# store the redacted summary, never the plaintext value.
+printf '%s' "{\"hook_event_name\":\"PostToolUse\",\"session_id\":\"gate\",\"cwd\":\"$HOME\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"export API_TOKEN=${PLANTED}\"},\"tool_response\":\"ok\"}" \
+  | rusty-brain-hooks --agent claude-code >/dev/null
+
+# 6. Exactly one DB, owner-only, with the capture landed and zero plaintext hits.
+DB_COUNT="$(find "$HOME" -name memory.db | wc -l | tr -d ' ')"
+[ "$DB_COUNT" = "1" ] || { echo "expected exactly 1 memory.db under HOME, found $DB_COUNT" >&2; exit 1; }
+DB="$(find "$HOME" -name memory.db)"
+MODE="$(mode_of "$DB")"
+[ "$MODE" = "600" ] || { echo "db must be 0600, got $MODE ($DB)" >&2; exit 1; }
+for sibling in "$DB-wal" "$DB-shm"; do
+  if [ -e "$sibling" ]; then
+    MODE="$(mode_of "$sibling")"
+    [ "$MODE" = "600" ] || { echo "${sibling##*/} must be 0600, got $MODE" >&2; exit 1; }
+  fi
+done
+grep -a "REDACTED:credential" "$DB" "$DB-wal" 2>/dev/null | grep -q . \
+  || { echo "hook capture did not land in the DB (no redaction marker found)" >&2; exit 1; }
+if grep -a "$PLANTED" "$DB" "$DB-wal" 2>/dev/null | grep -q .; then
+  echo "planted secret found in plaintext in the DB" >&2
+  exit 1
+fi
+
+# 7. Exactly one daemon: the auto-started one, identified by its pidfile.
+PIDFILE="$WORKDIR/rb/sock.pid"
+[ -f "$PIDFILE" ] || { echo "daemon pidfile missing: $PIDFILE" >&2; exit 1; }
+DAEMON_PID="$(cat "$PIDFILE")"
+kill -0 "$DAEMON_PID" || { echo "daemon (pid $DAEMON_PID) is not running" >&2; exit 1; }


### PR DESCRIPTION
## Summary

Implements **Phase 0** of [`docs/plans/2026-06-11-rusty-brain-road-to-tens.md`](docs/plans/2026-06-11-rusty-brain-road-to-tens.md) — the plan synthesized from the 2026-06-11 intensive review (57 verified findings) and its adversarial critique panel. Every workstream maps to confirmed findings; this PR closes the three day-one breaks and stops all debt that cannot be backfilled later.

### The three day-one breaks (fixed)

- **MCP idle-death (F01/F11/F48):** the daemon's 60s idle timeout permanently killed the MCP server's single connection. `ClientProxy` now reconnects with backoff; mutating ops only auto-retry when the failure was provably on send (no double-`remember`); the change subscriber reconnects and `poll_changes` reports subscriber health. Idle timeout is env-injectable (`RUSTY_BRAIN_IDLE_TIMEOUT_SECS`) so the reconnect e2e runs in seconds.
- **macOS path split-brain (F03/F12/F49):** hooks and daemon resolved different default socket *and* DB paths, silently writing two databases. New leaf crate **`rb-config`** is the single source of truth for paths and the auto-start env allowlist (which also gains the previously-missing `RB_EMBED_BACKEND`/`RB_LOCAL_MODEL`/`RB_JOBS_CONFIG`, F20); agreement tests pin hooks==CLI==daemon; macOS added to CI.
- **Namespace hijack (F04/F13/F54, F22):** detection walked past the git root and let any ancestor CLAUDE.md H1 claim the namespace. New resolution: repo-committed `.rusty-brain.toml` > `--namespace`/env > git-toplevel name; walk bounded at the repo root; H1 removed; repo-committed `project:` overrides are never honored unpinned (the F22 malicious-repo attack is now a regression test).

### Unbackfillable-debt stoppers

- **Provenance + durable oplog (F38/F41/F43):** migration 004 adds `origin_user/host/agent/source` + `session_id` (nullable, no FTS-churning backfill) and a sequence-numbered `memory_oplog` appended **in the same transaction** as every mutation. Handshake carries optional client identity (additive, no contract bump). Hook-written memories carry `origin_source=hook` and **confidence 0.7** — the ranking dampener's first real producer (F39 down-payment).
- **Secret hygiene (F23/F24-minimal):** DB file created 0600 (pre-created to close the umask window; WAL/SHM tightened on open); hook capture redacts AWS keys, bearer tokens, PEM blocks, and key/value secrets before storing. Full benchmarked redaction + retroactive scrub is W2.4.
- **Embedding-model invariant (F10/F20):** `meta.embedding_model` is seeded and verified at open; same-dim provider swaps refuse to start with an explicit `--accept-model-change` re-embed path — mixed vector spaces are now impossible.

### Also

- `update` tool returns its guidance verbatim as a validation error instead of opaque "internal error" (F55), and its schema documents the content-update limitation.
- Claude Code installer emits the documented single-shell-string hook form, tested against a recorded `settings.json` fixture (F50).
- Release workflow: tagged builds produce checksummed macOS+Linux artifacts with provenance attestation; `scripts/verify-fresh-install.sh` is the manual gate tier.
- Spike S1 answered: headless `claude -p` fires hooks; unprompted MCP calls need `permissions.allow` (recorded as a W3.2 prerequisite).

### Carryover (recorded in plan §3, owed before/with early Phase 1)

Global `config.toml`; namespace-rename helper; real hook-event payload fixtures; nightly real-Claude-Code smoke workflow.

## Review & gates

Implemented as 7 sequenced workstreams, each gated on green fmt/clippy/tests before commit; then a 3-reviewer pass over the full diff (**0 must-fix**, 15 should-fix → 12 applied, 3 recorded deferrals, 11 nits) and a fixer commit.

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace`: **852 passed, 4 ignored** (51 suites, ~11s) ✅
- `cargo deny check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated multi-platform release builds for macOS (Apple Silicon/Intel) and Linux.
  * Namespace identity pinning via `.rusty-brain.toml` at repository root.
  * Embedding model identity enforcement with opt-in model change acceptance.
  * Provenance tracking (user, host, agent, source, session ID) on all memories.
  * Confidence scoring for remembered content.
  * Secret redaction in hook captures.
  * CLI flags for namespace override (`--namespace`, `--accept-namespace-override`) and model changes (`--accept-model-change`).
  * Environment variable configuration for socket, database, namespace, and idle timeout.
  * Subscriber health monitoring and reconnection with exponential backoff.

* **Bug Fixes**
  * Content update error messaging now provides actionable guidance.

* **Documentation**
  * Installation guide with tagged release tarballs and source-build options.
  * Namespace resolution and pinning documentation.
  * Configuration reference for environment variables.
  * Architecture updates covering provenance, model identity, and operation logging.
  * Roadmap for future development milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->