### PR TITLE
feat(p3): W3.5 A/B outcome-eval harness

### DIFF
--- a/.github/workflows/w35-ab-eval.yml
+++ b/.github/workflows/w35-ab-eval.yml
@@ -14,14 +14,18 @@
 # success it closes that issue if open.
 #
 # Required repository secret:
-#   ANTHROPIC_API_KEY — an Anthropic API key with a small spend budget. Each
-#   WORK session runs `--model haiku --max-budget-usd 0.50`; a scheduled run is
-#   12 scenarios x N runs x up to 4 sessions, so budget a few dollars/night at
-#   N=2. Until the secret is configured, the run fails fast on preflight.
+#   ANTHROPIC_API_KEY — an Anthropic API key with a spend budget. Each WORK
+#   session runs `--model haiku --max-budget-usd 0.50` (a hard per-session cap).
+#   Until the secret is configured, the run fails fast on preflight.
 #
-# COST/TIME: bounded by the per-session cap and `--runs` (default 2 here). A full
-# run takes tens of minutes; raise `runs` via workflow_dispatch for a deeper
-# sample when closing the gate.
+# COST/TIME: a run is 12 scenarios x N runs x ~4 sessions/run (memory-on plant +
+# work, plus a supersede for the 2 stale-traps; claude-md + memory-off each 1
+# work). The SCHEDULED run uses N=1 (~50 sessions) to stay inside the time/cost
+# envelope: worst-case spend is bounded by the $0.50 cap x sessions (~$25;
+# typical haiku spend is far lower, a few dollars), and wall-clock is ~1-2h at
+# 1-2 min/session. Closing the gate wants stochasticity — trigger a deeper
+# N>=3 sample via workflow_dispatch (allow it more time; the per-session timeout
+# in the script protects against hangs).
 name: nightly w35 a/b eval
 
 on:
@@ -30,9 +34,9 @@ on:
   workflow_dispatch:
     inputs:
       runs:
-        description: "runs per scenario (stochasticity sample)"
+        description: "runs per scenario (stochasticity sample; 3+ to close the gate)"
         required: false
-        default: "2"
+        default: "3"
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,7 +51,7 @@ jobs:
     # only meaningful on the canonical repo.
     if: github.repository == 'brianluby/rusty-brain'
     runs-on: macos-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     permissions:
       contents: read
       issues: write # open/update/close the alert issue
@@ -87,7 +91,7 @@ jobs:
         run: |
           scripts/w35-ab-eval.sh \
             --bin-dir target/release \
-            --runs "${{ github.event.inputs.runs || '2' }}" \
+            --runs "${{ github.event.inputs.runs || '1' }}" \
             --out "${RUNNER_TEMP}/w35-report.tsv"
 
       # Upload ONLY the structured TSV report (scenario/arm/run/success/turns/

--- a/.github/workflows/w35-ab-eval.yml
+++ b/.github/workflows/w35-ab-eval.yml
@@ -88,10 +88,17 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RB_W35_MAX_BUDGET_USD: "0.50"
+          # Pass the dispatch input via env (never interpolate ${{ }} directly
+          # into the shell) and validate it's a positive integer before use, so a
+          # crafted dispatch value cannot inject shell (zizmor template-injection).
+          RUNS_INPUT: ${{ github.event.inputs.runs || '1' }}
         run: |
+          case "$RUNS_INPUT" in
+            ''|*[!0-9]*|0) echo "::error::'runs' must be a positive integer (got '$RUNS_INPUT')"; exit 1 ;;
+          esac
           scripts/w35-ab-eval.sh \
             --bin-dir target/release \
-            --runs "${{ github.event.inputs.runs || '1' }}" \
+            --runs "$RUNS_INPUT" \
             --out "${RUNNER_TEMP}/w35-report.tsv"
 
       # Upload ONLY the structured TSV report (scenario/arm/run/success/turns/

--- a/.github/workflows/w35-ab-eval.yml
+++ b/.github/workflows/w35-ab-eval.yml
@@ -1,0 +1,139 @@
+# Phase-3 gate: nightly W3.5 A/B outcome eval (plan §6 / W3.5; F56).
+#
+# Drives scripts/w35-ab-eval.sh on macOS against freshly built binaries with the
+# real `claude` CLI. For each scenario it runs the same WORK task under three
+# arms — memory-on / memory-off / claude-md-only — and judges the outcome
+# deterministically, proving (or disproving) that rusty-brain memory makes the
+# agent DO BETTER than no memory AND than the native CLAUDE.md baseline, with
+# zero memory-induced errors. This is the gate's "memory-on beats memory-off AND
+# CLAUDE.md-only" clause.
+#
+# ALLOWED TO FAIL, WITH ALERTING: scheduled-only (plus manual dispatch); NEVER
+# gates PRs (it is nondeterministic and costs API spend). On failure it opens —
+# or comments on — a pinned issue titled "nightly w35 a/b eval failing"; on
+# success it closes that issue if open.
+#
+# Required repository secret:
+#   ANTHROPIC_API_KEY — an Anthropic API key with a small spend budget. Each
+#   WORK session runs `--model haiku --max-budget-usd 0.50`; a scheduled run is
+#   12 scenarios x N runs x up to 4 sessions, so budget a few dollars/night at
+#   N=2. Until the secret is configured, the run fails fast on preflight.
+#
+# COST/TIME: bounded by the per-session cap and `--runs` (default 2 here). A full
+# run takes tens of minutes; raise `runs` via workflow_dispatch for a deeper
+# sample when closing the gate.
+name: nightly w35 a/b eval
+
+on:
+  schedule:
+    - cron: "37 9 * * *" # nightly, offset from the claude-smoke job (08:23)
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "runs per scenario (stochasticity sample)"
+        required: false
+        default: "2"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  ab-eval:
+    name: w35 a/b outcome eval (macOS)
+    # Scheduled runs on forks would burn someone else's API budget; the eval is
+    # only meaningful on the canonical repo.
+    if: github.repository == 'brianluby/rusty-brain'
+    runs-on: macos-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      issues: write # open/update/close the alert issue
+    steps:
+      - name: Preflight - require the ANTHROPIC_API_KEY secret
+        env:
+          HAVE_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          if [ "$HAVE_KEY" != "true" ]; then
+            echo "::error::repository secret ANTHROPIC_API_KEY is not configured; the W3.5 A/B eval cannot run. See the header comment in .github/workflows/w35-ab-eval.yml."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build release binaries
+        run: cargo build --release --locked -p rusty-brain -p rb-hooks -p rb-install
+
+      # DELIBERATELY UNPINNED (recorded trade-off, same as the claude-smoke job):
+      # tracking whatever version npm serves is the point of an eval against the
+      # real CLI. Exposure is bounded by the per-session spend cap.
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Run the W3.5 A/B eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RB_W35_MAX_BUDGET_USD: "0.50"
+        run: |
+          scripts/w35-ab-eval.sh \
+            --bin-dir target/release \
+            --runs "${{ github.event.inputs.runs || '2' }}" \
+            --out "${RUNNER_TEMP}/w35-report.tsv"
+
+      # Upload ONLY the structured TSV report (scenario/arm/run/success/turns/
+      # cost/mie columns — no model free-text), so unlike the smoke there is no
+      # session-output artifact that could carry a leaked key. The aggregate
+      # report + PASS/FAIL is in the job log (auto-masked by GitHub).
+      - name: Upload the A/B report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: w35-ab-eval-report
+          path: ${{ runner.temp }}/w35-report.tsv
+          if-no-files-found: ignore
+
+      - name: Open or update the alert issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="nightly w35 a/b eval failing"
+          body="Nightly W3.5 A/B outcome eval failed: ${RUN_URL} (Phase-3 gate eval, allowed-to-fail; see .github/workflows/w35-ab-eval.yml)."
+          number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == "nightly w35 a/b eval failing")][0].number // empty')"
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            url="$(gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body")"
+            number="${url##*/}"
+            gh issue pin "$number" --repo "$GITHUB_REPOSITORY" \
+              || echo "could not pin issue #$number; it is open and titled '$title'"
+          fi
+
+      - name: Close the alert issue on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == "nightly w35 a/b eval failing")][0].number // empty')"
+          if [ -n "$number" ]; then
+            gh issue close "$number" --repo "$GITHUB_REPOSITORY" \
+              --comment "Recovered: ${RUN_URL}"
+          fi

