### PR TITLE
diag(p4a): prompt-caching study harness + provisional ADR-3

### DIFF
--- a/.github/workflows/w35-cache-trace.yml
+++ b/.github/workflows/w35-cache-trace.yml
@@ -92,8 +92,16 @@ jobs:
           for cs in $CORPUS_INPUT; do
             case "$cs" in ''|*[!0-9]*) echo "::error::'corpus_sizes' has a non-numeric entry: '$cs'"; exit 1 ;; esac
           done
+          case "$CORPUS_INPUT" in
+            *[0-9]*) ;;
+            *) echo "::error::'corpus_sizes' must contain at least one number"; exit 1 ;;
+          esac
           case "$SCENARIOS_INPUT" in
             *[!a-z0-9\ _-]*) echo "::error::'scenarios' may contain only [a-z0-9 _-]"; exit 1 ;;
+          esac
+          case "$SCENARIOS_INPUT" in
+            *[a-z0-9]*) ;;
+            *) echo "::error::'scenarios' must contain at least one id"; exit 1 ;;
           esac
           scripts/w35-cache-trace.sh \
             --bin-dir target/release \

--- a/.github/workflows/w35-cache-trace.yml
+++ b/.github/workflows/w35-cache-trace.yml
@@ -1,0 +1,111 @@
+# P4a prompt-caching study (diagnostic; manual dispatch only; NEVER gates PRs).
+#
+# Drives scripts/w35-cache-trace.sh: for the named scenarios and corpus ladder it
+# runs the WORK session under FOUR arms (memory-on / steelman-baseline /
+# realistic-baseline / memory-off) with `--output-format stream-json --verbose`
+# and records the cached-vs-uncached input token breakdown that resolves ADR-3
+# (docs/eval/2026-06-19-p4a-caching-study.md). Uploads a structured TSV (numbers
+# + success flags only, no model free-text) — same artifact posture as
+# w35-ab-eval.yml / w35-trace.yml.
+#
+# Required repository secret:
+#   ANTHROPIC_API_KEY — each session runs --model haiku --max-budget-usd 0.50.
+#
+# The DEFAULT dispatch is a SMALL slice (1 scenario x a 3-point corpus ladder x
+# 1 run ~= 12 sessions) for a cheap daily cache-dynamics signal. CLOSE THE GATE
+# (ADR-3) with a manual dispatch at --runs 5 --corpus-sizes "0 50 200 500 1000"
+# for stochasticity (allow it more time).
+name: p4a cache trace
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "work runs per (scenario, arm, corpus) cell"
+        required: false
+        default: "1"
+      corpus_sizes:
+        description: "space-separated distractor counts (digits + spaces only)"
+        required: false
+        default: "0 50 500"
+      scenarios:
+        description: "space-separated scenario ids ([a-z0-9 _-] only)"
+        required: false
+        default: "dep-http-ureq"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  trace:
+    name: p4a cache trace (macOS)
+    if: github.repository == 'brianluby/rusty-brain'
+    runs-on: macos-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    steps:
+      - name: Preflight - require the ANTHROPIC_API_KEY secret
+        env:
+          HAVE_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          if [ "$HAVE_KEY" != "true" ]; then
+            echo "::error::repository secret ANTHROPIC_API_KEY is not configured; the cache trace cannot run."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build release binaries
+        run: cargo build --release --locked -p rusty-brain -p rb-hooks -p rb-install
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Run the cache trace
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RB_W35_MAX_BUDGET_USD: "0.50"
+          # Pass dispatch inputs via env (never interpolate ${{ }} into the shell)
+          # and validate before use, so a crafted value cannot inject shell.
+          RUNS_INPUT: ${{ github.event.inputs.runs || '1' }}
+          CORPUS_INPUT: ${{ github.event.inputs.corpus_sizes || '0 50 500' }}
+          SCENARIOS_INPUT: ${{ github.event.inputs.scenarios || 'dep-http-ureq' }}
+        run: |
+          case "$RUNS_INPUT" in
+            ''|*[!0-9]*|0) echo "::error::'runs' must be a positive integer (got '$RUNS_INPUT')"; exit 1 ;;
+          esac
+          case "$CORPUS_INPUT" in
+            *[!0-9\ ]*) echo "::error::'corpus_sizes' may contain only digits and spaces (got '$CORPUS_INPUT')"; exit 1 ;;
+          esac
+          for cs in $CORPUS_INPUT; do
+            case "$cs" in ''|*[!0-9]*) echo "::error::'corpus_sizes' has a non-numeric entry: '$cs'"; exit 1 ;; esac
+          done
+          case "$SCENARIOS_INPUT" in
+            *[!a-z0-9\ _-]*) echo "::error::'scenarios' may contain only [a-z0-9 _-]"; exit 1 ;;
+          esac
+          scripts/w35-cache-trace.sh \
+            --bin-dir target/release \
+            --runs "$RUNS_INPUT" \
+            --corpus-sizes "$CORPUS_INPUT" \
+            --scenarios "$SCENARIOS_INPUT" \
+            --out "${RUNNER_TEMP}/p4a-cache.tsv"
+
+      - name: Upload the cache-trace TSV
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: p4a-cache-report
+          path: ${{ runner.temp }}/p4a-cache.tsv
+          if-no-files-found: ignore

