### PR TITLE
feat(cli): add project init and import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "rb-embed",
  "rb-mcp",
  "rb-proto",
+ "rb-redact",
  "rb-types",
  "serde_json",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Client commands auto-start the daemon on first use (and connect to it thereafter
 so you can go straight to storing and recalling:
 
 ```bash
+# seed a fresh brain from existing project context (CLAUDE.md, README,
+# CHANGELOG.md, docs/**/*.md, and recent decision-ish git commits)
+rusty-brain init --yes
+
+# preview a one-off text/markdown import without storing anything
+rusty-brain import docs/architecture.md --dry-run
+
 # store a memory (namespace is detected from the current project / git root)
 rusty-brain remember "We use a single-writer daemon over SQLite WAL" \
   --type architecture_decision --importance 8 --tags storage --tags concurrency
@@ -184,6 +191,10 @@ rusty-brain link <from-id> <to-id> --type contradicts --reason "policy reversed"
 # retroactively redact secrets from every stored memory, then re-embed
 rusty-brain scrub
 rusty-brain reembed
+
+# list or undo first-run/import batches
+rusty-brain init --list-batches
+rusty-brain init --undo <batch-id>
 
 # add --json to any command for machine-readable output
 rusty-brain recall "sqlite" --json

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -27,6 +27,7 @@ rb-proto = { path = "../rb-proto" }
 rb-daemon = { path = "../rb-daemon" }
 rb-embed = { path = "../rb-embed" }
 rb-mcp = { path = "../rb-mcp" }
+rb-redact = { path = "../rb-redact" }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -81,6 +81,53 @@ pub enum Command {
     /// Run the MCP (Model Context Protocol) stdio server for agents.
     Mcp,
 
+    /// Seed memory from existing project context (first-run cold start).
+    Init {
+        /// Skip the confirmation prompt and store the planned memories.
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Print the import plan without storing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Maximum project files to scan (well-known root files + docs/).
+        #[arg(long, default_value_t = 50)]
+        max_files: usize,
+        /// Maximum bytes to read from any one source file.
+        #[arg(long, default_value_t = 65_536)]
+        max_bytes: usize,
+        /// Default importance 1-10 for seeded memories (source adapters may
+        /// nudge it, e.g. CLAUDE.md constraints are one point higher).
+        #[arg(long, default_value_t = 6, value_parser = value_parser!(u8).range(1..=10))]
+        importance: u8,
+        /// Undo a prior import batch by id (printed after a successful init/import).
+        #[arg(long, conflicts_with_all = ["dry_run", "list_batches"])]
+        undo: Option<String>,
+        /// List undoable import batches for the current database.
+        #[arg(long = "list-batches", conflicts_with_all = ["undo"])]
+        list_batches: bool,
+    },
+
+    /// Import a text/markdown file, or '-' for stdin, into the current namespace.
+    Import {
+        /// Path to a text/markdown file, or '-' to read stdin.
+        path: String,
+        /// Memory type applied to the imported item.
+        #[arg(long = "type", default_value = "insight", value_parser = parse_memory_type)]
+        memory_type: MemoryType,
+        /// Importance 1-10.
+        #[arg(long, default_value_t = 5, value_parser = value_parser!(u8).range(1..=10))]
+        importance: u8,
+        /// Tags (repeatable). An `import_batch:<id>` tag is added automatically.
+        #[arg(long)]
+        tags: Vec<String>,
+        /// Print the import plan without storing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Maximum bytes to read from the input.
+        #[arg(long, default_value_t = 65_536)]
+        max_bytes: usize,
+    },
+
     /// Store a new memory.
     Remember {
         /// Memory content (the body to remember). Required UNLESS `--batch` is
@@ -311,6 +358,94 @@ mod tests {
         let cli = Cli::parse_from(["rusty-brain", "--json", "subscribe"]);
         assert!(cli.json, "--json is a global flag and applies to subscribe");
         assert!(matches!(cli.command, Command::Subscribe { .. }));
+    }
+
+    #[test]
+    fn init_parses_yes_dry_run_and_bounds() {
+        let cli = Cli::parse_from([
+            "rusty-brain",
+            "init",
+            "--yes",
+            "--dry-run",
+            "--max-files",
+            "12",
+            "--max-bytes",
+            "4096",
+            "--importance",
+            "7",
+        ]);
+        match cli.command {
+            Command::Init {
+                yes,
+                dry_run,
+                max_files,
+                max_bytes,
+                importance,
+                undo,
+                list_batches,
+            } => {
+                assert!(yes);
+                assert!(dry_run);
+                assert_eq!(max_files, 12);
+                assert_eq!(max_bytes, 4096);
+                assert_eq!(importance, 7);
+                assert_eq!(undo, None);
+                assert!(!list_batches);
+            }
+            other => panic!("expected Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_parses_undo_and_list_batches_conflicts() {
+        let undo = Cli::parse_from(["rusty-brain", "init", "--undo", "import-abc"]);
+        assert!(matches!(undo.command, Command::Init { undo: Some(_), .. }));
+
+        let err = Cli::try_parse_from([
+            "rusty-brain",
+            "init",
+            "--undo",
+            "import-abc",
+            "--list-batches",
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn import_parses_file_type_tags_and_dry_run() {
+        let cli = Cli::parse_from([
+            "rusty-brain",
+            "import",
+            "docs/ADR.md",
+            "--type",
+            "architecture_decision",
+            "--importance",
+            "8",
+            "--tags",
+            "seed",
+            "--dry-run",
+            "--max-bytes",
+            "8192",
+        ]);
+        match cli.command {
+            Command::Import {
+                path,
+                memory_type,
+                importance,
+                tags,
+                dry_run,
+                max_bytes,
+            } => {
+                assert_eq!(path, "docs/ADR.md");
+                assert_eq!(memory_type, MemoryType::ArchitectureDecision);
+                assert_eq!(importance, 8);
+                assert_eq!(tags, vec!["seed"]);
+                assert!(dry_run);
+                assert_eq!(max_bytes, 8192);
+            }
+            other => panic!("expected Import, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -100,10 +100,16 @@ pub enum Command {
         #[arg(long, default_value_t = 6, value_parser = value_parser!(u8).range(1..=10))]
         importance: u8,
         /// Undo a prior import batch by id (printed after a successful init/import).
-        #[arg(long, conflicts_with_all = ["dry_run", "list_batches"])]
+        #[arg(
+            long,
+            conflicts_with_all = ["yes", "dry_run", "max_files", "max_bytes", "importance", "list_batches"]
+        )]
         undo: Option<String>,
         /// List undoable import batches for the current database.
-        #[arg(long = "list-batches", conflicts_with_all = ["undo"])]
+        #[arg(
+            long = "list-batches",
+            conflicts_with_all = ["yes", "dry_run", "max_files", "max_bytes", "importance", "undo"]
+        )]
         list_batches: bool,
     },
 
@@ -409,6 +415,25 @@ mod tests {
             "--list-batches",
         ])
         .unwrap_err();
+        assert!(err.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn init_undo_conflicts_with_scan_flags() {
+        let err = Cli::try_parse_from([
+            "rusty-brain",
+            "init",
+            "--undo",
+            "import-abc",
+            "--max-files",
+            "10",
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("cannot be used with"));
+
+        let err =
+            Cli::try_parse_from(["rusty-brain", "init", "--list-batches", "--importance", "7"])
+                .unwrap_err();
         assert!(err.to_string().contains("cannot be used with"));
     }
 

--- a/crates/rusty-brain/src/import.rs
+++ b/crates/rusty-brain/src/import.rs
@@ -224,7 +224,7 @@ fn derive_summary(text: &str, label: &str) -> String {
     for line in text.lines() {
         let t = line.trim();
         if let Some(heading) = t.strip_prefix('#') {
-            let heading = heading.trim();
+            let heading = heading.trim_start_matches('#').trim();
             if !heading.is_empty() {
                 return truncate_summary(heading);
             }
@@ -394,8 +394,7 @@ fn recent_decision_commits(root: &Path, limit: usize) -> Vec<ImportItem> {
 
 /// Store `items` over a single connection. Each item is redacted, then a
 /// read-only recall probe skips an exact-content duplicate (so re-running an
-/// import adds nothing). On `dry_run`, probes still run (so the plan reports
-/// duplicates) but nothing is stored and no ledger is written.
+/// import adds nothing).
 ///
 /// Returns the per-item outcome (the stored id, or `None` for skipped/failed)
 /// and aggregate counts.
@@ -404,7 +403,6 @@ pub async fn store_items(
     items: &[ImportItem],
     tag: &str,
     extra_tags: &[String],
-    dry_run: bool,
 ) -> anyhow::Result<(Vec<Option<MemoryId>>, ImportCounts)> {
     let mut ids = Vec::with_capacity(items.len());
     let mut counts = ImportCounts::default();
@@ -423,12 +421,6 @@ pub async fn store_items(
 
         if is_duplicate(client, &content).await? {
             counts.skipped_duplicate += 1;
-            ids.push(None);
-            continue;
-        }
-
-        if dry_run {
-            counts.new += 1;
             ids.push(None);
             continue;
         }
@@ -475,7 +467,7 @@ async fn is_duplicate(client: &mut Client, redacted_content: &str) -> anyhow::Re
         return Ok(false);
     }
     let (results, _degraded) = client
-        .recall_with_status(query, None, Vec::new(), 5)
+        .recall_with_status(query, None, Vec::new(), 20)
         .await?;
     let target = redacted_content.trim();
     Ok(results.iter().any(|r| r.memory.content.trim() == target))
@@ -493,11 +485,9 @@ pub fn write_ledger(db_path: &Path, batch_id: &str, ids: &[MemoryId]) -> anyhow:
         "batch": batch_id,
         "ids": ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
     });
-    // Atomic write: temp file 0600 + rename (the scratch/DB at-rest precedent).
+    // Atomic write: temp file created 0600 on Unix + rename.
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, payload.to_string())
-        .with_context(|| format!("writing ledger {}", tmp.display()))?;
-    set_private(&tmp)?;
+    write_private(&tmp, &payload.to_string())?;
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("installing ledger {}", path.display()))?;
     Ok(())
@@ -602,15 +592,23 @@ fn safe_ledger_name(batch_id: &str) -> String {
 }
 
 #[cfg(unix)]
-fn set_private(path: &Path) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt as _;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("chmod 0600 {}", path.display()))
+fn write_private(path: &Path, content: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("creating {}", path.display()))?;
+    f.write_all(content.as_bytes())
+        .with_context(|| format!("writing {}", path.display()))
 }
 
 #[cfg(not(unix))]
-fn set_private(_path: &Path) -> anyhow::Result<()> {
-    Ok(())
+fn write_private(path: &Path, content: &str) -> anyhow::Result<()> {
+    std::fs::write(path, content).with_context(|| format!("writing {}", path.display()))
 }
 
 #[cfg(test)]
@@ -651,6 +649,15 @@ mod tests {
             "no heading here"
         );
         assert_eq!(derive_summary("\n\n   \n", "docs/x.md"), "x.md");
+    }
+
+    #[test]
+    fn derive_summary_strips_all_heading_markers() {
+        assert_eq!(derive_summary("## Design\nbody", "x"), "Design");
+        assert_eq!(
+            derive_summary("### Deep Section\nbody", "x"),
+            "Deep Section"
+        );
     }
 
     #[test]

--- a/crates/rusty-brain/src/import.rs
+++ b/crates/rusty-brain/src/import.rs
@@ -1,0 +1,821 @@
+//! First-run cold-start and project import.
+//!
+//! Implements PRD `docs/prds/2026-07-02-init-and-project-import.md`: seed a
+//! fresh brain from existing project context (CLAUDE.md, README, docs/, the git
+//! log) so the first recall is non-empty, plus a general `import` for arbitrary
+//! text/markdown.
+//!
+//! Design rules (from the PRD):
+//! - No new storage schema. Everything flows through the existing wire
+//!   `remember` op; the daemon does enrich -> embed -> store, exactly like the
+//!   interactive `remember` command.
+//! - Every external byte is redacted client-side via `rb-redact` BEFORE it
+//!   touches the wire (the same discipline the capture hooks use), so a secret
+//!   in a source file never reaches the DB.
+//! - Each seeded memory carries an `import_batch:<id>` tag for reviewability
+//!   and bulk rollback. A small sidecar ledger under the DB dir records the
+//!   stored ids so `init --undo <batch>` removes exactly that set.
+//! - Idempotent: a content-equality recall probe skips a candidate whose
+//!   redacted content is already stored, so re-running `init` adds nothing.
+
+use anyhow::Context as _;
+use rb_proto::Client;
+use rb_redact::redact;
+use rb_types::{MemoryId, MemoryType};
+use std::path::{Path, PathBuf};
+
+/// Tag prefix stamping every seeded memory so a batch is reviewable and
+/// bulk-undoable. The full tag is `import_batch:<batch_id>`.
+pub const BATCH_TAG_PREFIX: &str = "import_batch:";
+
+/// A single extracted memory candidate (pre-redaction; redaction happens at
+/// store time so the dedup probe compares redacted-to-redacted).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImportItem {
+    pub summary: String,
+    pub content: String,
+    pub memory_type: MemoryType,
+    pub importance: u8,
+    /// Human-readable provenance label (file path, "git log", "stdin"). Stored
+    /// in the memory's `context` field so it shows in recall.
+    pub source: String,
+}
+
+/// Counts for an import run.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ImportCounts {
+    pub new: u64,
+    pub skipped_duplicate: u64,
+    pub failed: u64,
+}
+
+/// Counts for an undo run.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UndoCounts {
+    /// Successful delete ops issued. Soft-archive (`delete`) is idempotent: a
+    /// missing or already-archived id is an Ok no-op server-side, so re-running
+    /// an undo re-issues the same ops and reports the same count.
+    pub deleted: u64,
+}
+
+/// Knobs for a project scan.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanOptions {
+    pub max_files: usize,
+    pub max_bytes: usize,
+    pub importance: u8,
+}
+
+impl ScanOptions {
+    /// Conservative defaults: at most 50 files, 64 KiB each, importance 6.
+    pub fn defaults(importance: u8) -> Self {
+        Self {
+            max_files: 50,
+            max_bytes: 65_536,
+            importance,
+        }
+    }
+}
+
+/// Generate a fresh, filesystem-safe batch id.
+pub fn new_batch_id() -> String {
+    // Reuse the UUID generator already in the dependency closure (rb-types)
+    // rather than pulling in the `uuid` crate directly here.
+    format!("import-{}", MemoryId::new())
+}
+
+/// Build the full batch tag for a batch id.
+pub fn batch_tag(batch_id: &str) -> String {
+    format!("{BATCH_TAG_PREFIX}{batch_id}")
+}
+
+// ---------------------------------------------------------------------------
+// Source adapters (pure; unit-tested)
+// ---------------------------------------------------------------------------
+
+/// Detect candidate sources under `root` and extract items. Best-effort: a
+/// per-source error (unreadable file, non-UTF-8, git absent) is skipped, never
+/// fatal. `root` is normally the git toplevel (falling back to the given dir).
+pub fn scan_project(root: &Path, opts: ScanOptions) -> Vec<ImportItem> {
+    let scan_root = git_toplevel(root).unwrap_or_else(|| root.to_path_buf());
+    let mut items = Vec::new();
+    let mut budget = opts.max_files;
+
+    // Well-known root files, in priority order. Each is optional.
+    for name in ["CLAUDE.md", "AGENTS.md", "README.md", "CHANGELOG.md"] {
+        if budget == 0 {
+            return items;
+        }
+        let path = scan_root.join(name);
+        if path.is_file() {
+            if let Some(item) = extract_well_known(&path, opts) {
+                items.push(item);
+                budget -= 1;
+            }
+        }
+    }
+
+    // Markdown under docs/ (recursive, bounded). Hidden dirs and `target/` are
+    // skipped so build artifacts and VCS internals never get ingested.
+    if budget > 0 {
+        let docs = scan_root.join("docs");
+        if docs.is_dir() {
+            let mut md_files = Vec::new();
+            collect_markdown(&docs, &mut md_files);
+            md_files.sort();
+            for path in md_files {
+                if budget == 0 {
+                    break;
+                }
+                if let Some(item) = extract_doc(&path, opts) {
+                    items.push(item);
+                    budget -= 1;
+                }
+            }
+        }
+    }
+
+    // Recent decision-ish commits (bounded, best-effort, never fatal).
+    if budget > 0 {
+        for commit in recent_decision_commits(&scan_root, budget.min(30)) {
+            items.push(commit);
+        }
+    }
+
+    items
+}
+
+/// Extract one item from a file at `path` (used by `import <path>`). Returns
+/// `None` if the file cannot be read or yields no text.
+pub fn extract_file(
+    path: &Path,
+    max_bytes: usize,
+    memory_type: MemoryType,
+    importance: u8,
+) -> Option<ImportItem> {
+    let text = read_bounded_text(path, max_bytes)?;
+    if text.trim().is_empty() {
+        return None;
+    }
+    let source = path.display().to_string();
+    Some(extract_text(&source, &text, memory_type, importance))
+}
+
+/// Extract one item from in-memory text (stdin or an already-read file). The
+/// heuristic: the first heading or non-empty line becomes the summary; the full
+/// (bounded) text becomes the content.
+pub fn extract_text(
+    label: &str,
+    text: &str,
+    memory_type: MemoryType,
+    importance: u8,
+) -> ImportItem {
+    let summary = derive_summary(text, label);
+    ImportItem {
+        summary,
+        content: text.to_string(),
+        memory_type,
+        importance,
+        source: label.to_string(),
+    }
+}
+
+fn extract_well_known(path: &Path, opts: ScanOptions) -> Option<ImportItem> {
+    let text = read_bounded_text(path, opts.max_bytes)?;
+    if text.trim().is_empty() {
+        return None;
+    }
+    let base = path.file_name().and_then(|s| s.to_str()).unwrap_or("file");
+    let (memory_type, imp) = well_known_kind(base, opts.importance);
+    let source = path.display().to_string();
+    Some(extract_text(&source, &text, memory_type, imp))
+}
+
+fn extract_doc(path: &Path, opts: ScanOptions) -> Option<ImportItem> {
+    let text = read_bounded_text(path, opts.max_bytes)?;
+    if text.trim().is_empty() {
+        return None;
+    }
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    let (memory_type, imp) = if lower.contains("adr") || lower.contains("decision") {
+        (
+            MemoryType::ArchitectureDecision,
+            opts.importance.saturating_add(1).min(10),
+        )
+    } else {
+        (MemoryType::Insight, opts.importance)
+    };
+    let source = path.display().to_string();
+    Some(extract_text(&source, &text, memory_type, imp))
+}
+
+/// Pick a memory type + importance for a well-known root file.
+fn well_known_kind(base: &str, importance: u8) -> (MemoryType, u8) {
+    match base {
+        "CLAUDE.md" | "AGENTS.md" => (MemoryType::Constraint, importance.saturating_add(1).min(10)),
+        "CHANGELOG.md" => (MemoryType::Reference, importance.saturating_sub(1).max(1)),
+        _ => (MemoryType::Insight, importance), // README and anything else
+    }
+}
+
+/// Summary heuristic: first markdown heading, else first non-empty line, else a
+/// fallback derived from `label`. Trimmed to a readable width.
+fn derive_summary(text: &str, label: &str) -> String {
+    for line in text.lines() {
+        let t = line.trim();
+        if let Some(heading) = t.strip_prefix('#') {
+            let heading = heading.trim();
+            if !heading.is_empty() {
+                return truncate_summary(heading);
+            }
+        }
+        if !t.is_empty() {
+            return truncate_summary(t);
+        }
+    }
+    // Last resort: the source label (filename), cleaned up.
+    Path::new(label)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(truncate_summary)
+        .unwrap_or_else(|| "imported memory".to_string())
+}
+
+fn truncate_summary(s: &str) -> String {
+    const MAX: usize = 100;
+    if s.chars().count() <= MAX {
+        return s.trim().to_string();
+    }
+    let mut out: String = s.chars().take(MAX).collect();
+    if let Some(cut) = out.rfind(' ') {
+        out.truncate(cut);
+    }
+    out.push_str("...");
+    out
+}
+
+/// Read up to `max_bytes` from a file as lossy UTF-8. Returns `None` on error,
+/// empty, or binary content (contains a NUL byte).
+fn read_bounded_text(path: &Path, max_bytes: usize) -> Option<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buf = Vec::with_capacity(max_bytes.min(8 * 1024));
+    // `take` caps the read so a giant file is not fully loaded.
+    let n = file
+        .by_ref()
+        .take(max_bytes.try_into().unwrap_or(u64::MAX))
+        .read_to_end(&mut buf)
+        .ok()?;
+    if n == 0 || buf.contains(&0) {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Recursive, bounded `.md`/`.txt` collector. Skips hidden entries and common
+/// noise dirs (`target`, `node_modules`, `.git`).
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if file_type.is_dir() {
+            if name.starts_with('.') || matches!(name, "target" | "node_modules") {
+                continue;
+            }
+            collect_markdown(&path, out);
+        } else if file_type.is_file()
+            && (name.ends_with(".md") || name.ends_with(".txt"))
+            && !name.starts_with('.')
+        {
+            out.push(path);
+        }
+    }
+}
+
+/// Best-effort git toplevel resolution (shells out, like namespace detection).
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout);
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Whether a commit subject looks decision-grade (a durable choice a future
+/// session would act on), versus routine churn. Pure so it can be unit-tested.
+fn is_decisionish(subject: &str) -> bool {
+    const KEYWORDS: &[&str] = &[
+        "because",
+        "why",
+        "rationale",
+        "decision",
+        "decide",
+        "adopt",
+        "adopted",
+        "deprecate",
+        "deprecated",
+        "replace",
+        "replaced",
+        "migrate",
+        "switch",
+        "switched",
+        "should",
+        "must",
+    ];
+    let lower = subject.to_ascii_lowercase();
+    KEYWORDS.iter().any(|k| lower.contains(k))
+}
+
+/// Recent commits whose subject is decision-grade. Best-effort: git absent or a
+/// non-repo dir yields nothing. Bounded by `limit`.
+fn recent_decision_commits(root: &Path, limit: usize) -> Vec<ImportItem> {
+    let limit_u32 = u32::try_from(limit).unwrap_or(u32::MAX);
+    // Subject, body, hash, and record terminator are NUL-separated so commit
+    // bodies may contain newlines without splitting records.
+    let output = match std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "log",
+            &format!("-{limit_u32}"),
+            "--format=%s%x00%b%x00%H%x00",
+        ])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut items = Vec::new();
+    let mut parts = text.split('\0');
+    while let (Some(subject), Some(body), Some(hash)) = (parts.next(), parts.next(), parts.next()) {
+        let subject = subject.trim();
+        let body = body.trim();
+        let hash = hash.trim();
+        if subject.is_empty() || !is_decisionish(subject) {
+            continue;
+        }
+        let mut content = format!("commit {hash}: {subject}");
+        if !body.is_empty() {
+            content.push_str("\n\n");
+            content.push_str(body);
+        }
+        items.push(ImportItem {
+            summary: truncate_summary(subject),
+            content,
+            memory_type: MemoryType::Insight,
+            importance: 4,
+            source: format!("git log {hash}"),
+        });
+    }
+    items
+}
+
+// ---------------------------------------------------------------------------
+// Store / dedup / undo (async, over the existing wire path)
+// ---------------------------------------------------------------------------
+
+/// Store `items` over a single connection. Each item is redacted, then a
+/// read-only recall probe skips an exact-content duplicate (so re-running an
+/// import adds nothing). On `dry_run`, probes still run (so the plan reports
+/// duplicates) but nothing is stored and no ledger is written.
+///
+/// Returns the per-item outcome (the stored id, or `None` for skipped/failed)
+/// and aggregate counts.
+pub async fn store_items(
+    client: &mut Client,
+    items: &[ImportItem],
+    tag: &str,
+    extra_tags: &[String],
+    dry_run: bool,
+) -> anyhow::Result<(Vec<Option<MemoryId>>, ImportCounts)> {
+    let mut ids = Vec::with_capacity(items.len());
+    let mut counts = ImportCounts::default();
+
+    for item in items {
+        // Redact BEFORE probing/storing so the dedup comparison is
+        // redacted-to-redacted (stored content was redacted on the first run).
+        let content = redact(&item.content);
+        let context = redact(&item.source);
+
+        if content.trim().is_empty() {
+            counts.failed += 1;
+            ids.push(None);
+            continue;
+        }
+
+        if is_duplicate(client, &content).await? {
+            counts.skipped_duplicate += 1;
+            ids.push(None);
+            continue;
+        }
+
+        if dry_run {
+            counts.new += 1;
+            ids.push(None);
+            continue;
+        }
+
+        let mut tags = Vec::with_capacity(1 + extra_tags.len());
+        tags.push(tag.to_string());
+        tags.extend(extra_tags.iter().cloned());
+        match client
+            .remember(
+                content,
+                Some(context),
+                item.memory_type,
+                item.importance,
+                Vec::new(),
+                tags,
+                Vec::new(),
+                None,
+            )
+            .await
+        {
+            Ok(id) => {
+                counts.new += 1;
+                ids.push(Some(id));
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, source = %item.source, "import: remember failed");
+                counts.failed += 1;
+                ids.push(None);
+            }
+        }
+    }
+
+    Ok((ids, counts))
+}
+
+/// Read-only content-equality probe: `true` if an existing memory's redacted
+/// content exactly matches `redacted_content`. Reuses the existing recall path
+/// (issues zero writer ops - W1.8), so it is safe to call before every store.
+async fn is_duplicate(client: &mut Client, redacted_content: &str) -> anyhow::Result<bool> {
+    // Query with a bounded prefix (keeps the embed/FTS cheap); the exact match
+    // is confirmed by full-content equality below.
+    let query: String = redacted_content.chars().take(500).collect();
+    if query.trim().is_empty() {
+        return Ok(false);
+    }
+    let (results, _degraded) = client
+        .recall_with_status(query, None, Vec::new(), 5)
+        .await?;
+    let target = redacted_content.trim();
+    Ok(results.iter().any(|r| r.memory.content.trim() == target))
+}
+
+/// Persist the undo ledger for a batch (the stored ids). Co-located with the DB
+/// so it is naturally isolated per data dir (tests set `XDG_DATA_HOME`).
+pub fn write_ledger(db_path: &Path, batch_id: &str, ids: &[MemoryId]) -> anyhow::Result<()> {
+    let Some(dir) = ledger_dir(db_path) else {
+        anyhow::bail!("cannot resolve imports dir from db path");
+    };
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let path = dir.join(safe_ledger_name(batch_id));
+    let payload = serde_json::json!({
+        "batch": batch_id,
+        "ids": ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+    });
+    // Atomic write: temp file 0600 + rename (the scratch/DB at-rest precedent).
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, payload.to_string())
+        .with_context(|| format!("writing ledger {}", tmp.display()))?;
+    set_private(&tmp)?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("installing ledger {}", path.display()))?;
+    Ok(())
+}
+
+/// Read the ids recorded for a batch, if a ledger exists.
+pub fn read_ledger(db_path: &Path, batch_id: &str) -> Option<Vec<MemoryId>> {
+    use std::str::FromStr as _;
+    let dir = ledger_dir(db_path)?;
+    let path = dir.join(safe_ledger_name(batch_id));
+    let text = std::fs::read_to_string(&path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let arr = value.get("ids")?.as_array()?;
+    let mut ids = Vec::new();
+    for v in arr {
+        let s = v.as_str()?;
+        ids.push(MemoryId::from_str(s).ok()?);
+    }
+    Some(ids)
+}
+
+/// One undoable import batch, for discoverability (`init --list-batches`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchInfo {
+    pub id: String,
+    pub count: usize,
+}
+
+/// List all import batches with ledgered ids. Sorted by id for stable output.
+pub fn list_batches(db_path: &Path) -> Vec<BatchInfo> {
+    let Some(dir) = ledger_dir(db_path) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
+        let count = read_ledger(db_path, &id).map(|ids| ids.len()).unwrap_or(0);
+        out.push(BatchInfo { id, count });
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
+/// Undo a batch: delete each ledgered id over the wire (soft-archive cascades
+/// to vectors/FTS server-side, and is idempotent for already-archived ids),
+/// then remove the ledger.
+pub async fn undo_batch(
+    client: &mut Client,
+    db_path: &Path,
+    batch_id: &str,
+) -> anyhow::Result<UndoCounts> {
+    let ids = read_ledger(db_path, batch_id).context(
+        "no import ledger found for that batch id (run `rusty-brain init` to list batches)",
+    )?;
+    let mut counts = UndoCounts::default();
+    for id in &ids {
+        client
+            .delete(id.clone())
+            .await
+            .context("deleting imported memory")?;
+        counts.deleted += 1;
+    }
+    // Best-effort ledger removal; a failure here is not a data problem.
+    if let Some(dir) = ledger_dir(db_path) {
+        let _ = std::fs::remove_file(dir.join(safe_ledger_name(batch_id)));
+    }
+    Ok(counts)
+}
+
+fn ledger_dir(db_path: &Path) -> Option<PathBuf> {
+    db_path.parent().map(|p| p.join("imports"))
+}
+
+fn safe_ledger_name(batch_id: &str) -> String {
+    // batch ids are already filesystem-safe (`import-<uuid>`); sanitize
+    // defensively so a user-supplied `--undo` value cannot escape the dir.
+    let cleaned: String = batch_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{cleaned}.json")
+}
+
+#[cfg(unix)]
+fn set_private(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn batch_tag_uses_the_prefix() {
+        assert_eq!(batch_tag("import-abc"), "import_batch:import-abc");
+        assert!(new_batch_id().starts_with("import-"));
+    }
+
+    #[test]
+    fn well_known_kind_maps_policy_and_changelog() {
+        assert_eq!(well_known_kind("CLAUDE.md", 6), (MemoryType::Constraint, 7));
+        assert_eq!(
+            well_known_kind("AGENTS.md", 10),
+            (MemoryType::Constraint, 10)
+        );
+        assert_eq!(
+            well_known_kind("CHANGELOG.md", 6),
+            (MemoryType::Reference, 5)
+        );
+        assert_eq!(well_known_kind("README.md", 6), (MemoryType::Insight, 6));
+    }
+
+    #[test]
+    fn derive_summary_uses_first_heading_then_first_line() {
+        assert_eq!(
+            derive_summary("# My Project\n\nbody", "README.md"),
+            "My Project"
+        );
+        assert_eq!(
+            derive_summary("no heading here\nmore", "x"),
+            "no heading here"
+        );
+        assert_eq!(derive_summary("\n\n   \n", "docs/x.md"), "x.md");
+    }
+
+    #[test]
+    fn truncate_summary_is_idempotent_under_limit_and_adds_ellipsis_over() {
+        let short = "a short summary";
+        assert_eq!(truncate_summary(short), short);
+        let long: String = "word ".repeat(40);
+        let out = truncate_summary(&long);
+        assert!(out.ends_with("..."));
+        assert!(out.chars().count() <= 103);
+    }
+
+    #[test]
+    fn is_decisionish_matches_rationale_keywords() {
+        assert!(is_decisionish("Adopt tokio over async-std"));
+        assert!(is_decisionish("refactor: why we moved to sqlite"));
+        assert!(!is_decisionish("fix typo in readme"));
+        assert!(!is_decisionish("update deps"));
+    }
+
+    #[test]
+    fn recent_decision_commits_preserves_multiline_bodies() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        for args in [
+            ["config", "user.email", "test@example.invalid"],
+            ["config", "user.name", "Test User"],
+        ] {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+        fs::write(root.join("README.md"), "demo").unwrap();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["add", "README.md"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args([
+                "commit",
+                "-m",
+                "Adopt sqlite for storage",
+                "-m",
+                "First rationale line\n\nSecond rationale line",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        let items = recent_decision_commits(root, 5);
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].content.contains("First rationale line"));
+        assert!(items[0].content.contains("Second rationale line"));
+    }
+
+    #[test]
+    fn safe_ledger_name_neutralizes_path_traversal() {
+        assert_eq!(safe_ledger_name("import-abc"), "import-abc.json");
+        assert_eq!(
+            safe_ledger_name("../../etc/passwd"),
+            "______etc_passwd.json"
+        );
+    }
+
+    #[test]
+    fn read_bounded_text_skips_binary_and_empty() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("bin");
+        fs::write(&bin, b"a\x00b").unwrap();
+        assert!(read_bounded_text(&bin, 1024).is_none());
+
+        let empty = tmp.path().join("empty");
+        fs::write(&empty, b"").unwrap();
+        assert!(read_bounded_text(&empty, 1024).is_none());
+    }
+
+    #[test]
+    fn read_bounded_text_caps_at_max_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let big = tmp.path().join("big.txt");
+        fs::write(&big, b"abcdef").unwrap();
+        let got = read_bounded_text(&big, 3).unwrap();
+        assert_eq!(got, "abc");
+    }
+
+    #[test]
+    fn extract_text_carries_source_as_summary_fallback() {
+        let item = extract_text("stdin", "# Decision\nbody", MemoryType::Insight, 5);
+        assert_eq!(item.summary, "Decision");
+        assert_eq!(item.content, "# Decision\nbody");
+        assert_eq!(item.source, "stdin");
+        assert_eq!(item.memory_type, MemoryType::Insight);
+    }
+
+    #[test]
+    fn scan_project_reads_well_known_and_docs_and_skips_target() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(
+            root.join("README.md"),
+            "# Demo\n\nWe adopt sqlite for storage.",
+        )
+        .unwrap();
+        fs::write(root.join("CLAUDE.md"), "# Policy\nNever commit secrets.").unwrap();
+        let docs = root.join("docs");
+        fs::create_dir_all(docs.join("adr")).unwrap();
+        fs::write(
+            docs.join("adr").join("0001-vecs.md"),
+            "# ADR 1\nWe chose sqlite-vec.",
+        )
+        .unwrap();
+        fs::write(docs.join("notes.md"), "# Notes\nSome notes.").unwrap();
+        // Noise that must be ignored.
+        fs::create_dir_all(root.join("target")).unwrap();
+        fs::write(root.join("target").join("noise.md"), "build junk").unwrap();
+
+        let items = scan_project(root, ScanOptions::defaults(6));
+        let sources: Vec<&str> = items.iter().map(|i| i.source.as_str()).collect();
+        // README + CLAUDE + 2 docs; target excluded.
+        assert!(
+            sources.iter().all(|s| !s.contains("target")),
+            "target must be skipped: {sources:?}"
+        );
+        let has_readme = items.iter().any(|i| i.source.ends_with("README.md"));
+        let has_claude = items
+            .iter()
+            .any(|i| i.memory_type == MemoryType::Constraint && i.source.ends_with("CLAUDE.md"));
+        let has_adr = items
+            .iter()
+            .any(|i| i.memory_type == MemoryType::ArchitectureDecision);
+        assert!(has_readme, "README ingested: {sources:?}");
+        assert!(has_claude, "CLAUDE.md ingested as Constraint");
+        assert!(has_adr, "ADR doc ingested as ArchitectureDecision");
+    }
+
+    #[test]
+    fn write_then_read_ledger_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("mem.db");
+        let ids = vec![MemoryId::new(), MemoryId::new()];
+        write_ledger(&db, "import-xyz", &ids).unwrap();
+        let back = read_ledger(&db, "import-xyz").unwrap();
+        assert_eq!(back, ids);
+    }
+
+    #[test]
+    fn read_ledger_returns_none_for_missing_batch() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("mem.db");
+        assert!(read_ledger(&db, "import-missing").is_none());
+    }
+}

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod cli;
 pub mod client;
+pub mod import;
 pub mod logging;
 pub mod mcp;
 pub mod namespace_detect;

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -1,5 +1,7 @@
 //! Pure rendering of results to human text or JSON (stdout).
 
+use crate::import::{BatchInfo, ImportCounts, ImportItem, UndoCounts};
+use rb_redact::redact;
 use rb_types::{MemoryNote, SearchResult};
 
 /// Render recall hits. JSON: the raw `Vec<SearchResult>`. Human: one line per hit.
@@ -116,6 +118,102 @@ pub fn render_batch_remembered(count: u64, json: bool) -> String {
     } else {
         format!("Remembered {count} memories")
     }
+}
+
+/// Render the candidate import plan before writes happen.
+pub fn render_import_plan(items: &[ImportItem], json: bool) -> String {
+    if json {
+        let items: Vec<_> = items
+            .iter()
+            .map(|item| {
+                serde_json::json!({
+                    "source": redact(&item.source),
+                    "summary": redact(&item.summary),
+                    "type": item.memory_type.as_str(),
+                    "importance": item.importance,
+                })
+            })
+            .collect();
+        return serde_json::json!({"planned": items.len(), "items": items}).to_string();
+    }
+    if items.is_empty() {
+        return "No import candidates found.".to_string();
+    }
+    let mut out = format!("Import plan: {} candidate memories\n", items.len());
+    for item in items {
+        out.push_str(&format!(
+            "- [{} imp {}] {} ({})\n",
+            item.memory_type.as_str(),
+            item.importance,
+            redact(&item.summary),
+            redact(&item.source)
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// Render an import result. `dry_run` means no writes happened; counts still
+/// include duplicate probes.
+pub fn render_import_result(
+    batch_id: &str,
+    counts: ImportCounts,
+    dry_run: bool,
+    json: bool,
+) -> String {
+    if json {
+        return serde_json::json!({
+            "batch": batch_id,
+            "dry_run": dry_run,
+            "new": counts.new,
+            "skipped_duplicate": counts.skipped_duplicate,
+            "failed": counts.failed,
+        })
+        .to_string();
+    }
+    let verb = if dry_run {
+        "would remember"
+    } else {
+        "remembered"
+    };
+    let mut out = format!(
+        "Import batch {batch_id}: {verb} {} memories (skipped_duplicate={} failed={})",
+        counts.new, counts.skipped_duplicate, counts.failed
+    );
+    if !dry_run && counts.new > 0 {
+        out.push_str(&format!("\nUndo with: rusty-brain init --undo {batch_id}"));
+    }
+    out
+}
+
+/// Render an import-batch undo acknowledgement.
+pub fn render_import_undo(batch_id: &str, counts: UndoCounts, json: bool) -> String {
+    if json {
+        serde_json::json!({"batch": batch_id, "deleted": counts.deleted}).to_string()
+    } else {
+        format!(
+            "Undid import batch {batch_id}: deleted {} memories",
+            counts.deleted
+        )
+    }
+}
+
+/// Render undoable import batches.
+pub fn render_import_batches(batches: &[BatchInfo], json: bool) -> String {
+    if json {
+        let batches: Vec<_> = batches
+            .iter()
+            .map(|batch| serde_json::json!({"batch": batch.id, "count": batch.count}))
+            .collect();
+        return serde_json::json!({"batches": batches}).to_string();
+    }
+    if batches.is_empty() {
+        return "No import batches found.".to_string();
+    }
+    let mut out = String::from("Import batches:\n");
+    for batch in batches {
+        out.push_str(&format!("- {} ({} memories)\n", batch.id, batch.count));
+    }
+    out.trim_end().to_string()
 }
 
 /// Render a successful update acknowledgement.
@@ -347,6 +445,98 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(&render_batch_remembered(500, true)).unwrap();
         assert_eq!(parsed["count"].as_u64().unwrap(), 500);
+    }
+
+    #[test]
+    fn import_plan_renders_items_in_both_modes() {
+        let items = vec![ImportItem {
+            summary: "Use SQLite".to_string(),
+            content: "Use SQLite for local-first storage".to_string(),
+            memory_type: MemoryType::ArchitectureDecision,
+            importance: 8,
+            source: "docs/adr.md".to_string(),
+        }];
+
+        let human = render_import_plan(&items, false);
+        assert!(human.contains("Use SQLite"), "summary shown: {human}");
+
+        let json = render_import_plan(&items, true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["planned"].as_u64().unwrap(), 1);
+        assert_eq!(
+            parsed["items"][0]["type"].as_str().unwrap(),
+            "architecture_decision"
+        );
+    }
+
+    #[test]
+    fn import_plan_redacts_preview_metadata() {
+        let token = format!("sk-proj-{}", "A".repeat(40));
+        let items = vec![ImportItem {
+            summary: format!("token {token}"),
+            content: "not rendered".to_string(),
+            memory_type: MemoryType::Insight,
+            importance: 5,
+            source: format!("docs/{token}.md"),
+        }];
+
+        let human = render_import_plan(&items, false);
+        assert!(
+            !human.contains(&token),
+            "human preview leaked token: {human}"
+        );
+        assert!(human.contains("[REDACTED:model-api-key]"), "{human}");
+
+        let json = render_import_plan(&items, true);
+        assert!(!json.contains(&token), "json preview leaked token: {json}");
+        assert!(json.contains("[REDACTED:model-api-key]"), "{json}");
+    }
+
+    #[test]
+    fn import_result_includes_undo_hint_only_for_written_batches() {
+        let written = render_import_result(
+            "import-abc",
+            ImportCounts {
+                new: 2,
+                skipped_duplicate: 1,
+                failed: 0,
+            },
+            false,
+            false,
+        );
+        assert!(written.contains("init --undo import-abc"));
+
+        let dry_run = render_import_result(
+            "import-abc",
+            ImportCounts {
+                new: 2,
+                skipped_duplicate: 0,
+                failed: 0,
+            },
+            true,
+            false,
+        );
+        assert!(!dry_run.contains("--undo"));
+    }
+
+    #[test]
+    fn import_undo_and_batches_render_parseable_json() {
+        let undo = render_import_undo("import-abc", UndoCounts { deleted: 2 }, true);
+        let parsed: serde_json::Value = serde_json::from_str(&undo).unwrap();
+        assert_eq!(parsed["deleted"].as_u64().unwrap(), 2);
+
+        let batches = render_import_batches(
+            &[BatchInfo {
+                id: "import-abc".to_string(),
+                count: 2,
+            }],
+            true,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&batches).unwrap();
+        assert_eq!(
+            parsed["batches"][0]["batch"].as_str().unwrap(),
+            "import-abc"
+        );
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -1,9 +1,10 @@
 //! Async dispatch from parsed `Cli` to daemon/client behavior.
 
 use crate::cli::{Cli, Command};
-use crate::{client, output, paths, serve};
+use crate::{client, import, output, paths, serve};
 use anyhow::Context as _;
 use rb_types::MemoryId;
+use std::path::Path;
 use std::str::FromStr;
 
 /// Parse a CLI id argument into a `MemoryId`, surfacing a clear error.
@@ -97,6 +98,87 @@ async fn run_client(
     match command {
         Command::Serve { .. } => anyhow::bail!("internal: serve must be handled before run_client"),
         Command::Mcp => anyhow::bail!("internal: mcp must be handled before run_client"),
+        Command::Init {
+            yes,
+            dry_run,
+            max_files,
+            max_bytes,
+            importance,
+            undo,
+            list_batches,
+        } => {
+            if list_batches {
+                let batches = import::list_batches(db_path);
+                println!("{}", output::render_import_batches(&batches, json));
+                return Ok(());
+            }
+            if let Some(batch_id) = undo {
+                let counts = import::undo_batch(&mut client, db_path, &batch_id)
+                    .await
+                    .with_context(|| format!("undoing import batch {batch_id}"))?;
+                println!("{}", output::render_import_undo(&batch_id, counts, json));
+                return Ok(());
+            }
+
+            let root = std::env::current_dir().context("resolving current directory")?;
+            let items = import::scan_project(
+                &root,
+                import::ScanOptions {
+                    max_files,
+                    max_bytes,
+                    importance,
+                },
+            );
+            if items.is_empty() || dry_run {
+                println!("{}", output::render_import_plan(&items, json));
+                return Ok(());
+            }
+            if !yes {
+                if !json {
+                    println!("{}", output::render_import_plan(&items, false));
+                }
+                if !confirm_import(items.len())? {
+                    println!(
+                        "{}",
+                        if json {
+                            "{\"aborted\":true}"
+                        } else {
+                            "Aborted"
+                        }
+                    );
+                    return Ok(());
+                }
+            }
+            run_import_items(&mut client, db_path, &items, &[], false, json).await?;
+        }
+        Command::Import {
+            path,
+            memory_type,
+            importance,
+            tags,
+            dry_run,
+            max_bytes,
+        } => {
+            let item = if path == "-" {
+                use tokio::io::AsyncReadExt as _;
+                let mut text = String::new();
+                tokio::io::stdin()
+                    .take(u64::try_from(max_bytes).unwrap_or(u64::MAX))
+                    .read_to_string(&mut text)
+                    .await
+                    .context("reading import stdin")?;
+                import::extract_text("stdin", &text, memory_type, importance)
+            } else {
+                import::extract_file(Path::new(&path), max_bytes, memory_type, importance)
+                    .with_context(|| format!("import source {path:?} yielded no text"))?
+            };
+            let items = vec![item];
+            if dry_run {
+                println!("{}", output::render_import_plan(&items, json));
+                return Ok(());
+            }
+            run_import_items(&mut client, db_path, &items, &tags, false, json).await?;
+        }
         Command::Remember {
             content,
             memory_type,
@@ -403,6 +485,44 @@ async fn run_client(
         }
     }
     Ok(())
+}
+
+async fn run_import_items(
+    client: &mut rb_proto::Client,
+    db_path: &Path,
+    items: &[import::ImportItem],
+    extra_tags: &[String],
+    dry_run: bool,
+    json: bool,
+) -> anyhow::Result<()> {
+    let batch_id = import::new_batch_id();
+    let tag = import::batch_tag(&batch_id);
+    let (ids, counts) = import::store_items(client, items, &tag, extra_tags, dry_run)
+        .await
+        .context("storing imported memories")?;
+    let stored: Vec<MemoryId> = ids.into_iter().flatten().collect();
+    if !dry_run && !stored.is_empty() {
+        import::write_ledger(db_path, &batch_id, &stored).context("writing import undo ledger")?;
+    }
+    println!(
+        "{}",
+        output::render_import_result(&batch_id, counts, dry_run, json)
+    );
+    Ok(())
+}
+
+fn confirm_import(count: usize) -> anyhow::Result<bool> {
+    use std::io::Write as _;
+    eprint!("Store {count} imported memories? [y/N] ");
+    std::io::stderr().flush().context("flushing prompt")?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("reading confirmation")?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
 }
 
 #[cfg(test)]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -134,22 +134,17 @@ async fn run_client(
                 return Ok(());
             }
             if !yes {
-                if !json {
-                    println!("{}", output::render_import_plan(&items, false));
+                if json {
+                    println!("{{\"aborted\":true,\"error\":\"--yes is required with --json\"}}");
+                    return Ok(());
                 }
+                println!("{}", output::render_import_plan(&items, false));
                 if !confirm_import(items.len())? {
-                    println!(
-                        "{}",
-                        if json {
-                            "{\"aborted\":true}"
-                        } else {
-                            "Aborted"
-                        }
-                    );
+                    println!("Aborted");
                     return Ok(());
                 }
             }
-            run_import_items(&mut client, db_path, &items, &[], false, json).await?;
+            run_import_items(&mut client, db_path, &items, &[], json).await?;
         }
         Command::Import {
             path,
@@ -161,13 +156,18 @@ async fn run_client(
         } => {
             let item = if path == "-" {
                 use tokio::io::AsyncReadExt as _;
-                let mut text = String::new();
+                let mut buf = Vec::new();
                 tokio::io::stdin()
                     .take(u64::try_from(max_bytes).unwrap_or(u64::MAX))
-                    .read_to_string(&mut text)
+                    .read_to_end(&mut buf)
                     .await
                     .context("reading import stdin")?;
-                import::extract_text("stdin", &text, memory_type, importance)
+                import::extract_text(
+                    "stdin",
+                    &String::from_utf8_lossy(&buf),
+                    memory_type,
+                    importance,
+                )
             } else {
                 import::extract_file(Path::new(&path), max_bytes, memory_type, importance)
                     .with_context(|| format!("import source {path:?} yielded no text"))?
@@ -177,7 +177,7 @@ async fn run_client(
                 println!("{}", output::render_import_plan(&items, json));
                 return Ok(());
             }
-            run_import_items(&mut client, db_path, &items, &tags, false, json).await?;
+            run_import_items(&mut client, db_path, &items, &tags, json).await?;
         }
         Command::Remember {
             content,
@@ -492,21 +492,20 @@ async fn run_import_items(
     db_path: &Path,
     items: &[import::ImportItem],
     extra_tags: &[String],
-    dry_run: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     let batch_id = import::new_batch_id();
     let tag = import::batch_tag(&batch_id);
-    let (ids, counts) = import::store_items(client, items, &tag, extra_tags, dry_run)
+    let (ids, counts) = import::store_items(client, items, &tag, extra_tags)
         .await
         .context("storing imported memories")?;
     let stored: Vec<MemoryId> = ids.into_iter().flatten().collect();
-    if !dry_run && !stored.is_empty() {
+    if !stored.is_empty() {
         import::write_ledger(db_path, &batch_id, &stored).context("writing import undo ledger")?;
     }
     println!(
         "{}",
-        output::render_import_result(&batch_id, counts, dry_run, json)
+        output::render_import_result(&batch_id, counts, false, json)
     );
     Ok(())
 }

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -34,6 +34,59 @@ fn wait_for_socket(path: &Path, timeout: Duration) -> bool {
     std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
+fn spawn_daemon(exe: &Path, socket: &Path, db: &Path, config_home: &Path) -> Reap {
+    Reap(
+        Command::new(exe)
+            .arg("serve")
+            .env("RUSTY_BRAIN_SOCKET", socket)
+            .env("RUSTY_BRAIN_DB", db)
+            .env("XDG_CONFIG_HOME", config_home)
+            .env_remove("VOYAGE_API_KEY")
+            .env("RUST_LOG", "warn")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn daemon"),
+    )
+}
+
+fn cli(exe: &Path, socket: &Path, db: &Path, config_home: &Path, namespace: &str) -> Command {
+    let mut cmd = Command::new(exe);
+    cmd.env("RUSTY_BRAIN_SOCKET", socket)
+        .env("RUSTY_BRAIN_DB", db)
+        .env("XDG_CONFIG_HOME", config_home)
+        .env("RUSTY_BRAIN_NAMESPACE", namespace)
+        .env_remove("VOYAGE_API_KEY");
+    cmd
+}
+
+fn db_family_contains(db: &Path, needle: &[u8]) -> bool {
+    let Some(parent) = db.parent() else {
+        return false;
+    };
+    let Some(file_name) = db.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if !name.starts_with(file_name) {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        if bytes.windows(needle.len()).any(|w| w == needle) {
+            return true;
+        }
+    }
+    false
+}
+
 #[test]
 fn remember_then_recall_round_trips_through_the_binary() {
     let dir = tempfile::tempdir().unwrap();
@@ -186,5 +239,166 @@ fn remember_batch_bulk_loads_lines_from_stdin() {
     assert!(
         predicate::str::contains("9847").eval(&stdout),
         "recall did not surface a batch-loaded fact; got: {stdout}"
+    );
+}
+
+#[test]
+fn init_seeds_deduplicates_redacts_and_undoes_project_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("project");
+    std::fs::create_dir_all(project.join("docs")).unwrap();
+    let secret = "AKIAABCDEFGHIJKLMNOP";
+    std::fs::write(
+        project.join("README.md"),
+        format!("# Demo\n\nThe durable storage decision is sqlite vec. Secret {secret}\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("CLAUDE.md"),
+        "# Policy\nNever commit secrets.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("docs").join("adr-storage.md"),
+        "# Storage ADR\nWe adopted sqlite-vec for local-first memory retrieval.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("docs").join("usage.md"),
+        "# Usage\nRun rusty-brain init before the first session.\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("docs").join("constraints.md"),
+        "# Constraints\nThe daemon remains local-first and per-user.\n",
+    )
+    .unwrap();
+
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(
+        wait_for_socket(&socket, Duration::from_secs(10)),
+        "daemon socket never appeared at {}",
+        socket.display()
+    );
+
+    let init = cli(&exe, &socket, &db, dir.path(), "init-e2e")
+        .current_dir(&project)
+        .args(["--json", "init", "--yes"])
+        .output()
+        .expect("run init");
+    assert!(
+        init.status.success(),
+        "init failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let first: serde_json::Value = serde_json::from_slice(&init.stdout).unwrap();
+    let batch = first["batch"].as_str().unwrap().to_string();
+    assert!(
+        first["new"].as_u64().unwrap_or(0) >= 5,
+        "init should seed well-known files + docs: {}",
+        String::from_utf8_lossy(&init.stdout)
+    );
+    assert!(
+        !db_family_contains(&db, secret.as_bytes()),
+        "planted secret must be redacted before reaching sqlite files"
+    );
+
+    let recall = cli(&exe, &socket, &db, dir.path(), "init-e2e")
+        .current_dir(&project)
+        .args(["recall", "durable storage decision", "--limit", "10"])
+        .output()
+        .expect("run recall");
+    assert!(recall.status.success());
+    let stdout = String::from_utf8_lossy(&recall.stdout);
+    assert!(
+        stdout.contains("sqlite vec") || stdout.contains("sqlite-vec"),
+        "recall should surface seeded context; got: {stdout}"
+    );
+
+    let second = cli(&exe, &socket, &db, dir.path(), "init-e2e")
+        .current_dir(&project)
+        .args(["--json", "init", "--yes"])
+        .output()
+        .expect("run init second time");
+    assert!(second.status.success());
+    let second_report: serde_json::Value = serde_json::from_slice(&second.stdout).unwrap();
+    assert_eq!(
+        second_report["new"].as_u64(),
+        Some(0),
+        "second init should be idempotent: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+
+    let undo = cli(&exe, &socket, &db, dir.path(), "init-e2e")
+        .current_dir(&project)
+        .args(["--json", "init", "--undo", &batch])
+        .output()
+        .expect("undo init batch");
+    assert!(
+        undo.status.success(),
+        "undo failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&undo.stdout),
+        String::from_utf8_lossy(&undo.stderr)
+    );
+
+    let recall_after_undo = cli(&exe, &socket, &db, dir.path(), "init-e2e")
+        .current_dir(&project)
+        .args(["recall", "durable storage decision", "--limit", "10"])
+        .output()
+        .expect("recall after undo");
+    assert!(recall_after_undo.status.success());
+    let stdout = String::from_utf8_lossy(&recall_after_undo.stdout);
+    assert!(
+        !stdout.contains("sqlite vec") && !stdout.contains("sqlite-vec"),
+        "undo should remove the seeded batch from recall; got: {stdout}"
+    );
+}
+
+#[test]
+fn import_dry_run_prints_plan_and_stores_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let source = project.join("seed.md");
+    std::fs::write(
+        &source,
+        "# Dry Run Seed\nThe dry-run-only sentinel is never stored.\n",
+    )
+    .unwrap();
+
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(wait_for_socket(&socket, Duration::from_secs(10)));
+
+    let dry_run = cli(&exe, &socket, &db, dir.path(), "import-dry-run-e2e")
+        .current_dir(&project)
+        .args(["--json", "import", source.to_str().unwrap(), "--dry-run"])
+        .output()
+        .expect("run import dry-run");
+    assert!(
+        dry_run.status.success(),
+        "dry-run failed: stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&dry_run.stdout),
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    let plan: serde_json::Value = serde_json::from_slice(&dry_run.stdout).unwrap();
+    assert_eq!(plan["planned"].as_u64(), Some(1));
+
+    let recall = cli(&exe, &socket, &db, dir.path(), "import-dry-run-e2e")
+        .current_dir(&project)
+        .args(["recall", "dry-run-only sentinel", "--limit", "10"])
+        .output()
+        .expect("recall dry-run sentinel");
+    assert!(recall.status.success());
+    let stdout = String::from_utf8_lossy(&recall.stdout);
+    assert!(
+        stdout.contains("No stored memories match"),
+        "dry-run must not store the imported text; got: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary
- add `rusty-brain init` for first-run project context seeding
- add `rusty-brain import <path|->` with dry-run previews
- redact import preview metadata and content before probing/storing
- add import batch tagging, undo ledger, list/undo commands, and README quickstart docs
- cover init/import/dedup/redaction/undo with unit and e2e tests

## Verification
- `rtk cargo fmt --all --check`
- `rtk cargo test -p rusty-brain` => 117 passed
- `rtk cargo test -p rb-engine -p rb-redact` => 107 passed
- `rtk cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `rtk cargo test --workspace --all-targets --all-features` => 1249 passed, 10 ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands for seeding project context, importing text/markdown, listing import batches, and undoing a specific batch.
  * Added dry-run support so you can preview imports before anything is saved.
  * Added batch tracking with undo records for recently imported content.

* **Bug Fixes**
  * Improved duplicate handling so re-running initialization avoids storing the same content again.
  * Added redaction to reduce exposure of sensitive text in previews and stored data.

* **Documentation**
  * Expanded quickstart examples with initialization, dry-run import, batch listing, and undo workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->