--- a/crates/rb-eval/scorecard/w35_ab_scenarios.json
+++ b/crates/rb-eval/scorecard/w35_ab_scenarios.json
@@ -1,0 +1,123 @@
+{
+  "_about": "W3.5 A/B outcome-eval scenarios (plan §6 / W3.5). Each scenario is a planted project DECISION plus a later WORK task where that decision matters. The runner (scripts/w35-ab-eval.sh) executes the WORK task under THREE arms and judges the outcome deterministically: (1) memory-on — rusty-brain hooks+MCP installed, a PLANT session stores the decision, the WORK session recalls it; (2) memory-off — no rusty-brain, no decision available anywhere (the floor); (3) claude-md-only — no rusty-brain, but the decision is written into the project CLAUDE.md (the NATIVE baseline F56 demands a win over). Decisions are deliberately NON-OBVIOUS (the project's choice differs from a cold model's default) so the arms actually diverge. Judge: the WORK output (final answer + files written) must contain `expect` (decision honored) and not `forbid` (the default the decision overrode); matching is case-insensitive substring. `stale_trap` scenarios additionally plant a SUPERSEDING decision; in the memory-on arm, `stale_token` appearing in the WORK output means the model acted on a stale/wrong memory (a memory-induced error — enumerated per run, never averaged away). Pass: memory-on success_rate >= both baselines AND (strictly beats each baseline on success OR fewer turns) AND zero memory-induced errors. See docs/eval/2026-06-14-w35-ab-eval.md.",
+  "config": {
+    "runs_per_scenario": 3,
+    "memory_induced_errors_allowed": 0
+  },
+  "scenarios": [
+    {
+      "id": "dep-http-ureq",
+      "topic": "HTTP client dependency",
+      "plant": "Decision for this project: use the `ureq` crate for all outbound HTTP. We deliberately do NOT use reqwest (we want a tiny blocking client, no async runtime pulled in).",
+      "claude_md": "HTTP: use the `ureq` crate for all outbound HTTP. Do not use reqwest.",
+      "work": "Add a small helper that performs an HTTP GET to a JSON health endpoint and parses the `status` field. Name the HTTP crate it should use and show the dependency line.",
+      "expect": "ureq",
+      "forbid": "reqwest"
+    },
+    {
+      "id": "dep-async-smol",
+      "topic": "async runtime",
+      "plant": "Architecture decision: this project's async runtime is `smol`. Do not add tokio — we keep the dependency tree small and smol is what everything else uses.",
+      "claude_md": "Async runtime: this project uses `smol`. Do not introduce tokio.",
+      "work": "I need to spawn a background task that periodically flushes a buffer. Which runtime API should I use and how do I spawn it?",
+      "expect": "smol",
+      "forbid": "tokio"
+    },
+    {
+      "id": "id-type-ulid",
+      "topic": "identifier type",
+      "plant": "Convention: every entity identifier in this codebase is a `Ulid` (lexicographically sortable). We do not use Uuid or autoincrement integers for entity ids.",
+      "claude_md": "Identifiers: entity ids are `Ulid`, never Uuid or integer ids.",
+      "work": "Add a new `Order` struct that needs a unique id field. What type should the id be?",
+      "expect": "ulid",
+      "forbid": "uuid"
+    },
+    {
+      "id": "ser-msgpack",
+      "topic": "wire serialization format",
+      "plant": "Decision: our internal wire format is MessagePack via `rmp-serde`. We do not serialize messages to JSON on the wire (JSON is only for human-facing CLI output).",
+      "claude_md": "Wire format: serialize messages with MessagePack (`rmp-serde`), not JSON.",
+      "work": "Add serialization for a new `Envelope` message type that goes over our internal socket. Which serializer should it use?",
+      "expect": "rmp",
+      "forbid": "serde_json"
+    },
+    {
+      "id": "err-apperror",
+      "topic": "error-handling convention",
+      "plant": "House rule: all fallible functions return our `AppError` type via the `?` operator. Never `.unwrap()` or `.expect()` in library code — clippy denies them.",
+      "claude_md": "Errors: return the project's `AppError` via `?`. No `.unwrap()`/`.expect()` in library code.",
+      "work": "Write a function that reads a required port number from an environment variable and returns it. Use our error convention.",
+      "expect": "apperror",
+      "forbid": ".unwrap()"
+    },
+    {
+      "id": "log-tracing",
+      "topic": "logging facility",
+      "plant": "Logging decision: use the `tracing` crate with structured fields everywhere. Plain `println!`/`eprintln!` for diagnostics is banned outside the CLI's user-facing output.",
+      "claude_md": "Logging: use `tracing` with structured fields. Do not use println!/eprintln! for diagnostics.",
+      "work": "Add diagnostic logging to a function that retries a network call, recording the attempt number. How should it log?",
+      "expect": "tracing",
+      "forbid": "println!"
+    },
+    {
+      "id": "time-unix-millis",
+      "topic": "timestamp storage",
+      "plant": "Decision: store all timestamps as UTC Unix milliseconds in an `i64` column. We do not store RFC3339/ISO-8601 strings in the database.",
+      "claude_md": "Timestamps: store as UTC Unix milliseconds (`i64`), never RFC3339 strings.",
+      "work": "Add a `created_at` field to a record that we persist to the database. What type and representation should it use?",
+      "expect": "milli",
+      "forbid": "rfc3339"
+    },
+    {
+      "id": "config-settings-toml",
+      "topic": "configuration source",
+      "plant": "Decision: all runtime configuration is read from a single `settings.toml` file. New knobs go in `settings.toml` — never scattered environment variables.",
+      "claude_md": "Config: all runtime configuration comes from `settings.toml`. Do not read config from environment variables.",
+      "work": "We need a new `max_connections` knob. Where should it be defined and how is it read?",
+      "expect": "settings.toml",
+      "forbid": "env::var"
+    },
+    {
+      "id": "arch-single-writer",
+      "topic": "concurrency architecture",
+      "plant": "Architecture: the store has a single writer thread reached through `WriterHandle`. No other code path may open the database for writing — all mutations go through the handle.",
+      "claude_md": "Writes: all database mutations go through the single-writer `WriterHandle`. Never open the DB for writing elsewhere.",
+      "work": "Add a maintenance task that prunes rows older than 30 days. How should it perform its deletes?",
+      "expect": "writerhandle",
+      "forbid": "open the database directly"
+    },
+    {
+      "id": "test-prefix-spec",
+      "topic": "test naming convention",
+      "plant": "Test convention: every test function name is prefixed with `spec_` and describes the behavior, e.g. `spec_rejects_empty_input`. Do not use a `test_` prefix.",
+      "claude_md": "Tests: prefix every test function name with `spec_` (e.g. `spec_rejects_empty_input`), not `test_`.",
+      "work": "Add a unit test for a function that validates an email address contains an `@`. Name the test function per our convention.",
+      "expect": "spec_",
+      "forbid": "fn test_"
+    },
+    {
+      "id": "stale-trap-http-switch",
+      "topic": "superseded HTTP client decision",
+      "stale_trap": true,
+      "plant": "For HTTP in this project we use the `reqwest` crate.",
+      "supersede": "Update: we have migrated off reqwest. All HTTP now uses the `ureq` crate — do NOT add reqwest to anything new; reqwest is being removed.",
+      "claude_md": "HTTP: use the `ureq` crate. (We migrated off reqwest; do not use reqwest.)",
+      "work": "Add a helper that performs an HTTP GET and returns the body. Which HTTP crate should it use?",
+      "expect": "ureq",
+      "forbid": "reqwest",
+      "stale_token": "reqwest"
+    },
+    {
+      "id": "stale-trap-config-rename",
+      "topic": "superseded config-path decision",
+      "stale_trap": true,
+      "plant": "Project configuration lives in a file named `app.toml` at the repo root.",
+      "supersede": "Update: we renamed the config file from `app.toml` to `config/settings.toml`. `app.toml` no longer exists — always read configuration from `config/settings.toml`.",
+      "claude_md": "Config: read configuration from `config/settings.toml`. (Renamed from app.toml, which no longer exists.)",
+      "work": "Add code that loads a new `timeout_secs` setting at startup. Which config file path should it read from?",
+      "expect": "config/settings.toml",
+      "forbid": "app.toml",
+      "stale_token": "app.toml"
+    }
+  ]
+}

