### PR TITLE
chore: descope Gemini from cross-CLI terminus/capture work

### DIFF
--- a/crates/rb-agents/src/capability.rs
+++ b/crates/rb-agents/src/capability.rs
@@ -101,7 +101,7 @@ const CAPABILITIES: &[AgentCapability] = &[
         scorecard: SupportLevel::Unsupported,
         verified_lifecycle_source: "crates/rb-hooks/tests/fixtures/gemini/README.md",
         limitations: &[
-            "Native SessionEnd remains canonical Stop until a real lifecycle fixture proves a checkpoint or terminus boundary.",
+            "Native SessionEnd remains canonical Stop; terminus mapping is descoped (no lifecycle fixture planned).",
             "Prompt-time retrieval parity has not been verified.",
         ],
     },

--- a/crates/rb-agents/src/capability.rs
+++ b/crates/rb-agents/src/capability.rs
@@ -101,7 +101,7 @@ const CAPABILITIES: &[AgentCapability] = &[
         scorecard: SupportLevel::Unsupported,
         verified_lifecycle_source: "crates/rb-hooks/tests/fixtures/gemini/README.md",
         limitations: &[
-            "Native SessionEnd remains canonical Stop; terminus mapping is descoped (no lifecycle fixture planned).",
+            "Native SessionEnd remains canonical Stop; terminus mapping is descoped — no fixture/mapping work planned under the cross-CLI terminus track.",
             "Prompt-time retrieval parity has not been verified.",
         ],
     },

--- a/docs/follow-ups/2026-06-13-cross-cli-capture-inversion.md
+++ b/docs/follow-ups/2026-06-13-cross-cli-capture-inversion.md
@@ -8,7 +8,8 @@
   existed but was dormant; OpenCode's terminus mapping (Gap A) is now **landed**
   (`session.idle` → `SessionCheckpoint`, fixture-backed lifecycle test). Full
   OpenCode capture restoration still needs the separate `apply_patch`
-  tool-coverage fix (Gap B). Codex/Gemini remain fixture-gated.
+  tool-coverage fix (Gap B). Codex remains fixture-gated; Gemini is descoped
+  (2026-06-27).
 - **Severity:** Medium — a capture **regression** for non-Claude CLIs until resolved
 
 ## Summary
@@ -22,14 +23,15 @@ canonical `Stop`, while OpenCode now maps `session.idle` to canonical
 
 | CLI | terminal native event | canonical mapping |
 |---|---|---|
-| Gemini | `SessionEnd` | `Stop` (`crates/rb-agents/src/gemini.rs`) — fixture-gated |
+| Gemini | `SessionEnd` | `Stop` (`crates/rb-agents/src/gemini.rs`) — descoped |
 | Codex | `Stop` | `Stop` (`crates/rb-agents/src/codex.rs`) — fixture-gated |
 | OpenCode | `session.idle` | `SessionCheckpoint` (`crates/rb-agents/src/opencode.rs`) — **Gap A landed** |
 
 OpenCode's `session.idle` now folds via canonical `SessionCheckpoint` (Gap A,
 multi-fire checkpoint-safe), so its bash-tool scratch is captured again. Codex
-and Gemini remain on `Stop` until a recorded lifecycle fixture proves their
-terminus cadence. For any CLI still on `Stop`: `PostToolUse` appends to the
+remains on `Stop` until a recorded lifecycle fixture proves its terminus cadence.
+Gemini is **descoped** (2026-06-27): it stays on `Stop`, no worse than today, and
+no fixture/mapping work is planned for it under this track. For any CLI still on `Stop`: `PostToolUse` appends to the
 per-session scratch as designed, but no canonical fold ever fires, so the scratch
 is never folded into a summary — it simply ages out via `scratch::prune_stale`
 (24h). Net effect vs pre-W3.1 (while unmapped): per-event capture → **no new

--- a/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
+++ b/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
@@ -8,8 +8,9 @@
   (multi-fire checkpoint-safe), but restoring OpenCode capture also requires a
   separate `apply_patch` tool-coverage fix (Gap B), and scorecard enablement is a
   larger task than a flag flip — do NOT implement OpenCode end-to-end from the
