### PR TITLE
feat(p3): Class B (capture fidelity) — auto-capture dimension [DRAFT, not yet run]

### DIFF
--- a/crates/rb-eval/scorecard/memory_scorecard_scenarios.json
+++ b/crates/rb-eval/scorecard/memory_scorecard_scenarios.json
@@ -60,6 +60,36 @@
       "work": "I need to run the project's tests. What exact command should I use?",
       "expect": "nextest",
       "stale_token": "cargo test"
+    },
+    {
+      "id": "cap-http-ureq",
+      "dimension": "capture",
+      "plant_mode": "auto-capture",
+      "plant_session": "Team decision for this project: use the `ureq` crate for all outbound HTTP — deliberately NOT reqwest (we want a tiny blocking client, no async runtime). Please acknowledge you've noted this decision.",
+      "realistic_claude_md": "",
+      "steelman_claude_md": "HTTP: use the `ureq` crate for all outbound HTTP (not reqwest).",
+      "work": "Add a helper that performs an HTTP GET and returns the body. Which HTTP crate should it use?",
+      "expect": "ureq"
+    },
+    {
+      "id": "cap-error-apperror",
+      "dimension": "capture",
+      "plant_mode": "auto-capture",
+      "plant_session": "House rule we just agreed on: every fallible function returns our project `AppError` type via the `?` operator — never `.unwrap()` or `.expect()` in library code. Acknowledge this decision.",
+      "realistic_claude_md": "",
+      "steelman_claude_md": "Errors: return the project `AppError` via `?`; no `.unwrap()`/`.expect()` in library code.",
+      "work": "Write a function that reads a required port number from an environment variable. Follow our error-handling convention.",
+      "expect": "apperror"
+    },
+    {
+      "id": "cap-id-ulid",
+      "dimension": "capture",
+      "plant_mode": "auto-capture",
+      "plant_session": "Convention we decided today: every entity identifier in this codebase is a `Ulid` (lexicographically sortable) — not Uuid, not autoincrement integers. Please note this.",
+      "realistic_claude_md": "",
+      "steelman_claude_md": "Identifiers: entity ids are `Ulid` (not Uuid or integer ids).",
+      "work": "Add a new `Order` struct that needs a unique id field. What type should the id be?",
+      "expect": "ulid"
     }
   ]
 }

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -296,7 +296,7 @@ plant_explicit() { # home (env: RUSTY_BRAIN_*) <facts-json-array>
 
 run_scenario() { # row
   local row="$1"
-  local id dim plant_mode work expect forbid stale realistic steelman facts
+  local id dim plant_mode work expect forbid stale realistic steelman facts plant_session
   id="$(jq -r '.id' <<<"$row")"; dim="$(jq -r '.dimension' <<<"$row")"
   plant_mode="$(jq -r '.plant_mode' <<<"$row")"
   work="$(jq -r '.work' <<<"$row")"; expect="$(jq -r '.expect' <<<"$row")"
@@ -304,6 +304,7 @@ run_scenario() { # row
   realistic="$(jq -r '.realistic_claude_md // ""' <<<"$row")"
   steelman="$(jq -r '.steelman_claude_md // ""' <<<"$row")"
   facts="$(jq -c '.plant // []' <<<"$row")"
+  plant_session="$(jq -r '.plant_session // ""' <<<"$row")"
   local run=1
   while [ "$run" -le "$RUNS" ]; do
     local base="$WORKROOT/$id-r$run"
@@ -323,8 +324,28 @@ run_scenario() { # row
       rusty-brain serve >/dev/null 2>&1 &
       dpid=$!
       for _ in $(seq 1 50); do [ -S "$sock" ] && break; sleep 0.2; done
-      if [ "$plant_mode" = "explicit" ]; then plant_explicit "$wh" "$facts"; fi
-      # (auto-capture mode: a plant session would run here — wired with dimension B.)
+      if [ "$plant_mode" = "explicit" ]; then
+        plant_explicit "$wh" "$facts"
+      elif [ "$plant_mode" = "auto-capture" ]; then
+        # The real product loop: a decision EMERGES in a plant session whose
+        # SessionEnd hook folds it into the store — no explicit remember, no manual
+        # doc edit. The plant project keeps the installer defaults (incl. the
+        # CLAUDE.md memory-policy block): a faithful session, and any capture
+        # pollution it causes is a real gap this dimension is meant to surface.
+        ph="$mb/hp"; pp="$mb/pp"; seed_home "$ph"; mkdir -p "$pp"
+        install_rusty_brain "$ph" "$pp"
+        run_session "$ph" "$pp" "$plant_session" "$mb/plant.log"
+        # DIRECT capture fidelity (P-B metric): did the auto-captured summary
+        # actually land the fact? Distinguishes a CAPTURE miss from a RETRIEVAL
+        # miss. Logged, not gated — the scored signal is end-to-end memory-on
+        # success below; this tells us WHY when it is low.
+        cap=0
+        if ( export HOME="$wh"; export PATH="$BIN_DIR:$PATH"; rusty-brain --json recall "$work" 2>/dev/null ) \
+           | jq -e --arg e "$expect" 'any(.[]?; (((.memory.content // "") + " " + (.memory.summary // "")) | ascii_downcase) | contains($e | ascii_downcase))' >/dev/null 2>&1; then
+          cap=1
+        fi
+        echo "   capture_fidelity[$dim/$id r$run]: $cap (expect '$expect' present in the auto-captured store)"
+      fi
       score_session "$dim" "$id" "memory-on" "$run" "$wp" "$wh" "$work" "$expect" "$forbid" "$stale"
       kill "$dpid" 2>/dev/null || true
     )


### PR DESCRIPTION
**Draft** — Phase 4 of the scorecard redesign (#24/#25/#26/#27). The **capture** dimension: the only one that exercises auto-capture (P2). Built and validated offline; **NOT yet run in CI**, so the real result is unknown.

## What
- 3 capture scenarios (`cap-http-ureq`, `cap-error-apperror`, `cap-id-ulid`): a decision **emerges** in a `plant_session` whose **SessionEnd hook** folds it into the store — no explicit remember, no manual doc edit. **realistic** baseline = empty `CLAUDE.md` (the emergent decision nobody wrote down); **steelman** = the diligent human's current doc.
- `run_scenario` auto-capture branch: runs the plant session in a hooked project, then measures **direct capture fidelity** (does the auto-captured summary actually contain the fact?) — logged, distinguishing a *capture* miss from a *retrieval* miss — before scoring end-to-end recall.

## Validated offline only
JSON valid (4 freshness + 3 capture); `--self-test` 9/9; the full runner executes both dimensions against a stdin-draining stub `claude` with no bash errors.

## Why draft
The real capture result needs `claude` to fire `SessionEnd`, which only happens in CI. Per the earlier diagnosis, this run is **expected to expose the lossy-capture gap** (the auto-captured summary dropping the decision) — i.e. it may show memory-on failing to beat even an empty baseline. That's the intended diagnostic signal, not a regression. Mark ready + dispatch `memory-scorecard.yml` when you want that result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)