### PR TITLE
W3.5 prompt-caching study + ADR-3 (dimension A)

### DIFF
--- a/.github/workflows/w35-trace.yml
+++ b/.github/workflows/w35-trace.yml
@@ -63,6 +63,9 @@ jobs:
           npm install -g @anthropic-ai/claude-code
           claude --version
 
+      - name: Self-test (token math + cache aggregate, no API)
+        run: scripts/w35-trace-tools.sh --self-test
+
       - name: Run the tool trace
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,21 @@ All notable changes to rusty-brain are documented here. The format is based on
   `rusty-brain-install` binaries alongside `rusty-brain` in `~/.local/bin`,
   `chmod +x`, with SHA-256 verification of each copy.
 
+### Added — W3.5 cache-trace instrumentation (P4a)
+
+- **`scripts/w35-trace-tools.sh`** now emits four `tok_*` columns
+  (`tok_in`, `tok_cache_create`, `tok_cache_read`, `tok_out`) summed from each
+  `assistant` event's `.message.usage`, plus a per-arm `aggregate_cache` table
+  (mean buckets + `mean_ctx_vol` and cache-weighted `mean_eff_in`). This is
+  the prompt-caching study for W3.5 dimension A — `total_cost_usd` is already
+  cache-adjusted, so the buckets are surfaced **diagnostically** (raw token
+  counts double-count cheap cache reads and must never be the cost axis).
+  **ADR-3** and the investigation live in
+  `docs/eval/2026-06-19-w35-cache-study.md`; the measured scale run stays
+  deferred (no API key/spend). New `--self-test` validates the token math +
+  aggregate with no API; `.github/workflows/w35-trace.yml` runs it on every
+  dispatch before spending.
+
 ### Notes
 
 - The three agent-surface crates are workspace members but are **never** in the

--- a/docs/eval/2026-06-16-w35-criterion-redesign.md
+++ b/docs/eval/2026-06-16-w35-criterion-redesign.md
@@ -143,6 +143,12 @@ scorecard so the headline value is not silently dropped.
   and crank the corpus past comfortable context (500+ facts) so the retrieval
   edge — accuracy on a buried fact — actually bites. Token cost is the secondary
   axis; accuracy-at-scale is primary.
+- **Resolved (methodology), 2026-06-19 — see ADR-3 in
+  `docs/eval/2026-06-19-w35-cache-study.md`.** Score on `total_cost_usd`
+  (cache-adjusted by construction) + correctness, never raw input tokens; the
+  four `tok_*` buckets are surfaced diagnostically via `scripts/w35-trace-tools.sh`'s
+  cache aggregate. The measured run (scale corpus + spend) stays deferred; the
+  harness instrumentation + `--self-test` landed.
 
 ### B — Capture fidelity (build third; expect it to be the hardest bar)
 