--- a/docs/eval/2026-06-19-p4a-caching-study.md
+++ b/docs/eval/2026-06-19-p4a-caching-study.md
@@ -1,0 +1,198 @@
+# P4a — prompt-caching study (investigation + ADR-3)
+
+- **Status:** investigation findings established + harness landed (zero spend).
+  `scripts/w35-cache-trace.sh` + `--self-test` + `--aggregate` +
+  `.github/workflows/w35-cache-trace.yml` are in place. **ADR-3 is PROVISIONAL**
+  — the decision is deferred to a small measured run, with the thresholds that
+  pick the option pre-registered below (per the redesign's §P3: "pre-register
+  pass thresholds *before* running").
+- **Date:** 2026-06-19.
+- **Branch / worktree:** `feat/p4a-w35-caching-study` / `rusty-brain-p4a-caching-study`.
+- **Blocks:** dimension **A (Retrieval at scale)** of the W3.5 scorecard
+  (`docs/eval/2026-06-16-w35-criterion-redesign.md` §A), which names prompt
+  caching as the open question that gates its build.
+- **Carries over:** ADR-1 (single-fact parity with a fresh file is a non-goal)
+  and ADR-2 (the A/B is a cheap proxy; the Phase-5 pilot is ground truth). This
+  study does not re-litigate whether memory has value — it resolves the narrow
+  cache-economics question that determines *how dimension A must be measured and
+  how injection should be shaped*.
+
+## Why
+
+Redesign §A states the blocking question: a large CLAUDE.md is loaded once and
+sits in Claude Code's **cached prefix**, so its marginal per-turn input cost is
+near-zero after turn 1; memory, by contrast, re-injects every turn. A naive
+token comparison therefore makes memory look *worse* than the native baseline
+even when its retrieval accuracy is better. Dimension A cannot be built (nor its
+scorecard judged) until this is resolved: we need **cached vs uncached input
+tokens per arm**, at a corpus size where the retrieval edge actually bites.
+
+This study establishes the measurement architecture, records what is already
+known vs what must be measured, and locks the decision thresholds in ADR-3 so
+the measured run cannot be re-interpreted to fit a preferred outcome.
+
+## Injection mechanics (established from the code, zero spend)
+
+Both rusty-brain injection channels ride `hookSpecificOutput.additionalContext`
+(the only field Claude Code feeds back into the model — see
+`crates/rb-agents/src/claude_code.rs:98` and `crates/rb-hooks/src/capture.rs`):
+
+| channel | fires | content | varies per turn? |
+|---|---|---|---|
+| **SessionStart** (`capture::session_start`) | once per session | budgeted ≤600 tok / ≤10 items; source-aware (`startup`/`clear`→full, `compact`→constraints-only, `resume`→nothing) | **no** — stable across a session unless the store changes |
+| **UserPromptSubmit** (`capture::user_prompt_submit`) | every turn | top-`RECALL_INJECT_LIMIT` (=5) recalls for the prompt, ≤200 chars/line | **yes** — different query ⇒ different hits every turn by design |
+
+The cache asymmetry is therefore structural, not accidental:
+
+- **CLAUDE.md** lives in the cached prefix. After turn 1 it is served from cache
+  at ~10% of base input cost, regardless of how large it is (until the cache is
+  evicted — see U3).
+- **UserPromptSubmit recall** is inherently per-turn: its content changes each
+  turn, so it can never sit in a cross-turn cached prefix. It is full-price
+  input every turn.
+- **SessionStart digest** is *potentially* cacheable across turns (stable
+  content), **but only if** Claude Code places a cache breakpoint after it
+  rather than before it. That placement is the single biggest unknown (U1).
+
+## Investigation findings
+
+- **F1 — stream-json already emits the cache breakdown.** A single-turn
+  `claude -p --output-format stream-json --verbose` (probed 2026-06-19) emits the
+  full per-turn and aggregate usage, including:
+  `usage.input_tokens`, `usage.cache_creation_input_tokens`,
+  `usage.cache_read_input_tokens`, `usage.output_tokens`, and
+  `usage.cache_creation.ephemeral_{5m,1h}_input_tokens`. It appears in both the
+  per-turn `assistant` record (`message.usage`) and the final `result` record.
+  **Implication:** the measurement path is to extend the existing trace harness
+  — no parallel direct-API rig is required.
+- **F2 — the existing harness does not capture cache tokens.** `scripts/w35-trace-tools.sh`
+  parses `num_turns`, `total_cost_usd`, and the tool-name sequence only (the one
+  `cache_read` reference in the repo is an unrelated eval-corpus id
+  `pk_cache_poisoning_incident`). `total_cost_usd` *reflects* cache benefit
+  (cache reads are cheaper) but does not decompose it — two arms can post the
+  same cost with very different cache dynamics, which is exactly what dimension A
+  needs to tell apart.
+- **F3 — the cost asymmetry is bounded by construction.** Per-turn recall is
+  capped at 5 lines × ≤200 chars plus a fixed `UNTRUSTED_DATA_FRAME` preamble —
+  a small, bounded payload (the W3.3 token-accounting test already asserts the
+  ≤600-token SessionStart budget; UserPromptSubmit is tighter still). The
+  per-turn uncached cost of memory is therefore a small constant, not an
+  unbounded one.
+- **F4 — measured run blocked, harness work unblocked.** `claude` in this
+  environment returns `401 Invalid authentication credentials` for model calls
+  (hooks still fire — they are local and need no API auth), and the worktree has
+  no built binaries. So the investigation, ADR-3, the harness extension, and its
+  `--self-test` are all zero-spend and unblocked; only the final measured
+  dispatch waits on auth + a release build.
+
+## Unknowns the measured run must resolve
+
+- **U1 — injection placement vs cache breakpoints.** Does Claude Code place a
+  cache breakpoint *after* the SessionStart `additionalContext` (so the digest
+  is served from cache on turns 2..N) or *before* it (so it is re-sent at full
+  price every turn)? This determines whether the SessionStart channel is cheap
+  or expensive at scale, and is the first thing a 2-turn probe settles.
+- **U2 — per-arm cache economics across a corpus ladder.** For
+  `memory-on` / `realistic-baseline` / `steelman-baseline` / `memory-off` (the
+  redesign §P1 four arms), measure `cache_read_input_tokens`,
+  `cache_creation_input_tokens`, and `input_tokens` per turn at corpus sizes
+  that cross comfortable context (redesign §A: 500+ facts).
+- **U3 — the crossover.** At what corpus size does a steelman CLAUDE.md holding
+  all facts (a) stop being maintainable, (b) exceed practical prefix size, or
+  (c) get evicted from the cache by conversation growth — such that targeted
+  recall is net-cheap *even when uncached*? This is the corpus size at which
+  memory's retrieval edge is unambiguous.
+
+## ADR-3 — injection shape under prompt caching
+
+**Context:** redesign §A blocks dimension A on the caching question; F1–F4
+establish that it is measurable via the existing harness extended with cache
+fields; U1–U3 are what the measured run must settle.
+
+**Options:**
+
+- **Opt 1 — per-turn recall only (status quo for UserPromptSubmit).** Accept the
+  uncached per-turn cost; rely on the scale crossover (U3) and the bounded
+  payload (F3) to keep it net-neutral. Simplest; gives up nothing on retrieval
+  quality.
+- **Opt 2 — move injection into the cached prefix.** Make the injected set a
+  stable digest so it caches across turns. Buys cache-friendliness at the cost
+  of per-query targeting (recall no longer follows each prompt). Only sane if
+  U1 shows the SessionStart digest is *not* already cached.
+- **Opt 3 — hybrid: cache-stable SessionStart digest + tightly-bounded per-turn
+  recall (current architecture).** Keep the source-aware SessionStart digest
+  sized for cache stability and the per-turn recall at ≤5 items / ≤200 chars.
+  Measure that the combined per-turn uncached cost is dominated by the
+  retrieval-accuracy win at scale.
+
+**Provisional decision: Opt 3** (the current architecture), ratified or revised
+by the measured run. It is chosen *provisionally* because it costs nothing to
+hold (the code already implements it) and because F3 shows its per-turn payload
+is bounded.
+
+**Pre-registered thresholds (the measured run picks the final option):**
+
+1. If, at corpus ≥ 500 facts, `memory-on` retrieval accuracy ≥ `steelman-baseline`
+   accuracy **and** `memory-on` `cache_read_input_tokens / input_tokens` ratio is
+   within 20% of `steelman`'s (per-turn median over N≥5 runs) → **ratify Opt 3.**
+2. If `memory-on` accuracy wins but the cache ratio is worse than 20% (per-turn
+   uncached cost > ~1.3× steelman's) → **adopt Opt 2 for the SessionStart
+   channel only**, keeping per-turn UserPromptSubmit recall only where U1 + the
+   accuracy data show it changes outcomes.
+3. If neither accuracy nor economics win at scale → memory's value is
+   capture/freshness/reach (ADR-1), not retrieval@scale; **descope dimension A's
+   token-cost axis to informational** and keep accuracy-at-scale as the sole
+   primary metric.
+
+**Status: PROVISIONAL.** Thresholds locked here before any spend, per redesign
+§P3. The final ADR-3 is recorded by appending the measured numbers and the
+option they selected to this same doc.
+
+## Measurement architecture (LANDED; zero spend to stand up)
+
+- **Harness:** `scripts/w35-cache-trace.sh` (sibling to `w35-trace-tools.sh` /
+  `w35-ab-eval.sh`). Per WORK session it reads the session-AGGREGATE usage from
+  the stream-json `result` record — `input_tokens`,
+  `cache_creation_input_tokens`, `cache_read_input_tokens`, `output_tokens` —
+  alongside `num_turns` / `total_cost_usd`. `--self-test` exercises the
+  extraction + ADR-3 verdict math with no API (CI-safe); `--aggregate FILE`
+  re-scores a saved TSV (e.g. an uploaded nightly artifact) without re-running.
+- **Arms:** the redesign §P1 four — `memory-on`, `steelman-baseline`,
+  `realistic-baseline`, `memory-off`. Reuses `w35-ab-eval.sh`'s hermeticity
+  (isolated `HOME`, namespace, short `/tmp` socket, confound strip).
+- **Planting:** redesign §P2 explicit-plant mode — `memory-on` loads the target
+  (importance 8) + N distractors (importance 5) via direct `rusty-brain remember`
+  CLI calls (bypasses the lossy auto-summary; isolates a clean retrieval + cache
+  signal). Distractors are deterministic per scenario id (`gen_corpus`), off-topic
+  (fictional port numbers) so they never collide with an `expect`/`stale` token.
+- **Corpus ladder:** 0, 50, 200, 500, 1000 (distractors; +1 shared target, so
+  corpus=0 is the single-fact ADR-1 baseline). `steelman-baseline` holds target +
+  distractors inline in CLAUDE.md; `realistic-baseline` holds distractors only
+  (target omitted — the common "nobody wrote it down" reality).
+- **Variance:** N ≥ 5 runs per (scenario, arm, corpus-size) cell (redesign §P3);
+  a single-run dispatch is directional only and never gates. (The harness reports
+  per-cell means today; median + IQR aggregation is a follow-up — the gate-closing
+  run needs N≥5 first, so means are not yet load-bearing.)
+- **Verdicts:** `aggregate()` applies ADR-3's thresholds per corpus size
+  (`memory-on` vs `steelman-baseline`) and prints RATIFY-Opt-3 / Opt-2-candidate /
+  descope per cell, plus the hard gate (zero memory-induced errors).
+- **Dispatch:** `.github/workflows/w35-cache-trace.yml` (manual only, never gates
+  PRs). Default is a cheap slice (1 scenario × 3-point ladder × 1 run); close the
+  ADR-3 gate with a manual `--runs 5 --corpus-sizes "0 50 200 500 1000"` dispatch.
+- **Spend guard:** cheap model (`haiku`), hard `--max-budget-usd` per session,
+  per-session wall-clock `timeout` (when available) — the existing posture.
+
+## Build sequence
+
+0. **This doc** — lock the findings + provisional ADR-3 + thresholds (no code, no spend). ✅ done.
+1. **Harness + `--self-test` + `--aggregate` + dispatch workflow** (code, no spend): cache-token TSV columns, four-arm dual-baseline runner over a corpus ladder, pure-core aggregation, ADR-3 per-corpus verdicts. ✅ done (`scripts/w35-cache-trace.sh` `--self-test` passes; `.github/workflows/w35-cache-trace.yml`).
+2. **Smoke** (first spend, tiny): `--self-test` → a 1-scenario × 1-corpus-size dispatch at N=1 to confirm `expect`/cache fields discriminate on real haiku output; recalibrate any noisy cell. ← blocked on `ANTHROPIC_API_KEY` + a release build.
+3. **Measured run** (the spend): the full corpus ladder at N ≥ 5. Read the scorecard; apply the pre-registered thresholds.
+4. **Finalize ADR-3:** append the numbers and the selected option to this doc; unblock dimension A.
+
+## Notes / honesty
+
+- **Not per-PR CI:** nondeterministic and costs API spend; nightly/dispatch posture with alerting (the `w35-ab-eval.yml` pattern).
+- **The probe used to establish F1 401'd on auth** and so cost nothing; it still emitted the full usage schema, which is the only fact F1 depends on. The schema should be re-confirmed on the first authenticated run (step 2) in case a future claude build renames fields.
+- **U1 (breakpoint placement) is asserted by no source I could read** — it is a Claude Code implementation detail that must be measured, not assumed. ADR-3's provisional decision explicitly does not depend on U1's outcome; the thresholds route around either result.
+- Until the measured run is recorded, dimension A's "retrieval at scale" gate clause is **owed**, not met — recorded here so it is not silently declared passed.

--- a/docs/eval/2026-06-19-p4a-caching-study.md
+++ b/docs/eval/2026-06-19-p4a-caching-study.md
@@ -133,8 +133,11 @@ is bounded.
 **Pre-registered thresholds (the measured run picks the final option):**
 
 1. If, at corpus ≥ 500 facts, `memory-on` retrieval accuracy ≥ `steelman-baseline`
-   accuracy **and** `memory-on` `cache_read_input_tokens / input_tokens` ratio is
-   within 20% of `steelman`'s (per-turn median over N≥5 runs) → **ratify Opt 3.**
+   accuracy **and** `memory-on` cache-read ratio is within 20% of `steelman`'s
+   → **ratify Opt 3.** (cache-read ratio = `cache_read_input_tokens /
+   (cache_read_input_tokens + input_tokens)` — the fraction of input-side tokens
+   served from cache, computed as a per-cell session aggregate over N≥5 runs;
+   median + IQR is the recorded follow-up once N≥5 lands.)
 2. If `memory-on` accuracy wins but the cache ratio is worse than 20% (per-turn
    uncached cost > ~1.3× steelman's) → **adopt Opt 2 for the SessionStart
    channel only**, keeping per-turn UserPromptSubmit recall only where U1 + the

--- a/scripts/w35-cache-trace.sh
+++ b/scripts/w35-cache-trace.sh
@@ -51,7 +51,7 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SCENARIOS="$REPO_ROOT/crates/rb-eval/scorecard/w35_ab_scenarios.json"
+SCENARIOS_JSON="$REPO_ROOT/crates/rb-eval/scorecard/w35_ab_scenarios.json"
 MODEL="${RB_W35_MODEL:-haiku}"
 MAX_BUDGET_USD="${RB_W35_MAX_BUDGET_USD:-0.50}"
 # A failed session scores this many turns — a worst-case sentinel, well above a
@@ -302,7 +302,7 @@ if [ "$MODE" = "self-test" ]; then self_test; exit $?; fi
 if [ "$MODE" = "aggregate" ]; then
   [ -f "$REPORT_TSV" ] || { echo "tsv not found: $REPORT_TSV" >&2; exit 1; }
   mie_default=0
-  [ -f "$SCENARIOS" ] && mie_default="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS" 2>/dev/null || echo 0)"
+  [ -f "$SCENARIOS_JSON" ] && mie_default="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS_JSON" 2>/dev/null || echo 0)"
   aggregate "$REPORT_TSV" "$mie_default"
   exit $?
 fi
@@ -318,20 +318,24 @@ command -v jq      >/dev/null 2>&1 || { echo "jq not on PATH (needed to parse st
 command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (corpus generator + settings.json edit)" >&2; exit 1; }
 [ -n "${ANTHROPIC_API_KEY:-${CLAUDE_CODE_API_KEY:-${CLAUDE_API_KEY:-}}}" ] \
   || { echo "no Anthropic API credential in env (ANTHROPIC_API_KEY / CLAUDE_CODE_API_KEY) — the measured run is DEFERRED until one is set" >&2; exit 1; }
-[ -f "$SCENARIOS" ] || { echo "scenarios file not found: $SCENARIOS" >&2; exit 1; }
+[ -f "$SCENARIOS_JSON" ] || { echo "scenarios file not found: $SCENARIOS_JSON" >&2; exit 1; }
 
 # Validate free-form inputs (never interpolate a dispatch value into a shell).
 case "$CORPUS_SIZES" in *[!0-9\ ]*) echo "--corpus-sizes may contain only digits and spaces" >&2; exit 2 ;; esac
 for cs in $CORPUS_SIZES; do
   case "$cs" in ''|*[!0-9]*) echo "--corpus-sizes has a non-numeric entry: '$cs'" >&2; exit 2 ;; esac
 done
