### PR TITLE
feat(p3): add `remember --supersedes <id>` to the CLI

### DIFF
--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -97,6 +97,12 @@ pub enum Command {
         /// Tags (repeatable: `--tags a --tags b`).
         #[arg(long)]
         tags: Vec<String>,
+        /// Supersede an existing memory: store this as the replacement and
+        /// archive the prior memory in one atomic op (the `supersedes` edge —
+        /// see `link`, which rejects `--type supersedes` for this reason). Value
+        /// is the UUID of the memory being replaced.
+        #[arg(long)]
+        supersedes: Option<String>,
     },
 
     /// Recall memories matching a query.
@@ -447,6 +453,29 @@ mod tests {
             res.is_err(),
             "--type supersedes must be rejected at parse time"
         );
+    }
+
+    #[test]
+    fn remember_accepts_supersedes_id() {
+        // The supersede edge IS created here (the replacement-memory path that
+        // `link --type supersedes` points at). Default: no prior.
+        let plain = Cli::parse_from(["rusty-brain", "remember", "a new decision"]);
+        match plain.command {
+            Command::Remember { supersedes, .. } => assert_eq!(supersedes, None),
+            other => panic!("expected Remember, got {other:?}"),
+        }
+        let old = "0c8e7f76-3a4f-4f7e-9d3a-111111111111";
+        let cli = Cli::parse_from([
+            "rusty-brain",
+            "remember",
+            "the replacement",
+            "--supersedes",
+            old,
+        ]);
+        match cli.command {
+            Command::Remember { supersedes, .. } => assert_eq!(supersedes.as_deref(), Some(old)),
+            other => panic!("expected Remember, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -103,22 +103,42 @@ async fn run_client(
             importance,
             context,
             tags,
+            supersedes,
         } => {
-            let id = client
-                .remember(
-                    content,
-                    context,
-                    memory_type,
-                    importance,
-                    Vec::new(),
-                    tags,
-                    Vec::new(),
-                    // CLI `remember` declares no explicit prior: the daemon
-                    // applies the 1.0 baseline (and an enricher may fill it).
-                    None,
-                )
-                .await
-                .context("remember failed")?;
+            // CLI `remember` declares no explicit prior: the daemon applies the
+            // 1.0 baseline (and an enricher may fill it).
+            let id = match supersedes {
+                Some(old) => {
+                    let old = parse_id(&old).context("--supersedes must be a memory UUID")?;
+                    client
+                        .remember_superseding(
+                            content,
+                            context,
+                            memory_type,
+                            importance,
+                            Vec::new(),
+                            tags,
+                            Vec::new(),
+                            None,
+                            old,
+                        )
+                        .await
+                        .context("remember --supersedes failed")?
+                }
+                None => client
+                    .remember(
+                        content,
+                        context,
+                        memory_type,
+                        importance,
+                        Vec::new(),
+                        tags,
+                        Vec::new(),
+                        None,
+                    )
+                    .await
+                    .context("remember failed")?,
+            };
             println!("{}", output::render_remembered(&id, json));
         }
         Command::Recall {


### PR DESCRIPTION
Exposes the engine's existing `remember_superseding` (until now reachable only via the SessionEnd hook) on the CLI: store a replacement memory that archives a prior one in one atomic op — the same `supersedes` edge that `link --type supersedes` deliberately rejects ("created by storing a replacement memory, not by linking", `cli.rs:17`).

## Why
Unblocks the memory-value scorecard's **freshness dimension** (#25 / #24): explicitly planting a *superseded* state (X replaced by X') with no CLI for it was the Phase-2 blocker. Also a generally useful capability.

## What
- `remember` gains `--supersedes <UUID>`; when set, routes through `client.remember_superseding` instead of `remember`. Plain `remember` unchanged.
- Parses the id via the existing `parse_id` helper (clear error on a bad UUID).

## Verified
- `cargo test -p rusty-brain` (89 passed) incl. a new parse test; clippy + fmt clean.
- End-to-end smoke against a local daemon: store X (`reqwest`) → `remember --supersedes <id>` with X' (`ureq`) → `recall` returns **only** X'; the superseded X is archived and absent from active recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `remember` subcommand now accepts an optional `--supersedes <UUID>` argument. This allows users to create a new memory that replaces an existing one, with the replacement relationship being established atomically through the CLI. Users gain a dedicated, efficient mechanism for managing memory supersessions and tracking replacements reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->