### PR TITLE
ci(p3): dispatch-only memory-scorecard workflow

### DIFF
--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -1,0 +1,91 @@
+# Memory-value scorecard (W3.5 criterion redesign; manual dispatch only; NEVER
+# gates PRs). Drives scripts/memory-scorecard.sh: for each scenario it runs four
+# arms (memory-on, realistic-baseline, steelman-baseline, memory-off) and scores
+# the dimension (memory-on must BEAT the realistic baseline AND TIE the steelman),
+# with the only hard gate being zero memory-induced errors. See
+# docs/eval/2026-06-16-w35-criterion-redesign.md.
+#
+# Uploads a structured TSV (dimension/scenario/arm/run/success/turns/mie — counts
+# + booleans, no model free-text), same artifact posture as w35-ab-eval.yml.
+#
+# Required repository secret:
+#   ANTHROPIC_API_KEY — each session runs --model haiku --max-budget-usd 0.50.
+#   A run is (scenarios x 4 arms x N) sessions; the per-session cap bounds spend.
+#   Per the variance protocol (P3) a single run never gates — dispatch N>=5 for a
+#   real read; use N=1 first as a cheap plumbing smoke.
+name: memory scorecard
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "runs per (scenario, arm); N>=5 for a real read, 1 for a smoke"
+        required: false
+        default: "5"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: memory scorecard (macOS)
+    if: github.repository == 'brianluby/rusty-brain'
+    runs-on: macos-latest
+    timeout-minutes: 150
+    permissions:
+      contents: read
+    steps:
+      - name: Preflight - require the ANTHROPIC_API_KEY secret
+        env:
+          HAVE_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          if [ "$HAVE_KEY" != "true" ]; then
+            echo "::error::repository secret ANTHROPIC_API_KEY is not configured; the scorecard cannot run."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build release binaries
+        run: cargo build --release --locked -p rusty-brain -p rb-hooks -p rb-install
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Self-test (judge + scorecard math, no API)
+        run: scripts/memory-scorecard.sh --self-test
+
+      - name: Run the scorecard
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RB_SCORECARD_MAX_BUDGET_USD: "0.50"
+          # Pass the dispatch input via env (never interpolate ${{ }} into the
+          # shell) and validate it's a positive integer before use.
+          RUNS_INPUT: ${{ github.event.inputs.runs || '5' }}
+        run: |
+          case "$RUNS_INPUT" in
+            ''|*[!0-9]*|0) echo "::error::'runs' must be a positive integer (got '$RUNS_INPUT')"; exit 1 ;;
+          esac
+          scripts/memory-scorecard.sh \
+            --bin-dir target/release \
+            --runs "$RUNS_INPUT" \
+            --out "${RUNNER_TEMP}/memory-scorecard.tsv"
+
+      - name: Upload the scorecard TSV
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: memory-scorecard-report
+          path: ${{ runner.temp }}/memory-scorecard.tsv
+          if-no-files-found: ignore


### PR DESCRIPTION
Phase 3 plumbing (no spend): a dispatch-only workflow to run `scripts/memory-scorecard.sh` in CI — the only place the API key authenticates headlessly. Required on `main` to be dispatchable.

- brianluby-guarded, key-preflighted, runs `--self-test` (no API) before the live run.
- Uploads the structured TSV (dimension/scenario/arm/run/success/turns/mie — counts + booleans, no model free-text), same posture as `w35-ab-eval.yml`.
- `workflow_dispatch` with a `runs` input: N≥5 for a real read (variance protocol P3), N=1 as a cheap plumbing smoke. Never gates PRs.

Follows #24/#25/#26/#27. Next: dispatch a 1-run smoke, then Class C at N=5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added memory scorecard workflow for manual performance testing with downloadable results reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->