--- a/docs/eval/2026-06-19-w35-cache-study.md
+++ b/docs/eval/2026-06-19-w35-cache-study.md
@@ -1,0 +1,142 @@
+# W3.5 prompt-caching study — measuring cached vs uncached input (dimension A)
+
+- **Status:** proposed (investigation + ADR-3; harness instrumentation landed, measured run deferred — no API key / spend in the landing environment, per the repo's land-harness-first convention).
+- **Date:** 2026-06-19.
+- **Scope:** resolves the open question that gates dimension **A — Retrieval at scale** in the criterion redesign (`docs/eval/2026-06-16-w35-criterion-redesign.md`, "A only after the caching question is resolved"). This is P4a of the redesign build sequence.
+- **Companion harness:** `scripts/w35-trace-tools.sh` (extended: four `tok_*` columns + `aggregate_cache` + `--self-test`).
+
+---
+
+## Why
+
+The criterion redesign flagged a methodological trap before dimension A could be
+built. A large CLAUDE.md is loaded once and **cached**: its marginal per-turn
+input cost is near-zero (cache read). Memory, by design, re-injects each turn —
+the `UserPromptSubmit` hook injects a recall slice that depends on the user's
+latest prompt, so it is **dynamic per turn** and is a cache write / uncached
+input each time. A comparison that counts raw `input_tokens` would therefore
+make memory look *more* expensive than the CLAUDE.md baseline even when its
+*billable* cost is comparable. The redesign asked this to be resolved — by
+**measuring cached vs uncached input** — before building the dimension.
+
+## Investigation
+
+The data needed to resolve this **already exists** in the output the trace
+harness captures. `claude -p --output-format stream-json --verbose` emits one
+`assistant` event per turn, and each carries the API `message.usage` object with
+four buckets:
+
+- `input_tokens` — uncached input,
+- `cache_creation_input_tokens` — input written to the cache this call,
+- `cache_read_input_tokens` — input served from the cache (cheap),
+- `output_tokens`.
+
+`scripts/w35-trace-tools.sh` already ran both arms (`memory-on`, `claude-md`)
+under `stream-json --verbose`, but `emit_row` kept only `num_turns`,
+`total_cost_usd`, and tool-call names — it **discarded `message.usage`**. This
+study adds the four `tok_*` columns (session sums over assistant events) and a
+per-arm `aggregate_cache` table.
+
+### The key realization
+
+**`total_cost_usd` is already cache-adjusted.** The API bills cache reads and
+writes at their true rates, so `cost` is the honest, cache-correct cost axis —
+it never had the bug. The bug is in *raw token counting*: comparing arms on
+`input_tokens` (or any token sum that does not discount cache reads) overstates
+memory's per-turn cost, because the CLAUDE.md baseline's input volume is
+dominated by cheap cache reads while memory-on's injected slice is full-price
+each turn. The four buckets are surfaced **diagnostically** (to explain *why*
+costs differ and to show context-window pressure), not as a replacement for
+`cost`.
+
+Two derived figures in `aggregate_cache` make the distinction legible:
+
+- **`mean_ctx_vol`** = `in + cc + cr` — total tokens the model consumed as input
+  context. This is the context-window-pressure axis, and it is where a large
+  CLAUDE.md *legitimately* looks big without being expensive.
+- **`mean_eff_in`** = `in + 1.25·cc + 0.1·cr` — cache-weighted full-price input
+  equivalents (1.25 ≈ Anthropic's 5-min cache-*write* premium; 0.1 ≈ cache-*read*
+  fraction). Weighting `cc` at 1.25× matters because memory-on's hypothesis is high
+  per-turn cache *writes*; leaving `cc` at parity would systematically understate
+  its cost relative to claude-md (a directional bias in the metric whose purpose is
+  to catch directional bias). This should track `total_cost_usd`; if it diverges,
+  the 1.25 / 0.1 constants need recalibration for the run's model/cache-TTL.
+
+---
+
+## ADR-3: score dimension A on cost + accuracy, never raw input tokens; report cache buckets diagnostically
+
+**Context.** Dimension A (retrieval at scale) must show memory-on beating the
+realistic baseline and at least tying the steelman baseline on a *buried* fact
+among a large corpus, with token cost as the secondary axis. The caching
+asymmetry (above) means the choice of token metric is load-bearing.
+
+**Decision.**
+
+1. **The cost axis is `total_cost_usd`, not a raw token sum.** Memory-on is
+   compared against the dual baselines on correctness (primary) and
+   `total_cost_usd` (secondary, cache-adjusted by construction).
+2. **Raw input tokens are reported only as the four buckets** (`tok_in` /
+   `tok_cache_create` / `tok_cache_read` / `tok_out`) plus the two derived
+   figures, **diagnostically**. They are never the basis of a pass/fail
+   comparison between arms, because they double-count cheap cache reads.
+3. **The corpus is cranked past comfortable context** (≥500 facts, per the
+   redesign) so the *accuracy* edge on a buried fact actually bites — that is
+   where memory's value over a single cached CLAUDE.md is real, and it is the
+   primary axis for a reason.
+4. **`mean_eff_in` is a sanity check on cost**, not a tiebreaker: if it and
+   `total_cost_usd` disagree on which arm is cheaper, the cache constants (1.25
+   write / 0.1 read) are wrong for the model/TTL and are recalibrated before
+   reading the table. Note both multipliers are *systematic* — a wrong value
+   biases all arms in the same direction and so does NOT surface as a
+   disagreement; treat `mean_eff_in` as approximate and `total_cost_usd` as truth.
+
+**Consequences.** The dimension-A runner that inherits the shared scaffold
+(redesign build-sequence step 1) must emit the `tok_*` buckets; the scorecard's
+"token cost" axis means `total_cost_usd`. The harness change lands now so A's
+runner inherits it rather than retrofitting.
+
+**Deferred to the measured run (this is the "low spend" boundary).**
+
+- The `ANTHROPIC_API_KEY` repo secret + a small spend budget (the same one secret
+  that unblocks the W3.5 nightly eval, the W3.2 measured scorecard, and the
+  nightly claude-smoke).
+- The ≥500-fact scale corpus so the retrieval edge bites (content authoring,
+  no spend).
+- **Verification of the `message.usage` JSON path against live output.** The
+  parser is defensive (missing fields read `0` via `// 0`); the exact path
+  (`select(.type=="assistant") | .message.usage`) is confirmed against the
+  Anthropic Messages API usage shape but not yet against a real Claude Code
+  stream in this environment. First live run is the verification step — a
+  divergence shows up immediately (all-zero buckets), so it cannot silently
+  mislead.
+- Model/TTL-specific cache-pricing for the `0.1` constant (haiku placeholder).
+
+## Harness change (landed)
+
+- `emit_row` appends `tok_in`, `tok_cache_create`, `tok_cache_read`, `tok_out`
+  (session sums from `.message.usage`), via a pure `sum_usage` helper.
+- `aggregate_cache` prints per-arm mean buckets + `mean_ctx_vol` + `mean_eff_in`.
+- `--self-test` (CI-safe, no API) validates `sum_usage`, the `emit_row` column
+  wiring (incl. the missing-field `// 0` fallback), and the
+  `eff_in`/`ctx_vol` arithmetic over a synthetic stream-json fixture.
+- No protocol/contract change, no binary change. Output remains model-free-text
+  free (token counts + tool names only), so it stays a safe CI artifact.
+
+## Validation for this step
+
+```
+scripts/w35-trace-tools.sh --self-test   # PASS, no API
+```
+
+## Open questions for the measured run
+
+1. Does memory-on's per-turn `UserPromptSubmit` injection actually bust the cache
+   each turn (hypothesis: yes — it is per-prompt dynamic; the buckets will
+   confirm by showing high `cache_creation` / low `cache_read` on memory-on vs
+   the inverse on `claude-md`)?
+2. Corpus size at which the retrieval-accuracy edge over a cached CLAUDE.md
+   becomes statistically separable at N ≥ 5 runs.
+3. Whether the `mean_eff_in` ↔ `total_cost_usd` ratio holds for haiku's cache
+   pricing (calibrates the `1.25` write / `0.1` read constants; haiku vs a
+   1-hour-cache TTL would shift the write multiplier to ~2.0).

--- a/scripts/w35-trace-tools.sh
+++ b/scripts/w35-trace-tools.sh
@@ -12,10 +12,20 @@
 # hypothesis holds.
 #
 # Output: a structured TSV (scenario, arm, run, is_error, num_turns, cost,
-# n_tool_calls, n_rusty_brain_calls, tool_sequence) — TOOL NAMES ONLY, no model
-# free-text, so it is safe to upload as a CI artifact (mirrors w35-ab-eval.sh).
+# n_tool_calls, n_rusty_brain_calls, tok_in, tok_cache_create, tok_cache_read,
+# tok_out, tool_sequence) — TOOL NAMES ONLY, no model free-text, so it is safe
+# to upload as a CI artifact (mirrors w35-ab-eval.sh).
+#
+# The four tok_* columns (summed from each assistant event's .message.usage)
+# are the prompt-caching study instrumentation (ADR-3,
+# docs/eval/2026-06-19-w35-cache-study.md): claude-md's CLAUDE.md caches after
+# turn 1 (cache_read, cheap), while memory-on's per-turn UserPromptSubmit
+# injection is a cache_creation each turn. A naive raw-input-token comparison
+# makes memory look worse; cost is already cache-adjusted, so the buckets are
+# surfaced DIAGNOSTICALLY (per-arm cache aggregate appended to the report).
 #
 # Usage: w35-trace-tools.sh --bin-dir DIR [--runs N] [--out FILE] [--scenarios "id id ..."]
+#        w35-trace-tools.sh --self-test   # CI-safe: token math + aggregate, NO API
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -23,14 +33,15 @@ SCENARIOS_JSON="$REPO_ROOT/crates/rb-eval/scorecard/w35_ab_scenarios.json"
 MODEL="${RB_W35_MODEL:-haiku}"
 MAX_BUDGET_USD="${RB_W35_MAX_BUDGET_USD:-0.50}"
 
-BIN_DIR=""; RUNS="2"; OUT=""; SCENARIOS="time-unix-millis config-settings-toml arch-single-writer"
+BIN_DIR=""; RUNS="2"; OUT=""; SCENARIOS="time-unix-millis config-settings-toml arch-single-writer"; MODE="run"
 while [ $# -gt 0 ]; do
   case "$1" in
+    --self-test) MODE="self-test"; shift ;;
     --bin-dir)   BIN_DIR="${2:?--bin-dir needs a value}"; shift 2 ;;
     --runs)      RUNS="${2:?--runs needs a value}"; shift 2 ;;
     --out)       OUT="${2:?--out needs a value}"; shift 2 ;;
     --scenarios) SCENARIOS="${2:?--scenarios needs a value}"; shift 2 ;;
