### PR TITLE
feat(p3): Class C (freshness) scenarios + supersede-plant wiring

### DIFF
--- a/crates/rb-eval/scorecard/memory_scorecard_scenarios.json
+++ b/crates/rb-eval/scorecard/memory_scorecard_scenarios.json
@@ -1,0 +1,65 @@
+{
+  "_about": "Memory-value scorecard scenarios (W3.5 criterion redesign; see docs/eval/2026-06-16-w35-criterion-redesign.md). Each scenario scores memory on an axis where it STRUCTURALLY differs from a hand-maintained CLAUDE.md, against TWO baselines (P1): `realistic_claude_md` is the file a real team would actually have (here: STALE — it still records the original decision, because nobody updated the docs), and `steelman_claude_md` is a diligent human's file (current). A dimension passes only if memory-on BEATS the realistic baseline AND TIES the steelman — a win against only the strawman does not count. The runner (scripts/memory-scorecard.sh) runs four arms (memory-on, realistic-baseline, steelman-baseline, memory-off) and the ONLY hard gate is zero memory-induced errors (P4). Plant mode `explicit` stores facts via `rusty-brain remember` (isolating retrieval from lossy auto-capture, P2); a fact with `supersedes_prev:true` is stored as a superseding update of the prior fact (the supersede path Class C exercises). FRESHNESS (Class C): a decision X is later replaced by X'; memory auto-supersedes so recall returns X', while the realistic (un-updated) CLAUDE.md still says X. expect = the CURRENT value; stale_token = the superseded value (a memory-induced error iff the task fails AND the stale value appears). No `forbid` (a correct answer that names the old value in passing must not false-fail).",
+  "config": {
+    "runs_per_scenario": 5,
+    "memory_induced_errors_allowed": 0
+  },
+  "scenarios": [
+    {
+      "id": "fresh-http-switch",
+      "dimension": "freshness",
+      "plant_mode": "explicit",
+      "plant": [
+        { "content": "Decision: for outbound HTTP this project uses the `reqwest` crate." },
+        { "content": "Update: we migrated off reqwest. All HTTP now uses the `ureq` crate — do NOT add reqwest to anything new; it is being removed.", "supersedes_prev": true }
+      ],
+      "realistic_claude_md": "HTTP: use the `reqwest` crate for outbound HTTP.",
+      "steelman_claude_md": "HTTP: use the `ureq` crate for outbound HTTP. (Migrated off reqwest; do not use reqwest.)",
+      "work": "Add a helper that performs an HTTP GET and returns the response body. Name the HTTP crate it should use and show the dependency line.",
+      "expect": "ureq",
+      "stale_token": "reqwest"
+    },
+    {
+      "id": "fresh-config-rename",
+      "dimension": "freshness",
+      "plant_mode": "explicit",
+      "plant": [
+        { "content": "Decision: project configuration lives in a file named `app.toml` at the repo root." },
+        { "content": "Update: we renamed the config file from `app.toml` to `config/settings.toml`. `app.toml` no longer exists — always read configuration from `config/settings.toml`.", "supersedes_prev": true }
+      ],
+      "realistic_claude_md": "Config: read configuration from `app.toml` at the repo root.",
+      "steelman_claude_md": "Config: read configuration from `config/settings.toml`. (Renamed from app.toml, which no longer exists.)",
+      "work": "Add code that loads a new `timeout_secs` setting at startup. Which config file path should it read from?",
+      "expect": "config/settings.toml",
+      "stale_token": "app.toml"
+    },
+    {
+      "id": "fresh-id-type",
+      "dimension": "freshness",
+      "plant_mode": "explicit",
+      "plant": [
+        { "content": "Convention: entity identifiers in this codebase are `Uuid`." },
+        { "content": "Update: we switched all entity identifiers from Uuid to `Ulid` (lexicographically sortable). New entities use Ulid; do not use Uuid for ids.", "supersedes_prev": true }
+      ],
+      "realistic_claude_md": "Identifiers: entity ids are `Uuid`.",
+      "steelman_claude_md": "Identifiers: entity ids are `Ulid` (switched from Uuid; do not use Uuid for ids).",
+      "work": "Add a new `Order` struct that needs a unique id field. What type should the id be?",
+      "expect": "ulid",
+      "stale_token": "uuid"
+    },
+    {
+      "id": "fresh-test-runner",
+      "dimension": "freshness",
+      "plant_mode": "explicit",
+      "plant": [
+        { "content": "Decision: run the test suite with `cargo test`." },
+        { "content": "Update: we moved the test suite to `cargo nextest run` for parallelism and isolation. Use nextest, not plain `cargo test`, in CI and locally.", "supersedes_prev": true }
+      ],
+      "realistic_claude_md": "Testing: run the suite with `cargo test`.",
+      "steelman_claude_md": "Testing: run the suite with `cargo nextest run` (moved off plain cargo test).",
+      "work": "I need to run the project's tests. What exact command should I use?",
+      "expect": "nextest",
+      "stale_token": "cargo test"
+    }
+  ]
+}

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -268,15 +268,26 @@ score_session() { # dim id arm run proj home work expect forbid stale
 # SUPERSEDED state (Class C: X later replaced by X') is NOT yet expressible here —
 # the CLI has no `remember --supersedes` (supersede lives only in the engine's
 # remember_superseding, exercised by the hook). Class C must add that CLI flag, or
-# construct the superseded state another way; tracked as a Phase-2 open item.
+# construct the superseded state via `remember --supersedes`.
+#
+# Each fact: { content, supersedes_prev? }. Facts store in array order; a fact with
+# `supersedes_prev: true` is stored as a SUPERSEDING update of the immediately
+# prior planted fact (Class C: X then X' replacing X), archiving the predecessor so
+# recall returns only the current value — explicit, no lossy auto-capture (P2).
 plant_explicit() { # home (env: RUSTY_BRAIN_*) <facts-json-array>
   local home="$1" facts="$2"
   ( export HOME="$home"; export PATH="$BIN_DIR:$PATH"
-    local n i content
+    local n i content sup out last_id=""
     n="$(jq 'length' <<<"$facts")"
     for (( i=0; i<n; i++ )); do
       content="$(jq -r ".[$i].content" <<<"$facts")"
-      rusty-brain remember "$content" --type insight >/dev/null 2>&1 || true
+      sup="$(jq -r ".[$i].supersedes_prev // false" <<<"$facts")"
+      if [ "$sup" = "true" ] && [ -n "$last_id" ]; then
+        out="$(rusty-brain --json remember "$content" --type insight --supersedes "$last_id" 2>/dev/null)"
+      else
+        out="$(rusty-brain --json remember "$content" --type insight 2>/dev/null)"
+      fi
+      last_id="$(jq -r '.id // empty' <<<"$out" 2>/dev/null)"
     done
   )
 }
@@ -303,12 +314,15 @@ run_scenario() { # row
     install_rusty_brain "$wh" "$wp"; rm -f "$wp/CLAUDE.md"; rm -rf "$wp/.claude/skills"
     (
       export RUSTY_BRAIN_SOCKET="$sock" RUSTY_BRAIN_DB="$db" RUSTY_BRAIN_NAMESPACE="$ns"
-      # Start a daemon for the store, then plant.
+      # Start a daemon for the store and WAIT for the socket to bind before
+      # planting (a fixed sleep races the bind — observed flaky).
       rusty-brain serve >/dev/null 2>&1 &
-      sleep 1
+      local dpid=$!
+      for _ in $(seq 1 50); do [ -S "$sock" ] && break; sleep 0.2; done
       if [ "$plant_mode" = "explicit" ]; then plant_explicit "$wh" "$facts"; fi
       # (auto-capture mode: a plant session would run here — wired with dimension B.)
       score_session "$dim" "$id" "memory-on" "$run" "$wp" "$wh" "$work" "$expect" "$forbid" "$stale"
+      kill "$dpid" 2>/dev/null || true
     )
     rm -rf "$sockdir" 2>/dev/null || true
 


### PR DESCRIPTION
**Phase 2** of the scorecard redesign (#24 doc, #25 scaffold, #26 `--supersedes`). Wires the **freshness** dimension onto the scaffold.

## What
- `crates/rb-eval/scorecard/memory_scorecard_scenarios.json` — 4 freshness scenarios (http-switch, config-rename, id-type, test-runner). Each plants a decision **X** then a superseding **X'**. The **realistic** baseline is the STALE `CLAUDE.md` a real team would actually have (still records X — nobody updated the docs); the **steelman** is the current file. `expect` = current value; `stale_token` = superseded value (→ a memory-induced error only if the task fails *and* the stale value appears).
- `plant_explicit` now honors `supersedes_prev` — stores a fact as a superseding update of the prior one via `remember --supersedes`, archiving the predecessor (explicit plant, no lossy auto-capture; P2).
- Runner now **waits for the daemon socket to bind** before planting (a fixed sleep raced the bind) and reaps the daemon per run.

## The claim this scores
memory-on auto-supersedes → recall returns X'; the realistic (un-updated) CLAUDE.md still answers X (stale). Dimension passes iff memory-on **beats the stale realistic baseline AND ties the current steelman** — rigging-proof by construction.

## Validated offline (no API)
- JSON valid (4 scenarios); `--self-test` still 9/9.
- Local plant+recall dry-run on `fresh-http-switch`: planting X (reqwest) then X' (`--supersedes`) → recall returns **only** `ureq` (reqwest archived) — the exact memory-on state the dimension scores.

The four-arm run itself needs `claude` (**Phase 3 — the spend gate**, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive memory evaluation test scenarios for freshness conditions.
  * Improved reliability of test execution with enhanced socket availability handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->