--- a/crates/rb-eval/scorecard/w35_ab_scenarios.json
+++ b/crates/rb-eval/scorecard/w35_ab_scenarios.json
@@ -1,5 +1,5 @@
 {
-  "_about": "W3.5 A/B outcome-eval scenarios (plan §6 / W3.5). Each scenario is a planted project DECISION plus a later WORK task where that decision matters. The runner (scripts/w35-ab-eval.sh) executes the WORK task under THREE arms and judges the outcome deterministically: (1) memory-on — rusty-brain hooks+MCP installed, a PLANT session stores the decision, the WORK session recalls it; (2) memory-off — no rusty-brain, no decision available anywhere (the floor); (3) claude-md-only — no rusty-brain, but the decision is written into the project CLAUDE.md (the NATIVE baseline F56 demands a win over). Decisions are deliberately NON-OBVIOUS (the project's choice differs from a cold model's default) so the arms actually diverge. Judge: the WORK output (final answer + files written) must contain `expect` (decision honored) and not `forbid` (the default the decision overrode); matching is case-insensitive substring. `stale_trap` scenarios additionally plant a SUPERSEDING decision and deliberately set NO `forbid` (the superseded value will appear in any correct explanation of the migration, so it must not fail success); a memory-induced error is recorded only when the WORK task FAILED (expect absent) AND `stale_token` is present in the memory-on arm — i.e. the model actually produced the stale value instead of the current one (enumerated per run, never averaged away). Pass: memory-on success_rate >= both baselines AND (strictly beats each baseline on success OR fewer turns) AND zero memory-induced errors. See docs/eval/2026-06-14-w35-ab-eval.md.",
+  "_about": "W3.5 A/B outcome-eval scenarios (plan §6 / W3.5). Each scenario is a planted project DECISION plus a later WORK task where that decision matters. The runner (scripts/w35-ab-eval.sh) executes the WORK task under THREE arms and judges the outcome deterministically: (1) memory-on — rusty-brain hooks+MCP installed, a PLANT session stores the decision, the WORK session recalls it; (2) memory-off — no rusty-brain, no decision available anywhere (the floor); (3) claude-md-only — no rusty-brain, but the decision is written into the project CLAUDE.md (the NATIVE baseline F56 demands a win over). Decisions are deliberately NON-OBVIOUS (the project's choice differs from a cold model's default) so the arms actually diverge. Judge: EXPECT-ONLY (case-insensitive substring). Success = the model's OUTPUT contains `expect` (the project's chosen value). The judged text is the model's output ONLY — its final answer plus files it WROTE during the WORK session (mtime-newer than a marker) — never the seeded CLAUDE.md or other pre-existing files. A `forbid` token is deliberately NOT used: a correct answer that names the rejected default in passing (\"use smol, not tokio\") would false-fail, and because the claude-md arm reads that \"do not X\" text it would false-fail MORE than memory-on — faking memory's advantage over the native baseline. `stale_trap` scenarios additionally plant a SUPERSEDING decision; a memory-induced error is recorded only when the WORK task FAILED (expect absent) AND `stale_token` (the superseded value) is present in the memory-on arm — i.e. the model produced the stale value instead of the current one (enumerated per run, never averaged away). Pass: memory-on success_rate >= both baselines AND (strictly beats each baseline on success OR fewer turns) AND zero memory-induced errors. See docs/eval/2026-06-14-w35-ab-eval.md.",
   "config": {
     "runs_per_scenario": 3,
     "memory_induced_errors_allowed": 0
@@ -11,8 +11,7 @@
       "plant": "Decision for this project: use the `ureq` crate for all outbound HTTP. We deliberately do NOT use reqwest (we want a tiny blocking client, no async runtime pulled in).",
       "claude_md": "HTTP: use the `ureq` crate for all outbound HTTP. Do not use reqwest.",
       "work": "Add a small helper that performs an HTTP GET to a JSON health endpoint and parses the `status` field. Name the HTTP crate it should use and show the dependency line.",
-      "expect": "ureq",
-      "forbid": "reqwest"
+      "expect": "ureq"
     },
     {
       "id": "dep-async-smol",
@@ -20,8 +19,7 @@
       "plant": "Architecture decision: this project's async runtime is `smol`. Do not add tokio — we keep the dependency tree small and smol is what everything else uses.",
       "claude_md": "Async runtime: this project uses `smol`. Do not introduce tokio.",
       "work": "I need to spawn a background task that periodically flushes a buffer. Which runtime API should I use and how do I spawn it?",
-      "expect": "smol",
-      "forbid": "tokio"
+      "expect": "smol"
     },
     {
       "id": "id-type-ulid",
@@ -29,8 +27,7 @@
       "plant": "Convention: every entity identifier in this codebase is a `Ulid` (lexicographically sortable). We do not use Uuid or autoincrement integers for entity ids.",
       "claude_md": "Identifiers: entity ids are `Ulid`, never Uuid or integer ids.",
       "work": "Add a new `Order` struct that needs a unique id field. What type should the id be?",
-      "expect": "ulid",
-      "forbid": "uuid"
+      "expect": "ulid"
     },
     {
       "id": "ser-msgpack",
@@ -38,8 +35,7 @@
       "plant": "Decision: our internal wire format is MessagePack via `rmp-serde`. We do not serialize messages to JSON on the wire (JSON is only for human-facing CLI output).",
       "claude_md": "Wire format: serialize messages with MessagePack (`rmp-serde`), not JSON.",
       "work": "Add serialization for a new `Envelope` message type that goes over our internal socket. Which serializer should it use?",
-      "expect": "rmp",
-      "forbid": "serde_json"
+      "expect": "rmp"
     },
     {
       "id": "err-apperror",
@@ -47,8 +43,7 @@
       "plant": "House rule: all fallible functions return our `AppError` type via the `?` operator. Never `.unwrap()` or `.expect()` in library code — clippy denies them.",
       "claude_md": "Errors: return the project's `AppError` via `?`. No `.unwrap()`/`.expect()` in library code.",
       "work": "Write a function that reads a required port number from an environment variable and returns it. Use our error convention.",
-      "expect": "apperror",
-      "forbid": ".unwrap()"
+      "expect": "apperror"
     },
     {
       "id": "log-tracing",
@@ -56,8 +51,7 @@
       "plant": "Logging decision: use the `tracing` crate with structured fields everywhere. Plain `println!`/`eprintln!` for diagnostics is banned outside the CLI's user-facing output.",
       "claude_md": "Logging: use `tracing` with structured fields. Do not use println!/eprintln! for diagnostics.",
       "work": "Add diagnostic logging to a function that retries a network call, recording the attempt number. How should it log?",
-      "expect": "tracing",
-      "forbid": "println!"
+      "expect": "tracing"
     },
     {
       "id": "time-unix-millis",
@@ -65,8 +59,7 @@
       "plant": "Decision: store all timestamps as UTC Unix milliseconds in an `i64` column. We do not store RFC3339/ISO-8601 strings in the database.",
       "claude_md": "Timestamps: store as UTC Unix milliseconds (`i64`), never RFC3339 strings.",
       "work": "Add a `created_at` field to a record that we persist to the database. What type and representation should it use?",
-      "expect": "milli",
-      "forbid": "rfc3339"
+      "expect": "milli"
     },
     {
       "id": "config-settings-toml",
@@ -74,8 +67,7 @@
       "plant": "Decision: all runtime configuration is read from a single `settings.toml` file. New knobs go in `settings.toml` — never scattered environment variables.",
       "claude_md": "Config: all runtime configuration comes from `settings.toml`. Do not read config from environment variables.",
       "work": "We need a new `max_connections` knob. Where should it be defined and how is it read?",
-      "expect": "settings.toml",
-      "forbid": "env::var"
+      "expect": "settings.toml"
     },
     {
       "id": "arch-single-writer",
@@ -83,8 +75,7 @@
       "plant": "Architecture: the store has a single writer thread reached through `WriterHandle`. No other code path may open the database for writing — all mutations go through the handle.",
       "claude_md": "Writes: all database mutations go through the single-writer `WriterHandle`. Never open the DB for writing elsewhere.",
       "work": "Add a maintenance task that prunes rows older than 30 days. How should it perform its deletes?",
-      "expect": "writerhandle",
-      "forbid": "open the database directly"
+      "expect": "writerhandle"
     },
     {
       "id": "test-prefix-spec",
@@ -92,8 +83,7 @@
       "plant": "Test convention: every test function name is prefixed with `spec_` and describes the behavior, e.g. `spec_rejects_empty_input`. Do not use a `test_` prefix.",
       "claude_md": "Tests: prefix every test function name with `spec_` (e.g. `spec_rejects_empty_input`), not `test_`.",
       "work": "Add a unit test for a function that validates an email address contains an `@`. Name the test function per our convention.",
-      "expect": "spec_",
-      "forbid": "fn test_"
+      "expect": "spec_"
     },
     {
       "id": "stale-trap-http-switch",

--- a/crates/rb-eval/scorecard/w35_ab_scenarios.json
+++ b/crates/rb-eval/scorecard/w35_ab_scenarios.json
@@ -1,5 +1,5 @@
 {
-  "_about": "W3.5 A/B outcome-eval scenarios (plan §6 / W3.5). Each scenario is a planted project DECISION plus a later WORK task where that decision matters. The runner (scripts/w35-ab-eval.sh) executes the WORK task under THREE arms and judges the outcome deterministically: (1) memory-on — rusty-brain hooks+MCP installed, a PLANT session stores the decision, the WORK session recalls it; (2) memory-off — no rusty-brain, no decision available anywhere (the floor); (3) claude-md-only — no rusty-brain, but the decision is written into the project CLAUDE.md (the NATIVE baseline F56 demands a win over). Decisions are deliberately NON-OBVIOUS (the project's choice differs from a cold model's default) so the arms actually diverge. Judge: the WORK output (final answer + files written) must contain `expect` (decision honored) and not `forbid` (the default the decision overrode); matching is case-insensitive substring. `stale_trap` scenarios additionally plant a SUPERSEDING decision; in the memory-on arm, `stale_token` appearing in the WORK output means the model acted on a stale/wrong memory (a memory-induced error — enumerated per run, never averaged away). Pass: memory-on success_rate >= both baselines AND (strictly beats each baseline on success OR fewer turns) AND zero memory-induced errors. See docs/eval/2026-06-14-w35-ab-eval.md.",
+  "_about": "W3.5 A/B outcome-eval scenarios (plan §6 / W3.5). Each scenario is a planted project DECISION plus a later WORK task where that decision matters. The runner (scripts/w35-ab-eval.sh) executes the WORK task under THREE arms and judges the outcome deterministically: (1) memory-on — rusty-brain hooks+MCP installed, a PLANT session stores the decision, the WORK session recalls it; (2) memory-off — no rusty-brain, no decision available anywhere (the floor); (3) claude-md-only — no rusty-brain, but the decision is written into the project CLAUDE.md (the NATIVE baseline F56 demands a win over). Decisions are deliberately NON-OBVIOUS (the project's choice differs from a cold model's default) so the arms actually diverge. Judge: the WORK output (final answer + files written) must contain `expect` (decision honored) and not `forbid` (the default the decision overrode); matching is case-insensitive substring. `stale_trap` scenarios additionally plant a SUPERSEDING decision and deliberately set NO `forbid` (the superseded value will appear in any correct explanation of the migration, so it must not fail success); a memory-induced error is recorded only when the WORK task FAILED (expect absent) AND `stale_token` is present in the memory-on arm — i.e. the model actually produced the stale value instead of the current one (enumerated per run, never averaged away). Pass: memory-on success_rate >= both baselines AND (strictly beats each baseline on success OR fewer turns) AND zero memory-induced errors. See docs/eval/2026-06-14-w35-ab-eval.md.",
   "config": {
     "runs_per_scenario": 3,
     "memory_induced_errors_allowed": 0
@@ -104,7 +104,6 @@
       "claude_md": "HTTP: use the `ureq` crate. (We migrated off reqwest; do not use reqwest.)",
       "work": "Add a helper that performs an HTTP GET and returns the body. Which HTTP crate should it use?",
       "expect": "ureq",
-      "forbid": "reqwest",
       "stale_token": "reqwest"
     },
     {
@@ -116,7 +115,6 @@
       "claude_md": "Config: read configuration from `config/settings.toml`. (Renamed from app.toml, which no longer exists.)",
       "work": "Add code that loads a new `timeout_secs` setting at startup. Which config file path should it read from?",
       "expect": "config/settings.toml",
-      "forbid": "app.toml",
       "stale_token": "app.toml"
     }
   ]

--- a/docs/eval/2026-06-14-w35-ab-eval.md
+++ b/docs/eval/2026-06-14-w35-ab-eval.md
@@ -32,9 +32,18 @@ runs the same WORK task under:
 
 | Arm | Setup | What it proves |
 |---|---|---|
-| **memory-on** | rusty-brain hooks+MCP installed; a PLANT session stores the decision; the WORK session (fresh context, same namespace) recalls it | the product |
+| **memory-on** | rusty-brain hooks+MCP installed; a PLANT session stores the decision; the WORK session (fresh context, same namespace) recalls it via the deterministic UserPromptSubmit injection | the product |
 | **memory-off** | no rusty-brain, decision available nowhere | the floor — memory must beat *nothing* |
 | **claude-md** | no rusty-brain, but the decision is written into the project `CLAUDE.md` | the **native baseline** — memory must beat the thing users already have |
+
+**Confound control (fairness):** `rusty-brain-install` also appends a "recall
+before work" memory-policy block to `CLAUDE.md` and ships a skill (the W3.2(b)
+elicitation channel). The runner **strips both from the WORK project** in the
+memory-on arm, so the work session receives the decision *only* through the
+deterministic recall injection (the actual store mechanism), not through extra
+prose guidance the baselines lack. The PLANT project keeps the block (we want
+capture to fire there). This isolates the measured effect to the memory **store
++ recall**, not generic guidance.
 
 `stale_trap` scenarios additionally plant a **superseding** decision in the
 memory-on arm (e.g. "we migrated off reqwest to ureq"), so both the original and
@@ -49,8 +58,15 @@ json` → `.result`) plus any files the model wrote, and applies:
 
 - **success** = the scenario's `expect` token is present AND its `forbid` token
   (the default the decision overrode) is absent — case-insensitive substring.
-- **memory-induced error (mie)** = in the **memory-on arm only**, the scenario's
-  `stale_token` appears (the model acted on a stale/wrong memory).
+- **memory-induced error (mie)** = in the **memory-on arm only**, the WORK task
+  **failed** (`expect` absent) AND the scenario's `stale_token` is present — i.e.
+  the model produced the *superseded* value instead of the current one. Gating
+  mie on failure is deliberate: a substring grep cannot distinguish "acted on
+  the stale memory" from "named the superseded value while correctly choosing
+  the new one," so a *correct* answer that merely mentions the old value is not
+  an error. Stale-trap scenarios therefore set **no `forbid`** (the old value
+  appears in any honest migration explanation); `stale_token` + the failure gate
+  carry the signal.
 
 `turns` and `total_cost_usd` come straight from the JSON output. The judge and
 the aggregation are **pure** and exercised offline by `--self-test` (no API).
@@ -84,9 +100,14 @@ cargo build --release -p rusty-brain -p rb-hooks -p rb-install
 scripts/w35-ab-eval.sh --bin-dir target/release --runs 3 --out /tmp/w35.tsv
 ```
 
-The nightly workflow runs `--runs 2` for cost control (raise via the
-`workflow_dispatch` `runs` input for a deeper sample when closing the gate). Each
-WORK session uses a cheap model under a hard `--max-budget-usd` cap.
+The **scheduled** nightly runs `--runs 1` (~50 sessions, ~1–2h, a few dollars)
+as a daily signal; **close the gate** with a `workflow_dispatch` at `--runs 3+`
+for stochasticity (allow it more time). Each WORK session uses a cheap model
+under a hard `--max-budget-usd` cap plus a per-session wall-clock `timeout` (when
+available) so one hung session can't stall the run. The memory-on arm hard-fails
+loudly if the PLANT session's SessionStart hook didn't auto-start the daemon
+(otherwise the arm would silently run without memory and invalidate the
+comparison) — the nightly alert issue surfaces it.
 
 ## Notes / honesty
 

--- a/docs/eval/2026-06-14-w35-ab-eval.md
+++ b/docs/eval/2026-06-14-w35-ab-eval.md
@@ -1,0 +1,100 @@
+# A/B outcome eval (W3.5)
+
+- **Status:** Harness landed; the measured run is **DEFERRED** (needs `claude` +
+  `ANTHROPIC_API_KEY` + a small spend budget — the nightly infra). The
+  `.github/workflows/w35-ab-eval.yml` job runs it once the secret is set;
+  tracked per release.
+- **Date:** 2026-06-14
+- **Gate clause (§6 / W3.5):** "≥10 scenario pairs run headless via `claude -p`
+  with hooks+MCP installed… Arms: memory-on, memory-off, **CLAUDE.md-only**…
+  report task success, turns-to-completion, token cost, and **memory-induced
+  errors enumerated, not averaged away**. Memory-on must win on success/turns
+  within token budget."
+- **Artifacts:** scenarios
+  `crates/rb-eval/scorecard/w35_ab_scenarios.json` (12 scenario pairs, incl. 2
+  stale-traps); runner `scripts/w35-ab-eval.sh`; nightly job
+  `.github/workflows/w35-ab-eval.yml`.
+
+## Why this exists (vs the other two Phase-3 evals)
+
+This is the **outcome** eval — does memory make the agent *do better*? It is
+complementary to the W3.1 decision-grade **content** rubric (is what we capture
+worth keeping?) and the W3.2 elicitation **behavioral** scorecard (does the
+model *use* the tools?). A high score on either of those is worthless if memory
+doesn't change the result; this is the eval that proves value, and specifically
+**value over the native CLAUDE.md baseline** (F56).
+
+## The three arms
+
+Each scenario plants a deliberately **non-obvious** project decision (the
+project's choice differs from a cold model's default, so the arms diverge), then
+runs the same WORK task under:
+
+| Arm | Setup | What it proves |
+|---|---|---|
+| **memory-on** | rusty-brain hooks+MCP installed; a PLANT session stores the decision; the WORK session (fresh context, same namespace) recalls it | the product |
+| **memory-off** | no rusty-brain, decision available nowhere | the floor — memory must beat *nothing* |
+| **claude-md** | no rusty-brain, but the decision is written into the project `CLAUDE.md` | the **native baseline** — memory must beat the thing users already have |
+
+`stale_trap` scenarios additionally plant a **superseding** decision in the
+memory-on arm (e.g. "we migrated off reqwest to ureq"), so both the original and
+the replacement are in the store. They probe the risk the gate names explicitly:
+the model acting on a **stale/wrong memory**.
+
+## The judge (deterministic)
+
+Per the plan's "deterministic assertion on output/diff where possible." For each
+WORK session the judge inspects the final answer (`claude -p --output-format
+json` → `.result`) plus any files the model wrote, and applies:
+
+- **success** = the scenario's `expect` token is present AND its `forbid` token
+  (the default the decision overrode) is absent — case-insensitive substring.
+- **memory-induced error (mie)** = in the **memory-on arm only**, the scenario's
+  `stale_token` appears (the model acted on a stale/wrong memory).
+
+`turns` and `total_cost_usd` come straight from the JSON output. The judge and
+the aggregation are **pure** and exercised offline by `--self-test` (no API).
+
+An LLM judge is the documented fallback for scenarios that can't be judged on a
+token (none currently need it); the corpus is authored to be token-judgeable.
+
+## Pass criteria
+
+Computed by the pure aggregator (`aggregate` in the runner), over N runs/scenario:
+
+1. `memory-on success_rate ≥ memory-off` AND `≥ claude-md` — memory never hurts.
+2. memory-on **beats memory-off** on success_rate OR mean-turns.
+3. memory-on **beats claude-md** on success_rate OR mean-turns (the F56 win).
+4. **memory-induced errors == 0** — enumerated per (scenario, run), never folded
+   into an average; any occurrence fails the run and is listed individually.
+
+Token cost is reported per arm (informational — memory-on pays a small injection
+overhead; the question is whether it buys success/turns). The per-tool/injection
+**token budgets** themselves are separately gated by the W3.3 token-accounting CI
+test.
+
+## How to run
+
+```bash
+# Judge + scoring self-test (no API, CI-safe):
+scripts/w35-ab-eval.sh --self-test
+
+# Full measured run (needs claude + ANTHROPIC_API_KEY + spend):
+cargo build --release -p rusty-brain -p rb-hooks -p rb-install
+scripts/w35-ab-eval.sh --bin-dir target/release --runs 3 --out /tmp/w35.tsv
+```
+
+The nightly workflow runs `--runs 2` for cost control (raise via the
+`workflow_dispatch` `runs` input for a deeper sample when closing the gate). Each
+WORK session uses a cheap model under a hard `--max-budget-usd` cap.
+
+## Notes / honesty
+
+- **Not per-PR CI:** nondeterministic and costs API spend; it lives in the
+  nightly arm, allowed-to-fail with issue alerting (the claude-smoke pattern).
+- The deterministic token judge is **best-effort** — the first measured run
+  should confirm `expect`/`forbid` discriminate cleanly on real haiku output and
+  recalibrate any noisy scenario (the same caveat the W3.2 scorecard records).
+- Until the measured run is recorded, the Phase-3 gate clause "W3.5 nightly eval:
+  memory-on beats memory-off AND CLAUDE.md-only" is **owed**, not met — recorded
+  here and in §6 so it is not silently declared passed.

--- a/docs/eval/2026-06-14-w35-ab-eval.md
+++ b/docs/eval/2026-06-14-w35-ab-eval.md
@@ -56,8 +56,16 @@ Per the plan's "deterministic assertion on output/diff where possible." For each
 WORK session the judge inspects the final answer (`claude -p --output-format
 json` → `.result`) plus any files the model wrote, and applies:
 
-- **success** = the scenario's `expect` token is present AND its `forbid` token
-  (the default the decision overrode) is absent — case-insensitive substring.
+- **success** = the scenario's `expect` token (the project's chosen value) is
+  present in the model's output — case-insensitive substring. The judged text is
+  the model's output ONLY: its final `.result` plus files it *wrote during* the
+  WORK session (mtime-newer than a marker, size-capped), never the seeded
+  `CLAUDE.md` or other pre-existing files. A `forbid` token is deliberately
+  **not** used: a correct answer that names the rejected default in passing
+  ("use smol, not tokio") would false-fail, and because the claude-md arm reads
+  that "do not X" text it would false-fail *more* than memory-on — faking
+  memory's advantage over native. (The judge predicate still supports a `forbid`
+  arg; the corpus simply doesn't set one.)
 - **memory-induced error (mie)** = in the **memory-on arm only**, the WORK task
   **failed** (`expect` absent) AND the scenario's `stale_token` is present — i.e.
   the model produced the *superseded* value instead of the current one. Gating

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -294,6 +294,33 @@ Target: claudecode →8.5. This phase was redesigned after critique — the orig
   (2) added CLI clap-parse tests for the `feedback` command (valid kind parses;
   unknown/missing `--kind` rejected at parse time).
 