-  terminus decision alone. Codex and Gemini decisions are fixture-gated (decision
-  trees below). This is "Worker C" per the sequencing PRD.
+  terminus decision alone. Codex's decision is fixture-gated (decision tree
+  below). **Gemini is descoped** (2026-06-27) — removed from active scope; it
+  stays on canonical `Stop`. This is "Worker C" per the sequencing PRD.
 - **Related:**
   [cross-cli-capture-inversion follow-up](../follow-ups/2026-06-13-cross-cli-capture-inversion.md),
   [cross-agent fixture-recording spec](../specs/2026-06-23-cross-agent-fixture-recording.md),
@@ -142,7 +143,8 @@ existing `"patch" => "Edit"` arm does NOT cover it — the recorded tool name is
    `apply_patch` `tool.execute.after` fixture (record one — the committed fixture
    set lacks it).
 
-Gap A is the worked example the Codex/Gemini terminus decisions follow. Gap B is
+Gap A is the worked example the Codex terminus decision follows (Gemini
+descoped). Gap B is
 tracked alongside the Codex `apply_patch` follow-up.
 
 ### Codex — FIXTURE-GATED
@@ -166,20 +168,18 @@ Unrelated and still deferred: Codex `apply_patch` capture remains blocked upstre
 [apply_patch follow-up](../follow-ups/2026-06-02-codex-apply-patch-capture.md).
 Codex shell capture already works (`tool_name: "Bash"`).
 
-### Gemini — FIXTURE-GATED
+### Gemini — DESCOPED (2026-06-27)
 
-Gemini native events: `SessionStart`, `AfterTool`, `SessionEnd`, `PreCompress`
-(`crates/rb-agents/src/gemini.rs`). Native `SessionEnd` currently maps to canonical
-`Stop` (`gemini.rs:68`) precisely because its cadence is unverified — the adapter
-comment calls it ambiguous.
+Gemini is removed from the active cross-CLI terminus/capture work. Its adapter
+(`crates/rb-agents/src/gemini.rs`) stays as-is: native `SessionEnd` continues to
+map to canonical `Stop` (`gemini.rs:68`), so Gemini neither folds nor
+double-folds — its capture stays `Partial`, no worse than today. No Gemini
+lifecycle fixture will be recorded and no mapping change will be made under this
+plan.
 
-**Open question:** is Gemini's native `SessionEnd` a true once-per-session
-terminus or a per-turn stop? Record a Gemini lifecycle fixture (the recorder
-currently scopes codex+opencode; extend it, or capture Gemini by hand per the
-W3.4 recipe) and inspect the firing count.
-
-**Decision tree:** identical to Codex — once-per-session → canonical `SessionEnd`;
-per-turn → canonical `SessionCheckpoint`.
+If Gemini is reprioritized later, the work is unchanged from the Codex template:
+record a lifecycle fixture, inspect `terminus.json`, and map its `SessionEnd`
+once-per-session → canonical `SessionEnd` / per-turn → `SessionCheckpoint`.
 
 ## Scorecard targeting — a SEPARATE, larger task (do not couple to terminus mapping)
 
@@ -267,11 +267,11 @@ OpenCode scorecard — separate task (see "Scorecard targeting" above):
    `memory-scorecard.sh`, then flip `scorecard_agent_supported`. This is the bulk
    of the work and is NOT unlocked by terminus mapping alone.
 
