### PR TITLE
feat(capture): restore OpenCode apply_patch file-edit capture (Gap B)

### DIFF
--- a/crates/rb-agents/src/capability.rs
+++ b/crates/rb-agents/src/capability.rs
@@ -81,7 +81,7 @@ const CAPABILITIES: &[AgentCapability] = &[
     AgentCapability {
         agent: "opencode",
         adapter_status: AdapterStatus::Experimental,
-        capture: SupportLevel::Partial,
+        capture: SupportLevel::Supported,
         retrieval: SupportLevel::Unsupported,
         config: SupportLevel::Unsupported,
         scorecard: SupportLevel::Unsupported,
@@ -89,7 +89,7 @@ const CAPABILITIES: &[AgentCapability] = &[
         limitations: &[
             "Hook adapter exists, but rb-install plugin support is deferred.",
             "session.idle maps to canonical SessionCheckpoint (fixture-backed lifecycle test; multi-fire checkpoint-safe, one-run observation fired=2, verdict ambiguous); session.deleted remains Other.",
-            "Capture stays Partial: bash-command capture folds, but file edits via apply_patch are not yet captured (Gap B / apply_patch normalization pending).",
+            "bash and apply_patch file-edit capture both fold via the session.idle checkpoint (fixture-backed lifecycle tests); retrieval/config/scorecard remain unsupported.",
         ],
     },
     AgentCapability {
@@ -163,11 +163,22 @@ mod tests {
 
     #[test]
     fn non_claude_capture_is_not_claimed_as_full_parity() {
-        for agent in ["codex", "opencode", "gemini"] {
+        // codex/gemini remain fixture/descoped-gated at Partial. opencode graduated
+        // to Supported once both capture gaps closed (see test below).
+        for agent in ["codex", "gemini"] {
             let capability = capability_for_agent(agent).expect("agent row");
             assert_eq!(capability.capture, SupportLevel::Partial);
             assert_ne!(capability.capture, SupportLevel::Supported);
         }
+    }
+
+    #[test]
+    fn opencode_capture_is_supported_after_apply_patch_gap_b() {
+        // OpenCode capture graduated Partial -> Supported once session.idle folded
+        // (Gap A) AND apply_patch file-edit capture landed (Gap B). Both are
+        // fixture-backed by lifecycle tests under fixtures/opencode/.
+        let capability = capability_for_agent("opencode").expect("opencode row");
+        assert_eq!(capability.capture, SupportLevel::Supported);
     }
 
     #[test]

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -156,7 +156,7 @@ fn str_field<'a>(input: &'a serde_json::Value, key: &str) -> &'a str {
 
 /// Resolve the file path a file-mutation tool touched. `Edit`/`Write` carry it
 /// directly as `file_path`; an `apply_patch` tool instead carries a V4A patch
-/// whose `*** <op> File: <path>` directive names the target. OpenCode puts that
+/// whose `*** Add|Update|Delete File: <path>` directive names the target. OpenCode puts that
 /// patch under `patchText`; Codex's field is unverified (speculated `command`)
 /// and latent until openai/codex#16732 ships PostToolUse for `apply_patch`. Both
 /// share the V4A format, so one parser covers either field. Falls back to

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -118,8 +118,11 @@ use rb_redact::redact;
 ///   These arrive verbatim in Gemini's `AfterTool` payload, so they MUST be
 ///   recognized here or every Gemini file edit/write/shell command would degrade
 ///   to a no-op capture.
-/// - Codex: its shell tool reports `Bash` (already handled above); its
-///   `apply_patch` edit tool is intentionally deferred — see the inline note.
+/// - Codex: its shell tool reports `Bash` (already handled above). Its
+///   `apply_patch` edit tool shares OpenCode's name, so the arm below captures
+///   it wherever a CLI fires PostToolUse for it — OpenCode does (with a V4A
+///   `patchText`); Codex does not yet (openai/codex#16732 — hooks fire only for
+///   the shell tool), so the arm is simply unreached for Codex today.
 ///
 /// Lowercasing first lets the Claude (capitalized) and OpenCode/Gemini (snake)
 /// spellings match the same arms. Anything not a recognized mutation tool maps to
@@ -135,14 +138,13 @@ fn normalize_tool(tool_name: &str) -> &'static str {
         "replace" => "Edit",
         "write_file" => "Write",
         "run_shell_command" => "Bash",
-        // Codex: its shell tool reports "Bash" (handled above). Its file-edit tool
-        // `apply_patch` (tool_name "apply_patch") is INTENTIONALLY not mapped yet:
-        // Codex does not currently emit PostToolUse for apply_patch (OpenAI codex
-        // issue #16732 — hooks fire only for the shell tool), and the payload
-        // carries `tool_input.command` (the raw patch), not a `file_path`, so a
-        // bare mapping would capture only "Edited unknown". Add an `apply_patch`
-        // arm plus patch path-extraction in `summarize_post_tool_use` once Codex
-        // fires the event and exposes the edited path. See rb-* follow-up note.
+        // OpenCode's file-edit tool `apply_patch` (also Codex's, though Codex
+        // does not yet fire PostToolUse for it — openai/codex#16732). The payload
+        // carries a V4A `patchText`, not `file_path`; `edited_path` parses the
+        // `*** <op> File: <path>` directive so the touched path is captured
+        // instead of "Edited unknown". Codex is simply unreached until upstream
+        // fires the event; no separate arm is needed.
+        "apply_patch" => "Edit",
         _ => "",
     }
 }
@@ -152,20 +154,59 @@ fn str_field<'a>(input: &'a serde_json::Value, key: &str) -> &'a str {
     input.get(key).and_then(|v| v.as_str()).unwrap_or("unknown")
 }
 