+**Phase-3 progress — W3.5 A/B outcome-eval HARNESS (landed 2026-06-14; measured run still owed):**
+
+- *What landed (the harness, not the measured numbers):* the outcome eval that
+  proves memory makes the agent DO BETTER — complementary to the W3.1 content
+  rubric and the W3.2 behavioral scorecard. 12 scenario pairs
+  (`crates/rb-eval/scorecard/w35_ab_scenarios.json`, incl. 2 stale-traps), each
+  a deliberately NON-OBVIOUS project decision so the arms diverge. Runner
+  `scripts/w35-ab-eval.sh` runs each WORK task under THREE arms — **memory-on**
+  (rusty-brain plant→recall), **memory-off** (the floor), **claude-md** (the
+  native baseline F56 must beat) — via `claude -p --output-format json` (turns +
+  cost come straight from the CLI). Deterministic judge: WORK output must contain
+  `expect` and not `forbid`; stale-trap scenarios flag a **memory-induced error**
+  when the memory-on arm emits the superseded `stale_token` (enumerated per run,
+  never averaged). PASS = memory-on success_rate ≥ both baselines AND beats each
+  on success-or-turns AND zero memory-induced errors. The judge + the aggregator
+  are PURE and covered by `--self-test` (no API, CI-safe).
+- *Nightly infra:* `.github/workflows/w35-ab-eval.yml` clones the claude-smoke
+  posture — scheduled+dispatch, `ANTHROPIC_API_KEY` preflight, cheap-model +
+  hard per-session spend cap, allowed-to-fail with a pinned alert issue. It
+  uploads ONLY the structured TSV report (no model free-text), so there is no
+  artifact secret-leak surface (simpler than the smoke's log-scrub).
+- *Still owed (the MEASURED run):* needs the `ANTHROPIC_API_KEY` repo secret +
+  spend budget. Same one secret unblocks the existing nightly claude-smoke AND
+  the W3.2 scorecard measured run AND this. Until it runs, the gate clause
+  "memory-on beats memory-off AND CLAUDE.md-only" is recorded as OWED, not met.
+  Rubric: `docs/eval/2026-06-14-w35-ab-eval.md`.
+
 ---
 
 ## 7. Phase 4 — Prove it: eval gates, perf, fuzz

--- a/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
+++ b/docs/plans/2026-06-11-rusty-brain-road-to-tens.md
@@ -304,11 +304,16 @@ Target: claudecode →8.5. This phase was redesigned after critique — the orig
   `scripts/w35-ab-eval.sh` runs each WORK task under THREE arms — **memory-on**
   (rusty-brain plant→recall), **memory-off** (the floor), **claude-md** (the
   native baseline F56 must beat) — via `claude -p --output-format json` (turns +
-  cost come straight from the CLI). Deterministic judge: WORK output must contain
-  `expect` and not `forbid`; stale-trap scenarios flag a **memory-induced error**
-  when the memory-on arm emits the superseded `stale_token` (enumerated per run,
-  never averaged). PASS = memory-on success_rate ≥ both baselines AND beats each
-  on success-or-turns AND zero memory-induced errors. The judge + the aggregator
+  cost come straight from the CLI). Deterministic judge: EXPECT-ONLY — the
+  model's OUTPUT (final answer + files it wrote during WORK, never seeded files
+  like the claude-md arm's CLAUDE.md) must contain `expect`. A `forbid` token is
+  intentionally NOT used: it would false-fail correct answers that name the
+  rejected default, biasing the native baseline. Stale-trap scenarios flag a
+  **memory-induced error** only when the memory-on WORK task FAILS (`expect`
+  absent) AND the superseded `stale_token` is present — i.e. the model produced
+  the stale value instead of the current one (enumerated per run, never
+  averaged). PASS = memory-on success_rate ≥ both baselines AND beats each on
+  success-or-turns AND zero memory-induced errors. The judge + the aggregator
   are PURE and covered by `--self-test` (no API, CI-safe).
 - *Nightly infra:* `.github/workflows/w35-ab-eval.yml` clones the claude-smoke
   posture — scheduled+dispatch, `ANTHROPIC_API_KEY` preflight, cheap-model +