-    -h|--help)   sed -n '2,20p' "$0"; exit 2 ;;
+    -h|--help)   sed -n '2,28p' "$0"; exit 2 ;;
     *)           echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -40,27 +51,33 @@ case "$RUNS" in ''|*[!0-9]*|0) echo "--runs must be a positive integer" >&2; exi
 # anything else so a dispatch value can never inject shell.
 case "$SCENARIOS" in *[!a-z0-9\ _-]*) echo "--scenarios may contain only [a-z0-9 _-]" >&2; exit 2 ;; esac
 
-[ -n "$BIN_DIR" ] || { echo "need --bin-dir" >&2; exit 2; }
-BIN_DIR="$(cd "$BIN_DIR" && pwd)"
-for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
-  [ -x "$BIN_DIR/$bin" ] || { echo "missing binary: $BIN_DIR/$bin" >&2; exit 1; }
-done
-command -v claude  >/dev/null 2>&1 || { echo "claude not on PATH" >&2; exit 1; }
-command -v jq      >/dev/null 2>&1 || { echo "jq not on PATH" >&2; exit 1; }
-command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH" >&2; exit 1; }
-[ -n "${ANTHROPIC_API_KEY:-}" ] || { echo "ANTHROPIC_API_KEY is not set" >&2; exit 1; }
-[ -f "$SCENARIOS_JSON" ] || { echo "scenarios file not found: $SCENARIOS_JSON" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq not on PATH" >&2; exit 1; }
+
+# Run-mode-only prerequisites (--self-test needs only jq, above).
+if [ "$MODE" != "self-test" ]; then
+  [ -n "$BIN_DIR" ] || { echo "need --bin-dir" >&2; exit 2; }
+  BIN_DIR="$(cd "$BIN_DIR" && pwd)"
+  for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
+    [ -x "$BIN_DIR/$bin" ] || { echo "missing binary: $BIN_DIR/$bin" >&2; exit 1; }
+  done
+  command -v claude  >/dev/null 2>&1 || { echo "claude not on PATH" >&2; exit 1; }
+  command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH" >&2; exit 1; }
+  [ -n "${ANTHROPIC_API_KEY:-}" ] || { echo "ANTHROPIC_API_KEY is not set" >&2; exit 1; }
+  [ -f "$SCENARIOS_JSON" ] || { echo "scenarios file not found: $SCENARIOS_JSON" >&2; exit 1; }
+fi
 
 SESSION_TIMEOUT=""
-if command -v timeout >/dev/null 2>&1; then SESSION_TIMEOUT="timeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"
-elif command -v gtimeout >/dev/null 2>&1; then SESSION_TIMEOUT="gtimeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"; fi
+if [ "$MODE" != "self-test" ]; then
+  if command -v timeout >/dev/null 2>&1; then SESSION_TIMEOUT="timeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"
+  elif command -v gtimeout >/dev/null 2>&1; then SESSION_TIMEOUT="gtimeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"; fi
 
-unset RUSTY_BRAIN_DB RUSTY_BRAIN_SOCKET RUSTY_BRAIN_NAMESPACE RUSTY_BRAIN_IDLE_TIMEOUT_SECS
+  unset RUSTY_BRAIN_DB RUSTY_BRAIN_SOCKET RUSTY_BRAIN_NAMESPACE RUSTY_BRAIN_IDLE_TIMEOUT_SECS
 
-WORKROOT="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-trace.XXXXXX")"
-RESULTS="${OUT:-$WORKROOT/trace.tsv}"; : > "$RESULTS"
-cleanup() { rm -rf "$WORKROOT" 2>/dev/null || true; }
-trap cleanup EXIT
+  WORKROOT="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-trace.XXXXXX")"
+  RESULTS="${OUT:-$WORKROOT/trace.tsv}"; : > "$RESULTS"
+  cleanup() { rm -rf "$WORKROOT" 2>/dev/null || true; }
+  trap cleanup EXIT
+fi
 
 seed_home() { mkdir -p "$1"; printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"; }
 
@@ -93,10 +110,48 @@ PY
   )
 }
 