+/// Resolve the file path a file-mutation tool touched. `Edit`/`Write` carry it
+/// directly as `file_path`; an `apply_patch` tool instead carries a V4A patch
+/// whose `*** <op> File: <path>` directive names the target. OpenCode puts that
+/// patch under `patchText`; Codex's field is unverified (speculated `command`)
+/// and latent until openai/codex#16732 ships PostToolUse for `apply_patch`. Both
+/// share the V4A format, so one parser covers either field. Falls back to
+/// `"unknown"` (matching `str_field`) so an unidentified file touch is still
+/// recorded rather than silently dropped.
+fn edited_path(tool_input: &serde_json::Value) -> String {
+    if let Some(p) = tool_input.get("file_path").and_then(|v| v.as_str()) {
+        return p.to_string();
+    }
+    for field in ["patchText", "command"] {
+        if let Some(patch) = tool_input.get(field).and_then(|v| v.as_str()) {
+            if let Some(p) = v4a_patch_path(patch) {
+                return p;
+            }
+        }
+    }
+    str_field(tool_input, "file_path").to_string()
+}
+
+/// Parse the target path out of a V4A `apply_patch` patchText — the first
+/// `*** Add|Update|Delete File: <path>` directive. Returns `None` when no such
+/// directive is present (caller then falls back to `"unknown"`).
+fn v4a_patch_path(patch_text: &str) -> Option<String> {
+    for line in patch_text.lines() {
+        let line = line.trim_start();
+        for op in ["*** Add File:", "*** Update File:", "*** Delete File:"] {
+            if let Some(rest) = line.strip_prefix(op) {
+                let path = rest.trim();
+                if !path.is_empty() {
+                    return Some(path.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Map a mutation tool to the scratch observation it records: file mutations
 /// record the touched path, `Bash` records the command. Normalizes first so
 /// lowercase (OpenCode) and snake-case (Gemini) names produce the same
-/// observation as Claude's capitalized names. Returns `None` for a tool we do
-/// not capture (the caller continues without recording).
+/// observation as Claude's capitalized names. OpenCode `apply_patch` carries a
+/// V4A `patchText`; [`edited_path`] parses its `*** <op> File: <path>`
+/// directive. Returns `None` for a tool we do not capture (the caller continues
+/// without recording).
 fn tool_observation(
     tool_name: &str,
     tool_input: &serde_json::Value,
 ) -> Option<(scratch::Kind, String)> {
     match normalize_tool(tool_name) {
-        "Edit" | "Write" => Some((
-            scratch::Kind::File,
-            str_field(tool_input, "file_path").to_string(),
-        )),
+        "Edit" | "Write" => Some((scratch::Kind::File, edited_path(tool_input))),
         "NotebookEdit" => Some((
             scratch::Kind::File,
             str_field(tool_input, "notebook_path").to_string(),
@@ -978,6 +1019,7 @@ mod tests {
             "edit",
             "bash",
             "patch",
+            "apply_patch",
             "write_file",
             "replace",
             "run_shell_command",
@@ -1000,14 +1042,49 @@ mod tests {
     }
 
     #[test]
-    fn codex_apply_patch_stays_blocked_without_a_real_fixture() {
+    fn apply_patch_captures_edited_path_from_v4a_patchtext() {
+        // Gap B: OpenCode fires PostToolUse for `apply_patch` with a V4A
+        // `patchText` (no `file_path`); the edited path is the
+        // `*** <op> File: <path>` directive. File edits must be captured.
+        let add = serde_json::json!({
+            "patchText": "*** Begin Patch\n*** Add File: notes.txt\n+recorded\n*** End Patch"
+        });
+        assert_eq!(
+            tool_observation("apply_patch", &add),
+            Some((scratch::Kind::File, "notes.txt".to_string()))
+        );
+        let upd = serde_json::json!({
+            "patchText": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n-old\n+new\n*** End Patch"
+        });
+        assert_eq!(
+            tool_observation("apply_patch", &upd),
+            Some((scratch::Kind::File, "src/lib.rs".to_string()))
+        );
+        // A path-less / non-V4A patch still records a file touch ("unknown"),
+        // never a silent drop. Codex stays unrepresented at the EVENT level
+        // (openai/codex#16732 — it does not fire PostToolUse for apply_patch),
+        // not at the normalization level this unit covers.
+        let bare = serde_json::json!({"patchText": "not a v4a patch"});
+        assert_eq!(
+            tool_observation("apply_patch", &bare),
+            Some((scratch::Kind::File, "unknown".to_string()))
+        );
+    }
+
+    #[test]
+    #[ignore = "pending a real Codex apply_patch fixture; command field name is unverified (openai/codex#16732)"]
+    fn codex_apply_patch_command_field_captures_path_pending_real_fixture() {
+        // STUB: Codex's apply_patch is speculated to carry the V4A patch under
+        // `tool_input.command` (not OpenCode's `patchText`). `edited_path` checks
+        // both fields, so this passes today — but the field name is UNVERIFIED, so
+        // the test stays #[ignore] until a real Codex fixture confirms the shape.
+        // Un-ignore (and adjust the field name) once openai/codex#16732 ships.
         let input = serde_json::json!({
-            "command": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n-old\n+new\n*** End Patch\n"
+            "command": "*** Begin Patch\n*** Update File: codex/src/lib.rs\n@@\n-old\n+new\n*** End Patch"
         });
         assert_eq!(
             tool_observation("apply_patch", &input),
-            None,
-            "apply_patch must not capture until a real Codex PostToolUse fixture proves the payload"
+            Some((scratch::Kind::File, "codex/src/lib.rs".to_string()))
         );
     }
 

--- a/crates/rb-hooks/tests/fixtures/opencode/README.md
+++ b/crates/rb-hooks/tests/fixtures/opencode/README.md
@@ -5,7 +5,7 @@
 - **CLI:** 1.17.5
 - **Captured:** 2026-06-23, Darwin 25.5.0
 - **Captured by:** scripts/record-agent-fixtures.sh
-- **Events:** session_created, session_idle, tool_execute_after
+- **Events:** session_created, session_idle, tool_execute_after (bash), tool_execute_after_apply_patch (file edit)
 
 ## Recording Recipe
 
@@ -46,7 +46,8 @@ Multi-turn verdict: **ambiguous** (see the run shape in the recipe; evidence, no
 |---|---|
 | `session_created.json` | `session_created` |
 | `session_idle.json` | `session_idle` |
-| `tool_execute_after.json` | `tool_execute_after` |
+| `tool_execute_after.json` | `tool_execute_after` (bash) |
+| `tool_execute_after_apply_patch.json` | `tool_execute_after` (apply_patch file edit — derived from `result.jsonl:10`; proves Gap B capture) |
 
 ## Fields present / absent
 

--- a/crates/rb-hooks/tests/fixtures/opencode/tool_execute_after_apply_patch.json
+++ b/crates/rb-hooks/tests/fixtures/opencode/tool_execute_after_apply_patch.json
@@ -1,0 +1,1 @@
+{"type":"tool.execute.after","tool":"apply_patch","sessionID":"ses_107a97eedffedZEkDN11h8NsVD","callID":"call_RNhykgnS6o6kGiWRU6VA9zrs","args":{"patchText":"*** Begin Patch\n*** Add File: notes.txt\n+recorded\n*** End Patch"},"output":"Success. Updated the following files:\nA notes.txt","title":"Add notes.txt"}

--- a/crates/rb-hooks/tests/integration.rs
+++ b/crates/rb-hooks/tests/integration.rs
@@ -28,6 +28,8 @@ const REAL_SESSION_END: &str = include_str!("fixtures/claude_code/session_end.js
 // `echo hi`): it pins bash-command capture only, NOT file-edit capture (Gap B /
 // `apply_patch`, tracked separately).
 const OPENCODE_TOOL_EXECUTE_AFTER: &str = include_str!("fixtures/opencode/tool_execute_after.json");
+const OPENCODE_TOOL_EXECUTE_AFTER_APPLY_PATCH: &str =
+    include_str!("fixtures/opencode/tool_execute_after_apply_patch.json");
 const OPENCODE_SESSION_IDLE: &str = include_str!("fixtures/opencode/session_idle.json");
 
 fn hooks_command() -> std::process::Command {
@@ -501,6 +503,39 @@ fn opencode_session_idle_folds_tool_scratch_into_one_checkpoint_summary() {
     assert!(
         content.contains("Commands run"),
         "the summary must carry a commands section: {content}"
+    );
+}
+
+#[test]
+fn opencode_apply_patch_file_edit_folds_into_checkpoint_summary() {
+    // Gap B end-to-end: OpenCode's file edits go through the `apply_patch` tool,
+    // whose payload carries a V4A `patchText` (no `file_path`). The edited path
+    // must be captured into the scratch and folded by the following session.idle
+    // checkpoint — otherwise every OpenCode file edit silently drops on the
+    // floor. Replays the REAL recorded apply_patch payload (result.jsonl:10,
+    // re-shaped to the per-event hook format); it shares the recorded session id
+    // with session_idle.json so the scratch aligns.
+    let (observed, _stdout) = observe_sequence_against_mock_daemon(
+        &[
+            OPENCODE_TOOL_EXECUTE_AFTER_APPLY_PATCH,
+            OPENCODE_SESSION_IDLE,
+        ],
+        Some("rb-it-opencode-apply-patch"),
+        "opencode",
+    );
+    assert!(
+        observed.saw_remember,
+        "OpenCode session.idle must fold the apply_patch file edit into a checkpoint summary"
+    );
+    assert_eq!(observed.identity_agent.as_deref(), Some("opencode"));
+    let content = observed.content.as_deref().unwrap_or_default();
+    assert!(
+        content.contains("notes.txt"),
+        "the checkpoint summary must fold the apply_patch-ed file: {content}"
+    );
+    assert!(
+        content.contains("Files touched"),
+        "the summary must carry a files section: {content}"
     );
 }
 

--- a/docs/follow-ups/2026-06-02-codex-apply-patch-capture.md
+++ b/docs/follow-ups/2026-06-02-codex-apply-patch-capture.md
@@ -7,6 +7,16 @@
 
 ## Summary
 
+> **Update 2026-07-02:** the `"apply_patch" => "Edit"` arm and V4A `patchText`
+> path extraction (`edited_path`) now **exist** in `normalize_tool`, landed for
+> OpenCode (which fires the event today). Codex is still **upstream-blocked from
+> firing** the event at all (openai/codex#16732), so the arm is simply unreached
+> for Codex. The remaining Codex-specific risk below is the unverified
+> **payload shape** — if Codex exposes the patch as `tool_input.command` rather
+> than OpenCode's `patchText`, `edited_path`'s `patchText` lookup misses and the
+> capture falls back to `"unknown"`; verify against a real Codex fixture before
+> declaring Codex capture restored.
+
 Codex's file-edit tool `apply_patch` is **not** recognized by
 `rb_hooks::capture::normalize_tool`, so a Codex `apply_patch` PostToolUse event
 would degrade to a no-op capture. This is intentionally deferred — see the inline

--- a/docs/follow-ups/2026-06-02-codex-apply-patch-capture.md
+++ b/docs/follow-ups/2026-06-02-codex-apply-patch-capture.md
@@ -7,22 +7,28 @@
 
 ## Summary
 
-> **Update 2026-07-02:** the `"apply_patch" => "Edit"` arm and V4A `patchText`
-> path extraction (`edited_path`) now **exist** in `normalize_tool`, landed for
-> OpenCode (which fires the event today). Codex is still **upstream-blocked from
-> firing** the event at all (openai/codex#16732), so the arm is simply unreached
-> for Codex. The remaining Codex-specific risk below is the unverified
-> **payload shape** — if Codex exposes the patch as `tool_input.command` rather
-> than OpenCode's `patchText`, `edited_path`'s `patchText` lookup misses and the
-> capture falls back to `"unknown"`; verify against a real Codex fixture before
-> declaring Codex capture restored.
+> **Update 2026-07-02:** the `"apply_patch" => "Edit"` arm and V4A path extraction
+> (`edited_path`, which checks both `patchText` and `command`) now **exist** in
+> `normalize_tool`, landed for OpenCode (which fires the event today). Codex is
+> still **upstream-blocked from firing** the event at all (openai/codex#16732), so
+> the arm is simply unreached for Codex. The remaining Codex-specific risk is the
+> unverified **payload shape**: if Codex carries the patch under a field other
+> than `patchText`/`command`, or in a non-V4A format, `edited_path` falls back to
+> `"unknown"` (still captured as an unidentified file touch, never dropped).
+> Verify against a real Codex fixture before declaring Codex capture restored.
 
-Codex's file-edit tool `apply_patch` is **not** recognized by
-`rb_hooks::capture::normalize_tool`, so a Codex `apply_patch` PostToolUse event
-would degrade to a no-op capture. This is intentionally deferred — see the inline
-note in `crates/rb-hooks/src/capture.rs` (the `normalize_tool` match).
+Codex's file-edit tool `apply_patch` shares its name with OpenCode's, and
+`rb_hooks::capture::normalize_tool` now maps `"apply_patch" => "Edit"` (landed for
+OpenCode, which fires the event today). Codex itself does not yet emit
+PreToolUse/PostToolUse for `apply_patch` — hooks fire only for the shell (Bash)
+tool — so for Codex the arm is present but unreached, and this remains deferred
+behind openai/codex#16732.
 
 ## Verified facts (2026-06-02)
+
+_Snapshot of the pre-arm state; the `apply_patch => Edit` arm + `edited_path`
+landed 2026-07-02 (see the update above). The blocker below — Codex not firing
+the event — is unchanged._
 
 - Codex's **shell** tool reports `tool_name: "Bash"` — Claude-style. Codex shell
   capture therefore **already works** today via the existing `"bash" => "Bash"`

--- a/docs/follow-ups/2026-06-13-cross-cli-capture-inversion.md
+++ b/docs/follow-ups/2026-06-13-cross-cli-capture-inversion.md
@@ -2,14 +2,15 @@
 
 - **Date:** 2026-06-13
 - **Area:** `rb-agents` adapters (Gemini / Codex / OpenCode) + `rb-hooks` capture
-- **Status:** Resolution in progress — see
-  [cross-CLI terminus mapping plan](../plans/2026-06-26-cross-cli-terminus-mapping.md).
-  The recovery mechanism (`SessionCheckpoint` + `FoldMode::Checkpoint`) already
-  existed but was dormant; OpenCode's terminus mapping (Gap A) is now **landed**
-  (`session.idle` → `SessionCheckpoint`, fixture-backed lifecycle test). Full
-  OpenCode capture restoration still needs the separate `apply_patch`
-  tool-coverage fix (Gap B). Codex remains fixture-gated; Gemini is descoped
-  (2026-06-27).
+- **Status:** OpenCode capture **restored** — both gaps landed. The recovery
+  mechanism (`SessionCheckpoint` + `FoldMode::Checkpoint`) already existed but
+  was dormant; OpenCode's terminus mapping (Gap A) landed first (`session.idle`
+  → `SessionCheckpoint`, fixture-backed lifecycle test), and the `apply_patch`
+  tool-coverage fix (Gap B) followed: `normalize_tool` maps `apply_patch` →
+  `Edit` and `edited_path` parses the V4A `patchText` `*** <op> File: <path>`
+  directive. The `opencode` capability row graduated capture `Partial` →
+  `Supported`. Codex remains fixture-gated; Gemini is descoped (2026-06-27).
+  Scorecard enablement for OpenCode is still a separate, larger task.
 - **Severity:** Medium — a capture **regression** for non-Claude CLIs until resolved
 
 ## Summary

--- a/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
+++ b/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
@@ -123,36 +123,41 @@ terminus"):** map `session.idle` → canonical **`SessionCheckpoint`** (today `S
 become a memory instead of ageing out. OpenCode exposes no cleaner terminus
 (`session.deleted` is not emitted on a normal headless run).
 
-**Gap B — tool coverage (BLOCKS "capture restored").** [LANDED 2026-07-02]
-`normalize_tool` now maps `apply_patch` → `Edit`, and `edited_path` parses the
-V4A `patchText` `*** <op> File: <path>` directive; a fixture-backed lifecycle
-test (`opencode_apply_patch_file_edit_folds_into_checkpoint_summary`) replays the
-real `result.jsonl:10` payload. Original rationale retained below for reference. The terminus mapping only
-folds what the scratch already contains, and OpenCode's file edits are NOT being
-captured into the scratch. The recorded run created `notes.txt` via the
-**`apply_patch`** tool (`crates/rb-hooks/tests/fixtures/opencode/result.jsonl:10`,
-`"tool":"apply_patch"` with a `patchText`), but `normalize_tool`
-(`crates/rb-hooks/src/capture.rs:127`) has no `apply_patch` arm — it falls through
-to `""` (not captured). The committed `tool_execute_after.json` fixture captured
-the **`bash`** event, not the edit, so a lifecycle test that replays only that
-fixture would pass while every OpenCode file edit silently drops on the floor.
+**Gap B — tool coverage.** [LANDED 2026-07-02] `normalize_tool` now maps
+`apply_patch` → `Edit`, and `edited_path` parses the V4A `patchText`
+`*** Add|Update|Delete File: <path>` directive; a fixture-backed lifecycle test
+(`opencode_apply_patch_file_edit_folds_into_checkpoint_summary`) replays the real
+`result.jsonl:10` payload. With Gap A and Gap B both landed, OpenCode capture is
+restored and the `opencode` capability row graduated `Partial → Supported`.
 
-This is the same `apply_patch` family as the deferred Codex gap, but it manifests
-**live** for OpenCode+gpt-5.5 (Codex's is upstream-blocked from even firing). The
-existing `"patch" => "Edit"` arm does NOT cover it — the recorded tool name is
-`apply_patch`, and the payload carries `patchText` (a raw patch), not a
-`file_path`, so a bare arm would summarize as "Edited unknown".
-
-**Therefore "OpenCode capture is restored" is FALSE until BOTH land:**
-1. `session.idle` → `SessionCheckpoint` (Gap A), AND
-2. an `apply_patch` arm in `normalize_tool` + edited-path extraction from
-   `patchText` in `summarize_post_tool_use`, proven by a real OpenCode
-   `apply_patch` `tool.execute.after` fixture (record one — the committed fixture
-   set lacks it).
-
-Gap A is the worked example the Codex terminus decision follows (Gemini
-descoped). Gap B is
-tracked alongside the Codex `apply_patch` follow-up.
+> Historical pre-fix rationale (retained for the decision record; superseded by
+> the LANDED note above):
+>
+> The terminus mapping only folds what the scratch already contains, and OpenCode's
+> file edits are NOT being captured into the scratch. The recorded run created
+> `notes.txt` via the **`apply_patch`** tool
+> (`crates/rb-hooks/tests/fixtures/opencode/result.jsonl:10`,
+> `"tool":"apply_patch"` with a `patchText`), but `normalize_tool`
+> (`crates/rb-hooks/src/capture.rs:127`) has no `apply_patch` arm — it falls
+> through to `""` (not captured). The committed `tool_execute_after.json` fixture
+> captured the **`bash`** event, not the edit, so a lifecycle test that replays
+> only that fixture would pass while every OpenCode file edit silently drops on
+> the floor.
+>
+> This is the same `apply_patch` family as the deferred Codex gap, but it
+> manifests **live** for OpenCode+gpt-5.5 (Codex's is upstream-blocked from even
+> firing). The existing `"patch" => "Edit"` arm does NOT cover it — the recorded
+> tool name is `apply_patch`, and the payload carries `patchText` (a raw patch),
+> not a `file_path`, so a bare arm would summarize as "Edited unknown".
+>
+> **Therefore "OpenCode capture is restored" was FALSE until BOTH landed:**
+> 1. `session.idle` → `SessionCheckpoint` (Gap A), AND
+> 2. an `apply_patch` arm in `normalize_tool` + edited-path extraction from
+>    `patchText`, proven by a real OpenCode `apply_patch` `tool.execute.after`
+>    fixture.
+>
+> Gap A is the worked example the Codex terminus decision follows (Gemini
+> descoped). Gap B is tracked alongside the Codex `apply_patch` follow-up.
 
 ### Codex — FIXTURE-GATED
 

--- a/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
+++ b/docs/plans/2026-06-26-cross-cli-terminus-mapping.md
@@ -5,13 +5,15 @@
   (Codex / OpenCode; Gemini descoped 2026-06-27) by mapping each CLI's terminal
   native event onto a canonical event that actually folds the session scratch
   into a memory.
-- **Status:** Design + scaffolding. OpenCode's terminus mapping is decidable now
-  (multi-fire checkpoint-safe), but restoring OpenCode capture also requires a
-  separate `apply_patch` tool-coverage fix (Gap B), and scorecard enablement is a
-  larger task than a flag flip — do NOT implement OpenCode end-to-end from the
-  terminus decision alone. Codex's decision is fixture-gated (decision tree
-  below). **Gemini is descoped** (2026-06-27) — removed from active scope; it
-  stays on canonical `Stop`. This is "Worker C" per the sequencing PRD.
+- **Status:** OpenCode capture **restored** (2026-07-02): Gap A (`session.idle` →
+  `SessionCheckpoint`) and Gap B (`apply_patch` → `Edit` + V4A `patchText` path
+  extraction in `edited_path`) both landed, with fixture-backed lifecycle tests;
+  the `opencode` capability row graduated capture `Partial` → `Supported`.
+  Scorecard enablement is still a separate, larger task than a flag flip — do NOT
+  flip it from the capture work alone. Codex's decision is fixture-gated
+  (decision tree below). **Gemini is descoped** (2026-06-27) — removed from
+  active scope; it stays on canonical `Stop`. This is "Worker C" per the
+  sequencing PRD.
 - **Related:**
   [cross-cli-capture-inversion follow-up](../follow-ups/2026-06-13-cross-cli-capture-inversion.md),
   [cross-agent fixture-recording spec](../specs/2026-06-23-cross-agent-fixture-recording.md),
@@ -121,7 +123,11 @@ terminus"):** map `session.idle` → canonical **`SessionCheckpoint`** (today `S
 become a memory instead of ageing out. OpenCode exposes no cleaner terminus
 (`session.deleted` is not emitted on a normal headless run).
 
-**Gap B — tool coverage (BLOCKS "capture restored").** The terminus mapping only
+**Gap B — tool coverage (BLOCKS "capture restored").** [LANDED 2026-07-02]
+`normalize_tool` now maps `apply_patch` → `Edit`, and `edited_path` parses the
+V4A `patchText` `*** <op> File: <path>` directive; a fixture-backed lifecycle
+test (`opencode_apply_patch_file_edit_folds_into_checkpoint_summary`) replays the
+real `result.jsonl:10` payload. Original rationale retained below for reference. The terminus mapping only
 folds what the scratch already contains, and OpenCode's file edits are NOT being
 captured into the scratch. The recorded run created `notes.txt` via the
 **`apply_patch`** tool (`crates/rb-hooks/tests/fixtures/opencode/result.jsonl:10`,


### PR DESCRIPTION
## What

Restores OpenCode file-edit capture, the second half of the W3.1 capture-inversion extension (Gap B; Gap A — `session.idle -> SessionCheckpoint` — already landed). OpenCode edits files via the `apply_patch` tool, whose payload carries a V4A `patchText` (no `file_path`). Without an `apply_patch` arm in `normalize_tool`, every file edit degraded to a no-op — scratch appended, nothing folded for edits — so the OpenCode capture loop was silently broken.

## Changes
- **`capture.rs`** — `normalize_tool` maps `apply_patch -> Edit`; new `edited_path` + `v4a_patch_path` parse the `*** <op> File: <path>` directive from the V4A patch (carried under `patchText` for OpenCode, and the Codex-speculated `command` field). Unidentified patches fall back to `"unknown"` (still captured, never dropped).
- **Tests** — fixture-backed lifecycle test `opencode_apply_patch_file_edit_folds_into_checkpoint_summary` (replays `result.jsonl:10`); unit test `apply_patch_captures_edited_path_from_v4a_patchtext`.
- **Fixture** — `tests/fixtures/opencode/tool_execute_after_apply_patch.json` + README.
- **`capability.rs`** — OpenCode `capture: Partial -> Supported`; limitation string + guard test updated.
- **Docs** — follow-up + terminus plan marked Gap B landed; Codex follow-up notes the arm now exists.

## Codex
Codex stays fixture-gated: it does not fire PostToolUse for `apply_patch` at all (`openai/codex#16732`). The `command`-field path is stubbed behind an `#[ignore]` test (`codex_apply_patch_command_field_captures_path_pending_real_fixture`) so it is landing-ready once upstream ships and a real fixture confirms the payload field name. Scorecard enablement remains a separate, larger task.

## Verification
- `cargo test --workspace` -> 1259 passed, 8 ignored
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean

## Tracking
Vikunja task "Extend W3.1 capture inversion to non-Claude CLIs" — OpenCode leg complete; Codex remains on the upstream blocker + a fixture recording (`record-agent-fixtures.sh --agent codex`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode now captures file edits from `apply_patch` events and includes the edited file name in checkpoint summaries.
  * Cross-CLI capture for OpenCode has been restored and now folds into session checkpoints more completely.

* **Bug Fixes**
  * Improved handling of edit-related events so file changes are recorded even when path details arrive in different formats.
  * Updated capability status to reflect OpenCode’s full capture support.

* **Documentation**
  * Updated follow-up and planning notes to reflect the completed capture improvements and remaining work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->