--- a/scripts/w35-ab-eval.sh
+++ b/scripts/w35-ab-eval.sh
@@ -205,6 +205,11 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to edi
 [ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS")"
 MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS")"
 
+# A session that produced no parseable JSON result (timeout/error/budget) counts
+# as this many turns — a worst-case sentinel, well above a normal task, so a
+# failure can never make an arm look faster on the turns tiebreaker.
+TURNS_FAIL_SENTINEL="${RB_W35_TURNS_FAIL_SENTINEL:-99}"
+
 # Per-session wall-clock cap (defense against a hung session stalling the run).
 # `timeout` is GNU coreutils (not in macOS base); use it or `gtimeout` if present,
 # else run uncapped (the job-level timeout is the backstop). Empty -> no prefix.
@@ -278,37 +283,39 @@ PY
   )
 }
 
-# Build the judge text for a WORK session: the final `.result` from the JSON
-# output, plus any non-dotfile the model wrote in the project (the "output/diff"
-# the plan's judge inspects). Robust to a non-JSON log (budget/error): falls
-# back to the raw log so a failed parse never silently scores as success.
-collect_judge_text() {
-  local jsonlog="$1" proj="$2" out="$3"
-  if jq -e '.result' "$jsonlog" >/dev/null 2>&1; then
-    jq -r '.result' "$jsonlog" > "$out"
-  else
-    cp "$jsonlog" "$out"
-  fi
-  # Append files the model created/edited (skip dotdirs: .claude/.mcp.json/.git).
-  find "$proj" -type f -not -path '*/.*' -print0 2>/dev/null \
-    | xargs -0 cat >> "$out" 2>/dev/null || true
-}
-
-# Parse num_turns / total_cost_usd from a JSON-output log (0 when absent).
-json_turns() { jq -r '.num_turns // 0'      "$1" 2>/dev/null || echo 0; }
-json_cost()  { jq -r '.total_cost_usd // 0' "$1" 2>/dev/null || echo 0; }
-
 # Run the WORK session for one arm and append its result row to $RESULTS.
+#
+# Judge text = the model's OUTPUT only: the final `.result` from the JSON output
+# plus files the model WROTE DURING this session (mtime newer than a marker
+# stamped just before the run, each capped in size). Pre-seeded files — notably
+# the claude-md arm's seeded CLAUDE.md, which contains the decision's own
+# expect/stale tokens — are EXCLUDED, so the judge scores what the model produced,
+# not what it was handed. A non-JSON log (timeout/error/budget) falls back to the
+# raw log (so a failed session is judged, not silently skipped) AND scores
+# turns=$TURNS_FAIL_SENTINEL / cost=0 — a worst-case sentinel so a failure can
+# never make an arm look artificially fast on the turns tiebreaker.
 score_work() {
   local id="$1" arm="$2" run="$3" proj="$4" home="$5" work="$6" \
         expect="$7" forbid="$8" stale="$9"
-  local jlog="$proj/../work.json" jtext="$proj/../judge.txt"
+  local jlog="$proj/../work.json" jtext="$proj/../judge.txt" marker="$proj/../work.start"
+  : > "$marker"
   run_session "$home" "$proj" "$work" "$jlog" --output-format json
-  collect_judge_text "$jlog" "$proj" "$jtext"
-  local turns cost res
-  turns="$(json_turns "$jlog")"; cost="$(json_cost "$jlog")"
+  local turns cost
+  if jq -e '.result' "$jlog" >/dev/null 2>&1; then
+    jq -r '.result' "$jlog" > "$jtext"
+    turns="$(jq -r ".num_turns // $TURNS_FAIL_SENTINEL" "$jlog" 2>/dev/null || echo "$TURNS_FAIL_SENTINEL")"
+    cost="$(jq -r '.total_cost_usd // 0' "$jlog" 2>/dev/null || echo 0)"
+  else
+    cp "$jlog" "$jtext"           # failed/timeout: judge the raw log (-> success 0)
+    turns="$TURNS_FAIL_SENTINEL"; cost=0
+  fi
+  # Append ONLY files the model changed during this session (newer than marker),
+  # skipping large/binary files so one big write can't bloat the judge text.
+  find "$proj" -type f -not -path '*/.*' -newer "$marker" -size -256k -print0 2>/dev/null \
+    | xargs -0 cat >> "$jtext" 2>/dev/null || true
+  local res success mie
   res="$(judge_text "$jtext" "$expect" "$forbid" "$stale" "$arm")"
-  local success="${res% *}" mie="${res#* }"
+  success="${res% *}"; mie="${res#* }"
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$arm" "$run" "$success" "$turns" "$cost" "$mie" >> "$RESULTS"
   echo "   [$arm] success=$success turns=$turns cost=$cost mie=$mie"
 }
@@ -319,7 +326,13 @@ run_scenario_run() {
   local base="$WORKROOT/$id-r$run"
 
   # --- arm: memory-on (plant -> [supersede] -> work, shared store) -----------
-  local mbase="$base/on" sock="$base/on/sock" db="$base/on/memory.db" ns="rb-w35-$id-r$run"
+  # The Unix socket lives under a SHORT /tmp dir, not $WORKROOT: a temp HOME +
+  # long scenario id can push $WORKROOT/.../sock past macOS's ~104-byte sun_path
+  # limit and break daemon bind (the nightly-claude-smoke.sh socket-length note).
+  # The DB is a regular file (no length limit) so it stays under $WORKROOT.
+  local mbase="$base/on" db="$base/on/memory.db" ns="rb-w35-$id-r$run"
+  local sockdir; sockdir="$(mktemp -d "/tmp/rbw35.XXXXXX")"
+  local sock="$sockdir/s"
   mkdir -p "$mbase"
   local plant_home="$mbase/home_plant" plant_proj="$mbase/proj_plant"
   local work_home="$mbase/home_work" work_proj="$mbase/proj_work"
@@ -353,8 +366,10 @@ run_scenario_run() {
     }
     score_work "$id" "memory-on" "$run" "$work_proj" "$work_home" "$work" "$expect" "$forbid" "$stale"
   )
-  # Reap the session-started daemon for this run's store.
+  # Reap the session-started daemon for this run's store, then drop its short
+  # socket dir.
   if [ -f "$sock.pid" ]; then kill "$(cat "$sock.pid" 2>/dev/null)" 2>/dev/null || true; fi
+  rm -rf "$sockdir" 2>/dev/null || true
 
   # --- arm: claude-md-only (decision in CLAUDE.md, no rusty-brain) -----------
   local chome="$base/cmd/home" cproj="$base/cmd/proj"

--- a/scripts/w35-ab-eval.sh
+++ b/scripts/w35-ab-eval.sh
@@ -42,8 +42,15 @@ usage() { sed -n '2,31p' "$0"; exit 2; }
 # judge_text <textfile> <expect> <forbid> <stale_token> <arm>
 # Echoes "<success> <mie>" (each 0/1). Case-insensitive substring matching.
 #   success = expect present AND forbid absent (forbid empty => no forbid check)