-Codex / Gemini: record fixture → inspect `terminus.json` → apply the terminus
-decision tree (Gap A analog) → assess each one's file-edit tool coverage (Gap B
-analog) → then scorecard. Codex needs the operator's one-time `--setup-trust
-codex` before recording; Codex `apply_patch` stays upstream-blocked
-(openai/codex#16732).
+Codex: record fixture → inspect `terminus.json` → apply the terminus decision
+tree (Gap A analog) → assess its file-edit tool coverage (Gap B analog) → then
+scorecard. Codex needs the operator's one-time `--setup-trust codex` before
+recording; Codex `apply_patch` stays upstream-blocked (openai/codex#16732).
+(Gemini is descoped — see the Gemini section.)
 
 ## Risks / open questions
 

--- a/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
+++ b/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
@@ -2,8 +2,9 @@
 
 - **Date:** 2026-06-26
 - **Scope:** Resolve the post-W3.1 capture regression for the non-Claude CLIs
-  (Codex / OpenCode / Gemini) by mapping each CLI's terminal native event onto a
-  canonical event that actually folds the session scratch into a memory.
+  (Codex / OpenCode; Gemini descoped 2026-06-27) by mapping each CLI's terminal
+  native event onto a canonical event that actually folds the session scratch
+  into a memory.
 - **Status:** Design + scaffolding. OpenCode's terminus mapping is decidable now
   (multi-fire checkpoint-safe), but restoring OpenCode capture also requires a
   separate `apply_patch` tool-coverage fix (Gap B), and scorecard enablement is a

--- a/docs/prds/2026-06-23-next-work-sequencing.md
+++ b/docs/prds/2026-06-23-next-work-sequencing.md
@@ -13,7 +13,7 @@
    - This lets us say W3.5 is closed without overstating it.
 
 2. **Then do cross-agent capture/parity.**
-   - Record real lifecycle fixtures for Codex/OpenCode/Gemini.
+   - Record real lifecycle fixtures for Codex/OpenCode. (Gemini descoped 2026-06-27.)
    - Decide safe `SessionEnd`/`SessionCheckpoint` mappings.
    - Update the capability matrix and docs for Codex/OpenCode/Hermes (the matrix and Hermes discovery note already landed in PR #43) based on the recorded fixture evidence.
    - Only then expand scorecard targeting by agent.
@@ -39,7 +39,7 @@ Yes, work can overlap — but keep the branches separate.
 - **Within cross-agent**, fixture recording can be parallelized by CLI:
   - Codex lifecycle fixture
   - OpenCode lifecycle fixture
-  - Gemini lifecycle fixture
+  - ~~Gemini lifecycle fixture~~ (descoped 2026-06-27)
 
   Each should produce its own sanitized fixture notes before shared code mappings are changed.
 
@@ -52,7 +52,7 @@ Yes, work can overlap — but keep the branches separate.
 ### Practical split
 
 - **Worker A:** W3.5 closeout branch.
-- **Worker B:** Codex/OpenCode/Gemini lifecycle fixtures.
+- **Worker B:** Codex/OpenCode lifecycle fixtures (Gemini descoped 2026-06-27).
 - **Worker C** (after B has evidence): mapping / capability-matrix / agent-scorecard work.
 
 The main merge dependency is low: W3.5 closeout can merge first, and cross-agent parity can continue independently.


### PR DESCRIPTION
## Summary

Takes **Gemini off the active cross-CLI terminus/capture list**. After OpenCode Gap A landed (#48), the remaining cross-agent items are Codex and OpenCode Gap B — Gemini is being descoped.

The Gemini **adapter is unchanged and still functional**: native `SessionEnd` continues to map to canonical `Stop`, so Gemini neither folds nor double-folds and its `capture` stays `Partial` (no worse than today). No Gemini lifecycle fixture will be recorded and no mapping change is planned under this track. Removing the adapter entirely would be a much larger, destructive change and is intentionally **not** done here.

## Changes (docs + 1 string)

- **terminus-mapping plan** — replace the "Gemini — FIXTURE-GATED" section with a "Gemini — DESCOPED" note; drop Gemini from the status line, the TDD breakdown, and the Gap A worked-example reference.
- **cross-cli-capture-inversion follow-up** — mark the Gemini table row + status line as descoped.
- **next-work sequencing PRD** — drop Gemini from step 2, the parallelization list, and Worker B.
- **capability.rs** — reword the Gemini limitation so it no longer implies a planned fixture. `capture` stays `Partial`; no behavior change and no test asserts the string content.

## Test plan

Docs + one capability-string line. `capability.rs` tests pass (22), clippy + rustfmt clean. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Updates**
  * Updated how the Gemini agent’s terminus mapping is handled, aligning it with a descoped lifecycle behavior.
* **Documentation**
  * Updated planning and follow-up docs to reflect the current cross-CLI lifecycle and terminus mapping status.
  * Clarified that lifecycle fixture work is now focused on the remaining supported adapters, with sequencing/checklists adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->