+# Reject whitespace-only input (e.g. "   "): it passes the charset check above
+# but yields zero cells — a silent no-op run.
+case "$CORPUS_SIZES" in *[0-9]*) ;; *) echo "--corpus-sizes must contain at least one number" >&2; exit 2 ;; esac
 
 # Default scenarios: one stale-trap + two plain (cheap, exercises both judge paths).
 [ -n "$SCENARIOS" ] || SCENARIOS="dep-http-ureq config-settings-toml stale-trap-http-switch"
 case "$SCENARIOS" in *[!a-z0-9\ _-]*) echo "--scenarios may contain only [a-z0-9 _-]" >&2; exit 2 ;; esac
+case "$SCENARIOS" in *[a-z0-9]*) ;; *) echo "--scenarios must contain at least one id" >&2; exit 2 ;; esac
 
-[ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS")"
-MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS")"
+[ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS_JSON")"
+MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS_JSON")"
 
 # Per-session wall-clock cap (defense against a hung session stalling the run).
 SESSION_TIMEOUT=""
@@ -516,10 +520,8 @@ run_cell() { # <id> <run> <corpus> <plant> <claude_md> <work> <expect> <forbid> 
 echo "== P4a cache study (model=$MODEL, budget=\$$MAX_BUDGET_USD/session, runs=$RUNS) =="
 echo "   scenarios: $SCENARIOS"
 echo "   corpus sizes (distractors): $CORPUS_SIZES"
-rows=()
-while IFS= read -r row; do rows+=("$row"); done < <(jq -c '.scenarios[]' "$SCENARIOS")
 for id in $SCENARIOS; do
-  row="$(jq -c --arg id "$id" '.scenarios[]|select(.id==$id)' "$SCENARIOS")"
+  row="$(jq -c --arg id "$id" '.scenarios[]|select(.id==$id)' "$SCENARIOS_JSON")"
   [ -n "$row" ] || { echo "scenario not found: $id" >&2; continue; }
   plant="$(jq -r '.plant' <<<"$row")"
   claude_md="$(jq -r '.claude_md' <<<"$row")"

--- a/scripts/w35-cache-trace.sh
+++ b/scripts/w35-cache-trace.sh
@@ -1,0 +1,544 @@
+#!/usr/bin/env bash
+# P4a prompt-caching study (companion to scripts/w35-ab-eval.sh and
+# scripts/w35-trace-tools.sh; records ADR-3 in
+# docs/eval/2026-06-19-p4a-caching-study.md).
+#
+# The W3.5 scorecard's dimension A (Retrieval at scale) is gated on an open
+# question (redesign §A): a large CLAUDE.md sits in Claude Code's CACHED prefix
+# (marginal per-turn cost ~0 after turn 1), while memory re-injects each turn,
+# so a naive token comparison makes memory look worse. This harness resolves it
+# by measuring, per arm and across a corpus ladder, the cached-vs-uncached input
+# token breakdown that `claude -p --output-format stream-json --verbose` emits.
+#
+# Four arms (redesign §P1 dual baselines):
+#   memory-on          — rusty-brain hooks+MCP; the target + N distractors are
+#                        EXPLICITLY PLANTED via `rusty-brain remember` (redesign
+#                        §P2 explicit-plant mode: bypasses the lossy auto-summary
+#                        and isolates a clean retrieval + cache signal); the WORK
+#                        session recalls via the deterministic UserPromptSubmit
+#                        injection.
+#   steelman-baseline  — no rusty-brain; the target + N distractors are written
+#                        inline into CLAUDE.md (clean/current/complete). The
+#                        honest best case for the cached prefix; the arm ADR-3's
+#                        thresholds compare against.
+#   realistic-baseline — no rusty-brain; N distractors in CLAUDE.md but the
+#                        TARGET IS OMITTED (incomplete docs — the common reality).
+#   memory-off         — nothing; the floor.
+#
+# Corpus ladder (default 0 50 200 500 1000): N DISTRACTORS plus one shared
+# target, so corpus=0 is the single-fact case (ADR-1's parity baseline). At
+# large N a buried target is where memory's retrieval edge should bite and a
+# giant CLAUDE.md should start paying for its cache.
+#
+# Per WORK session the harness records: num_turns, total_cost_usd, AND the
+# session-aggregate usage.{input_tokens, cache_creation_input_tokens,
+# cache_read_input_tokens, output_tokens} — the cache economics ADR-3 needs.
+# The judge is the same deterministic expect-substring as w35-ab-eval.sh (the
+# model's OUTPUT only: final .result + files written this session, never the
+# seeded CLAUDE.md). The TSV carries ONLY numbers + the success flag — no model
+# free-text — so it is safe to upload as a CI artifact (same posture as the
+# other w35 harnesses).
+#
+# PASS verdicts are computed per corpus size against ADR-3's pre-registered
+# thresholds (memory-on vs steelman-baseline): see aggregate() below.
+#
+# STATUS: harness + pure --self-test landed; the measured run is DEFERRED — it
+# needs `claude` auth + a small spend budget + a release build. Run it via:
+#   cargo build --release -p rusty-brain -p rb-hooks -p rb-install
+#   scripts/w35-cache-trace.sh --bin-dir target/release
+# `--self-test` validates the usage-extraction + scoring math with NO API and is
+# CI-safe.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCENARIOS="$REPO_ROOT/crates/rb-eval/scorecard/w35_ab_scenarios.json"
+MODEL="${RB_W35_MODEL:-haiku}"
+MAX_BUDGET_USD="${RB_W35_MAX_BUDGET_USD:-0.50}"
+# A failed session scores this many turns — a worst-case sentinel, well above a
+# normal task, so a failure can never make an arm look faster on the turns/cache
+# tiebreakers. Defined early: extract_usage (exercised by --self-test) reads it.
+TURNS_FAIL_SENTINEL="${RB_W35_TURNS_FAIL_SENTINEL:-99}"
+
+usage() { sed -n '2,46p' "$0"; exit 2; }
+
+# --- usage extraction (pure; exercised by --self-test) -----------------------
+# extract_usage <stream-json-log>
+# Echoes one TSV row (7 fields), reading the session-AGGREGATE usage from the
+# final `result` record (the same record that carries num_turns/total_cost_usd;
+# it sums every turn's usage, so it is the session-total cache economics):
+#   is_error  num_turns  cost  input_tok  cache_create_tok  cache_read_tok  output_tok
+# A non-parseable log (timeout/error/budget) yields a worst-case sentinel row so
+# a failure can never make an arm look artificially cheap on the cache metrics:
+# turns=TURNS_FAIL_SENTINEL, every token field 0, is_error=true.
+extract_usage() {
+  local log="$1"
+  local r is_err turns cost inp cc cr out
+  r="$(jq -c 'select(.type=="result")' "$log" 2>/dev/null | tail -1)"
+  if [ -n "$r" ]; then
+    # `// true` would collapse an explicit false (jq's alt treats false as
+    # empty), so gate on field presence: absent is_error => assume error.
+    is_err="$(jq -r 'if has("is_error") then .is_error else true end' <<<"$r")"
+    turns="$(jq -r '.num_turns // 0'           <<<"$r")"
+    cost="$(jq -r '.total_cost_usd // 0'       <<<"$r")"
+    inp="$(jq -r '.usage.input_tokens // 0'                <<<"$r")"
+    cc="$(jq -r  '.usage.cache_creation_input_tokens // 0' <<<"$r")"
+    cr="$(jq -r  '.usage.cache_read_input_tokens // 0'     <<<"$r")"
+    out="$(jq -r '.usage.output_tokens // 0'   <<<"$r")"
+  else
+    is_err=true; turns="$TURNS_FAIL_SENTINEL"; cost=0; inp=0; cc=0; cr=0; out=0
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$is_err" "$turns" "$cost" "$inp" "$cc" "$cr" "$out"
+}
+
+# --- success judge (pure; exercised by --self-test) --------------------------
+# judge_text <textfile> <expect> <forbid> <stale_token> <arm> -> echoes "<success> <mie>".
+# Verbatim from scripts/w35-ab-eval.sh: expect-substring success (forbid absent
+# => no forbid check); a memory-induced error keys ONLY on the memory-on arm
+# failing AND the stale token being present. See w35-ab-eval.sh for rationale.
+judge_text() {
+  local file="$1" expect="$2" forbid="$3" stale="$4" arm="$5"
+  local success=0 mie=0
+  if grep -iqF -- "$expect" "$file" 2>/dev/null; then success=1; fi
+  if [ -n "$forbid" ] && grep -iqF -- "$forbid" "$file" 2>/dev/null; then success=0; fi
+  if [ "$arm" = "memory-on" ] && [ "$success" -eq 0 ] && [ -n "$stale" ] \
+     && grep -iqF -- "$stale" "$file" 2>/dev/null; then mie=1; fi
+  echo "$success $mie"
+}
+
+# --- aggregate + ADR-3 verdicts (pure; exercised by --self-test) -------------
+# Reads the results TSV:
+#   scenario<TAB>arm<TAB>corpus<TAB>run<TAB>success<TAB>turns<TAB>cost<TAB>input_tok<TAB>cache_create_tok<TAB>cache_read_tok<TAB>output_tok<TAB>mie
+# Prints a per-(arm,corpus) cache-economics table, then a per-corpus verdict
+# applying ADR-3's pre-registered thresholds (memory-on vs steelman-baseline).
+aggregate() {
+  local tsv="$1" mie_allowed="${2:-0}"
+  awk -F'\t' -v mie_allowed="$mie_allowed" '
+    function ratio(cr, inp) { if (cr+inp == 0) return 0; return cr/(cr+inp) }
+    {
+      arm=$2; c=$3; succ=$5; turns=$6; cost=$7; inp=$8; cc=$9; cr=$10; mie=$12;
+      key=arm SUBSEP c;
+      n[key]++; s[key]+=succ; t[key]+=turns; co[key]+=cost;
+      ti[key]+=inp; tcc[key]+=cc; tcr[key]+=cr;
+      if (arm=="memory-on" && mie==1) { mie_total++; mie_list = mie_list sprintf("    - %s corpus %s run %s\n", $1, c, $4); }
+      corpora[c]=1;
+    }
+    END {
+      narms = split("memory-on steelman-baseline realistic-baseline memory-off", arms, " ");
+      # sort corpus sizes ascending
+      ncorp=0; for (c in corpora) { ncorp++; corp[ncorp]=c }
+      # insertion sort (small N)
+      for (i=2;i<=ncorp;i++) { v=corp[i]; j=i-1; while (j>=1 && corp[j]+0 > v+0) { corp[j+1]=corp[j]; j-- } corp[j+1]=v }
+      printf "%-20s %6s %5s %8s %9s %10s %10s %10s %9s\n", "arm/corpus", "runs", "succ", "mturns", "mcost$", "m_input", "m_ccrea", "m_cread", "cache%";
+      for (ci=1; ci<=ncorp; ci++) {
+        c=corp[ci];
+        for (ai=1; ai<=narms; ai++) {
+          a=arms[ai]; key=a SUBSEP c;
+          if (n[key]==0) continue;
+          printf "%-12s/%-6s %6d %4.0f%% %9.2f %9.4f %10.0f %10.0f %10.0f %8.1f\n", \
+            a, c, n[key], 100*s[key]/n[key], t[key]/n[key], co[key]/n[key], \
+            ti[key]/n[key], tcc[key]/n[key], tcr[key]/n[key], \
+            100*ratio(tcr[key], ti[key]);
+        }
+      }
+      print "";
+      # ADR-3 verdicts: memory-on vs steelman-baseline, per corpus.
+      print "== ADR-3 verdicts (memory-on vs steelman-baseline; thresholds pre-registered) ==";
+      for (ci=1; ci<=ncorp; ci++) {
+        c=corp[ci];
+        onk ="memory-on" SUBSEP c;          stl="steelman-baseline" SUBSEP c;
+        if (n[onk]==0 || n[stl]==0) { printf "  corpus %-6s SKIP (an arm produced no runs)\n", c; continue }
+        on_acc = s[onk]/n[onk];             stl_acc = s[stl]/n[stl];
+        on_cr  = ratio(tcr[onk], ti[onk]);  stl_cr  = ratio(tcr[stl], ti[stl]);
+        acc_ok = (on_acc >= stl_acc);
+        # threshold 2 "within 20%" = memory-on cache% >= 0.8 * steelman cache%
+        cache_ok = (stl_cr == 0 ? (on_cr == 0) : (on_cr >= 0.8 * stl_cr));
+        printf "  corpus %-6s acc on %.2f vs stl %.2f [%s] | cache%% on %.1f vs stl %.1f [%s]\n", \
+          c, on_acc, stl_acc, (acc_ok?"ok":"NO"), 100*on_cr, 100*stl_cr, (cache_ok?"ok":"NO");
+        if (acc_ok && cache_ok) {
+          verdict="RATIFY Opt 3 (accuracy + cache within 20% of steelman)"
+        } else if (acc_ok && !cache_ok) {
+          verdict="Opt 2 candidate (accuracy wins; cache ratio > 20% worse — consider caching the SessionStart digest)"
+        } else if (!acc_ok && cache_ok) {
+          verdict="accuracy loses at scale (cache is fine) — investigate retrieval, not caching"
+        } else {
+          verdict="descope dimension A token-cost axis (value is capture/freshness/reach per ADR-1)"
+        }
+        printf "             -> %s\n", verdict;
+      }
+      print "";
+      mie_ok = (mie_total+0 <= mie_allowed+0);
+      printf "memory-induced errors: %d (allowed %d)\n", mie_total+0, mie_allowed+0;
+      if (mie_total+0 > 0) { printf "  enumerated (never averaged away):\n%s", mie_list; }
+      # The hard gate is still zero memory-induced errors (the safety property).
+      printf "p4a cache study: %s\n", (mie_ok ? "cache-economics recorded (see verdicts above)" : "FAIL (memory-induced errors)");
+      exit (mie_ok ? 0 : 1);
+    }
+  ' "$tsv"
+}
+
+# --- corpus generator (pure; deterministic; exercised indirectly) ------------
+# gen_corpus <scenario_id> <n>  -> prints n markdown-bullet distractor lines.
+# Deterministic (seeded by scenario_id) so re-runs are reproducible. Distractors
+# are deliberately OFF-TOPIC from any scenario target (port numbers for fictional
+# services) so they never accidentally contain an `expect`/`stale` token.
+gen_corpus() {
+  python3 - "$1" "$2" <<'PY'
+import sys, hashlib, random
+sid, n = sys.argv[1], int(sys.argv[2])
+seed = int(hashlib.sha256(sid.encode()).hexdigest()[:12], 16)
+random.seed(seed)
+ports = random.sample(range(4000, 60000), n)
+for i in range(n):
+    print(f"- Service port convention: `service-svc-{i:04d}` listens on port {ports[i]}; do not reassign it.")
+PY
+}
+
+# --- self-test (no API, no binaries) -----------------------------------------
+self_test() {
+  echo "== P4a self-test (usage extraction + ADR-3 math; no API) =="
+  local tmp fail=0
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/rb-p4a-selftest.XXXXXX")"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # --- extract_usage on a well-formed stream-json log. ---
+  local log="$tmp/work.jsonl"
+  # A result record with realistic cache numbers (turn1 writes the cache,
+  # turn2+ reads it) plus a couple of unrelated records that must be ignored.
+  {
+    printf '{"type":"system","subtype":"init"}\n'
+    printf '{"type":"assistant","message":{"usage":{"input_tokens":1500,"cache_read_input_tokens":0,"cache_creation_input_tokens":4000,"output_tokens":120}}}\n'
+    printf '{"type":"assistant","message":{"usage":{"input_tokens":60,"cache_read_input_tokens":5400,"cache_creation_input_tokens":0,"output_tokens":40}}}\n'
+    printf '{"type":"result","subtype":"success","is_error":false,"num_turns":2,"total_cost_usd":0.0123,"usage":{"input_tokens":1560,"cache_creation_input_tokens":4000,"cache_read_input_tokens":5400,"output_tokens":160},"result":"use ureq for HTTP"}\n'
+  } > "$log"
+  local got want
+  got="$(extract_usage "$log")"
+  want=$'false\t2\t0.0123\t1560\t4000\t5400\t160'
+  if [ "$got" = "$want" ]; then echo "ok: extract_usage reads aggregate cache fields"; else echo "BUG: extract_usage (want [$want] got [$got])"; fail=1; fi
+
+  # --- extract_usage on a non-parseable log (timeout/error) -> sentinel row. ---
+  : > "$tmp/empty.jsonl"
+  got="$(extract_usage "$tmp/empty.jsonl")"
+  want=$'true\t'"$TURNS_FAIL_SENTINEL"$'\t0\t0\t0\t0\t0'
+  if [ "$got" = "$want" ]; then echo "ok: extract_usage sentinel on empty log"; else echo "BUG: extract_usage empty (want [$want] got [$got])"; fail=1; fi
+
+  # --- judge_text (parity smoke with w35-ab-eval; one case per branch). ---
+  printf 'use the ureq crate\n' > "$tmp/n.txt"
+  printf 'use reqwest\n'        > "$tmp/old.txt"
+  check() { if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "BUG: $1 (want [$2] got [$3])"; fail=1; fi; }
+  check "judge success"             "1 0" "$(judge_text "$tmp/n.txt"   ureq ''   ''      memory-on)"
+  check "judge mie on fail+stale"   "0 1" "$(judge_text "$tmp/old.txt" ureq ''   reqwest memory-on)"
+  check "judge no mie off-arm"      "0 0" "$(judge_text "$tmp/old.txt" ureq ''   reqwest steelman-baseline)"
+
+  # --- aggregate: ADR-3 threshold 1 (RATIFY Opt 3) at a corpus size. ---
+  # memory-on ties steelman on accuracy AND cache% within 20% -> ratify.
+  local tsv="$tmp/ratify.tsv"
+  {
+    printf 's1\tmemory-on\t50\t1\t1\t3\t0.02\t600\t4000\t4400\t100\t0\n'
+    printf 's1\tsteelman-baseline\t50\t1\t1\t3\t0.02\t300\t4000\t8700\t100\t0\n'   # cache% 96.7
+    printf 's1\trealistic-baseline\t50\t1\t0\t5\t0.02\t300\t4000\t8700\t100\t0\n'
+    printf 's1\tmemory-off\t50\t1\t0\t5\t0.01\t6000\t0\t0\t100\t0\n'
+  } > "$tsv"
+  local verdict
+  verdict="$(aggregate "$tsv" 0 2>/dev/null | grep -F -A1 -- 'corpus 50' | tail -1)"
+  if printf '%s' "$verdict" | grep -qF "RATIFY Opt 3"; then echo "ok: ratify Opt 3 when acc+cache within bounds"; else echo "BUG: ratify verdict (got [$verdict])"; fail=1; fi
+
+  # --- aggregate: ADR-3 threshold 2 (Opt 2 candidate) — cache ratio > 20% worse. ---
+  # memory-on cache% 88, steelman cache% 99 -> 88 < 0.8*99=79.2? no, 88>=79.2 so still ok.
+  # Push memory-on cache% down to 60 to force the Opt-2 branch: steelman 99, mem 60 -> 60<79.2 -> candidate.
+  local tsv2="$tmp/opt2.tsv"
+  {
+    printf 's1\tmemory-on\t500\t1\t1\t3\t0.02\t4000\t4000\t6000\t100\t0\n'          # cache% 60
+    printf 's1\tsteelman-baseline\t500\t1\t1\t3\t0.02\t100\t4000\t9900\t100\t0\n'   # cache% 99
+    printf 's1\trealistic-baseline\t500\t1\t0\t5\t0.02\t100\t4000\t9900\t100\t0\n'
+    printf 's1\tmemory-off\t500\t1\t0\t5\t0.01\t10000\t0\t0\t100\t0\n'
+  } > "$tsv2"
+  verdict="$(aggregate "$tsv2" 0 2>/dev/null | grep -F -A1 -- 'corpus 500' | tail -1)"
+  if printf '%s' "$verdict" | grep -qF "Opt 2 candidate"; then echo "ok: Opt 2 candidate when cache ratio > 20% worse"; else echo "BUG: opt2 verdict (got [$verdict])"; fail=1; fi
+
+  # --- aggregate: a memory-induced error fails the hard gate. ---
+  local tsv3="$tmp/mie.tsv"
+  {
+    printf 's1\tmemory-on\t50\t1\t0\t3\t0.02\t600\t4000\t4400\t100\t1\n'
+    printf 's1\tsteelman-baseline\t50\t1\t1\t3\t0.02\t300\t4000\t8700\t100\t0\n'
+    printf 's1\tmemory-off\t50\t1\t0\t5\t0.01\t6000\t0\t0\t100\t0\n'
+  } > "$tsv3"
+  if aggregate "$tsv3" 0 >/dev/null 2>&1; then echo "BUG: mie did not fail the hard gate"; fail=1; else echo "ok: mie fails the hard gate"; fi
+
+  # --- gen_corpus is deterministic + off-topic. ---
+  local a b
+  a="$(gen_corpus dep-http-ureq 3)"
+  b="$(gen_corpus dep-http-ureq 3)"
+  if [ "$a" = "$b" ]; then echo "ok: gen_corpus deterministic"; else echo "BUG: gen_corpus not deterministic"; fail=1; fi
+  if printf '%s' "$a" | grep -qiwF "ureq"; then echo "BUG: gen_corpus leaked the target token"; fail=1; else echo "ok: gen_corpus off-topic"; fi
+
+  [ "$fail" -eq 0 ] && { echo "self-test PASS"; return 0; } || { echo "self-test FAIL" >&2; return 1; }
+}
+
+# --- arg parsing -------------------------------------------------------------
+BIN_DIR=""
+MODE="run"
+RUNS=""
+REPORT_TSV=""
+CORPUS_SIZES="0 50 200 500 1000"
+SCENARIOS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test)    MODE="self-test"; shift ;;
+    --aggregate)    MODE="aggregate"; REPORT_TSV="${2:?--aggregate needs a value}"; shift 2 ;;
+    --bin-dir)      BIN_DIR="${2:?--bin-dir needs a value}"; shift 2 ;;
+    --runs)         RUNS="${2:?--runs needs a value}"; shift 2 ;;
+    --out)          REPORT_TSV="${2:?--out needs a value}"; shift 2 ;;
+    --corpus-sizes) CORPUS_SIZES="${2:?--corpus-sizes needs a value}"; shift 2 ;;
+    --scenarios)    SCENARIOS="${2:?--scenarios needs a value}"; shift 2 ;;
+    -h|--help)      usage ;;
+    *)              usage ;;
+  esac
+done
+
+if [ "$MODE" = "self-test" ]; then self_test; exit $?; fi
+
+# Re-score a saved results TSV (e.g. an uploaded nightly artifact) without
+# re-running any sessions. Reads MIE_ALLOWED from the scenarios file when present.
+if [ "$MODE" = "aggregate" ]; then
+  [ -f "$REPORT_TSV" ] || { echo "tsv not found: $REPORT_TSV" >&2; exit 1; }
+  mie_default=0
+  [ -f "$SCENARIOS" ] && mie_default="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS" 2>/dev/null || echo 0)"
+  aggregate "$REPORT_TSV" "$mie_default"
+  exit $?
+fi
+
+# --- real-run prerequisites --------------------------------------------------
+[ -n "$BIN_DIR" ] || usage
+BIN_DIR="$(cd "$BIN_DIR" && pwd)"
+for bin in rusty-brain rusty-brain-hooks rusty-brain-install; do
+  [ -x "$BIN_DIR/$bin" ] || { echo "missing binary: $BIN_DIR/$bin (cargo build --release -p rusty-brain -p rb-hooks -p rb-install)" >&2; exit 1; }
+done
+command -v claude  >/dev/null 2>&1 || { echo "claude not on PATH (npm install -g @anthropic-ai/claude-code)" >&2; exit 1; }
+command -v jq      >/dev/null 2>&1 || { echo "jq not on PATH (needed to parse stream-json usage)" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 not on PATH (corpus generator + settings.json edit)" >&2; exit 1; }
+[ -n "${ANTHROPIC_API_KEY:-${CLAUDE_CODE_API_KEY:-${CLAUDE_API_KEY:-}}}" ] \
+  || { echo "no Anthropic API credential in env (ANTHROPIC_API_KEY / CLAUDE_CODE_API_KEY) — the measured run is DEFERRED until one is set" >&2; exit 1; }
+[ -f "$SCENARIOS" ] || { echo "scenarios file not found: $SCENARIOS" >&2; exit 1; }
+
+# Validate free-form inputs (never interpolate a dispatch value into a shell).
+case "$CORPUS_SIZES" in *[!0-9\ ]*) echo "--corpus-sizes may contain only digits and spaces" >&2; exit 2 ;; esac
+for cs in $CORPUS_SIZES; do
+  case "$cs" in ''|*[!0-9]*) echo "--corpus-sizes has a non-numeric entry: '$cs'" >&2; exit 2 ;; esac
+done
+
+# Default scenarios: one stale-trap + two plain (cheap, exercises both judge paths).
+[ -n "$SCENARIOS" ] || SCENARIOS="dep-http-ureq config-settings-toml stale-trap-http-switch"
+case "$SCENARIOS" in *[!a-z0-9\ _-]*) echo "--scenarios may contain only [a-z0-9 _-]" >&2; exit 2 ;; esac
+
+[ -n "$RUNS" ] || RUNS="$(jq -r '.config.runs_per_scenario // 3' "$SCENARIOS")"
+MIE_ALLOWED="$(jq -r '.config.memory_induced_errors_allowed // 0' "$SCENARIOS")"
+
+# Per-session wall-clock cap (defense against a hung session stalling the run).
+SESSION_TIMEOUT=""
+if command -v timeout  >/dev/null 2>&1; then SESSION_TIMEOUT="timeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"
+elif command -v gtimeout >/dev/null 2>&1; then SESSION_TIMEOUT="gtimeout ${RB_W35_SESSION_TIMEOUT_SECS:-300}"; fi
+
+# Hermeticity (mirrors w35-ab-eval.sh): clear any rusty-brain path/namespace
+# overrides inherited from the environment so the baselines cannot silently gain
+# memory. The memory-on arm RE-sets these in its own subshell per (scenario, run).
+unset RUSTY_BRAIN_DB RUSTY_BRAIN_SOCKET RUSTY_BRAIN_NAMESPACE RUSTY_BRAIN_IDLE_TIMEOUT_SECS
+
+WORKROOT="$(mktemp -d "${TMPDIR:-/tmp}/rb-p4a-cache.XXXXXX")"
+RESULTS="${REPORT_TSV:-$WORKROOT/results.tsv}"
+: > "$RESULTS"
+cleanup() { rm -rf "$WORKROOT" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Seed Claude Code's onboarding flag in a fresh HOME so headless mode never
+# stalls on first-run setup.
+seed_home() { mkdir -p "$1"; printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"; }
+
+# Run ONE headless session whose stdout is captured to $log. Output format is
+# stream-json --verbose so the per-turn + result usage records (with the cache
+# token breakdown) are captured. Cheap model + hard spend cap + wall-clock cap.
+run_session() {
+  local home="$1" proj="$2" prompt="$3" log="$4"; shift 4
+  (
+    export HOME="$home"
+    unset XDG_RUNTIME_DIR XDG_CACHE_HOME XDG_DATA_HOME XDG_CONFIG_HOME XDG_STATE_HOME
+    export PATH="$BIN_DIR:$PATH"
+    cd "$proj"
+    ${SESSION_TIMEOUT} claude -p "$prompt" \
+      --setting-sources project --model "$MODEL" --max-budget-usd "$MAX_BUDGET_USD" \
+      --permission-mode acceptEdits --allowedTools "Bash Edit Write" "$@" \
+      >"$log" 2>&1 || true
+  )
+}
+
+# Install rusty-brain hooks + project MCP into a memory-on session's project
+# (verbatim from w35-ab-eval.sh; proven hermetic install path).
+install_rusty_brain() {
+  local home="$1" proj="$2"
+  (
+    export HOME="$home"
+    export PATH="$BIN_DIR:$PATH"
+    cd "$proj"
+    rusty-brain-install install --agents claude-code >/dev/null
+    python3 - "$proj/.claude/settings.json" "$proj/.mcp.json" "$BIN_DIR/rusty-brain" <<'PY'
+import json, sys
+settings_path, mcp_path, server_cmd = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(mcp_path, "w") as f:
+    json.dump({"mcpServers": {"rusty-brain": {"command": server_cmd, "args": ["mcp"]}}}, f, indent=2)
+    f.write("\n")
+with open(settings_path) as f:
+    s = json.load(f)
+s["enableAllProjectMcpServers"] = True
+with open(settings_path, "w") as f:
+    json.dump(s, f, indent=2)
+    f.write("\n")
+PY
+  )
+}
+
+# Bulk-plant the corpus into the memory-on store via direct `rusty-brain remember`
+# CLI calls (redesign §P2 explicit-plant mode). The caller (run_cell's memory-on
+# subshell) exports RUSTY_BRAIN_SOCKET/DB/NAMESPACE, so the first call auto-starts
+# the daemon on the shared socket and later calls + the WORK session's hooks all
+# reach the SAME store. target at importance 8 so it surfaces in recall;
+# distractors at importance 5.
+plant_corpus() { # <target_text> <scenario_id> <n_distractors>
+  local target="$1" sid="$2" n="$3"
+  local cmd="$BIN_DIR/rusty-brain"
+  "$cmd" remember "$target" --importance 8 >/dev/null 2>&1 || true
+  if [ "$n" -gt 0 ]; then
+    local facts
+    facts="$(gen_corpus "$sid" "$n")"
+    while IFS= read -r fact; do
+      [ -n "$fact" ] || continue
+      "$cmd" remember "${fact#- }" --importance 5 >/dev/null 2>&1 || true
+    done <<<"$facts"
+  fi
+}
+
+# Run the WORK session for one arm and append its result row to $RESULTS.
+# Judge text = the model's OUTPUT only: the final `.result` from the stream-json
+# result record + files the model WROTE DURING this session (mtime newer than a
+# marker, size-capped). Pre-seeded files (notably the steelman CLAUDE.md, which
+# holds the target) are EXCLUDED. Cache fields come from extract_usage.
+score_work() { # <id> <arm> <corpus> <run> <proj> <home> <work> <expect> <forbid> <stale>
+  local id="$1" arm="$2" corpus="$3" run="$4" proj="$5" home="$6" work="$7" \
+        expect="$8" forbid="$9" stale="${10}"
+  local log="$proj/../work.jsonl" text="$proj/../judge.txt" marker="$proj/../work.start"
+  : > "$marker"
+  run_session "$home" "$proj" "$work" "$log" --output-format stream-json --verbose
+  # Judge text starts at the final .result (empty/absent => judge the raw log,
+  # which fails success and is never silently skipped).
+  if jq -e 'select(.type=="result")|.result' "$log" >/dev/null 2>&1; then
+    jq -r 'select(.type=="result")|.result' "$log" | tail -1 > "$text"
+  else
+    cp "$log" "$text"
+  fi
+  find "$proj" -type f -not -path '*/.*' -newer "$marker" -size -256k -print0 2>/dev/null \
+    | xargs -0 cat >> "$text" 2>/dev/null || true
+  local u success mie
+  u="$(extract_usage "$log")"           # is_err turns cost input cc cr out
+  local is_err turns cost inp cc cr out
+  is_err="$(cut -f1 <<<"$u")"; turns="$(cut -f2 <<<"$u")"; cost="$(cut -f3 <<<"$u")"
+  inp="$(cut -f4 <<<"$u")"; cc="$(cut -f5 <<<"$u")"; cr="$(cut -f6 <<<"$u")"; out="$(cut -f7 <<<"$u")"
+  # success = expect-judged correctness; a server-level is_error forces failure.
+  local res; res="$(judge_text "$text" "$expect" "$forbid" "$stale" "$arm")"
+  success="${res% *}"; mie="${res#* }"
+  if [ "$is_err" = "true" ]; then success=0; fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$id" "$arm" "$corpus" "$run" "$success" "$turns" "$cost" \
+    "$inp" "$cc" "$cr" "$out" "$mie" >> "$RESULTS"
+  printf '   [%-18s c=%-4s] succ=%s turns=%s cost=%s cache%%=%.1f (cr=%s/%s)\n' \
+    "$arm" "$corpus" "$success" "$turns" "$cost" \
+    "$(awk -v cr="$cr" -v inp="$inp" 'BEGIN{ if(cr+inp==0) print 0; else printf "%.1f", 100*cr/(cr+inp) }')" \
+    "$cr" "$((cr + inp))"
+}
+
+run_cell() { # <id> <run> <corpus> <plant> <claude_md> <work> <expect> <forbid> <stale>
+  local id="$1" run="$2" corpus="$3" plant="$4" claude_md="$5" work="$6" \
+        expect="$7" forbid="$8" stale="$9"
+  local n=$((corpus))   # distractor count
+  local base="$WORKROOT/$id-c${corpus}-r$run"
+  local distractors=""
+  if [ "$n" -gt 0 ]; then distractors="$(gen_corpus "$id" "$n")"; fi
+
+  # --- arm: memory-on (explicit plant of target + N distractors) -------------
+  # Short /tmp socket dir (a long $WORKROOT path can exceed macOS's ~104-byte
+  # sun_path limit — the nightly-claude-smoke.sh socket-length note).
+  local mbase="$base/on"
+  local sockdir; sockdir="$(mktemp -d "/tmp/rbp4a.XXXXXX")"
+  local sock="$sockdir/s" db="$base/on/memory.db" ns="rb-p4a-$id-c${corpus}-r$run"
+  local wh="$mbase/home" wp="$mbase/proj"
+  seed_home "$wh"; mkdir -p "$wp"
+  install_rusty_brain "$wh" "$wp"
+  # Confound strip (fairness, same as w35-ab-eval): remove the installer's
+  # "recall before work" CLAUDE.md block + skill so the WORK session gets the
+  # target ONLY through the deterministic UserPromptSubmit recall injection.
+  rm -f "$wp/CLAUDE.md"
+  rm -rf "$wp/.claude/skills"
+  (
+    # Scope the per-run store to this subshell (so the baselines below cannot
+    # inherit it) AND reach the WORK session's hooks: run_session's nested
+    # subshell inherits these, so the UserPromptSubmit recall hook connects to
+    # the PLANTED store. Without this export, recall would hit the empty default
+    # store and memory-on would silently run without memory — the exact
+    # invalidity the redesign warns about. Mirrors w35-ab-eval.sh.
+    export RUSTY_BRAIN_SOCKET="$sock" RUSTY_BRAIN_DB="$db" RUSTY_BRAIN_NAMESPACE="$ns"
+    plant_corpus "$plant" "$id" "$n"
+    # The first remember must have auto-started the daemon (pidfile = socket.pid).
+    # If it did not, the memory-on arm would silently run WITHOUT memory and the
+    # whole comparison would be invalid — fail loudly.
+    [ -f "$sock.pid" ] || { echo "ERROR: memory-on daemon did not auto-start for $id c=$corpus run $run" >&2; exit 1; }
+    score_work "$id" "memory-on" "$corpus" "$run" "$wp" "$wh" "$work" "$expect" "$forbid" "$stale"
+  )
+  [ -f "$sock.pid" ] && kill "$(cat "$sock.pid" 2>/dev/null)" 2>/dev/null || true
+  rm -rf "$sockdir" 2>/dev/null || true
+
+  # --- arm: steelman-baseline (target + distractors in CLAUDE.md) ------------
+  local sh="$base/stl/home" sp="$base/stl/proj"
+  seed_home "$sh"; mkdir -p "$sp"
+  { printf '# Project conventions\n\n%s\n\n## Other decisions\n' "$claude_md";
+    [ -n "$distractors" ] && printf '%s\n' "$distractors"; } > "$sp/CLAUDE.md"
+  score_work "$id" "steelman-baseline" "$corpus" "$run" "$sp" "$sh" "$work" "$expect" "$forbid" "$stale"
+
+  # --- arm: realistic-baseline (distractors only; target OMITTED) ------------
+  local rh="$base/real/home" rp="$base/real/proj"
+  seed_home "$rh"; mkdir -p "$rp"
+  { printf '# Project conventions\n\n## Other decisions\n';
+    [ -n "$distractors" ] && printf '%s\n' "$distractors"; } > "$rp/CLAUDE.md"
+  score_work "$id" "realistic-baseline" "$corpus" "$run" "$rp" "$rh" "$work" "$expect" "$forbid" "$stale"
+
+  # --- arm: memory-off (nothing) ---------------------------------------------
+  local oh="$base/off/home" op="$base/off/proj"
+  seed_home "$oh"; mkdir -p "$op"
+  score_work "$id" "memory-off" "$corpus" "$run" "$op" "$oh" "$work" "$expect" "$forbid" "$stale"
+}
+
+echo "== P4a cache study (model=$MODEL, budget=\$$MAX_BUDGET_USD/session, runs=$RUNS) =="
+echo "   scenarios: $SCENARIOS"
+echo "   corpus sizes (distractors): $CORPUS_SIZES"
+rows=()
+while IFS= read -r row; do rows+=("$row"); done < <(jq -c '.scenarios[]' "$SCENARIOS")
+for id in $SCENARIOS; do
+  row="$(jq -c --arg id "$id" '.scenarios[]|select(.id==$id)' "$SCENARIOS")"
+  [ -n "$row" ] || { echo "scenario not found: $id" >&2; continue; }
+  plant="$(jq -r '.plant' <<<"$row")"
+  claude_md="$(jq -r '.claude_md' <<<"$row")"
+  work="$(jq -r '.work' <<<"$row")"
+  expect="$(jq -r '.expect' <<<"$row")"
+  forbid="$(jq -r '.forbid // ""' <<<"$row")"
+  stale="$(jq -r '.stale_token // ""' <<<"$row")"
+  for corpus in $CORPUS_SIZES; do
+    run=1
+    while [ "$run" -le "$RUNS" ]; do
+      echo "-- $id (corpus $corpus, run $run/$RUNS)"
+      run_cell "$id" "$run" "$corpus" "$plant" "$claude_md" "$work" "$expect" "$forbid" "$stale"
+      run=$((run + 1))
+    done
+  done
+done
+
+echo
+echo "== results =="
+aggregate "$RESULTS" "$MIE_ALLOWED"
+echo
+echo "report: $RESULTS"


### PR DESCRIPTION
## What

Resolves the W3.5 scorecard **dimension-A blocker** — `docs/eval/2026-06-16-w35-criterion-redesign.md` §A names prompt caching as the open question gating "Retrieval at scale": a large CLAUDE.md sits in Claude Code's cached prefix (marginal per-turn cost ~0), while memory re-injects each turn, so a naive token comparison makes memory look worse. This PR stands up the measurement architecture and records a **provisional ADR-3**; the measured run that finalizes it is a separate, spend-gated step.

## Files

- `docs/eval/2026-06-19-p4a-caching-study.md` — investigation + **ADR-3 (provisional)** with pre-registered thresholds (per redesign §P3: "pre-register pass thresholds *before* running").
- `scripts/w35-cache-trace.sh` — four-arm (`memory-on` / `steelman-baseline` / `realistic-baseline` / `memory-off`) corpus-ladder harness; captures cached-vs-uncached input tokens from `claude -p --output-format stream-json --verbose`; applies the ADR-3 verdicts per corpus size. Ships `--self-test` (pure, CI-safe) and `--aggregate FILE` (re-score a saved TSV).
- `.github/workflows/w35-cache-trace.yml` — manual dispatch only (never gates PRs); cheap default slice, full-ladder gate-closing dispatch.
- `docs/eval/2026-06-16-w35-criterion-redesign.md` — §A cross-reference so the blocker's resolution is discoverable.

## How to run

```bash
scripts/w35-cache-trace.sh --self-test                 # CI-safe, no API
scripts/w35-cache-trace.sh --bin-dir target/release    # measured run (needs API key + spend)
```

## Self-review note

Caught and fixed one blocking bug during self-review: the memory-on WORK session's hooks weren't receiving `RUSTY_BRAIN_*` (the script exported short-name vars at function scope while `run_session` only re-exports `HOME`/`PATH`), so recall would have hit the empty default store and silently posted `success=0` at every corpus size. Now exports `RUSTY_BRAIN_*` inside the memory-on subshell, mirroring `w35-ab-eval.sh`. Verified by inspection + `grep` + `--self-test`; this integration-glue class is fully closed by the smoke run (build-sequence step 2).

## Status

- ✅ harness + `--self-test` + `--aggregate` + dispatch workflow (zero spend)
- ⏳ measured run (build-sequence steps 2–4) blocked on `ANTHROPIC_API_KEY` + spend; it appends the measured numbers and the selected option to the ADR-3 doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added evaluation documentation for prompt-caching performance study and measurement methodology

* **Chores**
  * Added automated testing workflow for cache optimization analysis
  * Added measurement script for cache economics and performance evaluation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->