### PR TITLE
feat(p3): W3.7 usefulness signal (memory_feedback)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,8 @@
       "mcp__rusty-brain__recall",
       "mcp__rusty-brain__get",
       "mcp__rusty-brain__context",
-      "mcp__rusty-brain__update"
+      "mcp__rusty-brain__update",
+      "mcp__rusty-brain__memory_feedback"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ MCP-capable agent at it as a stdio server, for example:
 }
 ```
 
-It exposes ten tools: `remember`, `recall`, `get`, `list`, `graph`, `update`,
-`link` (e.g. mark one memory as contradicting another), `delete`, `context`, and
-`poll_changes` (drains buffered change notifications).
+It exposes eleven tools: `remember`, `recall`, `get`, `list`, `graph`, `update`,
+`link` (e.g. mark one memory as contradicting another), `delete`, `context`,
+`memory_feedback` (report whether a recalled memory was `helpful`/`wrong`/`stale`,
+nudging its trust prior), and `poll_changes` (drains buffered change
+notifications).
 
 ### Capture hooks (optional)
 

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -586,6 +586,7 @@ fn is_admin_op(req: &Request) -> bool {
         | Request::Graph { .. }
         | Request::Update { .. }
         | Request::Link { .. }
+        | Request::Feedback { .. }
         | Request::Delete { .. }
         | Request::Context
         | Request::Subscribe { .. }
@@ -1050,6 +1051,13 @@ where
             reason,
         } => match engine.link(from, to, link_type, reason).await {
             Ok(()) => Response::Linked,
+            Err(e) => error_to_response(e),
+        },
+        // Namespace-scoped usefulness signal (W3.7): the engine verifies the
+        // memory lives in this connection's namespace; `provenance` supplies the
+        // giver (`origin_user`) recorded for the W5c per-author rollup.
+        Request::Feedback { id, kind } => match engine.feedback(id, kind, provenance).await {
+            Ok(confidence) => Response::FeedbackRecorded { confidence },
             Err(e) => error_to_response(e),
         },
         // Admin op (peer-gated above): retroactive secret redaction across all

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -104,6 +104,18 @@ enum WriteCommand {
         link: Box<rb_types::MemoryLink>,
         reply: oneshot::Sender<Result<()>>,
     },
+    /// Record a usefulness-feedback event for a memory and nudge its trust prior
+    /// (W3.7). Namespace-verified like `Update` before the store writes the event
+    /// row + confidence + oplog in one transaction. The typed reply carries the
+    /// post-nudge `confidence` (the `RenameNamespace`/`Scrub` typed-reply
+    /// precedent).
+    RecordFeedback {
+        namespace: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<String>,
+        reply: oneshot::Sender<Result<f32>>,
+    },
     /// Apply a batch of BUFFERED access bumps (W1.8). Recall and `get` never
     /// enqueue a writer command for access tracking — they accumulate into
     /// [`AccessBuffer`]; this command carries the periodic/shutdown flush.
@@ -1196,6 +1208,57 @@ fn writer_loop(
                     break;
                 }
             }
+            WriteCommand::RecordFeedback {
+                namespace,
+                id,
+                kind,
+                principal,
+                reply,
+            } => {
+                // Capture the typed payload via the RenameNamespace/Scrub
+                // pattern (run_store_op is Result<()>-only).
+                let mut confidence = None;
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    // Mirror the Update arm: verify the row lives in the caller's
+                    // namespace before mutating, fail closed (NotFound) on a
+                    // missing or cross-namespace id.
+                    |s| match s.get_memory(&id) {
+                        Ok(Some(note)) if note.namespace == namespace => {
+                            confidence =
+                                Some(s.record_feedback(&id, kind, principal.as_deref())?);
+                            Ok(())
+                        }
+                        Ok(Some(_)) | Ok(None) => Err(Error::NotFound(id.clone())),
+                        Err(e) => Err(e),
+                    },
+                );
+                let changed = report.result.is_ok();
+                let writer_usable = report.writer_usable;
+                let result = report.result.and_then(|()| {
+                    confidence.ok_or_else(|| {
+                        Error::Storage("feedback completed without an outcome".to_string())
+                    })
+                });
+                let _ = reply.send(result);
+                // Feedback nudges confidence (durable ranking state), so
+                // subscribers observe it as an Updated change.
+                if changed {
+                    publish_change_stamped(
+                        &events,
+                        store.as_ref(),
+                        id,
+                        namespace,
+                        ChangeKind::Updated,
+                    );
+                }
+                if !writer_usable {
+                    break;
+                }
+            }
             WriteCommand::FlushAccesses { bumps, reply } => {
                 // No MemoryChanged event: access tracking is observability-only.
                 let report = run_store_op(
@@ -1567,6 +1630,33 @@ impl MemoryBackend for StoreHandle {
             reply,
         };
         self.send_write(cmd, rx).await
+    }
+
+    async fn record_feedback(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<String>,
+    ) -> Result<f32> {
+        // Bespoke send with a typed reply payload (the `rename_namespace`/`scrub`
+        // precedent); `send_write` only carries `Result<()>`.
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(Error::Storage("writer thread unavailable".to_string()));
+        }
+        let (reply, rx) = oneshot::channel();
+        self.writer_tx
+            .send(WriteCommand::RecordFeedback {
+                namespace: ns,
+                id,
+                kind,
+                principal,
+                reply,
+            })
+            .await
+            .map_err(|_| Error::Storage("writer thread unavailable".to_string()))?;
+        rx.await
+            .map_err(|_| Error::Storage("writer dropped reply".to_string()))?
     }
 
     async fn record_access(&self, id: MemoryId) -> Result<()> {
@@ -2404,6 +2494,56 @@ mod tests {
             row.base_importance, base,
             "the author prior must survive the job write"
         );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_record_feedback_is_namespace_scoped_and_nudges_confidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("feedback-write".to_string());
+
+        let mut m = note(&ns, "a decision worth grading");
+        m.confidence = 0.8;
+        let id = m.id.clone();
+        handle.write(m, Some(vec![0.1f32; DIM])).await.unwrap();
+
+        // Cross-namespace feedback fails closed, exactly like Update.
+        let err = handle
+            .record_feedback(
+                Namespace::Global,
+                id.clone(),
+                rb_types::FeedbackKind::Wrong,
+                Some("alice".to_string()),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::NotFound(_)),
+            "cross-namespace feedback must be NotFound, got {err:?}"
+        );
+
+        // In-namespace `wrong` lowers confidence through the single writer and
+        // the typed reply carries the post-nudge value.
+        let after = handle
+            .record_feedback(
+                ns.clone(),
+                id.clone(),
+                rb_types::FeedbackKind::Wrong,
+                Some("alice".to_string()),
+            )
+            .await
+            .unwrap();
+        assert!((after - 0.5).abs() < 1e-6, "0.8 - 0.30 = 0.50, got {after}");
+        let stored = handle
+            .get(ns, id)
+            .await
+            .unwrap()
+            .expect("memory present")
+            .confidence;
+        assert!((stored - 0.5).abs() < 1e-6, "the row reflects the nudge");
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -1223,11 +1223,17 @@ fn writer_loop(
                     &db_path,
                     embedding_dim,
                     embedding_model.as_deref(),
-                    // Mirror the Update arm: verify the row lives in the caller's
-                    // namespace before mutating, fail closed (NotFound) on a
-                    // missing or cross-namespace id.
+                    // Verify the row lives in the caller's namespace AND is still
+                    // active before mutating. The archived check is enforced HERE,
+                    // at the single-writer serialization point, to close the TOCTOU
+                    // the engine's pre-check (a pooled read) leaves open: a memory
+                    // archived between that read and this command must not receive
+                    // feedback. Fail closed (NotFound) on missing/cross-namespace/
+                    // archived — feedback targets live, recallable memories.
                     |s| match s.get_memory(&id) {
-                        Ok(Some(note)) if note.namespace == namespace => {
+                        Ok(Some(note))
+                            if note.namespace == namespace && note.archived_at.is_none() =>
+                        {
                             confidence =
                                 Some(s.record_feedback(&id, kind, principal.as_deref())?);
                             Ok(())
@@ -2538,12 +2544,40 @@ mod tests {
             .unwrap();
         assert!((after - 0.5).abs() < 1e-6, "0.8 - 0.30 = 0.50, got {after}");
         let stored = handle
-            .get(ns, id)
+            .get(ns.clone(), id.clone())
             .await
             .unwrap()
             .expect("memory present")
             .confidence;
         assert!((stored - 0.5).abs() < 1e-6, "the row reflects the nudge");
+
+        // Once archived, the writer-level guard rejects feedback (NotFound),
+        // closing the TOCTOU even when the engine's pre-check is bypassed.
+        handle.archive(ns.clone(), id.clone()).await.unwrap();
+        let err = handle
+            .record_feedback(
+                ns.clone(),
+                id.clone(),
+                rb_types::FeedbackKind::Helpful,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::NotFound(_)),
+            "feedback on an archived row must be NotFound at the writer, got {err:?}"
+        );
+        // The archived row's confidence is untouched by the rejected feedback.
+        let unchanged = handle
+            .get(ns, id)
+            .await
+            .unwrap()
+            .expect("memory present")
+            .confidence;
+        assert!(
+            (unchanged - 0.5).abs() < 1e-6,
+            "rejected feedback left confidence intact"
+        );
 
         handle.shutdown().await;
     }

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -48,6 +48,19 @@ pub trait MemoryBackend: Send + Sync {
     async fn archive(&self, ns: Namespace, id: MemoryId) -> rb_types::Result<()>;
     /// Persist a directed link (write path).
     async fn add_link(&self, link: rb_types::MemoryLink) -> rb_types::Result<()>;
+    /// Record a usefulness-feedback event for `id` and nudge its trust prior
+    /// (W3.7): the explicit usefulness/correctness signal `access_count` is not
+    /// (it counts "returned", not "useful"). `principal` is the giver (the
+    /// connection's `origin_user`), recorded for the W5c per-author trust
+    /// rollup. Returns `id`'s `confidence` after the bounded, clamped nudge. A
+    /// missing or out-of-namespace id is `Error::NotFound`.
+    async fn record_feedback(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<String>,
+    ) -> rb_types::Result<f32>;
     /// Bump access metadata for `id` (best-effort at call sites). W1.8:
     /// implementations MAY defer the bump — the daemon buffers it in memory
     /// and flushes batches off the read path, so recall/`get` issue zero
@@ -231,6 +244,21 @@ mod tests {
                 .ok_or_else(|| rb_types::Error::NotFound(link.source_id.clone()))?;
             note.links.push(link);
             Ok(())
+        }
+        async fn record_feedback(
+            &self,
+            ns: Namespace,
+            id: MemoryId,
+            kind: rb_types::FeedbackKind,
+            _principal: Option<String>,
+        ) -> rb_types::Result<f32> {
+            let mut guard = self.notes.lock().unwrap();
+            let note = guard
+                .get_mut(&id)
+                .filter(|note| note.namespace == ns)
+                .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+            note.confidence = (note.confidence + kind.confidence_delta()).clamp(0.0, 1.0);
+            Ok(note.confidence)
         }
         async fn record_access(&self, id: MemoryId) -> rb_types::Result<()> {
             let mut guard = self.notes.lock().unwrap();

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -844,7 +844,18 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         kind: rb_types::FeedbackKind,
         provenance: &Provenance,
     ) -> rb_types::Result<f32> {
-        if self.get_scoped(id.clone()).await?.is_none() {
+        // Feedback targets a LIVE, recallable memory: recall never returns
+        // archived rows, so an archived target is a caller error. Reject it
+        // (NotFound) via the `active_in_namespace` check `graph` uses — distinct
+        // from `update`/`link`, whose metadata edits remain valid on archived
+        // rows. This also avoids a pointless confidence nudge + `Updated` event
+        // on a soft-deleted memory.
+        let active = self
+            .get_scoped(id.clone())
+            .await?
+            .as_ref()
+            .is_some_and(|note| self.active_in_namespace(note));
+        if !active {
             return Err(rb_types::Error::NotFound(id));
         }
         self.backend
@@ -2236,6 +2247,20 @@ mod tests {
                 rb_types::FeedbackKind::Stale,
                 &Provenance::default(),
             )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn feedback_rejects_an_archived_memory() {
+        // Feedback is about live, recallable memories; an archived (soft-deleted)
+        // target is a caller error => NotFound (the `graph` active-scope rule).
+        let eng = engine();
+        let id = eng.remember(input("doomed but graded", 5)).await.unwrap();
+        eng.delete(id.clone()).await.unwrap();
+        let err = eng
+            .feedback(id, rb_types::FeedbackKind::Wrong, &Provenance::default())
             .await
             .unwrap_err();
         assert!(matches!(err, rb_types::Error::NotFound(_)), "{err}");

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -831,6 +831,32 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
             .await
     }
 
+    /// Record a usefulness-feedback event for a memory in this namespace (W3.7
+    /// / F37): the explicit usefulness/correctness signal `access_count` is not
+    /// (it counts "returned", not "useful"). Verifies `id` lives in the engine's
+    /// namespace (fail-closed `NotFound`), then records the event and nudges the
+    /// trust prior through the backend. `provenance` supplies the giver
+    /// (`origin_user`) for the W5c per-author trust rollup. Returns the memory's
+    /// `confidence` after the bounded nudge.
+    pub async fn feedback(
+        &self,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        provenance: &Provenance,
+    ) -> rb_types::Result<f32> {
+        if self.get_scoped(id.clone()).await?.is_none() {
+            return Err(rb_types::Error::NotFound(id));
+        }
+        self.backend
+            .record_feedback(
+                self.namespace.clone(),
+                id,
+                kind,
+                provenance.origin_user.clone(),
+            )
+            .await
+    }
+
     /// Soft-delete (archive) a memory. Spec §12: delete == soft archive.
     pub async fn delete(&self, id: MemoryId) -> rb_types::Result<()> {
         if self.get_scoped(id.clone()).await?.is_none() {
@@ -2142,6 +2168,74 @@ mod tests {
         eng.backend().insert_note(foreign);
         let err = eng
             .link(local, foreign_id, rb_types::LinkType::Contradicts, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn feedback_nudges_confidence_for_a_known_memory() {
+        let eng = engine();
+        let id = eng.remember(input("decision", 5)).await.unwrap();
+        // A fresh MCP/CLI write starts at the full-trust 1.0 baseline.
+        let before = eng.get(id.clone()).await.unwrap().unwrap().confidence;
+        assert!((before - 1.0).abs() < 1e-6);
+
+        let after = eng
+            .feedback(
+                id.clone(),
+                rb_types::FeedbackKind::Wrong,
+                &Provenance::default(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            (after - 0.70).abs() < 1e-6,
+            "1.0 - 0.30 = 0.70, got {after}"
+        );
+        let stored = eng.get(id.clone()).await.unwrap().unwrap().confidence;
+        assert!((stored - 0.70).abs() < 1e-6, "get reflects the nudge");
+
+        let after2 = eng
+            .feedback(id, rb_types::FeedbackKind::Helpful, &Provenance::default())
+            .await
+            .unwrap();
+        assert!(
+            (after2 - 0.75).abs() < 1e-6,
+            "0.70 + 0.05 = 0.75, got {after2}"
+        );
+    }
+
+    #[tokio::test]
+    async fn feedback_rejects_unknown_and_cross_namespace() {
+        let eng = engine();
+        // Missing id => NotFound.
+        let err = eng
+            .feedback(
+                MemoryId::new(),
+                rb_types::FeedbackKind::Helpful,
+                &Provenance::default(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "{err}");
+
+        // A memory in another namespace is invisible to this engine => NotFound.
+        let foreign = note(
+            Namespace::Project("other".into()),
+            "foreign",
+            MemoryType::Insight,
+            5,
+            &[],
+        );
+        let foreign_id = foreign.id.clone();
+        eng.backend().insert_note(foreign);
+        let err = eng
+            .feedback(
+                foreign_id,
+                rb_types::FeedbackKind::Stale,
+                &Provenance::default(),
+            )
             .await
             .unwrap_err();
         assert!(matches!(err, rb_types::Error::NotFound(_)), "{err}");

--- a/crates/rb-engine/src/test_support.rs
+++ b/crates/rb-engine/src/test_support.rs
@@ -282,6 +282,22 @@ impl MemoryBackend for MockBackend {
         Ok(())
     }
 
+    async fn record_feedback(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        _principal: Option<String>,
+    ) -> rb_types::Result<f32> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .filter(|note| note.namespace == ns)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.confidence = (note.confidence + kind.confidence_delta()).clamp(0.0, 1.0);
+        Ok(note.confidence)
+    }
+
     async fn record_accesses(&self, ids: Vec<MemoryId>) -> rb_types::Result<()> {
         use std::sync::atomic::Ordering;
         self.record_access_calls.fetch_add(1, Ordering::SeqCst);

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -128,6 +128,22 @@ impl MemoryBackend for VecBackend {
         Ok(())
     }
 
+    async fn record_feedback(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        _principal: Option<String>,
+    ) -> rb_types::Result<f32> {
+        let mut guard = self.notes.lock().unwrap();
+        let note = guard
+            .get_mut(&id)
+            .filter(|note| note.namespace == ns)
+            .ok_or_else(|| rb_types::Error::NotFound(id.clone()))?;
+        note.confidence = (note.confidence + kind.confidence_delta()).clamp(0.0, 1.0);
+        Ok(note.confidence)
+    }
+
     async fn record_accesses(&self, ids: Vec<MemoryId>) -> rb_types::Result<()> {
         let mut guard = self.notes.lock().unwrap();
         // Trait contract: duplicates within one call bump once (mirrors

--- a/crates/rb-eval/src/backend.rs
+++ b/crates/rb-eval/src/backend.rs
@@ -152,6 +152,23 @@ impl MemoryBackend for SqliteBackend {
         store.record_access(&id)
     }
 
+    async fn record_feedback(
+        &self,
+        ns: Namespace,
+        id: MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<String>,
+    ) -> rb_types::Result<f32> {
+        let store = self.lock()?;
+        // Namespace-scope like the daemon does before delegating to the store.
+        match store.get_memory(&id)? {
+            Some(note) if note.namespace == ns => {
+                store.record_feedback(&id, kind, principal.as_deref())
+            }
+            _ => Err(rb_types::Error::NotFound(id)),
+        }
+    }
+
     async fn record_accesses(&self, ids: Vec<MemoryId>) -> rb_types::Result<()> {
         let store = self.lock()?;
         store.record_accesses(&ids)

--- a/crates/rb-install/src/installers/claude_code.rs
+++ b/crates/rb-install/src/installers/claude_code.rs
@@ -31,6 +31,7 @@ const MCP_ALLOW_ENTRIES: &[&str] = &[
     "mcp__rusty-brain__get",
     "mcp__rusty-brain__context",
     "mcp__rusty-brain__update",
+    "mcp__rusty-brain__memory_feedback",
 ];
 
 /// Skill directory name under `.claude/skills/` (W3.2(b)).
@@ -173,6 +174,7 @@ mod tests {
                 "mcp__rusty-brain__get".to_string(),
                 "mcp__rusty-brain__context".to_string(),
                 "mcp__rusty-brain__update".to_string(),
+                "mcp__rusty-brain__memory_feedback".to_string(),
             ],
             "fragment must allowlist exactly the default advertised toolset (no wildcard)"
         );

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -6,7 +6,7 @@ use crate::jsonrpc::{JsonRpcError, INVALID_PARAMS, METHOD_NOT_FOUND};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rb_proto::{Request, Response};
-use rb_types::{MemoryId, MemoryNote, MemoryType, MemoryUpdates};
+use rb_types::{FeedbackKind, MemoryId, MemoryNote, MemoryType, MemoryUpdates};
 use serde_json::{json, Value};
 use std::str::FromStr;
 
@@ -225,6 +225,14 @@ pub fn build_request(name: &str, args: &Value) -> Result<Request, ToolError> {
             id: parse_id(args)?,
         }),
         "context" => Ok(Request::Context),
+        "memory_feedback" => {
+            let id = parse_id(args)?;
+            let kind_raw = require_str(args, "kind")?;
+            // Forward FeedbackKind's own guidance ("expected helpful, wrong, or
+            // stale") as INVALID_PARAMS, mirroring the `link` type parse.
+            let kind = FeedbackKind::parse(kind_raw).map_err(|e| invalid(e.to_string()))?;
+            Ok(Request::Feedback { id, kind })
+        }
         other => Err(JsonRpcError::new(
             METHOD_NOT_FOUND,
             format!("unknown tool '{other}'"),
@@ -431,6 +439,12 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
         }
         Response::Updated => ToolContent::json(json!({ "ok": true }), false),
         Response::Linked => ToolContent::json(json!({ "ok": true }), false),
+        // W3.7: echo the post-nudge trust prior so the model sees the effect.
+        Response::FeedbackRecorded { confidence } => ToolContent {
+            text: format!("feedback recorded (confidence now {confidence:.2})"),
+            structured: json!({ "confidence": confidence }),
+            is_error: false,
+        },
         Response::Deleted => ToolContent::json(json!({ "ok": true }), false),
         Response::ContextResult {
             recent,
@@ -599,6 +613,35 @@ mod tests {
         }
         let d = build_request("delete", &json!({ "id": id.to_string() })).unwrap();
         assert!(matches!(d, Request::Delete { .. }));
+    }
+
+    #[test]
+    fn build_memory_feedback_parses_id_and_kind() {
+        let id = MemoryId::new();
+        let f = build_request(
+            "memory_feedback",
+            &json!({ "id": id.to_string(), "kind": "stale" }),
+        )
+        .unwrap();
+        match f {
+            Request::Feedback { kind, .. } => assert_eq!(kind, rb_types::FeedbackKind::Stale),
+            other => panic!("expected Feedback, got {other:?}"),
+        }
+        // An unknown kind fails closed with INVALID_PARAMS + guidance.
+        let err = build_request(
+            "memory_feedback",
+            &json!({ "id": id.to_string(), "kind": "useless" }),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::INVALID_PARAMS);
+        assert!(
+            err.message.contains("helpful, wrong, or stale"),
+            "{}",
+            err.message
+        );
+        // A missing kind is a missing-required-string error.
+        let err = build_request("memory_feedback", &json!({ "id": id.to_string() })).unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::INVALID_PARAMS);
     }
 
     #[test]
@@ -945,6 +988,12 @@ mod tests {
             "error variant carries an `error` key"
         );
         assert!(err.is_error, "error variant sets the isError flag");
+
+        // W3.7: feedback echoes the post-nudge confidence in text + structured.
+        let fb = response_to_content(Response::FeedbackRecorded { confidence: 0.4 }, now);
+        assert!(!fb.is_error);
+        assert!(fb.text.contains("0.40"), "{}", fb.text);
+        assert!((fb.structured["confidence"].as_f64().unwrap() - 0.4).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -439,12 +439,13 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
         }
         Response::Updated => ToolContent::json(json!({ "ok": true }), false),
         Response::Linked => ToolContent::json(json!({ "ok": true }), false),
-        // W3.7: echo the post-nudge trust prior so the model sees the effect.
-        Response::FeedbackRecorded { confidence } => ToolContent {
-            text: format!("feedback recorded (confidence now {confidence:.2})"),
-            structured: json!({ "confidence": confidence }),
-            is_error: false,
-        },
+        // W3.7: an ack like Updated/Linked/Deleted — JSON in `text` (not a
+        // projected markdown line), so clients that parse `content[].text` as
+        // JSON for non-recall tools stay consistent. Echoes the post-nudge
+        // trust prior so the model sees the effect.
+        Response::FeedbackRecorded { confidence } => {
+            ToolContent::json(json!({ "ok": true, "confidence": confidence }), false)
+        }
         Response::Deleted => ToolContent::json(json!({ "ok": true }), false),
         Response::ContextResult {
             recent,
@@ -989,10 +990,12 @@ mod tests {
         );
         assert!(err.is_error, "error variant sets the isError flag");
 
-        // W3.7: feedback echoes the post-nudge confidence in text + structured.
+        // W3.7: feedback is an ack — JSON in `text` (== structured), like
+        // Updated/Linked/Deleted — echoing the post-nudge confidence.
         let fb = response_to_content(Response::FeedbackRecorded { confidence: 0.4 }, now);
         assert!(!fb.is_error);
-        assert!(fb.text.contains("0.40"), "{}", fb.text);
+        let fb_text: serde_json::Value = serde_json::from_str(&fb.text).unwrap();
+        assert!((fb_text["confidence"].as_f64().unwrap() - 0.4).abs() < 1e-6);
         assert!((fb.structured["confidence"].as_f64().unwrap() - 0.4).abs() < 1e-6);
     }
 

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -286,6 +286,7 @@ mod tests {
                 }
                 Request::Update { .. } => Response::Updated,
                 Request::Link { .. } => Response::Linked,
+                Request::Feedback { .. } => Response::FeedbackRecorded { confidence: 0.7 },
                 Request::Delete { .. } => Response::Deleted,
                 Request::Context => Response::ContextResult {
                     recent: vec![note()],
@@ -411,8 +412,15 @@ mod tests {
         let r = req("tools/list", Some(2), json!({}));
         let resp = handle_request(r, &mut proxy).await.unwrap();
         let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
-        assert_eq!(tools.len(), 5);
-        for name in ["remember", "recall", "get", "context", "update"] {
+        assert_eq!(tools.len(), 6);
+        for name in [
+            "remember",
+            "recall",
+            "get",
+            "context",
+            "update",
+            "memory_feedback",
+        ] {
             assert!(
                 tools.iter().any(|t| t["name"] == name),
                 "default set includes {name}"

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -37,7 +37,14 @@ fn memory_type_enum() -> Value {
 /// Single source of truth for the default advertised set: the installer's
 /// `permissions.allow` allowlist (rb-install) is drift-tested against this, so
 /// every advertised default tool is auto-approved and none stalls a headless run.
-pub const DEFAULT_TOOLS: [&str; 5] = ["remember", "recall", "get", "context", "update"];
+pub const DEFAULT_TOOLS: [&str; 6] = [
+    "remember",
+    "recall",
+    "get",
+    "context",
+    "update",
+    "memory_feedback",
+];
 
 /// True when `RB_MCP_FULL_TOOLSET` is set (to any value): advertise every tool.
 fn full_toolset_enabled() -> bool {
@@ -216,6 +223,26 @@ pub fn tool_definitions() -> Vec<ToolDef> {
             }),
         },
         ToolDef {
+            name: "memory_feedback",
+            description: "Report whether a recalled memory was actually useful. Use AFTER \
+                          acting on a memory recall surfaced: 'helpful' if it helped, \
+                          'wrong' if it was incorrect, 'stale' if it was once right but is \
+                          now outdated. This is the usefulness signal access counts cannot \
+                          capture; it adjusts the memory's trust so future recalls improve.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string",
+                            "description": "Memory id (UUID) the feedback is about." },
+                    "kind": { "type": "string",
+                              "enum": ["helpful", "wrong", "stale"],
+                              "description": "helpful = was useful; wrong = incorrect; \
+                                              stale = outdated." }
+                },
+                "required": ["id", "kind"]
+            }),
+        },
+        ToolDef {
             name: "poll_changes",
             description: "Drain buffered change notifications for the current \
                           namespace since the last poll. Returns up to `max` events, \
@@ -241,7 +268,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn exposes_exactly_the_ten_tools() {
+    fn exposes_exactly_the_eleven_tools() {
         let names: BTreeSet<&str> = tool_definitions().iter().map(|t| t.name).collect();
         let expected: BTreeSet<&str> = [
             "remember",
@@ -253,28 +280,36 @@ mod tests {
             "link",
             "delete",
             "context",
+            "memory_feedback",
             "poll_changes",
         ]
         .into_iter()
         .collect();
         assert_eq!(
             names, expected,
-            "tool set must be the 8 spine tools + link + poll_changes"
+            "tool set must be the 8 spine tools + link + memory_feedback + poll_changes"
         );
-        assert_eq!(tool_definitions().len(), 10);
+        assert_eq!(tool_definitions().len(), 11);
     }
 
     #[test]
     fn advertised_default_set_is_the_token_economy_subset() {
-        // W3.3: by default tools/list advertises only remember/recall/get/
-        // context/update; the rest are gated behind RB_MCP_FULL_TOOLSET.
+        // By default tools/list advertises remember/recall/get/context/update +
+        // memory_feedback (W3.7); the rest are gated behind RB_MCP_FULL_TOOLSET.
         let default: BTreeSet<&str> = advertised_tool_definitions_for(false)
             .iter()
             .map(|t| t.name)
             .collect();
-        let expected: BTreeSet<&str> = ["remember", "recall", "get", "context", "update"]
-            .into_iter()
-            .collect();
+        let expected: BTreeSet<&str> = [
+            "remember",
+            "recall",
+            "get",
+            "context",
+            "update",
+            "memory_feedback",
+        ]
+        .into_iter()
+        .collect();
         assert_eq!(
             default, expected,
             "default tools/list = the W3.3 token-economy subset"

--- a/crates/rb-mcp/src/transport.rs
+++ b/crates/rb-mcp/src/transport.rs
@@ -288,14 +288,14 @@ mod tests {
         assert_eq!(responses[0]["id"], 1);
         assert_eq!(responses[0]["result"]["serverInfo"]["name"], "rusty-brain");
 
-        // tools/list (id 2) — W3.3: the DEFAULT advertised set is 5 tools
-        // (remember/recall/get/context/update); the rest are behind
-        // RB_MCP_FULL_TOOLSET.
+        // tools/list (id 2) — the DEFAULT advertised set is 6 tools
+        // (remember/recall/get/context/update + memory_feedback, W3.7); the
+        // rest are behind RB_MCP_FULL_TOOLSET.
         assert_eq!(responses[1]["id"], 2);
         let expected_tools = if std::env::var_os("RB_MCP_FULL_TOOLSET").is_some() {
-            10
+            11
         } else {
-            5
+            6
         };
         assert_eq!(
             responses[1]["result"]["tools"].as_array().unwrap().len(),
@@ -413,11 +413,11 @@ mod tests {
             "error for over-long line has null id"
         );
         assert_eq!(responses[1]["id"], 11);
-        // W3.3: default advertised toolset is 5 (RB_MCP_FULL_TOOLSET gates the rest).
+        // Default advertised toolset is 6 (RB_MCP_FULL_TOOLSET gates the rest).
         let expected_tools = if std::env::var_os("RB_MCP_FULL_TOOLSET").is_some() {
-            10
+            11
         } else {
-            5
+            6
         };
         assert_eq!(
             responses[1]["result"]["tools"].as_array().unwrap().len(),

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -5,8 +5,8 @@ use crate::frame::{read_frame, write_frame};
 use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
 use crate::{response_error_to_error, Response as Resp};
 use rb_types::{
-    Error, MemoryChanged, MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace, Result,
-    SearchResult,
+    Error, FeedbackKind, MemoryChanged, MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace,
+    Result, SearchResult,
 };
 use std::path::Path;
 use tokio::net::UnixStream;
@@ -378,6 +378,16 @@ impl Client {
         }
     }
 
+    /// Record a usefulness signal about a recalled memory (W3.7). Returns the
+    /// memory's `confidence` after the bounded nudge.
+    pub async fn feedback(&mut self, id: MemoryId, kind: FeedbackKind) -> Result<f32> {
+        let resp = self.request(Request::Feedback { id, kind }).await?;
+        match resp {
+            Resp::FeedbackRecorded { confidence } => Ok(confidence),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
     /// Soft-archive a memory.
     pub async fn delete(&mut self, id: MemoryId) -> Result<()> {
         let resp = self.request(Request::Delete { id }).await?;
@@ -724,6 +734,7 @@ mod wrapper_tests {
                 },
                 Request::Update { .. } => Response::Updated,
                 Request::Link { .. } => Response::Linked,
+                Request::Feedback { .. } => Response::FeedbackRecorded { confidence: 0.7 },
                 Request::Delete { .. } => Response::Deleted,
                 Request::Context => Response::ContextResult {
                     recent: vec![note()],

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -1,6 +1,6 @@
 use rb_types::{
-    JobKind, LinkType, MemoryChanged, MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace,
-    SearchResult,
+    FeedbackKind, JobKind, LinkType, MemoryChanged, MemoryId, MemoryNote, MemoryType,
+    MemoryUpdates, Namespace, SearchResult,
 };
 use serde::{Deserialize, Serialize};
 
@@ -175,6 +175,21 @@ pub enum Request {
     /// Reembed / NamespaceRename. Replies with `Response::Scrubbed`. Additive
     /// variant per the `NamespaceRename` precedent (no CONTRACT_VERSION bump).
     Scrub,
+    /// Record a usefulness signal about a recalled memory (W3.7 / F37): the
+    /// distinct correctness/usefulness signal `access_count` is not (it counts
+    /// "returned", not "useful"). Namespace-scoped like `Update`/`Link` (NOT an
+    /// admin op) — the engine verifies `id` lives in the connection's namespace.
+    /// The daemon records a durable event row + an oplog entry and nudges the
+    /// memory's `confidence` (single-axis coupling, see `FeedbackKind`),
+    /// replying with `Response::FeedbackRecorded { confidence }`. Additive
+    /// variant per the `Link`/`Scrub` precedent: an old daemon fails to decode
+    /// it and closes the connection (no CONTRACT_VERSION bump — the handshake
+    /// version gates the shape of SHARED result types, and a new op the old
+    /// daemon simply does not implement is not such a change).
+    Feedback {
+        id: MemoryId,
+        kind: FeedbackKind,
+    },
 }
 
 /// Aggregate per-channel recall hit-contribution totals (W1.0), surfaced on
@@ -264,6 +279,13 @@ pub enum Response {
         scanned: u64,
         redacted: u64,
         reembed_pending: u64,
+    },
+    /// Acknowledges a `Request::Feedback` (W3.7): `confidence` is the target
+    /// memory's trust prior AFTER the bounded nudge, so the caller can surface
+    /// the effect. Additive variant; old clients never see it because they never
+    /// send the request.
+    FeedbackRecorded {
+        confidence: f32,
     },
     Error {
         kind: String,
@@ -564,6 +586,10 @@ mod tests {
                 merge: true,
             },
             Request::Scrub,
+            Request::Feedback {
+                id: MemoryId::new(),
+                kind: rb_types::FeedbackKind::Wrong,
+            },
         ]
     }
 
@@ -654,6 +680,7 @@ mod tests {
                 vectors: 9,
             },
             Response::Linked,
+            Response::FeedbackRecorded { confidence: 0.4 },
             Response::Scrubbed {
                 scanned: 200,
                 redacted: 3,

--- a/crates/rb-store/migrations/008_memory_feedback.sql
+++ b/crates/rb-store/migrations/008_memory_feedback.sql
@@ -16,16 +16,20 @@
 -- disagree. Purely additive (new table only — no ALTER on `memories`), so the
 -- FTS triggers are untouched and the migration is trigger-safe.
 --
--- No foreign key to `memories(memory_id)`: the codebase does not PRAGMA
--- foreign_keys=ON, `memory_oplog` deliberately carries none either, and
--- memories are soft-deleted (archived, never removed), so a dangling reference
--- cannot arise in practice. The engine verifies the target exists in the
--- caller's namespace before the writer inserts here.
+-- No foreign key to `memories(memory_id)` — even though `foreign_keys=ON` (set
+-- in `SqliteStore::init`): `memory_feedback` is an append-only EVENT LOG, so it
+-- deliberately matches `memory_oplog` (the sibling op log, also FK-free) rather
+-- than the relational tables. Coupling an append-only log to row lifecycle would
+-- fight a future hard purge (W5b); memories are otherwise soft-deleted (archived,
+-- never removed), and the engine + the in-transaction existence check in
+-- `record_feedback` guard against orphan rows. The `kind` CHECK mirrors the
+-- enum-column convention (memories.memory_type, memory_links.link_type) and MUST
+-- stay in lockstep with `rb_types::FeedbackKind::as_str`.
 CREATE TABLE memory_feedback (
   id        INTEGER PRIMARY KEY AUTOINCREMENT,
   memory_id TEXT NOT NULL,
   namespace TEXT NOT NULL,
-  kind      TEXT NOT NULL,            -- helpful|wrong|stale (FeedbackKind::as_str)
+  kind      TEXT NOT NULL CHECK (kind IN ('helpful', 'wrong', 'stale')),  -- FeedbackKind::as_str
   principal TEXT,                     -- the giver (origin_user), or NULL when unknown
   at        INTEGER NOT NULL          -- unix seconds
 );

--- a/crates/rb-store/migrations/008_memory_feedback.sql
+++ b/crates/rb-store/migrations/008_memory_feedback.sql
@@ -1,0 +1,37 @@
+-- 008_memory_feedback.sql (W3.7, F37)
+--
+-- The usefulness signal. `access_count` (migration 001) counts how often a
+-- memory was RETURNED by recall, not whether it was actually USEFUL. This table
+-- records the distinct, explicit signal a caller reports via the
+-- `memory_feedback` MCP tool / `rusty-brain feedback` CLI: helpful | wrong |
+-- stale. It is the non-circular input the W5c per-author trust weighting needs
+-- (aggregate by the target memory's existing provenance columns) and the
+-- positive signal the W1.9 importance recalibration can consume.
+--
+-- One row per feedback EVENT (an event log, not a counter) so a consumer can
+-- reconstruct counts via GROUP BY, weight by recency (`at`), or attribute by
+-- `principal` (the giver) without losing information. Recorded in the SAME
+-- transaction as the confidence nudge + the `memory_oplog` row the daemon
+-- appends (op = 'feedback'), so the durable change log and this table never
+-- disagree. Purely additive (new table only — no ALTER on `memories`), so the
+-- FTS triggers are untouched and the migration is trigger-safe.
+--
+-- No foreign key to `memories(memory_id)`: the codebase does not PRAGMA
+-- foreign_keys=ON, `memory_oplog` deliberately carries none either, and
+-- memories are soft-deleted (archived, never removed), so a dangling reference
+-- cannot arise in practice. The engine verifies the target exists in the
+-- caller's namespace before the writer inserts here.
+CREATE TABLE memory_feedback (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  memory_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  kind      TEXT NOT NULL,            -- helpful|wrong|stale (FeedbackKind::as_str)
+  principal TEXT,                     -- the giver (origin_user), or NULL when unknown
+  at        INTEGER NOT NULL          -- unix seconds
+);
+
+-- Per-memory aggregation (W1.9 helpful tally; W5c per-author rollup joins via
+-- memory_id -> memories provenance).
+CREATE INDEX idx_memory_feedback_memory ON memory_feedback(memory_id);
+-- Namespace-scoped, recency-ordered scans for team-mode trust rollups (W5c).
+CREATE INDEX idx_memory_feedback_ns_at ON memory_feedback(namespace, at);

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -109,6 +109,21 @@ pub trait Store {
     /// Mark `old` as superseded by `new` AND archive `old`, in one transaction.
     /// Fails closed (rolls back) if `new` does not exist (FK on `superseded_by`).
     fn supersede(&self, old: &MemoryId, new: &MemoryId) -> Result<()>;
+    /// Record one usefulness-feedback event for `id` and nudge its `confidence`
+    /// (W3.7): in ONE transaction, append a `memory_feedback` row (kind +
+    /// `principal` giver), clamp `confidence + kind.confidence_delta()` to
+    /// `0.0..=1.0` and UPDATE the row, and append a `memory_oplog` `feedback`
+    /// entry — so the event log, the trust prior, and the durable change log can
+    /// never disagree. Returns the post-nudge `confidence`. A missing id is
+    /// `Error::NotFound` (the daemon already verifies namespace membership, but
+    /// this fails closed independently). `updated_at` is intentionally NOT
+    /// bumped (like `set_confidence`): feedback is not an authorial content edit.
+    fn record_feedback(
+        &self,
+        id: &MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<&str>,
+    ) -> Result<f32>;
     /// Fetch all of `ids` that exist AND belong to `ns`, returned in the SAME
     /// order as `ids` (missing/out-of-namespace ids skipped). One query; fixes
     /// the recall N+1. Links are loaded per returned note.
@@ -2568,6 +2583,61 @@ impl Store for SqliteStore {
         })
     }
 
+    fn record_feedback(
+        &self,
+        id: &MemoryId,
+        kind: rb_types::FeedbackKind,
+        principal: Option<&str>,
+    ) -> Result<f32> {
+        let now = chrono::Utc::now().timestamp();
+        // Transaction: the feedback event row, the confidence nudge, and the
+        // oplog entry commit (or roll back) together — the usefulness signal,
+        // the trust prior, and the durable change log must never disagree.
+        immediate_tx(&self.conn, || {
+            // Read the current confidence + namespace fail-closed: a missing id
+            // is NotFound (the daemon already namespace-checks, but the store
+            // does not depend on that). The namespace rides into the feedback
+            // row and the oplog entry.
+            let row = match self.conn.query_row(
+                "SELECT confidence, namespace FROM memories WHERE memory_id = ?1",
+                rusqlite::params![id.to_string()],
+                |r| Ok((r.get::<_, f64>(0)?, r.get::<_, String>(1)?)),
+            ) {
+                Ok(v) => v,
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    return Err(Error::NotFound(id.clone()))
+                }
+                Err(e) => return Err(Error::Storage(e.to_string())),
+            };
+            let (current, namespace) = row;
+            // Single-axis confidence coupling (W3.7): clamp to the canonical
+            // 0.0..=1.0 range so one nudge can never push the prior out of band.
+            let new_confidence = ((current as f32) + kind.confidence_delta()).clamp(0.0, 1.0);
+            self.conn
+                .execute(
+                    "UPDATE memories SET confidence = ?1 WHERE memory_id = ?2",
+                    rusqlite::params![new_confidence as f64, id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            self.conn
+                .execute(
+                    "INSERT INTO memory_feedback (memory_id, namespace, kind, principal, at)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![id.to_string(), namespace, kind.as_str(), principal, now],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            // Durable oplog entry: the kind + resulting confidence ride in
+            // `details` so a replay/audit can reconstruct the nudge.
+            let details = serde_json::json!({
+                "kind": kind.as_str(),
+                "confidence": new_confidence,
+            })
+            .to_string();
+            append_oplog(&self.conn, &self.site_id, "feedback", id, &details)?;
+            Ok(new_confidence)
+        })
+    }
+
     fn get_many(&self, ns: &Namespace, ids: &[MemoryId]) -> Result<Vec<MemoryNote>> {
         if ids.is_empty() {
             return Ok(Vec::new());
@@ -4579,6 +4649,126 @@ mod update_tests {
         store.set_confidence(&MemoryId::new(), 0.2).unwrap();
         let still = store.get_memory(&m.id).unwrap().unwrap();
         assert!((still.confidence - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
+    fn record_feedback_logs_event_moves_confidence_and_appends_oplog() {
+        use rb_types::FeedbackKind;
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("rb".into());
+        let mut m = MemoryNote::new(ns.clone(), "body".into(), MemoryType::Insight, 5);
+        m.confidence = 0.5;
+        store.insert_memory(&m, None).unwrap();
+
+        // `wrong` lowers confidence by the bounded delta and returns the result.
+        let after = store
+            .record_feedback(&m.id, FeedbackKind::Wrong, Some("alice"))
+            .unwrap();
+        assert!((after - 0.2).abs() < 1e-6, "0.5 - 0.30 = 0.20, got {after}");
+        let got = store.get_memory(&m.id).unwrap().unwrap();
+        assert!(
+            (got.confidence - 0.2).abs() < 1e-6,
+            "row reflects the nudge"
+        );
+
+        // `helpful` raises it back up by its (smaller) delta.
+        let after2 = store
+            .record_feedback(&m.id, FeedbackKind::Helpful, None)
+            .unwrap();
+        assert!(
+            (after2 - 0.25).abs() < 1e-6,
+            "0.20 + 0.05 = 0.25, got {after2}"
+        );
+
+        // Two event rows recorded, with kind + principal preserved (NULL when none).
+        let rows: Vec<(String, Option<String>, String)> = {
+            let mut stmt = store
+                .conn
+                .prepare(
+                    "SELECT kind, principal, namespace FROM memory_feedback
+                     WHERE memory_id = ?1 ORDER BY id",
+                )
+                .unwrap();
+            stmt.query_map(rusqlite::params![m.id.to_string()], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap()
+        };
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0],
+            ("wrong".into(), Some("alice".into()), ns.as_db_string())
+        );
+        assert_eq!(rows[1], ("helpful".into(), None, ns.as_db_string()));
+
+        // Each feedback event appended exactly one `feedback` oplog row.
+        let oplog_feedback: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_oplog WHERE op = 'feedback' AND memory_id = ?1",
+                rusqlite::params![m.id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(oplog_feedback, 2, "one oplog row per feedback event");
+    }
+
+    #[test]
+    fn record_feedback_clamps_confidence_to_the_canonical_range() {
+        use rb_types::FeedbackKind;
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ns = Namespace::Project("rb".into());
+        let mut m = MemoryNote::new(ns, "body".into(), MemoryType::Insight, 5);
+        m.confidence = 1.0;
+        store.insert_memory(&m, None).unwrap();
+
+        // Many `wrong` reports floor at 0.0, never below.
+        let mut last = 1.0;
+        for _ in 0..10 {
+            last = store
+                .record_feedback(&m.id, FeedbackKind::Wrong, None)
+                .unwrap();
+        }
+        assert!(
+            (last - 0.0).abs() < 1e-6,
+            "wrong feedback floors at 0.0, got {last}"
+        );
+
+        // Many `helpful` reports cap at 1.0, never above.
+        let mut hi = 0.0;
+        for _ in 0..40 {
+            hi = store
+                .record_feedback(&m.id, FeedbackKind::Helpful, None)
+                .unwrap();
+        }
+        assert!(
+            (hi - 1.0).abs() < 1e-6,
+            "helpful feedback caps at 1.0, got {hi}"
+        );
+    }
+
+    #[test]
+    fn record_feedback_missing_id_is_not_found_and_writes_nothing() {
+        use rb_types::FeedbackKind;
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let missing = MemoryId::new();
+        let err = store
+            .record_feedback(&missing, FeedbackKind::Helpful, None)
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound(_)), "got {err:?}");
+
+        // Fail-closed: the rolled-back transaction left no event row behind.
+        let count: i64 = store
+            .conn
+            .query_row("SELECT COUNT(*) FROM memory_feedback", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "a NotFound feedback inserts no row");
     }
 
     #[test]

--- a/crates/rb-store/tests/migration_reproducibility.rs
+++ b/crates/rb-store/tests/migration_reproducibility.rs
@@ -152,6 +152,21 @@ fn fresh_db_exercises_every_query_path() {
         "stale FTS token 'concurrent' must be removed when a's content is updated"
     );
 
+    // --- record_feedback: migration 008 memory_feedback table + confidence nudge
+    // (a missing table/column here fails the whole gate, which is the point).
+    let conf_before = store.get_memory(&a.id).unwrap().unwrap().confidence;
+    let conf_after = store
+        .record_feedback(&a.id, rb_types::FeedbackKind::Wrong, Some("alice"))
+        .unwrap();
+    assert!(
+        conf_after < conf_before,
+        "wrong feedback lowers confidence ({conf_before} -> {conf_after})"
+    );
+    assert!(
+        (store.get_memory(&a.id).unwrap().unwrap().confidence - conf_after).abs() < 1e-6,
+        "the row reflects the nudged confidence"
+    );
+
     // --- archive_memory: soft delete; dropped from active list + keyword search
     store.archive_memory(&b.id).unwrap();
     let active_after = store.list(&ns, None, 10).unwrap();

--- a/crates/rb-types/src/feedback_kind.rs
+++ b/crates/rb-types/src/feedback_kind.rs
@@ -1,0 +1,125 @@
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+
+/// A usefulness signal a caller reports about a recalled memory (W3.7, F37).
+///
+/// Distinct from `access_count`, which counts how often a memory was RETURNED,
+/// not whether it was actually useful. `memory_feedback` is the explicit
+/// usefulness/correctness signal the W2.2 confidence machinery and the W5c
+/// per-author trust weighting need.
+///
+/// Serializes in `snake_case` (matching the `JobKind` precedent); the variants
+/// are single lowercase words, so the wire / DB / CLI strings are
+/// `helpful` | `wrong` | `stale`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeedbackKind {
+    /// The memory was useful in the context it was recalled into.
+    Helpful,
+    /// The memory is incorrect — strong evidence against its trustworthiness.
+    Wrong,
+    /// The memory was once correct but is now outdated.
+    Stale,
+}
+
+impl FeedbackKind {
+    /// Stable string form used by the CLI `--kind` argument, the MCP tool enum,
+    /// and the `memory_oplog` / `memory_feedback` `kind` column. MUST stay in
+    /// lockstep with the `serde(rename_all = "snake_case")` form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FeedbackKind::Helpful => "helpful",
+            FeedbackKind::Wrong => "wrong",
+            FeedbackKind::Stale => "stale",
+        }
+    }
+
+    /// Parse a CLI/MCP/db string into a `FeedbackKind`. Fail closed on unknown
+    /// values (the `JobKind` precedent: a parse failure is `InvalidArgument`, so
+    /// no dedicated `Error` variant or `error_map` arm is needed — the parse
+    /// result is consumed at the CLI/MCP boundary, never travels the wire).
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "helpful" => Ok(FeedbackKind::Helpful),
+            "wrong" => Ok(FeedbackKind::Wrong),
+            "stale" => Ok(FeedbackKind::Stale),
+            other => Err(Error::InvalidArgument(format!(
+                "unknown feedback kind: {other} (expected helpful, wrong, or stale)"
+            ))),
+        }
+    }
+
+    /// The bounded confidence nudge this feedback applies to the target memory's
+    /// trust prior (W3.7 confidence coupling — single-axis: all three kinds move
+    /// `confidence`). `helpful` raises it toward full trust; `wrong`/`stale`
+    /// lower it, `wrong` more sharply than `stale` (incorrect outweighs merely
+    /// outdated). The store clamps `confidence + delta` to the canonical
+    /// `0.0..=1.0` range, so a single nudge can never push a memory out of range
+    /// and several `wrong` reports are required to fully erode trust.
+    pub fn confidence_delta(&self) -> f32 {
+        match self {
+            FeedbackKind::Helpful => 0.05,
+            FeedbackKind::Wrong => -0.30,
+            FeedbackKind::Stale => -0.15,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    const ALL: [FeedbackKind; 3] = [
+        FeedbackKind::Helpful,
+        FeedbackKind::Wrong,
+        FeedbackKind::Stale,
+    ];
+
+    #[test]
+    fn serde_uses_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&FeedbackKind::Helpful).unwrap(),
+            r#""helpful""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FeedbackKind::Wrong).unwrap(),
+            r#""wrong""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FeedbackKind::Stale).unwrap(),
+            r#""stale""#
+        );
+    }
+
+    #[test]
+    fn parse_is_inverse_of_as_str_for_all_variants() {
+        for kind in ALL {
+            assert_eq!(FeedbackKind::parse(kind.as_str()).unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn serde_round_trips_all_variants() {
+        for kind in ALL {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: FeedbackKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown() {
+        let err = FeedbackKind::parse("useless").unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn helpful_raises_and_wrong_stale_lower_with_wrong_sharpest() {
+        assert!(FeedbackKind::Helpful.confidence_delta() > 0.0);
+        assert!(FeedbackKind::Wrong.confidence_delta() < 0.0);
+        assert!(FeedbackKind::Stale.confidence_delta() < 0.0);
+        // `wrong` (incorrect) erodes trust more sharply than `stale` (outdated).
+        assert!(FeedbackKind::Wrong.confidence_delta() < FeedbackKind::Stale.confidence_delta());
+    }
+}

--- a/crates/rb-types/src/feedback_kind.rs
+++ b/crates/rb-types/src/feedback_kind.rs
@@ -25,7 +25,8 @@ pub enum FeedbackKind {
 impl FeedbackKind {
     /// Stable string form used by the CLI `--kind` argument, the MCP tool enum,
     /// and the `memory_oplog` / `memory_feedback` `kind` column. MUST stay in
-    /// lockstep with the `serde(rename_all = "snake_case")` form.
+    /// lockstep with the `serde(rename_all = "snake_case")` form AND the
+    /// `migration 008` `CHECK (kind IN (...))` constraint.
     pub fn as_str(&self) -> &'static str {
         match self {
             FeedbackKind::Helpful => "helpful",

--- a/crates/rb-types/src/lib.rs
+++ b/crates/rb-types/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod change;
 mod error;
+mod feedback_kind;
 mod job;
 mod link;
 mod link_type;
@@ -19,6 +20,7 @@ mod validate;
 
 pub use change::{ChangeKind, MemoryChanged};
 pub use error::{Error, Result};
+pub use feedback_kind::FeedbackKind;
 pub use job::JobKind;
 pub use link::{MemoryLink, SIMILARITY_LINK_MAX_COSINE_DISTANCE};
 pub use link_type::LinkType;

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -1,11 +1,16 @@
 //! Command-line surface for the `rusty-brain` binary (clap derive).
 
 use clap::{value_parser, Parser, Subcommand};
-use rb_types::{LinkType, MemoryType};
+use rb_types::{FeedbackKind, LinkType, MemoryType};
 
 /// Parse a `--type` value into a `MemoryType` using the canonical db strings.
 fn parse_memory_type(s: &str) -> Result<MemoryType, String> {
     MemoryType::parse(s).map_err(|e| e.to_string())
+}
+
+/// Parse a feedback `--kind` value into a `FeedbackKind` (helpful|wrong|stale).
+fn parse_feedback_kind(s: &str) -> Result<FeedbackKind, String> {
+    FeedbackKind::parse(s).map_err(|e| e.to_string())
 }
 
 /// Parse a link `--type` value into a `LinkType` using the canonical db strings.
@@ -171,6 +176,16 @@ pub enum Command {
         /// Why this link exists (stored on the edge).
         #[arg(long)]
         reason: Option<String>,
+    },
+
+    /// Record a usefulness signal about a memory (W3.7): `helpful`, `wrong`, or
+    /// `stale`. Nudges the memory's trust prior so future recalls improve.
+    Feedback {
+        /// Memory id (UUID) the feedback is about.
+        id: String,
+        /// Feedback kind: `helpful`, `wrong`, or `stale`.
+        #[arg(long = "kind", value_parser = parse_feedback_kind)]
+        kind: FeedbackKind,
     },
 
     /// Soft-delete (archive) a memory.

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -456,6 +456,32 @@ mod tests {
     }
 
     #[test]
+    fn feedback_parses_id_and_kind() {
+        let id = "0c8e7f76-3a4f-4f7e-9d3a-111111111111";
+        let cli = Cli::parse_from(["rusty-brain", "feedback", id, "--kind", "wrong"]);
+        match cli.command {
+            Command::Feedback { id: got, kind } => {
+                assert_eq!(got, id);
+                assert_eq!(kind, FeedbackKind::Wrong);
+            }
+            other => panic!("expected Feedback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn feedback_rejects_unknown_kind_and_requires_it() {
+        // An invalid --kind fails at parse time (value_parser = parse_feedback_kind).
+        let res = Cli::try_parse_from(["rusty-brain", "feedback", "an-id", "--kind", "useless"]);
+        assert!(
+            res.is_err(),
+            "unknown --kind must be rejected at parse time"
+        );
+        // --kind is required.
+        let res = Cli::try_parse_from(["rusty-brain", "feedback", "an-id"]);
+        assert!(res.is_err(), "--kind is required for feedback");
+    }
+
+    #[test]
     fn parses_scrub_subcommand() {
         let cli = Cli::parse_from(["rusty-brain", "scrub"]);
         assert!(

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -126,6 +126,15 @@ pub fn render_linked(json: bool) -> String {
     }
 }
 
+/// Render a successful feedback acknowledgement, echoing the post-nudge trust prior.
+pub fn render_feedback(confidence: f32, json: bool) -> String {
+    if json {
+        format!("{{\"confidence\":{confidence}}}")
+    } else {
+        format!("Feedback recorded (confidence now {confidence:.2})")
+    }
+}
+
 /// Render a successful delete acknowledgement.
 pub fn render_deleted(json: bool) -> String {
     if json {
@@ -343,6 +352,14 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(parsed["deleted"].as_bool(), Some(true));
         assert_eq!(render_deleted(false), "Deleted");
+    }
+
+    #[test]
+    fn feedback_renders_confidence_in_both_modes() {
+        let json = render_feedback(0.4, true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!((parsed["confidence"].as_f64().unwrap() - 0.4).abs() < 1e-6);
+        assert!(render_feedback(0.4, false).contains("0.40"));
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -198,6 +198,11 @@ async fn run_client(
                 .context("link failed")?;
             println!("{}", output::render_linked(json));
         }
+        Command::Feedback { id, kind } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let confidence = client.feedback(id, kind).await.context("feedback failed")?;
+            println!("{}", output::render_feedback(confidence, json));
+        }
         Command::Delete { id } => {
             let id = parse_id(&id).context("invalid memory id")?;
             client.delete(id).await.context("delete failed")?;

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -244,6 +244,49 @@ Target: claudecode →8.5. This phase was redesigned after critique — the orig
   stays the W3.2 installer for now, not yet the "thin wrapper preferring native
   channels" (that step is APM-dependent).
 
+**Phase-3 progress — W3.7 usefulness signal / `memory_feedback` (landed 2026-06-14, 1161 tests green):**
+
+- *The distinct usefulness signal:* a new `memory_feedback` MCP tool +
+  `rusty-brain feedback <id> --kind <helpful|wrong|stale>` CLI report whether a
+  recalled memory was actually useful — the signal `access_count` (which counts
+  "returned", not "useful") cannot provide. `FeedbackKind` lives in `rb-types`
+  (snake_case serde + `parse`→`InvalidArgument`, the `JobKind` precedent;
+  `confidence_delta()` carries the coupling policy). Wired end to end:
+  `Request::Feedback { id, kind }` + `Response::FeedbackRecorded { confidence }`
+  (new variants, NO `CONTRACT_VERSION` bump — the `Link`/`Scrub` precedent: an
+  old daemon fails to decode a new op and closes; the handshake version gates the
+  shape of SHARED result types, which this is not). Namespace-scoped, NOT an
+  admin op — the engine verifies the target lives in the connection's namespace.
+- *Storage (event log, not a counter):* migration `008_memory_feedback.sql`
+  adds a `memory_feedback` table — one row per event (`memory_id`, `namespace`,
+  `kind`, `principal` = the giver's `origin_user`, `at`). Purely additive (no
+  `ALTER` on `memories`, so the FTS triggers are untouched). It is the
+  non-circular input W5c per-author trust weighting needs (aggregate by the
+  target memory's existing provenance via `GROUP BY`) and the positive signal
+  W1.9 importance recalibration can consume. `Store::record_feedback` writes the
+  event row + the confidence nudge + a `memory_oplog` `feedback` entry in ONE
+  transaction, so the event log, the trust prior, and the durable change log can
+  never disagree (the `set_confidence`/`supersede` precedent); `updated_at` is
+  deliberately not bumped (feedback is not an authorial content edit). The daemon
+  routes it through the single writer (`WriteCommand::RecordFeedback`, typed
+  `Result<f32>` reply via the `RenameNamespace`/`Scrub` outcome-capture pattern)
+  and publishes an `Updated` change event.
+- *Confidence coupling (single trust axis):* all three kinds move `confidence`,
+  clamped to `0.0..=1.0` — `helpful` +0.05 (toward full trust), `stale` −0.15,
+  `wrong` −0.30 (incorrect erodes trust more sharply than merely outdated). A
+  single nudge can never push the prior out of range, and several `wrong` reports
+  are required to fully erode trust. This unblocks W2.2's confidence producer,
+  W5c's non-circular trust input, and W1.9's importance recalibration (which
+  ships disabled until a separate activation, now that its usefulness signal
+  exists).
+- *Tool surface:* `memory_feedback` joins `DEFAULT_TOOLS` (advertised by default,
+  not gated behind `RB_MCP_FULL_TOOLSET`) — the signal only accumulates if the
+  model actually calls it after recall, which is the whole point. The
+  `DEFAULT_TOOLS`↔`MCP_ALLOW_ENTRIES`↔committed `.claude/settings.json` drift
+  guards forced the allowlist + committed-config updates in lockstep; the
+  token-accounting CI test confirms the 6-tool default `tools/list` stays under
+  the 900-token budget. F37 closed.
+
 ---
 
 ## 7. Phase 4 — Prove it: eval gates, perf, fuzz

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -244,7 +244,7 @@ Target: claudecode →8.5. This phase was redesigned after critique — the orig
   stays the W3.2 installer for now, not yet the "thin wrapper preferring native
   channels" (that step is APM-dependent).
 
-**Phase-3 progress — W3.7 usefulness signal / `memory_feedback` (landed 2026-06-14, 1161 tests green):**
+**Phase-3 progress — W3.7 usefulness signal / `memory_feedback` (landed 2026-06-14, 1164 tests green):**
 
 - *The distinct usefulness signal:* a new `memory_feedback` MCP tool +
   `rusty-brain feedback <id> --kind <helpful|wrong|stale>` CLI report whether a
@@ -286,6 +286,13 @@ Target: claudecode →8.5. This phase was redesigned after critique — the orig
   guards forced the allowlist + committed-config updates in lockstep; the
   token-accounting CI test confirms the 6-tool default `tools/list` stays under
   the 900-token budget. F37 closed.
+- *Adversarial review (6-dimension fan-out + per-finding verification):* 2
+  findings confirmed, both fixed. (1) feedback on an ARCHIVED memory now returns
+  `NotFound` at the engine level (the `graph` active-scope rule) — feedback is
+  about live, recallable memories, so an archived target is a caller error,
+  avoiding a pointless confidence nudge + `Updated` event on a soft-deleted row.
+  (2) added CLI clap-parse tests for the `feedback` command (valid kind parses;
+  unknown/missing `--kind` rejected at parse time).
 
 ---
 


### PR DESCRIPTION
## W3.7 — Usefulness signal (`memory_feedback`)

Closes the last self-contained Phase-3 work item (F37). Adds the explicit
usefulness/correctness signal `access_count` cannot provide (it counts
*returned*, not *useful*): a `memory_feedback` MCP tool + `rusty-brain feedback
<id> --kind helpful|wrong|stale` CLI that record whether a recalled memory was
actually useful and nudge its trust prior.

Unblocks **W2.2** (confidence producer), **W5c** (non-circular per-author trust
input), and **W1.9** (importance recalibration's positive signal).

### Design decisions
- **Single trust axis:** all three kinds move `confidence`, clamped `0.0..=1.0` —
  `helpful` +0.05, `stale` −0.15, `wrong` −0.30 (incorrect erodes trust more
  sharply than merely outdated). A single nudge can never leave the valid range.
- **Dedicated event-log table** (`memory_feedback`): one row per event with the
  giver (`principal`) + namespace, so W5c can aggregate per author non-circularly
  (the table is the raw signal; confidence is derived from it, never the reverse).
- **Advertised by default:** the tool joins `DEFAULT_TOOLS` — the signal only
  accumulates if the model actually calls it after recall.

### Wire protocol
`Request::Feedback { id, kind }` + `Response::FeedbackRecorded { confidence }` are
**new variants, no `CONTRACT_VERSION` bump** (the `Link`/`Scrub` precedent: an old
daemon fails to decode a new op and closes; the handshake version gates the shape
of *shared result types*, which this is not). Namespace-scoped, **not** an admin op.

### Storage & atomicity
Migration `008_memory_feedback.sql` is purely additive (no `ALTER` on `memories`,
so the FTS triggers are untouched). `Store::record_feedback` writes the event row
+ the clamped confidence nudge + a `memory_oplog` `feedback` entry in **one
transaction** (the `set_confidence`/`supersede` precedent), so the event log, the
trust prior, and the durable change log can never disagree. Routed through the
single writer (`WriteCommand::RecordFeedback`, typed reply via the
`RenameNamespace`/`Scrub` outcome-capture pattern).

### Adversarial review
6-dimension fan-out + per-finding verification → 2 findings confirmed, both fixed:
- feedback on an **archived** memory now returns `NotFound` at the engine level
  (the `graph` active-scope rule) — feedback is about live/recallable memories.
- added CLI clap-parse tests for the `feedback` command.

### Touchpoints
`rb-types` (FeedbackKind) · `rb-proto` (variants + Client::feedback) · `rb-store`
(migration + record_feedback) · `rb-engine` (trait + engine.feedback across all
backends) · `rb-daemon` (writer + dispatch) · `rb-mcp` (tool + DEFAULT_TOOLS +
routing) · `rb-install` + committed `.claude/settings.json` (drift guards) ·
`rusty-brain` CLI.

**1164 tests green** · `cargo fmt` clean · `clippy --workspace --all-targets`
clean · token-accounting CI test confirms the 6-tool default `tools/list` stays
under the 900-token budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory feedback functionality: users can now rate recalled memories as `helpful`, `wrong`, or `stale` via the new `memory_feedback` MCP tool or `rusty-brain feedback` CLI command.
  * Memory confidence scores are automatically adjusted based on feedback, improving future recall quality.

* **Documentation**
  * Updated README to reflect the expanded tool catalog and feedback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->