### PR TITLE
fix(p3): scorecard runner unbound-variable under set -u

### DIFF
--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -307,8 +307,10 @@ run_scenario() { # row
     local base="$WORKROOT/$id-r$run"
     echo "-- $dim/$id (run $run/$RUNS) [$plant_mode]"
 
-    # memory-on
-    local mb="$base/on" db="$mb/memory.db" ns="rb-sc-$id-r$run"
+    # memory-on. NOTE: split the `local`s — a single `local a=.. b=$a` does NOT
+    # see the sibling under `set -u` (b errors as unbound).
+    local mb="$base/on"
+    local db="$mb/memory.db" ns="rb-sc-$id-r$run"
     local sockdir; sockdir="$(mktemp -d /tmp/rbsc.XXXXXX)"; local sock="$sockdir/s"
     local wh="$mb/hw" wp="$mb/wp"; seed_home "$wh"; mkdir -p "$wp"
     install_rusty_brain "$wh" "$wp"; rm -f "$wp/CLAUDE.md"; rm -rf "$wp/.claude/skills"
@@ -317,7 +319,7 @@ run_scenario() { # row
       # Start a daemon for the store and WAIT for the socket to bind before
       # planting (a fixed sleep races the bind — observed flaky).
       rusty-brain serve >/dev/null 2>&1 &
-      local dpid=$!
+      dpid=$!
       for _ in $(seq 1 50); do [ -S "$sock" ] && break; sleep 0.2; done
       if [ "$plant_mode" = "explicit" ]; then plant_explicit "$wh" "$facts"; fi
       # (auto-capture mode: a plant session would run here — wired with dimension B.)


### PR DESCRIPTION
The smoke run (#28's workflow, runs=1) died at the first scenario: `mb: unbound variable`. `local mb="$base/on" db="$mb/memory.db"` referenced `$mb` in the same `local`, which under `set -u` isn't yet set. Split the declaration; `dpid` made a plain subshell assignment.

**Root cause is a coverage gap:** `--self-test` covers only the pure judge/aggregation, never `run_scenario`, so the live runner had literally never executed before CI. Fixed by running the **full runner offline** against a stub `claude` (the runner only shells out to `claude` for work sessions; plant uses the real `rusty-brain`) + debug binaries — all 4 scenarios × 4 arms complete, the scorecard aggregates, the safety gate evaluates, no bash errors. Self-test still 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed variable initialization issues in the memory scorecard script to prevent runtime errors when executing under strict shell mode settings
- Improved process identifier tracking to ensure proper background process management and consistent resource cleanup during memory profiling

**Refactor**
- Optimized variable declaration patterns to enhance script reliability and compatibility with strict execution environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->