### PR TITLE
fix(p3): update nightly-claude-smoke for W3.1 SessionEnd capture

### DIFF
--- a/scripts/nightly-claude-smoke.sh
+++ b/scripts/nightly-claude-smoke.sh
@@ -109,7 +109,8 @@ mkdir -p "$PROJ"
 cd "$PROJ"
 
 # Hooks: the real installer writes the project .claude/settings.json block
-# (SessionStart / PostToolUse / Stop / PreCompact -> rusty-brain-hooks).
+# (SessionStart / UserPromptSubmit / PostToolUse / Stop / SessionEnd / PreCompact
+# -> rusty-brain-hooks). Post-W3.1, SessionEnd is the single capture point.
 rusty-brain-install install --agents claude-code
 grep -q "rusty-brain-hooks" "$PROJ/.claude/settings.json" \
   || { echo "installer did not write the hook block to .claude/settings.json" >&2; exit 1; }
@@ -178,10 +179,15 @@ sleep "$IDLE_WAIT"
 kill -0 "$PID1" || { echo "daemon (pid $PID1) died during the idle window" >&2; exit 1; }
 
 # --- 5. Recall: the SAME daemon serves the captured memory --------------------
-rusty-brain recall "nightly smoke sentinel" >"$WORKDIR/recall-output.log" 2>&1 \
+# Post-W3.1 capture is SessionEnd-centric: one redacted "Session summary" insight
+# per session, not a per-command memory. Recall in human mode prints only the
+# ~150-char enriched summary prefix (the "Goal:" preamble), which truncates before
+# the captured command line; use --json so the assertion below sees the full
+# memory content (where the sentinel lives, in the "Commands run:" section).
+rusty-brain --json recall "nightly smoke sentinel" >"$WORKDIR/recall-output.log" 2>&1 \
   || { echo "recall failed:" >&2; cat "$WORKDIR/recall-output.log" >&2; exit 1; }
 grep -F "$SENTINEL" "$WORKDIR/recall-output.log" >/dev/null \
-  || { echo "recall did not return the captured session command:" >&2; cat "$WORKDIR/recall-output.log" >&2; exit 1; }
+  || { echo "recall did not return the captured session summary:" >&2; cat "$WORKDIR/recall-output.log" >&2; exit 1; }
 echo "recall round-trip OK (post-idle)"
 
 # --- 6. Exactly ONE 0600 DB ----------------------------------------------------
@@ -218,6 +224,10 @@ grep -aq -- "$SENTINEL" "${FILES[@]}" \
   || { echo "hook capture did not land in the DB (sentinel not found)" >&2; exit 1; }
 grep -aq "REDACTED:" "${FILES[@]}" \
   || { echo "no redaction marker found in the DB" >&2; exit 1; }
+# Specific to THIS planted key: prove redaction fired on the AWS key itself, not
+# merely that some unrelated credential produced a REDACTED: marker.
+grep -aq -- "REDACTED:aws-key" "${FILES[@]}" \
+  || { echo "planted AWS key was not redacted as [REDACTED:aws-key] in the DB" >&2; exit 1; }
 if grep -aq -- "$PLANTED" "${FILES[@]}"; then
   echo "planted fake AWS key found in PLAINTEXT in the DB" >&2
   exit 1


### PR DESCRIPTION
## Problem

The `nightly claude smoke` (gate tier (b) / spike S1) was failing on the `Run the smoke` step — **after** preflight, so the `ANTHROPIC_API_KEY` secret is wired correctly. The recall step returned a `(insight) Session summary.` memory, and the test's `grep` for the planted sentinel failed.

## Root cause (stale test, not a regression)

Diagnosed via a multi-agent workflow and adversarially verified against the code. Two compounding effects, both downstream of **W3.1 capture inversion** (PR #13), neither a product/security defect:

1. **Capture is now SessionEnd-centric.** PostToolUse writes zero memories (appends redacted observations to a per-session scratch); the single capture point is SessionEnd, which folds everything into one templated `Session summary.` insight (`crates/rb-hooks/src/capture.rs:623-744`). The smoke was written against the old per-PostToolUse-command model and never updated.
2. **Display-vs-content truncation.** The sentinel *is* stored (in the summary's `Commands run:` section), but `recall` renders only the `summary` field, which — with the heuristic enricher (`RB_ENRICH_*` unset in the script) — is just the first 150 chars of content (`Session summary.\nGoal: ...`), truncating right before the sentinel.

## Security guarantee: verified intact

Redaction (`rb_redact::redact`) runs on every disk-touching path (scratch append, SessionEnd fold, PreCompact); the daemon only ever receives already-redacted content, and the transcript reader drops `tool_use`/`tool_result` blocks. Running the real redactor on the exact planted command yields `export AWS_ACCESS_KEY_ID=[REDACTED:aws-key] && echo nightly-smoke-sentinel` — key gone, sentinel kept, marker present. The DB-byte security assertions still hold and are unchanged.

## Fix

- `recall` round-trip now uses `--json` so the assertion reads full memory content (where the sentinel lives), not the truncated human summary line.
- Refreshed stale wording/comments for the W3.1 one-summary-per-session model (incl. the installer event list: SessionStart / UserPromptSubmit / PostToolUse / Stop / SessionEnd / PreCompact).
- Added a `[REDACTED:aws-key]`-specific at-rest assertion, proving redaction fired on *this* planted key rather than on some unrelated credential.
- DB-byte security assertions otherwise unchanged.

## Validation

Dispatched the workflow on this branch — **green in 3m21s** (run 27626604194), including the previously-failing `Run the smoke` step; the success path auto-closed the alert issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced nightly smoke test verification to validate session capture behavior and confirm data redaction markers are properly stored in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->