+# Sum per-session token usage from a stream-json --verbose log. Echoes one
+# tab-separated line: tok_in<TAB>tok_cache_create<TAB>tok_cache_read<TAB>tok_out.
+# Pure over the log (no daemon, no API); each assistant event's .message.usage is
+# summed; missing fields read as 0 (defensive — the path is verified on first run).
+sum_usage() { # log
+  jq -r 'select(.type=="assistant") | .message.usage // empty |
+         [ (.input_tokens // 0),
+           (.cache_creation_input_tokens // 0),
+           (.cache_read_input_tokens // 0),
+           (.output_tokens // 0) ] | @tsv' "$1" 2>/dev/null \
+    | awk -F'\t' '{ i+=$1; cc+=$2; cr+=$3; o+=$4 }
+                   END { printf "%d\t%d\t%d\t%d\n", i+0, cc+0, cr+0, o+0 }'
+}
+
+# Cache-token aggregate (pure awk over the results TSV). Per arm reports the mean
+# of each token bucket plus two derived figures: mean_ctx_vol (in+cc+cr — what the
+# model consumed as input context) and mean_eff_in (in+1.25*cc+0.1*cr — cache-weighted
+# full-price input equivalents, a sanity check against total_cost_usd; 1.25 = Anthropic's
+# 5-min cache-write premium, 0.1 = cache-read fraction). total_cost_usd is ALREADY
+# cache-adjusted by the API, so it stays the honest cost axis; this table explains WHY
+# costs differ (see ADR-3, docs/eval/2026-06-19-w35-cache-study.md).
+aggregate_cache() { # results_tsv
+  awk -F'\t' '
+    { arm=$2; n[arm]++;
+      tin[arm]+=$9; tcc[arm]+=$10; tcr[arm]+=$11; tout[arm]+=$12 }
+    END {
+      printf "%-10s %5s %10s %10s %10s %10s %12s %12s\n",
+        "arm","runs","mean_in","mean_cc","mean_cr","mean_out","mean_ctx_vol","mean_eff_in";
+      split("memory-on claude-md", order, " ");
+      for (i=1;i<=2;i++){ a=order[i]; if (n[a]) {
+        mi=tin[a]/n[a]; mcc=tcc[a]/n[a]; mcr=tcr[a]/n[a]; mo=tout[a]/n[a];
+        printf "%-10s %5d %10.0f %10.0f %10.0f %10.0f %12.0f %12.0f\n",
+          a, n[a], mi, mcc, mcr, mo, (mi+mcc+mcr), (mi+1.25*mcc+0.1*mcr);
+      }}
+    }' "$1"
+}
+
 # Parse a stream-json --verbose work log -> append one TSV row + echo a summary.
 emit_row() { # id arm run log
   local id="$1" arm="$2" run="$3" log="$4"
   local is_err turns cost names n_tool n_rb seq
+  local tin tcc tcr tou
   is_err="$(jq -r 'select(.type=="result")|.is_error' "$log" 2>/dev/null | tail -1)"; : "${is_err:=true}"
   turns="$(jq -r 'select(.type=="result")|.num_turns'  "$log" 2>/dev/null | tail -1)"; : "${turns:=0}"
   cost="$(jq -r 'select(.type=="result")|.total_cost_usd' "$log" 2>/dev/null | tail -1)"; : "${cost:=0}"
@@ -108,10 +163,12 @@ emit_row() { # id arm run log
   else
     n_tool=0; n_rb=0; seq="-"
   fi
-  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$id" "$arm" "$run" "$is_err" "$turns" "$cost" "$n_tool" "$n_rb" "$seq" >> "$RESULTS"
-  printf '   [%-9s] is_error=%s turns=%s cost=%s tool_calls=%s rusty_brain=%s seq=%s\n' \
-    "$arm r$run" "$is_err" "$turns" "$cost" "$n_tool" "$n_rb" "$seq"
+  IFS=$'\t' read -r tin tcc tcr tou < <(sum_usage "$log")
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$id" "$arm" "$run" "$is_err" "$turns" "$cost" "$n_tool" "$n_rb" \
+    "$tin" "$tcc" "$tcr" "$tou" "$seq" >> "$RESULTS"
+  printf '   [%-9s] is_error=%s turns=%s cost=%s tool_calls=%s rusty_brain=%s tok(in/cc/cr/out)=%s/%s/%s/%s seq=%s\n' \
+    "$arm r$run" "$is_err" "$turns" "$cost" "$n_tool" "$n_rb" "$tin" "$tcc" "$tcr" "$tou" "$seq"
 }
 
 trace_scenario() { # row
@@ -156,9 +213,65 @@ trace_scenario() { # row
   done
 }
 
+self_test() {
+  echo "== W3.5 cache-trace self-test (token math + aggregate; no API) =="
+  local tmp fail=0 log row sums
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-cache.XXXXXX")"
+  trap 'rm -rf "$tmp"' RETURN
+  log="$tmp/fixture.jsonl"
+  # Two turns with usage (turn 1 writes cache, turn 2 reads it), plus a turn whose
+  # usage OMITS the cache fields (exercises the // 0 fallback), and a result event.
+  cat >"$log" <<'JSON'
+{"type":"system","subtype":"init","session_id":"s1"}
+{"type":"assistant","message":{"id":"msg_a","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1000,"cache_creation_input_tokens":5000,"cache_read_input_tokens":0,"output_tokens":50}}}
+{"type":"assistant","message":{"id":"msg_b","type":"message","role":"assistant","content":[{"type":"text","text":"yo"}],"usage":{"input_tokens":1200,"cache_creation_input_tokens":0,"cache_read_input_tokens":5000,"output_tokens":30}}}
+{"type":"assistant","message":{"id":"msg_c","type":"message","role":"assistant","content":[{"type":"text","text":"hm"}],"usage":{"input_tokens":50,"output_tokens":10}}}
+{"type":"result","subtype":"success","is_error":false,"num_turns":2,"total_cost_usd":0.0123,"session_id":"s1","result":"done"}
+JSON
+
+  check() { if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "BUG: $1 (want '$2' got '$3')" >&2; fail=1; fi; }
+
+  # sum_usage: in=1000+1200+50=2250; cc=5000; cr=5000; out=50+30+10=90.
+  sums="$(sum_usage "$log")"
+  check "sum_usage -> in/cc/cr/out" "$(printf '2250\t5000\t5000\t90')" "$sums"
+
+  # emit_row wires the parsed buckets into columns 9-12 and cost/turns into 4-6.
+  RESULTS="$tmp/emit.tsv"; : > "$RESULTS"
+  emit_row "sid" "memory-on" "1" "$log"
+  row="$(tail -1 "$RESULTS")"
+  check "emit_row token columns (cols 9-12)" "$(printf '2250\t5000\t5000\t90')" \
+        "$(printf '%s\n' "$row" | cut -f9-12)"
+  check "emit_row is_error/turns/cost (cols 4-6)" "$(printf 'false\t2\t0.0123')" \
+        "$(printf '%s\n' "$row" | cut -f4-6)"
+
+  # aggregate_cache arithmetic (1 run/arm => means == the single values).
+  # eff_in = in + 1.25*cc + 0.1*cr  (1.25 = cache-write premium, 0.1 = cache-read frac):
+  #   memory-on eff_in = 2000+1.25*6000+0.1*500 = 9550; ctx_vol = 2000+6000+500 = 8500
+  #   claude-md  eff_in = 1500+1.25*1000+0.1*8000 = 3550
+  local agg_tsv out meff_on meff_cmd mcr_cmd mctx_on
+  agg_tsv="$tmp/agg.tsv"
+  printf 'scenario\tarm\trun\tis_error\tnum_turns\tcost\tn_tool_calls\tn_rusty_brain_calls\ttok_in\ttok_cache_create\ttok_cache_read\ttok_out\ttool_sequence\n' >"$agg_tsv"
+  printf 's\tmemory-on\t1\tfalse\t2\t0.01\t0\t0\t2000\t6000\t500\t100\t-\n' >>"$agg_tsv"
+  printf 's\tclaude-md\t1\tfalse\t2\t0.01\t0\t0\t1500\t1000\t8000\t80\t-\n' >>"$agg_tsv"
+  out="$(aggregate_cache "$agg_tsv")"
+  meff_on="$(printf '%s\n' "$out" | awk '$1=="memory-on"{print $8}')"
+  meff_cmd="$(printf '%s\n' "$out" | awk '$1=="claude-md"{print $8}')"
+  mcr_cmd="$(printf '%s\n' "$out" | awk '$1=="claude-md"{print $5}')"
+  mctx_on="$(printf '%s\n' "$out" | awk '$1=="memory-on"{print $7}')"
+  check "aggregate eff_in memory-on (2000+1.25*6000+0.1*500=9550)" "9550" "$meff_on"
+  check "aggregate eff_in claude-md (1500+1.25*1000+0.1*8000=3550)" "3550" "$meff_cmd"
+  check "aggregate mean_cache_read claude-md (8000)" "8000" "$mcr_cmd"
+  check "aggregate mean_ctx_vol memory-on (2000+6000+500=8500)" "8500" "$mctx_on"
+
+  if [ "$fail" -eq 0 ]; then echo "self-test PASS"; return 0; fi
+  echo "self-test FAIL" >&2; return 1
+}
+
+if [ "$MODE" = "self-test" ]; then self_test; exit $?; fi
+
 echo "== W3.5 tool-trace (model=$MODEL, budget=\$$MAX_BUDGET_USD/session, runs=$RUNS) =="
 echo "   scenarios: $SCENARIOS"
-printf 'scenario\tarm\trun\tis_error\tnum_turns\tcost\tn_tool_calls\tn_rusty_brain_calls\ttool_sequence\n'
+printf 'scenario\tarm\trun\tis_error\tnum_turns\tcost\tn_tool_calls\tn_rusty_brain_calls\ttok_in\ttok_cache_create\ttok_cache_read\ttok_out\ttool_sequence\n'
 for id in $SCENARIOS; do
   row="$(jq -c --arg id "$id" '.scenarios[]|select(.id==$id)' "$SCENARIOS_JSON")"
   [ -n "$row" ] || { echo "scenario not found: $id" >&2; continue; }
@@ -174,5 +287,8 @@ awk -F'\t' '
     split("memory-on claude-md", o, " ");
     for (i=1;i<=2;i++){ a=o[i]; if(n[a]) printf "%-10s %6d %12.2f %18.2f\n", a, n[a], t[a]/n[a], rb[a]/n[a]; }
   }' "$RESULTS"
+echo
+echo "== cache-token aggregate (cached vs uncached input; see ADR-3) =="
+aggregate_cache "$RESULTS"
 echo
 echo "report: $RESULTS"

--- a/scripts/w35-trace-tools.sh
+++ b/scripts/w35-trace-tools.sh
@@ -113,7 +113,13 @@ PY
 # Sum per-session token usage from a stream-json --verbose log. Echoes one
 # tab-separated line: tok_in<TAB>tok_cache_create<TAB>tok_cache_read<TAB>tok_out.
 # Pure over the log (no daemon, no API); each assistant event's .message.usage is
-# summed; missing fields read as 0 (defensive — the path is verified on first run).
+# summed; missing fields read as 0 (defensive). The .message.usage path matches the
+# Anthropic API usage shape — live verification is on the deferred measured run, and
+# --self-test (run by CI before every dispatch) guards it: a broken path yields
+# all-zeros, which the fixture's 2250/5000/5000/90 would fail on. All-zeros is ALSO
+# legitimate for an errored session (no assistant events); at runtime such a row is
+# already flagged by is_error=true/num_turns=0 (see emit_row), so it is not confused
+# with a path bug (which would show is_error=false, num_turns>0, tok=0).
 sum_usage() { # log
   jq -r 'select(.type=="assistant") | .message.usage // empty |
          [ (.input_tokens // 0),
@@ -219,8 +225,12 @@ self_test() {
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/rb-w35-cache.XXXXXX")"
   trap 'rm -rf "$tmp"' RETURN
   log="$tmp/fixture.jsonl"
-  # Two turns with usage (turn 1 writes cache, turn 2 reads it), plus a turn whose
-  # usage OMITS the cache fields (exercises the // 0 fallback), and a result event.
+  # Three assistant events carry usage: msg_a writes cache, msg_b reads it, msg_c
+  # OMITS the cache fields to exercise the // 0 fallback. The result event's
+  # num_turns is a SEMANTIC CLI count and is deliberately != the assistant-event
+  # count (3) — emit_row reads it straight from .result.num_turns, so the
+  # turns/cost wiring (cols 4-6 below) is checked independently of how many usage
+  # events precede it (as in real stream-json, where num_turns != assistant count).
   cat >"$log" <<'JSON'
 {"type":"system","subtype":"init","session_id":"s1"}
 {"type":"assistant","message":{"id":"msg_a","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1000,"cache_creation_input_tokens":5000,"cache_read_input_tokens":0,"output_tokens":50}}}


### PR DESCRIPTION
Resolves the open question gating W3.5 dimension A (retrieval at scale):
**prompt caching** (`docs/eval/2026-06-16-w35-criterion-redesign.md`, "A only
after the caching question is resolved").

## Why
A large CLAUDE.md caches after turn 1 (cheap cache reads), while memory-on's
per-turn `UserPromptSubmit` injection is a cache write each turn — so a naive
raw input-token comparison makes memory look worse. This needed resolving
before dimension A could be built.

## The decision (ADR-3)
**`total_cost_usd` is already cache-adjusted by the API** — it never had the
bug. The bug is comparing arms on raw input tokens (double-counts cheap cache
reads). Dimension A is therefore scored on **cost + correctness, never raw
input tokens**; the four `tok_*` buckets are surfaced **diagnostically** only.
Investigation + ADR-3: `docs/eval/2026-06-19-w35-cache-study.md`.

## What landed (no spend)
`scripts/w35-trace-tools.sh` now emits `tok_in` / `tok_cache_create` /
`tok_cache_read` / `tok_out` (session sums from `.message.usage`) + a per-arm
`aggregate_cache` table (mean buckets, `mean_ctx_vol`, and cache-weighted
`mean_eff_in = in + 1.25·cc + 0.1·cr` as a sanity check against cost).
- New **`--self-test`** (CI-safe, no API) validates the token math + aggregate
  arithmetic over a synthetic stream-json fixture.
- `.github/workflows/w35-trace.yml` runs the self-test on every dispatch before
  spending (mirrors `memory-scorecard.yml`).

## Deferred (the "low spend" boundary)
The measured scale run — ≥500-fact corpus + `ANTHROPIC_API_KEY` + spend, and
live verification of the `.message.usage` JSON path. Parser is defensive
(missing fields read `0`; all-zero buckets would surface a miss immediately).

## Verification
- `scripts/w35-trace-tools.sh --self-test` → PASS
- `shellcheck -x` clean on new code (remaining SC2030/2164 are pre-existing in `run_session`/`install_rusty_brain`).

## Commits
- `docs(p3)`: prompt-caching study + ADR-3
- `diag(p3)`: W3.5 cache-token instrumentation + self-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-test mode that validates tool functionality without requiring API credentials or scenario setup.
  * Introduced diagnostic token metrics showing cache performance (input, cache-create, cache-read, output tokens).
  * Added cache-aware aggregation reporting with effectiveness metrics.

* **Documentation**
  * Added methodology guide for W3.5 prompt-caching evaluation and cache-weighted cost analysis.

* **Chores**
  * Updated CI workflow to automatically run self-test validation before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->