### PR TITLE
[codex] Add fixture-gated session checkpoints

### DIFF
--- a/crates/rb-agents/src/event.rs
+++ b/crates/rb-agents/src/event.rs
@@ -193,4 +193,29 @@ mod tests {
         let ev = HookEvent::Other("UserPromptSubmit".to_string());
         assert_eq!(ev, HookEvent::Other("UserPromptSubmit".to_string()));
     }
+
+    #[test]
+    fn session_checkpoint_is_distinct_from_session_end_and_stop() {
+        // The three boundary variants serve different lifecycle roles (a
+        // non-terminal checkpoint, a true terminus, a per-turn stop) and must
+        // never compare equal — capture routes on exactly this distinction.
+        let checkpoint = HookEvent::SessionCheckpoint {
+            reason: Some("Stop".to_string()),
+        };
+        let session_end = HookEvent::SessionEnd {
+            reason: Some("Stop".to_string()),
+        };
+        let stop = HookEvent::Stop {
+            last_assistant_message: None,
+            stop_hook_active: false,
+        };
+        assert_ne!(
+            checkpoint, session_end,
+            "SessionCheckpoint must be distinct from SessionEnd"
+        );
+        assert_ne!(
+            checkpoint, stop,
+            "SessionCheckpoint must be distinct from Stop"
+        );
+    }
 }

--- a/crates/rb-agents/src/event.rs
+++ b/crates/rb-agents/src/event.rs
@@ -28,6 +28,12 @@ pub enum HookEvent {
         last_assistant_message: Option<String>,
         stop_hook_active: bool,
     },
+    /// A best-available adapter-specific boundary for CLIs that do not expose a
+    /// verified session terminus. The runtime folds scratch into a live summary
+    /// here without clearing scratch, so later checkpoints supersede the prior
+    /// summary while preserving early observations. This is deliberately
+    /// distinct from [`SessionEnd`].
+    SessionCheckpoint { reason: Option<String> },
     /// The agent SESSION is ending (distinct from a per-turn [`Stop`]). This is
     /// W3.1's single capture point: the runtime folds the per-session scratch
     /// file + transcript into ONE summary memory here. `reason` is the CLI's