-#   mie     = 1 only when arm is "memory-on", stale_token is non-empty, and the
-#             stale token appears (the model acted on a stale/wrong memory)
+#   mie     = a MEMORY-INDUCED ERROR: only on the memory-on arm, only when the
+#             task FAILED (success==0) AND the stale token is present. Keying mie
+#             on failure is deliberate: a substring grep cannot tell "acted on
+#             the stale memory" from "mentioned the superseded value while
+#             correctly choosing the new one" — so a CORRECT answer that merely
+#             names the old value (success==1) is NOT a memory-induced error.
+#             Stale-trap scenarios therefore set NO `forbid` (the old value
+#             appearing in passing must not fail success); `stale_token` + the
+#             success==0 gate carry the error signal instead.
 judge_text() {
   local file="$1" expect="$2" forbid="$3" stale="$4" arm="$5"
   local success=0 mie=0
@@ -53,7 +60,8 @@ judge_text() {
   if [ -n "$forbid" ] && grep -iqF -- "$forbid" "$file" 2>/dev/null; then
     success=0
   fi
-  if [ "$arm" = "memory-on" ] && [ -n "$stale" ] && grep -iqF -- "$stale" "$file" 2>/dev/null; then
+  if [ "$arm" = "memory-on" ] && [ "$success" -eq 0 ] && [ -n "$stale" ] \
+     && grep -iqF -- "$stale" "$file" 2>/dev/null; then
     mie=1
   fi
   echo "$success $mie"
@@ -110,18 +118,21 @@ self_test() {
   trap 'rm -rf "$tmp"' RETURN
 
   # judge_text cases.
-  printf 'use the ureq crate for HTTP\n' > "$tmp/honored.txt"
-  printf 'use reqwest for HTTP\n'        > "$tmp/violated.txt"
-  printf 'use ureq, never reqwest\n'     > "$tmp/mentions-both.txt"
+  printf 'use the ureq crate for HTTP\n' > "$tmp/new-only.txt"     # uses new, no old
+  printf 'use reqwest for HTTP\n'        > "$tmp/old-only.txt"     # uses old, not new
+  printf 'use ureq, never reqwest\n'     > "$tmp/new-names-old.txt" # uses new, names old in passing
 
   check() { # <desc> <expected "succ mie"> <actual>
     if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "BUG: $1 (want '$2' got '$3')"; fail=1; fi
   }
-  check "honored => success, no mie"        "1 0" "$(judge_text "$tmp/honored.txt"  ureq reqwest reqwest memory-on)"
-  check "violated => fail + mie (memory-on)" "0 1" "$(judge_text "$tmp/violated.txt" ureq reqwest reqwest memory-on)"
-  check "violated in claude-md => fail, no mie" "0 0" "$(judge_text "$tmp/violated.txt" ureq reqwest reqwest claude-md)"
-  check "forbid present beats expect => fail + mie" "0 1" "$(judge_text "$tmp/mentions-both.txt" ureq reqwest reqwest memory-on)"
-  check "no stale token configured => no mie" "1 0" "$(judge_text "$tmp/honored.txt" ureq reqwest '' memory-on)"
+  # Stale-trap scenarios set NO forbid; success is expect-only, mie keys on failure.
+  check "trap: new only => success, no mie"                 "1 0" "$(judge_text "$tmp/new-only.txt"      ureq '' reqwest memory-on)"
+  check "trap: correct but names superseded value => success, NO mie" "1 0" "$(judge_text "$tmp/new-names-old.txt" ureq '' reqwest memory-on)"
+  check "trap: acted on stale (old, not new) => fail + mie" "0 1" "$(judge_text "$tmp/old-only.txt"      ureq '' reqwest memory-on)"
+  check "trap: acted-on-stale in claude-md => fail, no mie" "0 0" "$(judge_text "$tmp/old-only.txt"      ureq '' reqwest claude-md)"
+  # Non-trap scenarios set forbid; no stale token => never an mie.
+  check "non-trap: forbid present => fail, no mie"          "0 0" "$(judge_text "$tmp/old-only.txt"      ureq reqwest '' memory-on)"
+  check "non-trap: honored => success, no mie"              "1 0" "$(judge_text "$tmp/new-only.txt"      ureq reqwest '' memory-on)"
 
   # aggregate: a PASSING result set (memory-on best, no MIE).
   pass_tsv="$tmp/pass.tsv"
@@ -144,12 +155,17 @@ self_test() {
   } > "$nowin_tsv"
   if aggregate "$nowin_tsv" 0 >/dev/null; then echo "BUG: no-win set passed"; fail=1; else echo "ok: no-win set fails"; fi
 
-  # aggregate: a memory-induced error fails even when success/turns win.
+  # aggregate: a single memory-induced error fails the run even though memory-on
+  # otherwise wins on success-rate and turns (mie implies a failed run, so it
+  # rides on the run2 row with success=0; memory-on still beats both baselines).
   mie_tsv="$tmp/mie.tsv"
   {
-    printf 's1\tmemory-on\t1\t1\t2\t0.02\t1\n'
+    printf 's1\tmemory-on\t1\t1\t2\t0.02\t0\n'
+    printf 's1\tmemory-on\t2\t0\t2\t0.02\t1\n'
     printf 's1\tmemory-off\t1\t0\t5\t0.01\t0\n'
+    printf 's1\tmemory-off\t2\t0\t5\t0.01\t0\n'
     printf 's1\tclaude-md\t1\t0\t5\t0.02\t0\n'
+    printf 's1\tclaude-md\t2\t0\t5\t0.02\t0\n'
   } > "$mie_tsv"
   if aggregate "$mie_tsv" 0 >/dev/null; then echo "BUG: memory-induced error did not fail the run"; fail=1; else echo "ok: memory-induced error fails the run"; fi
 
@@ -189,6 +205,23 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to edi
 [ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS")"
 MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS")"
 
+# Per-session wall-clock cap (defense against a hung session stalling the run).
+# `timeout` is GNU coreutils (not in macOS base); use it or `gtimeout` if present,
+# else run uncapped (the job-level timeout is the backstop). Empty -> no prefix.
+SESSION_TIMEOUT=""
+if command -v timeout >/dev/null 2>&1; then
+  SESSION_TIMEOUT="timeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"
+elif command -v gtimeout >/dev/null 2>&1; then
+  SESSION_TIMEOUT="gtimeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"
+fi
+
+# Hermeticity (mirrors nightly-claude-smoke.sh): clear any rusty-brain path/
+# namespace overrides inherited from the environment. The memory-on arm RE-sets
+# these inside its own subshell per (scenario, run); clearing them here keeps the
+# memory-off and claude-md baselines from inheriting a CI-set store and silently
+# gaining memory. ANTHROPIC_API_KEY stays exported — claude needs it.
+unset RUSTY_BRAIN_DB RUSTY_BRAIN_SOCKET RUSTY_BRAIN_NAMESPACE RUSTY_BRAIN_IDLE_TIMEOUT_SECS
+
 WORKROOT="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-abeval.XXXXXX")"
 RESULTS="${REPORT_TSV:-$WORKROOT/results.tsv}"
 : > "$RESULTS"
@@ -200,7 +233,11 @@ trap cleanup EXIT
 seed_home() { mkdir -p "$1"; printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"; }
 
 # Run ONE headless session whose stdout is captured to $log. Extra args ($@)
-# tune output format. The session runs with a cheap model + hard spend cap.
+# tune output format. The session runs with a cheap model + hard spend cap, and
+# (when a `timeout` binary is available) a per-session wall-clock cap so one hung
+# session cannot stall the whole multi-session run — the spend cap bounds cost,
+# not wall-clock. A timed-out/failed session leaves a non-JSON log, which scores
+# as a failure (never silently as success).
 run_session() {
   local home="$1" proj="$2" prompt="$3" log="$4"; shift 4
   (
@@ -208,7 +245,7 @@ run_session() {
     unset XDG_RUNTIME_DIR XDG_CACHE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_STATE_HOME
     export PATH="$BIN_DIR:$PATH"
     cd "$proj"
-    claude -p "$prompt" \
+    ${SESSION_TIMEOUT} claude -p "$prompt" \
       --setting-sources project --model "$MODEL" --max-budget-usd "$MAX_BUDGET_USD" \
       --permission-mode acceptEdits --allowedTools "Bash Edit Write" "$@" \
       >"$log" 2>&1 || true
@@ -216,9 +253,12 @@ run_session() {
 }
 
 # Install rusty-brain hooks + project MCP into a memory-on session's project.
+# Runs under the session's isolated HOME so a project install can never read or
+# write the caller's real ~/.claude.
 install_rusty_brain() {
-  local proj="$1"
+  local home="$1" proj="$2"
   (
+    export HOME="$home"
     export PATH="$BIN_DIR:$PATH"
     cd "$proj"
     rusty-brain-install install --agents claude-code >/dev/null
@@ -285,14 +325,32 @@ run_scenario_run() {
   local work_home="$mbase/home_work" work_proj="$mbase/proj_work"
   seed_home "$plant_home"; mkdir -p "$plant_proj"
   seed_home "$work_home";  mkdir -p "$work_proj"
-  install_rusty_brain "$plant_proj"
-  install_rusty_brain "$work_proj"
+  install_rusty_brain "$plant_home" "$plant_proj"
+  install_rusty_brain "$work_home" "$work_proj"
+  # Fairness (avoid a confound): the installer appends a "recall before work"
+  # memory-policy block to CLAUDE.md + ships a skill (the W3.2(b) elicitation
+  # channel). Strip BOTH from the WORK project so the memory-on work session
+  # gets the decision ONLY through the deterministic UserPromptSubmit recall
+  # injection (channel a — the actual store mechanism), not through extra prose
+  # guidance the baselines lack. The PLANT project keeps the block (we want
+  # capture to fire there). Project install writes <proj>/CLAUDE.md +
+  # <proj>/.claude/skills (verified in rb-install claude_code.rs).
+  rm -f "$work_proj/CLAUDE.md"
+  rm -rf "$work_proj/.claude/skills"
   (
     export RUSTY_BRAIN_SOCKET="$sock" RUSTY_BRAIN_DB="$db" RUSTY_BRAIN_NAMESPACE="$ns"
     run_session "$plant_home" "$plant_proj" "$plant" "$mbase/plant.log"
     if [ -n "$supersede" ]; then
       run_session "$plant_home" "$plant_proj" "$supersede" "$mbase/supersede.log"
     fi
+    # The PLANT session's SessionStart hook must have auto-started the daemon
+    # (pidfile = <socket>.pid). If it did not, the memory-on arm would silently
+    # run WITHOUT memory and the whole comparison would be invalid — fail loudly
+    # (the nightly job's alert issue surfaces it), matching the smoke's contract.
+    [ -f "$sock.pid" ] || {
+      echo "ERROR: memory-on daemon did not auto-start for $id run $run (SessionStart hook?)" >&2
+      exit 1
+    }
     score_work "$id" "memory-on" "$run" "$work_proj" "$work_home" "$work" "$expect" "$forbid" "$stale"
   )
   # Reap the session-started daemon for this run's store.

--- a/scripts/w35-ab-eval.sh
+++ b/scripts/w35-ab-eval.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# W3.5 A/B outcome eval (plan §6 / W3.5; F56). Does memory actually make the
+# agent DO BETTER — not just use the tools? For each scenario
+# (crates/rb-eval/scorecard/w35_ab_scenarios.json) it runs the same WORK task
+# under THREE arms and judges the outcome deterministically:
+#
+#   memory-on   — rusty-brain hooks+MCP installed; a PLANT session stores the
+#                 project decision, the WORK session (fresh context, same
+#                 namespace) recalls it.
+#   memory-off  — no rusty-brain, no decision anywhere: the baseline floor.
+#   claude-md   — no rusty-brain, but the decision is written into the project
+#                 CLAUDE.md: the NATIVE baseline the value-over-native proof
+#                 (F56) must beat.
+#
+# Each WORK session runs `claude -p --output-format json`, so num_turns and
+# total_cost_usd come straight from the CLI. The judge is deterministic: the
+# WORK output (final answer + files written) must contain the scenario's
+# `expect` token and not its `forbid` token (case-insensitive substring). For
+# `stale_trap` scenarios the memory-on arm also checks `stale_token` — its
+# presence means the model acted on a stale/wrong memory: a MEMORY-INDUCED
+# ERROR, enumerated per run, NEVER averaged into a rate.
+#
+# PASS (plan §6: "memory-on must win on success/turns within token budget"):
+#   memory-on success_rate >= BOTH baselines, AND beats each baseline on
+#   success-rate OR mean-turns, AND zero memory-induced errors.
+#
+# STATUS: harness landed; the measured run is DEFERRED — it needs `claude` +
+# ANTHROPIC_API_KEY + a small spend budget (the W3.5 nightly infra). Run it via:
+#   cargo build --release -p rusty-brain -p rb-hooks -p rb-install
+#   scripts/w35-ab-eval.sh --bin-dir target/release
+# `--self-test` validates the judge + scoring math with NO API and is CI-safe.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCENARIOS="$REPO_ROOT/crates/rb-eval/scorecard/w35_ab_scenarios.json"
+MODEL="${RB_W35_MODEL:-haiku}"
+MAX_BUDGET_USD="${RB_W35_MAX_BUDGET_USD:-0.50}"
+
+usage() { sed -n '2,31p' "$0"; exit 2; }
+
+# --- judge (pure; exercised by --self-test) ----------------------------------
+# judge_text <textfile> <expect> <forbid> <stale_token> <arm>
+# Echoes "<success> <mie>" (each 0/1). Case-insensitive substring matching.
+#   success = expect present AND forbid absent (forbid empty => no forbid check)
+#   mie     = 1 only when arm is "memory-on", stale_token is non-empty, and the
+#             stale token appears (the model acted on a stale/wrong memory)
+judge_text() {
+  local file="$1" expect="$2" forbid="$3" stale="$4" arm="$5"
+  local success=0 mie=0
+  if grep -iqF -- "$expect" "$file" 2>/dev/null; then
+    success=1
+  fi
+  if [ -n "$forbid" ] && grep -iqF -- "$forbid" "$file" 2>/dev/null; then
+    success=0
+  fi
+  if [ "$arm" = "memory-on" ] && [ -n "$stale" ] && grep -iqF -- "$stale" "$file" 2>/dev/null; then
+    mie=1
+  fi
+  echo "$success $mie"
+}
+
+# --- aggregate + score (pure; exercised by --self-test) ----------------------
+# Reads a results TSV (scenario<TAB>arm<TAB>run<TAB>success<TAB>turns<TAB>cost<TAB>mie)
+# from $1, prints the per-arm report + PASS/FAIL, returns 0 on PASS else 1.
+# `mie_allowed` ($2) caps tolerated memory-induced errors (default 0).
+aggregate() {
+  local tsv="$1" mie_allowed="${2:-0}"
+  awk -F'\t' -v mie_allowed="$mie_allowed" '
+    {
+      arm=$2; succ=$4; turns=$5; cost=$6; mie=$7;
+      n[arm]++; s[arm]+=succ; t[arm]+=turns; c[arm]+=cost;
+      if (arm=="memory-on" && mie==1) { mie_total++; mie_list = mie_list sprintf("    - %s run %s\n", $1, $3); }
+    }
+    END {
+      split("memory-on memory-off claude-md", order, " ");
+      printf "%-12s %6s %8s %10s %12s\n", "arm", "runs", "success", "mean_turns", "mean_cost$";
+      for (i=1;i<=3;i++) {
+        a=order[i];
+        if (n[a]==0) { printf "%-12s %6s %8s %10s %12s\n", a, 0, "n/a", "n/a", "n/a"; continue }
+        rate[a]=s[a]/n[a]; mt[a]=t[a]/n[a]; mc[a]=c[a]/n[a];
+        printf "%-12s %6d %7.2f%% %10.2f %12.4f\n", a, n[a], rate[a]*100, mt[a], mc[a];
+      }
+      print "";
+      on=rate["memory-on"]; off=rate["memory-off"]; cm=rate["claude-md"];
+      ont=mt["memory-on"]; offt=mt["memory-off"]; cmt=mt["claude-md"];
+      if (n["memory-on"]==0 || n["memory-off"]==0 || n["claude-md"]==0) {
+        print "score: FAIL (an arm produced no runs)"; exit 1;
+      }
+      success_ok = (on >= off && on >= cm);
+      beats_off  = (on > off || ont < offt);
+      beats_cm   = (on > cm  || ont < cmt);
+      mie_ok     = (mie_total+0 <= mie_allowed+0);
+      printf "memory-on >= both baselines on success: %s (on %.2f vs off %.2f, claude-md %.2f)\n", (success_ok?"yes":"NO"), on, off, cm;
+      printf "memory-on beats memory-off (success or turns): %s\n", (beats_off?"yes":"NO");
+      printf "memory-on beats claude-md (success or turns):  %s\n", (beats_cm?"yes":"NO");
+      printf "memory-induced errors: %d (allowed %d)\n", mie_total+0, mie_allowed+0;
+      if (mie_total+0 > 0) { printf "  enumerated (never averaged away):\n%s", mie_list; }
+      pass = (success_ok && beats_off && beats_cm && mie_ok);
+      printf "w35 a/b eval: %s\n", (pass?"PASS":"FAIL");
+      exit (pass?0:1);
+    }
+  ' "$tsv"
+}
+
+# --- self-test (no API) ------------------------------------------------------
+self_test() {
+  echo "== W3.5 self-test (judge + scoring; no API) =="
+  local tmp fail=0
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-selftest.XXXXXX")"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # judge_text cases.
+  printf 'use the ureq crate for HTTP\n' > "$tmp/honored.txt"
+  printf 'use reqwest for HTTP\n'        > "$tmp/violated.txt"
+  printf 'use ureq, never reqwest\n'     > "$tmp/mentions-both.txt"
+
+  check() { # <desc> <expected "succ mie"> <actual>
+    if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "BUG: $1 (want '$2' got '$3')"; fail=1; fi
+  }
+  check "honored => success, no mie"        "1 0" "$(judge_text "$tmp/honored.txt"  ureq reqwest reqwest memory-on)"
+  check "violated => fail + mie (memory-on)" "0 1" "$(judge_text "$tmp/violated.txt" ureq reqwest reqwest memory-on)"
+  check "violated in claude-md => fail, no mie" "0 0" "$(judge_text "$tmp/violated.txt" ureq reqwest reqwest claude-md)"
+  check "forbid present beats expect => fail + mie" "0 1" "$(judge_text "$tmp/mentions-both.txt" ureq reqwest reqwest memory-on)"
+  check "no stale token configured => no mie" "1 0" "$(judge_text "$tmp/honored.txt" ureq reqwest '' memory-on)"
+
+  # aggregate: a PASSING result set (memory-on best, no MIE).
+  pass_tsv="$tmp/pass.tsv"
+  {
+    printf 's1\tmemory-on\t1\t1\t3\t0.02\t0\n'
+    printf 's1\tmemory-off\t1\t0\t5\t0.01\t0\n'
+    printf 's1\tclaude-md\t1\t1\t4\t0.02\t0\n'
+    printf 's2\tmemory-on\t1\t1\t3\t0.02\t0\n'
+    printf 's2\tmemory-off\t1\t0\t5\t0.01\t0\n'
+    printf 's2\tclaude-md\t1\t0\t4\t0.02\t0\n'
+  } > "$pass_tsv"
+  if aggregate "$pass_tsv" 0 >/dev/null; then echo "ok: passing result set passes"; else echo "BUG: passing result set failed"; fail=1; fi
+
+  # aggregate: memory-on tied on success AND no fewer turns => FAIL (no win).
+  nowin_tsv="$tmp/nowin.tsv"
+  {
+    printf 's1\tmemory-on\t1\t1\t5\t0.02\t0\n'
+    printf 's1\tmemory-off\t1\t1\t5\t0.01\t0\n'
+    printf 's1\tclaude-md\t1\t1\t5\t0.02\t0\n'
+  } > "$nowin_tsv"
+  if aggregate "$nowin_tsv" 0 >/dev/null; then echo "BUG: no-win set passed"; fail=1; else echo "ok: no-win set fails"; fi
+
+  # aggregate: a memory-induced error fails even when success/turns win.
+  mie_tsv="$tmp/mie.tsv"
+  {
+    printf 's1\tmemory-on\t1\t1\t2\t0.02\t1\n'
+    printf 's1\tmemory-off\t1\t0\t5\t0.01\t0\n'
+    printf 's1\tclaude-md\t1\t0\t5\t0.02\t0\n'
+  } > "$mie_tsv"
+  if aggregate "$mie_tsv" 0 >/dev/null; then echo "BUG: memory-induced error did not fail the run"; fail=1; else echo "ok: memory-induced error fails the run"; fi
+
+  [ "$fail" -eq 0 ] && { echo "self-test PASS"; return 0; } || { echo "self-test FAIL" >&2; return 1; }
+}
+
+# --- arg parsing -------------------------------------------------------------
+BIN_DIR=""
+MODE="run"
+RUNS=""
+REPORT_TSV=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test) MODE="self-test"; shift ;;
+    --bin-dir)   BIN_DIR="${2:?--bin-dir needs a value}"; shift 2 ;;
+    --runs)      RUNS="${2:?--runs needs a value}"; shift 2 ;;
+    --out)       REPORT_TSV="${2:?--out needs a value}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *)           usage ;;
+  esac
+done
+
+if [ "$MODE" = "self-test" ]; then self_test; exit $?; fi
+
+# --- real run prerequisites --------------------------------------------------
+[ -n "$BIN_DIR" ] || usage
+BIN_DIR="$(cd "$BIN_DIR" && pwd)"
+for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
+  [ -x "$BIN_DIR/$bin" ] || { echo "missing binary: $BIN_DIR/$bin (cargo build --release -p rusty-brain -p rb-hooks -p rb-install)" >&2; exit 1; }
+done
+command -v claude  >/dev/null 2>&1 || { echo "claude not on PATH (npm install -g @anthropic-ai/claude-code)" >&2; exit 1; }
+command -v jq      >/dev/null 2>&1 || { echo "jq not on PATH (needed to read scenarios + parse --output-format json)" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (needed to edit .claude/settings.json)" >&2; exit 1; }
+[ -n "${ANTHROPIC_API_KEY:-}" ] || { echo "ANTHROPIC_API_KEY is not set — the measured run is DEFERRED until it is" >&2; exit 1; }
+[ -f "$SCENARIOS" ] || { echo "scenarios file not found: $SCENARIOS" >&2; exit 1; }
+
+[ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS")"
+MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS")"
+
+WORKROOT="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-abeval.XXXXXX")"
+RESULTS="${REPORT_TSV:-$WORKROOT/results.tsv}"
+: > "$RESULTS"
+cleanup() { rm -rf "$WORKROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Seed Claude Code's onboarding flag in a fresh HOME so headless mode never
+# stalls on first-run setup.
+seed_home() { mkdir -p "$1"; printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"; }
+
+# Run ONE headless session whose stdout is captured to $log. Extra args ($@)
+# tune output format. The session runs with a cheap model + hard spend cap.
+run_session() {
+  local home="$1" proj="$2" prompt="$3" log="$4"; shift 4
+  (
+    export HOME="$home"
+    unset XDG_RUNTIME_DIR XDG_CACHE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_STATE_HOME
+    export PATH="$BIN_DIR:$PATH"
+    cd "$proj"
+    claude -p "$prompt" \
+      --setting-sources project --model "$MODEL" --max-budget-usd "$MAX_BUDGET_USD" \
+      --permission-mode acceptEdits --allowedTools "Bash Edit Write" "$@" \
+      >"$log" 2>&1 || true
+  )
+}
+
+# Install rusty-brain hooks + project MCP into a memory-on session's project.
+install_rusty_brain() {
+  local proj="$1"
+  (
+    export PATH="$BIN_DIR:$PATH"
+    cd "$proj"
+    rusty-brain-install install --agents claude-code >/dev/null
+    python3 - "$proj/.claude/settings.json" "$proj/.mcp.json" "$BIN_DIR/rusty-brain" <<'PY'
+import json, sys
+settings_path, mcp_path, server_cmd = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(mcp_path, "w") as f:
+    json.dump({"mcpServers": {"rusty-brain": {"command": server_cmd, "args": ["mcp"]}}}, f, indent=2)
+    f.write("\n")
+with open(settings_path) as f:
+    s = json.load(f)
+s["enableAllProjectMcpServers"] = True
+with open(settings_path, "w") as f:
+    json.dump(s, f, indent=2)
+    f.write("\n")
+PY
+  )
+}
+
+# Build the judge text for a WORK session: the final `.result` from the JSON
+# output, plus any non-dotfile the model wrote in the project (the "output/diff"
+# the plan's judge inspects). Robust to a non-JSON log (budget/error): falls
+# back to the raw log so a failed parse never silently scores as success.
+collect_judge_text() {
+  local jsonlog="$1" proj="$2" out="$3"
+  if jq -e '.result' "$jsonlog" >/dev/null 2>&1; then
+    jq -r '.result' "$jsonlog" > "$out"
+  else
+    cp "$jsonlog" "$out"
+  fi
+  # Append files the model created/edited (skip dotdirs: .claude/.mcp.json/.git).
+  find "$proj" -type f -not -path '*/.*' -print0 2>/dev/null \
+    | xargs -0 cat >> "$out" 2>/dev/null || true
+}
+
+# Parse num_turns / total_cost_usd from a JSON-output log (0 when absent).
+json_turns() { jq -r '.num_turns // 0'      "$1" 2>/dev/null || echo 0; }
+json_cost()  { jq -r '.total_cost_usd // 0' "$1" 2>/dev/null || echo 0; }
+
+# Run the WORK session for one arm and append its result row to $RESULTS.
+score_work() {
+  local id="$1" arm="$2" run="$3" proj="$4" home="$5" work="$6" \
+        expect="$7" forbid="$8" stale="$9"
+  local jlog="$proj/../work.json" jtext="$proj/../judge.txt"
+  run_session "$home" "$proj" "$work" "$jlog" --output-format json
+  collect_judge_text "$jlog" "$proj" "$jtext"
+  local turns cost res
+  turns="$(json_turns "$jlog")"; cost="$(json_cost "$jlog")"
+  res="$(judge_text "$jtext" "$expect" "$forbid" "$stale" "$arm")"
+  local success="${res% *}" mie="${res#* }"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$arm" "$run" "$success" "$turns" "$cost" "$mie" >> "$RESULTS"
+  echo "   [$arm] success=$success turns=$turns cost=$cost mie=$mie"
+}
+
+run_scenario_run() {
+  local id="$1" run="$2" plant="$3" supersede="$4" claude_md="$5" work="$6" \
+        expect="$7" forbid="$8" stale="$9"
+  local base="$WORKROOT/$id-r$run"
+
+  # --- arm: memory-on (plant -> [supersede] -> work, shared store) -----------
+  local mbase="$base/on" sock="$base/on/sock" db="$base/on/memory.db" ns="rb-w35-$id-r$run"
+  mkdir -p "$mbase"
+  local plant_home="$mbase/home_plant" plant_proj="$mbase/proj_plant"
+  local work_home="$mbase/home_work" work_proj="$mbase/proj_work"
+  seed_home "$plant_home"; mkdir -p "$plant_proj"
+  seed_home "$work_home";  mkdir -p "$work_proj"
+  install_rusty_brain "$plant_proj"
+  install_rusty_brain "$work_proj"
+  (
+    export RUSTY_BRAIN_SOCKET="$sock" RUSTY_BRAIN_DB="$db" RUSTY_BRAIN_NAMESPACE="$ns"
+    run_session "$plant_home" "$plant_proj" "$plant" "$mbase/plant.log"
+    if [ -n "$supersede" ]; then
+      run_session "$plant_home" "$plant_proj" "$supersede" "$mbase/supersede.log"
+    fi
+    score_work "$id" "memory-on" "$run" "$work_proj" "$work_home" "$work" "$expect" "$forbid" "$stale"
+  )
+  # Reap the session-started daemon for this run's store.
+  if [ -f "$sock.pid" ]; then kill "$(cat "$sock.pid" 2>/dev/null)" 2>/dev/null || true; fi
+
+  # --- arm: claude-md-only (decision in CLAUDE.md, no rusty-brain) -----------
+  local chome="$base/cmd/home" cproj="$base/cmd/proj"
+  seed_home "$chome"; mkdir -p "$cproj"
+  printf '# Project conventions\n\n%s\n' "$claude_md" > "$cproj/CLAUDE.md"
+  score_work "$id" "claude-md" "$run" "$cproj" "$chome" "$work" "$expect" "$forbid" "$stale"
+
+  # --- arm: memory-off (nothing) ---------------------------------------------
+  local ohome="$base/off/home" oproj="$base/off/proj"
+  seed_home "$ohome"; mkdir -p "$oproj"
+  score_work "$id" "memory-off" "$run" "$oproj" "$ohome" "$work" "$expect" "$forbid" "$stale"
+}
+
+echo "== W3.5 A/B outcome eval (model=$MODEL, budget=\$$MAX_BUDGET_USD/session, runs=$RUNS) =="
+rows=()
+while IFS= read -r row; do rows+=("$row"); done < <(jq -c '.scenarios[]' "$SCENARIOS")
+for row in "${rows[@]}"; do
+  id="$(jq -r '.id' <<<"$row")"
+  plant="$(jq -r '.plant' <<<"$row")"
+  supersede="$(jq -r '.supersede // ""' <<<"$row")"
+  claude_md="$(jq -r '.claude_md' <<<"$row")"
+  work="$(jq -r '.work' <<<"$row")"
+  expect="$(jq -r '.expect' <<<"$row")"
+  forbid="$(jq -r '.forbid // ""' <<<"$row")"
+  stale="$(jq -r '.stale_token // ""' <<<"$row")"
+  run=1
+  while [ "$run" -le "$RUNS" ]; do
+    echo "-- scenario: $id (run $run/$RUNS)"
+    run_scenario_run "$id" "$run" "$plant" "$supersede" "$claude_md" "$work" "$expect" "$forbid" "$stale"
+    run=$((run + 1))
+  done
+done
+
+echo
+echo "== results =="
+aggregate "$RESULTS" "$MIE_ALLOWED"


### PR DESCRIPTION
## W3.5 — A/B outcome eval (harness)

The Phase-3 **outcome** eval: does rusty-brain memory make the agent *do better*,
not just *use the tools*? Complementary to the W3.1 content rubric and the W3.2
behavioral scorecard. **Harness only** — the measured run is API-gated (deferred
until the `ANTHROPIC_API_KEY` repo secret + spend budget exist).

### What it does
For each of **12 scenario pairs** (10 non-obvious project decisions + 2
stale-traps), runs the same WORK task under **three arms** via real headless
`claude -p --output-format json` (turns + cost straight from the CLI):

- **memory-on** — rusty-brain installed; a PLANT session stores the decision; the
  WORK session recalls it via the deterministic UserPromptSubmit injection.
- **memory-off** — nothing (the floor).
- **claude-md** — the decision written into `CLAUDE.md` (the **native baseline**
  the value-over-native proof, F56, must beat).

Deterministic judge (expect/forbid substrings + `--output-format json` metrics);
memory-induced errors enumerated on stale-traps, never averaged. **PASS** =
memory-on ≥ both baselines on success AND beats each on success-or-turns AND zero
memory-induced errors. The judge + aggregator are **pure** with an offline
`--self-test` (no API, CI-safe).

### Nightly infra
`.github/workflows/w35-ab-eval.yml` clones the claude-smoke posture (scheduled +
dispatch, `ANTHROPIC_API_KEY` preflight, hard per-session spend cap, allowed-to-
fail with a pinned alert issue). Uploads only the structured TSV report — no
model free-text, so no secret-leak surface.

### Adversarial review (4 dimensions → 8 findings confirmed, all fixed)
- **Confound (critical):** the installer's "recall before work" policy block gave
  memory-on guidance the baselines lacked → strip it from the WORK project so the
  comparison isolates the memory **store**, not generic guidance.
- **mie false-positives (major):** a correct answer naming the superseded value
  was scored as a memory-induced error → mie is now failure-gated and traps drop
  `forbid`.
- **Hermeticity (major):** `unset RUSTY_BRAIN_*` so baselines can't inherit a
  CI store; run the installer under the isolated HOME.
- **Daemon validity (critical):** hard-fail if the memory-on daemon didn't
  auto-start (else the arm silently runs without memory).
- **CI (major):** per-session `timeout`; `timeout-minutes` 180; scheduled
  `--runs 1` (bounded); dispatch `--runs 3` to close the gate; concrete cost.

(6 further candidate findings were refuted during verification.)

### Why this unblocks the gate
The harness is the buildable half of the last Phase-3 gate clause. Setting the
`ANTHROPIC_API_KEY` secret (one action) then lets the nightly job — and the
existing claude-smoke + the W3.2 scorecard — produce their measured numbers.

`--self-test` ✓ · `shellcheck -S warning` clean · `actionlint` clean · no Rust
touched (script/JSON/YAML/docs only). Rubric: `docs/eval/2026-06-14-w35-ab-eval.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added nightly A/B evaluation workflow for automated testing
  * Added evaluation harness and test scenario definitions

* **Documentation**
  * Added evaluation methodology documentation
  * Updated project roadmap with evaluation progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->