--- a/crates/rb-agents/src/event.rs
+++ b/crates/rb-agents/src/event.rs
@@ -33,6 +33,12 @@ pub enum HookEvent {
     /// here without clearing scratch, so later checkpoints supersede the prior
     /// summary while preserving early observations. This is deliberately
     /// distinct from [`SessionEnd`].
+    ///
+    /// Supersede only chains across checkpoints that STORE successfully: a
+    /// degraded checkpoint (no daemon, or a store error) leaves both the scratch
+    /// and the prior-summary id untouched, so the next successful checkpoint
+    /// stores fresh. Repeated degraded checkpoints therefore never accumulate
+    /// un-superseded live memories — they store nothing at all.
     SessionCheckpoint { reason: Option<String> },
     /// The agent SESSION is ending (distinct from a per-turn [`Stop`]). This is
     /// W3.1's single capture point: the runtime folds the per-session scratch

--- a/crates/rb-agents/src/gemini.rs
+++ b/crates/rb-agents/src/gemini.rs
@@ -51,9 +51,10 @@ impl AgentCli for GeminiCli {
         let session_id = str_field(raw, "session_id");
 
         // Gemini's native hook event names differ from Claude's: the tool event is
-        // `AfterTool` (not `PostToolUse`), the stop event is `SessionEnd` (not
-        // `Stop`), and the pre-compaction event is `PreCompress` (not `PreCompact`).
-        // Map each native name onto the canonical [`HookEvent`].
+        // `AfterTool` (not `PostToolUse`), the stop-looking event is `SessionEnd`
+        // (not `Stop`), and the pre-compaction event is `PreCompress` (not
+        // `PreCompact`). `SessionEnd` stays a no-op Stop until a real fixture
+        // proves a better checkpoint or terminus boundary.
         let event = match raw.get("hook_event_name").and_then(Value::as_str) {
             Some("SessionStart") => HookEvent::SessionStart {
                 source: str_field(raw, "source"),
@@ -166,7 +167,8 @@ mod tests {
 
     #[test]
     fn parses_session_end_as_stop() {
-        // Gemini's stop event is named `SessionEnd`; it maps to canonical `Stop`.
+        // Gemini's boundary event is named `SessionEnd`, but without a verified
+        // true terminus fixture it maps to Stop, not checkpoint or canonical SessionEnd.
         let raw = json!({
             "hook_event_name": "SessionEnd",
             "last_assistant_message": "finished"

--- a/crates/rb-agents/tests/cross_adapter.rs
+++ b/crates/rb-agents/tests/cross_adapter.rs
@@ -94,3 +94,48 @@ fn render_output_continue_is_true_for_all_four() {
         );
     }
 }
+
+#[test]
+fn non_claude_boundary_events_stay_stop_until_fixture_verified() {
+    let cases = [
+        (
+            AgentId::Gemini,
+            serde_json::json!({
+                "hook_event_name": "SessionEnd",
+                "cwd": "/proj",
+                "session_id": "s"
+            }),
+            "SessionEnd",
+        ),
+        (
+            AgentId::Codex,
+            serde_json::json!({
+                "hook_event_name": "Stop",
+                "cwd": "/proj",
+                "session_id": "s"
+            }),
+            "Stop",
+        ),
+        (
+            AgentId::OpenCode,
+            serde_json::json!({
+                "type": "session.idle",
+                "directory": "/proj",
+                "sessionID": "s"
+            }),
+            "session.idle",
+        ),
+    ];
+    for (id, raw, reason) in cases {
+        let cli = agent_for(id);
+        let ctx = cli.parse_input(&raw);
+        assert_eq!(
+            ctx.event,
+            HookEvent::Stop {
+                last_assistant_message: None,
+                stop_hook_active: false,
+            },
+            "{id:?} boundary {reason:?} must not checkpoint until a real fixture verifies it"
+        );
+    }
+}

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -611,8 +611,7 @@ pub async fn pre_compact(
 /// How [`fold_session_summary`] resets the scratch once a fold is durably
 /// stored: `End` clears the buffer (true terminus), `Checkpoint` retains it so a
 /// later checkpoint re-folds early observations while superseding the live
-/// summary. Defined before its callers per the codebase's define-before-use
-/// convention.
+/// summary. Defined before its callers for readability.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FoldMode {
     End,

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -1739,6 +1739,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_checkpoint_without_scratch_continues() {
+        // No session id means scratch is None; the checkpoint must still
+        // continue (fail-open), never panic or block.
+        let result = session_checkpoint(None, None, std::path::Path::new("/tmp"), None).await;
+        assert!(result.continue_execution);
+    }
+
+    #[tokio::test]
     async fn session_checkpoint_with_nothing_to_fold_and_no_prior_id_is_a_noop() {
         // A fresh session that checkpoints before any tool runs: nothing to fold
         // and no prior id. Distinct from the End branch, which would write the

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -1,7 +1,8 @@
 //! The capture flows, INVERTED for W3.1: SessionStart (inject context),
 //! PostToolUse (append a redacted observation to the per-session scratch — ZERO
 //! memories), Stop (store nothing), SessionEnd (fold scratch + transcript into
-//! ONE summary memory, update-as-supersede), PreCompact (one decision snapshot
+//! ONE summary memory, update-as-supersede), SessionCheckpoint (non-Claude
+//! fallback fold without clearing scratch), PreCompact (one decision snapshot
 //! from the transcript). Every flow returns a `HookResult` with
 //! `continue_execution: true`; nothing ever blocks.
 
@@ -551,15 +552,10 @@ async fn git_modified_files(cwd: &std::path::Path) -> Vec<String> {
 /// is honored defensively — a Stop the hook itself forced must never re-enter
 /// capture — though this flow writes nothing regardless. Always continues.
 ///
-/// KNOWN LIMITATION (W3.1 is Phase-3 "Claude Code value"): the non-Claude
-/// adapters map their terminal event to canonical `Stop` (Gemini `SessionEnd`,
-/// Codex `Stop`, OpenCode `session.idle`) and none emit a verified canonical
-/// `SessionEnd`, so those CLIs do NOT get the SessionEnd scratch fold yet — their
-/// PostToolUse scratch ages out unflushed. Folding on canonical `Stop` is unsafe
-/// because Claude's `Stop` is per-turn (it would over-capture), so restoring
-/// non-Claude capture needs each adapter to model its true session-end cadence.
-/// Tracked in `docs/follow-ups/2026-06-13-cross-cli-capture-inversion.md` — an
-/// explicit, non-silent gap, not an oversight.
+/// Non-Claude adapters may emit
+/// [`HookEvent::SessionCheckpoint`](rb_agents::HookEvent::SessionCheckpoint)
+/// once real fixtures verify an appropriate boundary. Until then, canonical
+/// `Stop` remains a pure no-op for every adapter.
 pub fn stop(stop_hook_active: bool) -> HookResult {
     if stop_hook_active {
         tracing::debug!("Stop with stop_hook_active=true: no capture (W3.1)");
@@ -612,19 +608,49 @@ pub async fn pre_compact(
     continue_only()
 }
 
-/// SessionEnd flow (W3.1): the single capture point. Fold the per-session
-/// scratch (files/commands/failures) + the transcript (goals/decisions) +
-/// working-tree changes into ONE summary memory. If a prior summary exists for
-/// this session (a resumed-then-re-ended session), supersede it
-/// (update-as-supersede) so exactly one live summary remains. The scratch is
-/// reset afterward, retaining the new summary id for a future resume. Always
-/// continues; with no scratch (no session id) or nothing worth summarizing,
-/// stores nothing.
+/// SessionEnd flow (W3.1): the single capture point for CLIs with a verified
+/// terminus. Fold the per-session scratch (files/commands/failures) + the
+/// transcript (goals/decisions) + working-tree changes into ONE summary memory.
+/// If a prior summary exists for this session (a resumed-then-re-ended session),
+/// supersede it (update-as-supersede) so exactly one live summary remains. The
+/// scratch is reset afterward, retaining the new summary id for a future resume.
+/// Always continues; with no scratch (no session id) or nothing worth
+/// summarizing, stores nothing.
 pub async fn session_end(
     client: Option<&mut DaemonClient>,
     scratch: Option<&Scratch>,
     cwd: &Path,
     transcript_path: Option<&Path>,
+) -> HookResult {
+    fold_session_summary(client, scratch, cwd, transcript_path, FoldMode::End).await
+}
+
+/// SessionCheckpoint flow: non-Claude fallback for CLIs that expose a
+/// best-available boundary but no fixture-verified true session terminus. It
+/// folds the same summary as [`session_end`], but retains scratch after storing
+/// so subsequent checkpoints preserve early observations and supersede the one
+/// live summary instead of creating unbounded live memories.
+pub async fn session_checkpoint(
+    client: Option<&mut DaemonClient>,
+    scratch: Option<&Scratch>,
+    cwd: &Path,
+    transcript_path: Option<&Path>,
+) -> HookResult {
+    fold_session_summary(client, scratch, cwd, transcript_path, FoldMode::Checkpoint).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FoldMode {
+    End,
+    Checkpoint,
+}
+
+async fn fold_session_summary(
+    client: Option<&mut DaemonClient>,
+    scratch: Option<&Scratch>,
+    cwd: &Path,
+    transcript_path: Option<&Path>,
+    mode: FoldMode,
 ) -> HookResult {
     let Some(scratch) = scratch else {
         return continue_only();
@@ -637,9 +663,11 @@ pub async fn session_end(
     };
 
     let Some(content) = build_session_summary(&data, &git_files, &transcript) else {
-        // Nothing worth folding: clear the buffer (keeping any prior id), write
-        // nothing.
-        scratch.mark_folded(data.prior_summary_id.as_deref());
+        // Nothing worth folding: a true SessionEnd clears the empty buffer; a
+        // checkpoint leaves it as-is because it is not a lifecycle terminus.
+        if mode == FoldMode::End {
+            scratch.mark_folded(data.prior_summary_id.as_deref());
+        }
         return continue_only();
     };
     let content = redact(&content);
@@ -654,9 +682,15 @@ pub async fn session_end(
     if let Some(new_id) =
         store_session_summary(client, content, data.prior_summary_id.as_deref()).await
     {
-        // Stored: reset the buffer, retaining the new id so a resumed session
-        // supersedes THIS summary instead of duplicating it.
-        scratch.mark_folded(Some(&new_id.to_string()));
+        let new_id = new_id.to_string();
+        match mode {
+            // Stored: reset the buffer, retaining the new id so a resumed session
+            // supersedes THIS summary instead of duplicating it.
+            FoldMode::End => scratch.mark_folded(Some(&new_id)),
+            // Stored: retain observations so the next checkpoint summary includes
+            // both early and late turns while superseding this live summary.
+            FoldMode::Checkpoint => scratch.mark_checkpointed(&new_id),
+        }
     }
     continue_only()
 }
@@ -896,6 +930,18 @@ mod tests {
         ] {
             assert!(!is_captured(t), "{t} (gemini) should not be captured");
         }
+    }
+
+    #[test]
+    fn codex_apply_patch_stays_blocked_without_a_real_fixture() {
+        let input = serde_json::json!({
+            "command": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n-old\n+new\n*** End Patch\n"
+        });
+        assert_eq!(
+            tool_observation("apply_patch", &input),
+            None,
+            "apply_patch must not capture until a real Codex PostToolUse fixture proves the payload"
+        );
     }
 
     #[test]
@@ -1598,6 +1644,31 @@ mod tests {
             "buffer is preserved on a degraded write"
         );
         assert_eq!(data.commands, vec!["cargo build"]);
+    }
+
+    #[tokio::test]
+    async fn session_checkpoint_preserves_scratch_on_a_degraded_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let scratch = scratch_at(tmp.path());
+        scratch.append(scratch::Kind::File, "src/lib.rs");
+        scratch.append(scratch::Kind::Command, "cargo build");
+        let result = session_checkpoint(None, Some(&scratch), tmp.path(), None).await;
+        assert!(result.continue_execution);
+        let data = scratch.read();
+        assert_eq!(data.files, vec!["src/lib.rs"]);
+        assert_eq!(data.commands, vec!["cargo build"]);
+    }
+
+    #[tokio::test]
+    async fn session_checkpoint_with_nothing_to_fold_does_not_clear_prior_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let scratch = scratch_at(tmp.path());
+        scratch.mark_checkpointed("mem-123");
+        let result = session_checkpoint(None, Some(&scratch), tmp.path(), None).await;
+        assert!(result.continue_execution);
+        let data = scratch.read();
+        assert!(data.is_empty());
+        assert_eq!(data.prior_summary_id.as_deref(), Some("mem-123"));
     }
 
     #[tokio::test]

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -608,6 +608,17 @@ pub async fn pre_compact(
     continue_only()
 }
 
+/// How [`fold_session_summary`] resets the scratch once a fold is durably
+/// stored: `End` clears the buffer (true terminus), `Checkpoint` retains it so a
+/// later checkpoint re-folds early observations while superseding the live
+/// summary. Defined before its callers per the codebase's define-before-use
+/// convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FoldMode {
+    End,
+    Checkpoint,
+}
+
 /// SessionEnd flow (W3.1): the single capture point for CLIs with a verified
 /// terminus. Fold the per-session scratch (files/commands/failures) + the
 /// transcript (goals/decisions) + working-tree changes into ONE summary memory.
@@ -637,12 +648,6 @@ pub async fn session_checkpoint(
     transcript_path: Option<&Path>,
 ) -> HookResult {
     fold_session_summary(client, scratch, cwd, transcript_path, FoldMode::Checkpoint).await
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FoldMode {
-    End,
-    Checkpoint,
 }
 
 async fn fold_session_summary(
@@ -803,8 +808,71 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
 
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use rb_proto::{
+        read_frame, write_frame, Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION,
+    };
+    use rb_types::Namespace;
+    use tokio::net::UnixListener;
+    use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
     fn scratch_at(tmp: &std::path::Path) -> Scratch {
         Scratch::at(tmp.join("scratch.json"))
+    }
+
+    /// What an in-process mock daemon observed: per Remember the (content,
+    /// supersedes) it received, and the id it issued back, in order.
+    #[derive(Default)]
+    struct MockObserved {
+        remembers: Vec<(String, Option<MemoryId>)>,
+        issued: Vec<MemoryId>,
+    }
+
+    /// Accept ONE connection, handshake-ack, then answer every Remember on it with
+    /// a fresh id while recording what arrived. A reused [`DaemonClient`] keeps a
+    /// single connection across calls, so the whole sequence lands here.
+    async fn serve_remembers(listener: UnixListener, state: Arc<Mutex<MockObserved>>) {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut framed: Framed<_, LengthDelimitedCodec> =
+            Framed::new(stream, LengthDelimitedCodec::new());
+        if read_frame::<_, Handshake>(&mut framed).await.is_err() {
+            return;
+        }
+        let _ = write_frame(
+            &mut framed,
+            &HandshakeAck {
+                contract_version: CONTRACT_VERSION,
+                ok: true,
+                message: None,
+            },
+        )
+        .await;
+        while let Ok(req) = read_frame::<_, Request>(&mut framed).await {
+            let resp = match req {
+                Request::Remember {
+                    content,
+                    supersedes,
+                    ..
+                } => {
+                    let id = MemoryId::new();
+                    let mut s = state.lock().unwrap();
+                    s.remembers.push((content, supersedes));
+                    s.issued.push(id.clone());
+                    Response::Remembered { id }
+                }
+                _ => Response::Pong {
+                    contract_version: CONTRACT_VERSION,
+                    recall_channels: None,
+                },
+            };
+            if write_frame(&mut framed, &resp).await.is_err() {
+                break;
+            }
+        }
     }
 
     // ---- redaction (capture-time secret scrubbing) -----------------------
@@ -1669,6 +1737,96 @@ mod tests {
         let data = scratch.read();
         assert!(data.is_empty());
         assert_eq!(data.prior_summary_id.as_deref(), Some("mem-123"));
+    }
+
+    #[tokio::test]
+    async fn session_checkpoint_with_nothing_to_fold_and_no_prior_id_is_a_noop() {
+        // A fresh session that checkpoints before any tool runs: nothing to fold
+        // and no prior id. Distinct from the End branch, which would write the
+        // (absent) prior id back — the checkpoint touches scratch not at all.
+        let tmp = tempfile::tempdir().unwrap();
+        let scratch = scratch_at(tmp.path());
+        let result = session_checkpoint(None, Some(&scratch), tmp.path(), None).await;
+        assert!(result.continue_execution);
+        let data = scratch.read();
+        assert!(data.is_empty());
+        assert_eq!(data.prior_summary_id, None);
+    }
+
+    #[tokio::test]
+    async fn session_checkpoint_stored_path_retains_scratch_and_supersedes() {
+        // The novel semantic of this PR, exercised through a LIVE store (not the
+        // degraded `client = None` path): a stored checkpoint must call
+        // `mark_checkpointed` (retain buffer + record the new id), NOT
+        // `mark_folded` (clear). A second checkpoint then re-folds the retained
+        // scratch and supersedes the first summary. A regression that swapped in
+        // `mark_folded` would clear the buffer and fail this test.
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let state = Arc::new(Mutex::new(MockObserved::default()));
+        let server = tokio::spawn(serve_remembers(listener, Arc::clone(&state)));
+
+        let mut client = DaemonClient::connect(
+            &socket,
+            Namespace::Project("rb-checkpoint-test".into()),
+            Duration::from_secs(5),
+            None,
+            None,
+        )
+        .await
+        .expect("connect to the mock daemon");
+
+        let scratch = scratch_at(tmp.path());
+        scratch.append(scratch::Kind::File, "src/lib.rs");
+        scratch.append(scratch::Kind::Command, "cargo test");
+
+        // Checkpoint #1: folds + stores, then RETAINS the buffer.
+        let r1 = session_checkpoint(Some(&mut client), Some(&scratch), tmp.path(), None).await;
+        assert!(r1.continue_execution);
+        let d1 = scratch.read();
+        assert_eq!(
+            d1.files,
+            vec!["src/lib.rs"],
+            "a STORED checkpoint must retain the buffer (mark_checkpointed, not mark_folded)"
+        );
+        assert_eq!(d1.commands, vec!["cargo test"]);
+        assert!(
+            d1.prior_summary_id.is_some(),
+            "a stored checkpoint records the new summary id for the next supersede"
+        );
+
+        // Checkpoint #2: re-folds the retained scratch, superseding #1's summary.
+        let r2 = session_checkpoint(Some(&mut client), Some(&scratch), tmp.path(), None).await;
+        assert!(r2.continue_execution);
+        assert_eq!(
+            scratch.read().files,
+            vec!["src/lib.rs"],
+            "a second stored checkpoint still retains the buffer"
+        );
+
+        let observed = state.lock().unwrap();
+        assert_eq!(
+            observed.remembers.len(),
+            2,
+            "each stored checkpoint sends exactly one Remember"
+        );
+        assert_eq!(
+            observed.remembers[0].1, None,
+            "the first checkpoint has no prior summary to supersede"
+        );
+        assert_eq!(
+            observed.remembers[1].1.as_ref(),
+            observed.issued.first(),
+            "the second checkpoint supersedes the first summary's id"
+        );
+        assert!(
+            observed.remembers[1].0.contains("src/lib.rs"),
+            "the retained scratch feeds the next checkpoint fold: {}",
+            observed.remembers[1].0
+        );
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/crates/rb-hooks/src/dispatch.rs
+++ b/crates/rb-hooks/src/dispatch.rs
@@ -34,6 +34,15 @@ pub async fn dispatch(
         HookEvent::Stop {
             stop_hook_active, ..
         } => capture::stop(*stop_hook_active),
+        HookEvent::SessionCheckpoint { .. } => {
+            capture::session_checkpoint(
+                client.take(),
+                scratch,
+                &ctx.cwd,
+                ctx.transcript_path.as_deref(),
+            )
+            .await
+        }
         HookEvent::SessionEnd { .. } => {
             capture::session_end(
                 client.take(),
@@ -129,6 +138,27 @@ mod tests {
             scratch.read().files,
             vec!["src/lib.rs"],
             "a degraded SessionEnd preserves the scratch"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_checkpoint_event_routes_and_preserves_scratch_when_degraded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let scratch = Scratch::at(tmp.path().join("scratch.json"));
+        scratch.append(scratch::Kind::File, "src/lib.rs");
+        let result = dispatch(
+            None,
+            Some(&scratch),
+            &ctx(HookEvent::SessionCheckpoint {
+                reason: Some("Stop".to_string()),
+            }),
+        )
+        .await;
+        assert!(result.continue_execution);
+        assert_eq!(
+            scratch.read().files,
+            vec!["src/lib.rs"],
+            "a degraded checkpoint preserves the scratch"
         );
     }
 }

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -182,7 +182,8 @@ async fn capture_phase(
 ) -> HookResult {
     // W3.1: PostToolUse (scratch append) and Stop (no-op) never touch the
     // daemon, so they skip the connect cost entirely; only SessionStart /
-    // SessionCheckpoint / SessionEnd / PreCompact read or write the store.
+    // UserPromptSubmit / SessionCheckpoint / SessionEnd / PreCompact read or
+    // write the store (see `event_needs_daemon`).
     let mut client = if event_needs_daemon(&ctx.event) {
         DaemonClient::connect(
             socket,

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -182,7 +182,7 @@ async fn capture_phase(
 ) -> HookResult {
     // W3.1: PostToolUse (scratch append) and Stop (no-op) never touch the
     // daemon, so they skip the connect cost entirely; only SessionStart /
-    // SessionEnd / PreCompact read or write the store.
+    // SessionCheckpoint / SessionEnd / PreCompact read or write the store.
     let mut client = if event_needs_daemon(&ctx.event) {
         DaemonClient::connect(
             socket,
@@ -200,13 +200,15 @@ async fn capture_phase(
 
 /// True for events that read or write the store (and so need a daemon
 /// connection): SessionStart (inject), UserPromptSubmit (recall + inject),
-/// SessionEnd (fold + store), PreCompact (store). Local-only events —
-/// PostToolUse (scratch append), Stop (no-op), Other — skip the connect.
+/// SessionCheckpoint/SessionEnd (fold + store), PreCompact (store). Local-only
+/// events — PostToolUse (scratch append), Stop (no-op), Other — skip the
+/// connect.
 fn event_needs_daemon(event: &HookEvent) -> bool {
     matches!(
         event,
         HookEvent::SessionStart { .. }
             | HookEvent::UserPromptSubmit { .. }
+            | HookEvent::SessionCheckpoint { .. }
             | HookEvent::SessionEnd { .. }
             | HookEvent::PreCompact { .. }
     )
@@ -476,5 +478,16 @@ mod tests {
             name, "rusty-brain-hooks",
             "auto-start must NOT target the hooks binary"
         );
+    }
+
+    #[test]
+    fn checkpoint_needs_daemon_but_stop_does_not() {
+        assert!(event_needs_daemon(&HookEvent::SessionCheckpoint {
+            reason: Some("Stop".to_string())
+        }));
+        assert!(!event_needs_daemon(&HookEvent::Stop {
+            last_assistant_message: Some("done".to_string()),
+            stop_hook_active: false,
+        }));
     }
 }

--- a/crates/rb-hooks/src/main.rs
+++ b/crates/rb-hooks/src/main.rs
@@ -491,4 +491,63 @@ mod tests {
             stop_hook_active: false,
         }));
     }
+
+    #[test]
+    fn event_needs_daemon_is_true_for_all_store_events() {
+        // Every event that reads or writes the store must request a daemon
+        // connection. Adding a new store event without listing it here (or the
+        // inline comment in capture_phase) is the exact drift this pins down.
+        let store_events = [
+            HookEvent::SessionStart {
+                source: Some("startup".to_string()),
+            },
+            HookEvent::UserPromptSubmit {
+                prompt: Some("help me refactor".to_string()),
+            },
+            HookEvent::SessionCheckpoint {
+                reason: Some("Stop".to_string()),
+            },
+            HookEvent::SessionCheckpoint { reason: None },
+            HookEvent::SessionEnd {
+                reason: Some("clear".to_string()),
+            },
+            HookEvent::PreCompact {
+                custom_instructions: None,
+            },
+        ];
+        for event in &store_events {
+            assert!(
+                event_needs_daemon(event),
+                "{event:?} must need the daemon (reads or writes the store)"
+            );
+        }
+    }
+
+    #[test]
+    fn event_needs_daemon_is_false_for_all_local_only_events() {
+        // Local-only events skip the connect cost; none read or write the store.
+        let local_events = [
+            HookEvent::PostToolUse {
+                tool_name: "Edit".to_string(),
+                tool_input: serde_json::json!({"file_path": "/x"}),
+                tool_response: serde_json::json!("ok"),
+            },
+            HookEvent::Stop {
+                last_assistant_message: None,
+                stop_hook_active: false,
+            },
+            HookEvent::Stop {
+                last_assistant_message: Some("done".to_string()),
+                stop_hook_active: true,
+            },
+            HookEvent::Other("UnknownEvent".to_string()),
+            HookEvent::Other(String::new()),
+        ];
+        for event in &local_events {
+            assert!(
+                !event_needs_daemon(event),
+                "{event:?} must NOT need the daemon (local-only, no store access)"
+            );
+        }
+    }
 }

--- a/crates/rb-hooks/src/scratch.rs
+++ b/crates/rb-hooks/src/scratch.rs
@@ -143,6 +143,16 @@ impl Scratch {
         self.write(&data);
     }
 
+    /// Record the latest checkpoint summary id while retaining observations.
+    /// Used by non-Claude fallback boundaries where no true session terminus is
+    /// available: later checkpoints supersede the live summary without losing
+    /// early-session scratch entries.
+    pub fn mark_checkpointed(&self, summary_id: &str) {
+        let mut data = self.read();
+        data.prior_summary_id = Some(summary_id.to_string());
+        self.write(&data);
+    }
+
     /// Atomically write (temp file 0600 + rename), creating the parent 0700.
     /// Best-effort. The scratch holds best-effort-redacted plaintext, so it gets
     /// the same at-rest posture as the DB and socket: `docs/THREAT_MODEL.md`
@@ -340,6 +350,24 @@ mod tests {
             Some("mem-123"),
             "prior summary id survives a post-fold append"
         );
+    }
+
+    #[test]
+    fn mark_checkpointed_keeps_buffer_and_updates_summary_id() {
+        let (_d, s) = scratch();
+        s.append(Kind::File, "src/lib.rs");
+        s.append(Kind::Command, "cargo test");
+        s.mark_checkpointed("mem-123");
+        let data = s.read();
+        assert_eq!(data.files, vec!["src/lib.rs"]);
+        assert_eq!(data.commands, vec!["cargo test"]);
+        assert_eq!(data.prior_summary_id.as_deref(), Some("mem-123"));
+
+        s.append(Kind::File, "src/main.rs");
+        s.mark_checkpointed("mem-456");
+        let data = s.read();
+        assert_eq!(data.files, vec!["src/lib.rs", "src/main.rs"]);
+        assert_eq!(data.prior_summary_id.as_deref(), Some("mem-456"));
     }
 
     #[test]

--- a/crates/rb-hooks/src/scratch.rs
+++ b/crates/rb-hooks/src/scratch.rs
@@ -378,6 +378,69 @@ mod tests {
     }
 
     #[test]
+    fn mark_checkpointed_on_fresh_scratch_sets_id_without_creating_stray_entries() {
+        // mark_checkpointed on a completely empty scratch (no appends, no prior
+        // id) must only set prior_summary_id — the observation buffer stays empty
+        // (is_empty considers the buffers, not the id).
+        let (_d, s) = scratch();
+        s.mark_checkpointed("mem-000");
+        let data = s.read();
+        assert!(data.files.is_empty());
+        assert!(data.commands.is_empty());
+        assert!(data.failures.is_empty());
+        assert_eq!(data.prior_summary_id.as_deref(), Some("mem-000"));
+        assert!(data.is_empty(), "no observations recorded");
+    }
+
+    #[test]
+    fn mark_checkpointed_after_mark_folded_updates_the_id_without_restoring_buffer() {
+        // A SessionEnd (mark_folded) followed by a SessionCheckpoint
+        // (mark_checkpointed) with no new work: the buffer stays clear and only
+        // the id advances.
+        let (_d, s) = scratch();
+        s.append(Kind::File, "src/first.rs");
+        s.mark_folded(Some("end-id-1"));
+        let d1 = s.read();
+        assert!(d1.is_empty());
+        assert_eq!(d1.prior_summary_id.as_deref(), Some("end-id-1"));
+
+        s.mark_checkpointed("cp-id-2");
+        let d2 = s.read();
+        assert!(
+            d2.is_empty(),
+            "buffer stays empty after mark_checkpointed with no new appends"
+        );
+        assert_eq!(d2.prior_summary_id.as_deref(), Some("cp-id-2"));
+    }
+
+    #[test]
+    fn mark_checkpointed_supersedes_prior_id_from_mark_folded_with_new_appends() {
+        // Resume-after-fold: mark_folded clears + sets the id; a new append then a
+        // checkpoint must keep BOTH the post-fold entry AND the latest id, while
+        // the pre-fold entries stay cleared.
+        let (_d, s) = scratch();
+        s.append(Kind::Command, "cargo build");
+        s.mark_folded(Some("old-end-id"));
+        s.append(Kind::File, "src/new.rs");
+        s.mark_checkpointed("cp-id-after-resume");
+        let data = s.read();
+        assert_eq!(
+            data.files,
+            vec!["src/new.rs"],
+            "the post-fold append is retained"
+        );
+        assert!(
+            data.commands.is_empty(),
+            "pre-fold commands were cleared by mark_folded"
+        );
+        assert_eq!(
+            data.prior_summary_id.as_deref(),
+            Some("cp-id-after-resume"),
+            "mark_checkpointed advances the id from the prior mark_folded value"
+        );
+    }
+
+    #[test]
     fn mark_folded_with_none_clears_buffer() {
         let (_d, s) = scratch();
         s.append(Kind::Failure, "boom");

--- a/crates/rb-hooks/src/scratch.rs
+++ b/crates/rb-hooks/src/scratch.rs
@@ -147,6 +147,13 @@ impl Scratch {
     /// Used by non-Claude fallback boundaries where no true session terminus is
     /// available: later checkpoints supersede the live summary without losing
     /// early-session scratch entries.
+    ///
+    /// Like [`Scratch::append`], this is a best-effort, non-atomic
+    /// read-modify-write (last writer wins): the per-event hook binary is
+    /// single-process, so the only race is two overlapping hook processes for the
+    /// same session. A checkpoint racing a concurrent `append` could drop the
+    /// just-appended entry — an accepted file-level posture for coarse-grained,
+    /// best-effort capture, not a correctness guarantee.
     pub fn mark_checkpointed(&self, summary_id: &str) {
         let mut data = self.read();
         data.prior_summary_id = Some(summary_id.to_string());

--- a/crates/rb-hooks/tests/fixtures/codex/README.md
+++ b/crates/rb-hooks/tests/fixtures/codex/README.md
@@ -1,0 +1,56 @@
+# Codex Fixture Status
+
+## Provenance
+
+- **CLI:** Codex CLI `0.142.0` (`codex --version`)
+- **OS:** macOS 26.5.1, arm64
+- **Capture date:** 2026-06-23
+
+## Recording Recipe
+
+Planned recipe:
+
+1. Create a throwaway project with `.codex/hooks.json`.
+2. Register command hooks for `SessionStart`, `PostToolUse`, `Stop`, and
+   `PreCompact` that append raw stdin JSON to per-event files.
+3. Run a multi-turn `codex exec` session that performs one Bash command.
+4. Separately run a current Codex session that uses `apply_patch` and verify
+   whether it emits `PostToolUse`, the exact `tool_name`, and the raw patch
+   payload location.
+5. Sanitize only local paths and secrets before committing the JSON fixtures.
+
+This recording is **blocked in this worktree**. `codex doctor --json` reports
+ChatGPT auth is configured, but provider reachability fails under the restricted
+network environment. Running an authenticated session would also update
+user/global Codex state outside the owned worktree. Hand-authored JSON is not
+committed as a fixture.
+
+## Sanitization Table
+
+| What | Recorded value | Committed value |
+|---|---|---|
+| Real hook payloads | Not recorded | Not committed |
+
+## Multi-Turn Event Cadence
+
+Not fixture-verified in this worktree. The installer registers
+`SessionStart`, `PostToolUse`, `Stop`, and `PreCompact`, but no committed
+multi-turn capture proves whether native `Stop` is a true terminus or a
+per-turn boundary.
+
+## Mapping / Fallback
+
+Codex native `Stop` remains canonical `Stop` until a real fixture proves a
+better checkpoint or true terminus boundary. The `SessionCheckpoint`
+infrastructure exists in `rb-hooks`, but Codex does not emit it yet.
+
+Codex `apply_patch` capture remains blocked. The capture layer intentionally
+does not recognize `tool_name: "apply_patch"` until a real current Codex
+`PostToolUse` fixture proves the event shape and raw patch payload location.
+
+## Known Absences
+
+- No real transcript path fixture.
+- No verified true session terminus.
+- No committed raw payload JSON.
+- No `apply_patch` `PostToolUse` fixture.

--- a/crates/rb-hooks/tests/fixtures/gemini/README.md
+++ b/crates/rb-hooks/tests/fixtures/gemini/README.md
@@ -1,0 +1,47 @@
+# Gemini Fixture Status
+
+## Provenance
+
+- **CLI:** Gemini CLI `0.46.0` (`gemini --version`)
+- **OS:** macOS 26.5.1, arm64
+- **Capture date:** 2026-06-23
+
+## Recording Recipe
+
+Planned recipe:
+
+1. Create a throwaway project with `.gemini/settings.json`.
+2. Register command hooks for `SessionStart`, `AfterTool`, `SessionEnd`, and
+   `PreCompress` that append raw stdin JSON to per-event files.
+3. Run a multi-turn headless Gemini session that performs one file write and one
+   shell command.
+4. Sanitize only local paths and secrets before committing the JSON fixtures.
+
+This recording is **blocked in this worktree**. A real run would require model
+auth/network access and may read or update user/global Gemini state outside the
+owned worktree. Hand-authored JSON is not committed as a fixture.
+
+## Sanitization Table
+
+| What | Recorded value | Committed value |
+|---|---|---|
+| Real hook payloads | Not recorded | Not committed |
+
+## Multi-Turn Event Cadence
+
+Not fixture-verified in this worktree. The installer registers
+`SessionStart`, `AfterTool`, `SessionEnd`, and `PreCompress`, but no committed
+multi-turn capture proves whether native `SessionEnd` is a true terminus or a
+per-turn boundary.
+
+## Mapping / Fallback
+
+Gemini native `SessionEnd` remains canonical `Stop` until a real fixture proves
+a better checkpoint or true terminus boundary. The `SessionCheckpoint`
+infrastructure exists in `rb-hooks`, but Gemini does not emit it yet.
+
+## Known Absences
+
+- No real transcript path fixture.
+- No verified true session terminus.
+- No committed raw payload JSON.

--- a/crates/rb-hooks/tests/fixtures/opencode/README.md
+++ b/crates/rb-hooks/tests/fixtures/opencode/README.md
@@ -1,0 +1,51 @@
+# OpenCode Fixture Status
+
+## Provenance
+
+- **CLI:** OpenCode `1.17.5` (`opencode --version`)
+- **OS:** macOS 26.5.1, arm64
+- **Capture date:** 2026-06-23
+
+## Recording Recipe
+
+Planned recipe:
+
+1. Create a throwaway OpenCode project with a local plugin that logs hook event
+   payloads.
+2. Register capture for `session.created`, `tool.execute.after`,
+   `session.idle`, `session.compacted`, and `session.deleted`.
+3. Run a multi-turn `opencode run` session that performs one file write and one
+   shell command.
+4. Sanitize only local paths and secrets before committing the JSON fixtures.
+
+This recording is **blocked in this worktree**. OpenCode hook installation is
+not implemented in `rb-install` on this branch, and a real run would require
+model auth/network access plus plugin/config writes outside the owned worktree.
+Hand-authored JSON is not committed as a fixture.
+
+## Sanitization Table
+
+| What | Recorded value | Committed value |
+|---|---|---|
+| Real hook payloads | Not recorded | Not committed |
+
+## Multi-Turn Event Cadence
+
+Not fixture-verified in this worktree. The adapter recognizes
+`session.created`, `tool.execute.after`, `session.idle`, and
+`session.compacted`, but no committed multi-turn capture proves whether
+`session.idle` or `session.deleted` is a true terminus.
+
+## Mapping / Fallback
+
+OpenCode native `session.idle` remains canonical `Stop` until a real fixture
+proves a better checkpoint or true terminus boundary. The `SessionCheckpoint`
+infrastructure exists in `rb-hooks`, but OpenCode does not emit it yet. Native
+`session.deleted` remains `Other` until a real fixture proves terminal behavior.
+
+## Known Absences
+
+- No `rb-install` OpenCode plugin support in this branch.
+- No real transcript path fixture.
+- No verified true session terminus.
+- No committed raw payload JSON.


### PR DESCRIPTION
## Summary

This PR adds fixture-gated `SessionCheckpoint` infrastructure for non-Claude capture recovery without making any unverified adapter boundary reachable yet.

The W3.1 capture inversion moved durable session summaries to `SessionEnd`, while `Stop` became a no-op because Claude Code uses it as a per-turn event. That left Gemini, Codex, and OpenCode without safe automatic capture unless their native lifecycle events can be proven to represent either a true terminus or a safe checkpoint boundary.

## Root Cause

The non-Claude adapters have stop-looking events, but this branch does not yet have real multi-turn fixtures proving their event cadence. Mapping those events directly to `SessionEnd` would risk over-capture if they fire per turn, and mapping them to a checkpoint without fixtures would still make an unverified lifecycle assumption.

Codex `apply_patch` capture is similarly blocked because there is no current real fixture proving the exact `PostToolUse` shape or where the raw patch payload appears. Capturing it prematurely could store raw patch body content instead of only file paths.

## Fix

- Adds canonical `HookEvent::SessionCheckpoint`.
- Routes checkpoint events through `rb-hooks`.
- Folds checkpoint scratch into one live summary using the same summary builder as `SessionEnd`.
- Retains scratch after a successful checkpoint so later checkpoints supersede the previous live summary while preserving earlier observations.
- Keeps `SessionEnd` behavior unchanged: durable fold then scratch reset.
- Keeps Gemini `SessionEnd`, Codex `Stop`, and OpenCode `session.idle` mapped to canonical no-op `Stop` until real fixtures prove a safer boundary.
- Adds fixture blocker READMEs for Gemini, Codex, and OpenCode with provenance, planned recording recipes, cadence gaps, and known absences.
- Adds a guard test proving Codex `apply_patch` remains uncaptured until fixture-backed.

## User Impact

Claude behavior is preserved. Non-Claude capture remains conservative instead of silently over-capturing or storing unverified data. The checkpoint path is now available and tested for future fixture-backed adapter mappings.

## Validation

- `cargo fmt --all --check`
- `git --no-optional-locks diff --check`
- `cargo test -p rb-agents`
- `cargo test -p rb-hooks`
- `cargo test -p rb-install forty_turn_session_produces_at_most_five_memories`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session checkpoint event handling for non-Claude adapters to preserve session state across boundaries.

* **Tests**
  * Expanded test coverage to verify checkpoint behavior across adapters and session state preservation.

* **Documentation**
  * Added fixture status documentation detailing test availability and recording status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->