### PR TITLE
Cross-agentic agent parity closeout (Vikunja #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,10 @@ notifications).
 `rusty-brain-install` wires the `rusty-brain-hooks` binary into a supported agent
 CLI's hook configuration so that file edits, session starts/stops, and similar events
 are captured into memory automatically. The hooks are **fail-open**: any error
-degrades silently and never blocks the agent. Adapters exist for several agent CLIs;
-coverage is still being expanded.
+degrades silently and never blocks the agent. The agent surface is
+**cross-agentic**: OpenCode and Codex are first-class targets alongside Claude
+Code, with Hermes discovery-gated. Per-agent setup, validation commands, and
+troubleshooting live in [docs/AGENTS.md](docs/AGENTS.md).
 
 Current agent capability matrix:
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ Current agent capability matrix:
 | Agent | Adapter | Capture | Retrieval | Config | Scorecard | Lifecycle source / limitation |
 |---|---|---|---|---|---|---|
 | `claude-code` | stable | supported | supported | supported | supported | Fixture-backed `SessionEnd` lifecycle under `crates/rb-hooks/tests/fixtures/claude_code/`. |
-| `codex` | experimental | partial | unsupported | partial | unsupported | `Stop` remains a no-op boundary until real fixtures prove a checkpoint or terminus; `apply_patch` capture is blocked. |
-| `opencode` | experimental | partial | unsupported | unsupported | unsupported | Adapter exists, but installer/plugin support and lifecycle fixtures are still deferred. |
-| `gemini` | experimental | partial | unsupported | partial | unsupported | Native `SessionEnd` remains canonical `Stop` until real fixtures prove a safer boundary. |
+| `codex` | experimental | partial | unsupported | partial | unsupported | `Stop` remains a no-op boundary until real fixtures prove a checkpoint or terminus; `apply_patch` capture is upstream-blocked ([openai/codex#16732](https://github.com/openai/codex/issues/16732)). |
+| `opencode` | experimental | supported | unsupported | unsupported | unsupported | `session.idle` folds via canonical `SessionCheckpoint`; bash and `apply_patch` file-edit capture are fixture-backed. Installer/plugin support is deferred. |
+| `gemini` | experimental | partial | unsupported | partial | unsupported | Native `SessionEnd` remains canonical `Stop`; terminus mapping is descoped from the cross-CLI track. |
 | `hermes` | discovery | unknown | unknown | unknown | unsupported | Discovery-gated; no hook names or config paths are hard-coded. |
 
 The scorecard runner is target-aware:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ notifications).
 CLI's hook configuration so that file edits, session starts/stops, and similar events
 are captured into memory automatically. The hooks are **fail-open**: any error
 degrades silently and never blocks the agent. The agent surface is
-**cross-agentic**: OpenCode and Codex are first-class targets alongside Claude
-Code, with Hermes discovery-gated. Per-agent setup, validation commands, and
+**cross-agentic**: OpenCode and Codex are first-priority targets alongside
+Claude Code, with Hermes discovery-gated. Per-agent setup, validation commands, and
 troubleshooting live in [docs/AGENTS.md](docs/AGENTS.md).
 
 Current agent capability matrix:

--- a/crates/rb-agents/tests/capability_docs.rs
+++ b/crates/rb-agents/tests/capability_docs.rs
@@ -114,6 +114,34 @@ fn readme_matrix_matches_capability_source_of_truth() {
             !row[6].is_empty(),
             "README {want_id} lifecycle/limitation cell must not be empty"
         );
+        for marker in limitation_markers(capability.agent) {
+            assert!(
+                row[6].contains(marker),
+                "README {want_id} lifecycle/limitation cell drifted: expected it to \
+                 mention {marker:?} (per capability.rs limitations), got {:?}",
+                row[6]
+            );
+        }
+    }
+}
+
+/// Stable anchor tokens the README limitation prose must keep, per agent.
+///
+/// The prose cell is an editorial summary, not a verbatim render of
+/// `AgentCapability::limitations` (which would bloat the table), so the guard
+/// pins the load-bearing caveat of each row instead: the fixture backing for
+/// claude-code, the upstream blocker for codex, the fold event + install
+/// deferral for opencode, the descoping decision for gemini, and the
+/// discovery gate for hermes. Dropping one of these in a rewrite is exactly
+/// the stale-prose failure this test exists to catch.
+fn limitation_markers(agent: &str) -> &'static [&'static str] {
+    match agent {
+        "claude-code" => &["crates/rb-hooks/tests/fixtures/claude_code/"],
+        "codex" => &["openai/codex#16732", "fixture"],
+        "opencode" => &["SessionCheckpoint", "deferred"],
+        "gemini" => &["descoped"],
+        "hermes" => &["Discovery-gated"],
+        other => panic!("no limitation markers defined for agent {other:?}"),
     }
 }
 

--- a/crates/rb-agents/tests/capability_docs.rs
+++ b/crates/rb-agents/tests/capability_docs.rs
@@ -1,0 +1,132 @@
+//! Guards the README agent capability matrix against drift from the code's
+//! source of truth (`rb_agents::capability`).
+//!
+//! The README table is user-facing documentation; `capability.rs` is what the
+//! adapters and scorecard actually honor. Editing one without the other is a
+//! recurring failure mode (the opencode row went stale when capture graduated
+//! Partial -> Supported), so this test parses the README table and asserts
+//! every cell matches the matrix.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::path::Path;
+
+use rb_agents::{agent_capabilities, AdapterStatus, SupportLevel};
+
+const MATRIX_MARKER: &str = "Current agent capability matrix:";
+
+fn readme_text() -> String {
+    // CARGO_MANIFEST_DIR = <workspace>/crates/rb-agents; README sits at the root.
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../README.md");
+    std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+}
+
+/// Extract the capability table rows (agent rows only) that follow the marker.
+fn readme_matrix_rows(readme: &str) -> Vec<Vec<String>> {
+    let after_marker = readme
+        .split_once(MATRIX_MARKER)
+        .unwrap_or_else(|| panic!("README is missing the marker line {MATRIX_MARKER:?}"))
+        .1;
+    after_marker
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with('|'))
+        .take_while(|line| line.trim_start().starts_with('|'))
+        .filter(|line| {
+            // Drop the header row and the |---| separator row.
+            let body = line.trim().trim_matches('|');
+            !body.contains("Agent")
+                && !body.trim_matches('-').trim().starts_with("---")
+                && !body.replace(['-', '|', ' '], "").is_empty()
+        })
+        .map(|line| {
+            line.trim()
+                .trim_start_matches('|')
+                .trim_end_matches('|')
+                .split('|')
+                .map(|cell| cell.trim().to_string())
+                .collect()
+        })
+        .collect()
+}
+
+fn adapter_status_token(status: AdapterStatus) -> &'static str {
+    match status {
+        AdapterStatus::Stable => "stable",
+        AdapterStatus::Experimental => "experimental",
+        AdapterStatus::Discovery => "discovery",
+        AdapterStatus::Unsupported => "unsupported",
+    }
+}
+
+fn support_level_token(level: SupportLevel) -> &'static str {
+    match level {
+        SupportLevel::Supported => "supported",
+        SupportLevel::Partial => "partial",
+        SupportLevel::Unsupported => "unsupported",
+        SupportLevel::Unknown => "unknown",
+    }
+}
+
+#[test]
+fn readme_matrix_matches_capability_source_of_truth() {
+    let readme = readme_text();
+    let rows = readme_matrix_rows(&readme);
+    let matrix = agent_capabilities();
+
+    assert_eq!(
+        rows.len(),
+        matrix.len(),
+        "README capability table has {} agent rows, capability.rs has {}",
+        rows.len(),
+        matrix.len()
+    );
+
+    for capability in matrix {
+        let want_id = format!("`{}`", capability.agent);
+        let row = rows
+            .iter()
+            .find(|cells| cells.first().map(String::as_str) == Some(want_id.as_str()))
+            .unwrap_or_else(|| panic!("README matrix is missing a row for {want_id}"));
+        assert!(
+            row.len() >= 7,
+            "README row for {want_id} has {} cells, expected at least 7",
+            row.len()
+        );
+
+        let expect = [
+            adapter_status_token(capability.adapter_status),
+            support_level_token(capability.capture),
+            support_level_token(capability.retrieval),
+            support_level_token(capability.config),
+            support_level_token(capability.scorecard),
+        ];
+        let columns = ["adapter", "capture", "retrieval", "config", "scorecard"];
+        for (idx, (column, want)) in columns.iter().zip(expect).enumerate() {
+            assert_eq!(
+                row[idx + 1],
+                want,
+                "README {want_id} `{column}` cell drifted from capability.rs \
+                 (README says {:?}, code says {want:?})",
+                row[idx + 1]
+            );
+        }
+        assert!(
+            !row[6].is_empty(),
+            "README {want_id} lifecycle/limitation cell must not be empty"
+        );
+    }
+}
+
+#[test]
+fn readme_lists_scorecard_agent_targets() {
+    // CA5/CA7: the README must document per-agent scorecard invocation,
+    // including the aggregate target.
+    let readme = readme_text();
+    for target in ["claude-code", "codex", "opencode", "all"] {
+        let needle = format!("--agent {target}");
+        assert!(
+            readme.contains(&needle),
+            "README must document `scripts/memory-scorecard.sh {needle}`"
+        );
+    }
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,152 @@
+# Agent Support
+
+rusty-brain is a cross-agentic memory system: the current sprint targets
+OpenCode and Codex as first-class agents alongside Claude Code, with Hermes as
+a discovery-gated candidate (see
+`docs/prds/2026-06-23-cross-agentic-agent-parity.md`).
+
+The source of truth for per-agent support is the capability matrix in
+`crates/rb-agents/src/capability.rs`. The README table is a rendered copy,
+guarded against drift by `crates/rb-agents/tests/capability_docs.rs`. Every
+agent is scored on four dimensions:
+
+| Dimension | Meaning |
+|---|---|
+| capture | tool/session events are folded into memories automatically |
+| retrieval | relevant memories are injected back into the agent's context |
+| config | `rusty-brain-install` can wire the hooks into the agent's config |
+| scorecard | `scripts/memory-scorecard.sh` can measure memory value for the agent |
+
+Statuses are honest by design: `partial`/`unsupported`/`unknown` mean exactly
+that, and unsupported paths fail with actionable messages rather than silently
+succeeding.
+
+## Claude Code (stable)
+
+The lead adapter; fully supported on all four dimensions.
+
+```bash
+rusty-brain-install install --agents claude-code            # project scope
+rusty-brain-install install --agents claude-code --global   # per-user scope
+rusty-brain-install status
+```
+
+- Events wired: `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Stop`,
+  `SessionEnd`, `PreCompact`.
+- Capture: the per-session scratch folds into one summary at `SessionEnd`.
+- Retrieval: `SessionStart` injects session context; `UserPromptSubmit`
+  performs prompt-time recall with untrusted-context framing and a token
+  budget.
+- Scorecard: `scripts/memory-scorecard.sh --agent claude-code --runs 1`.
+
+## Codex (experimental)
+
+```bash
+rusty-brain-install install --agents codex            # writes <project>/.codex/hooks.json
+rusty-brain-install install --agents codex --global   # writes ~/.codex/hooks.json
+```
+
+- Events wired: `SessionStart`, `PostToolUse`, `Stop`, `PreCompact`.
+- Capture — **partial**: shell (`Bash`) tool use is captured into the
+  per-session scratch, but Codex's native `Stop` stays mapped to canonical
+  `Stop` (a no-op boundary), so the scratch is never folded into a summary.
+  The terminus mapping is fixture-gated: it will not be promoted until a
+  recorded Codex lifecycle fixture proves whether `Stop` fires per-turn or
+  per-session (`docs/plans/2026-06-26-cross-cli-terminus-mapping.md`).
+  `apply_patch` file edits are additionally upstream-blocked — Codex does not
+  emit `PostToolUse` for them
+  ([openai/codex#16732](https://github.com/openai/codex/issues/16732), see
+  `docs/follow-ups/2026-06-02-codex-apply-patch-capture.md`).
+- Retrieval — **unsupported**: the closest equivalent to Claude's
+  `UserPromptSubmit` injection is Codex's `SessionStart` context injection
+  (returned via `hookSpecificOutput.additionalContext`), which is active.
+  Native `UserPromptSubmit` payloads parse to `Other` and are not acted on
+  until a recorded fixture verifies their shape. There is no prompt-time
+  recall for Codex today; do not assume parity.
+- Scorecard — **skipped** with `phase=capture`:
+  `scripts/memory-scorecard.sh --agent codex --runs 1` prints a
+  machine-readable skip line and exits 0.
+
+## OpenCode (experimental)
+
+- Capture — **supported** and fixture-backed: `session.created` maps to
+  canonical `SessionStart`, `tool.execute.after` records tool use (including
+  `apply_patch` file edits, with the edited path parsed from the V4A patch
+  text), and `session.idle` maps to canonical `SessionCheckpoint`, which
+  folds the scratch checkpoint-safely (`session.idle` can fire more than once
+  per session).
+- Config — **installer deferred, by decision**: OpenCode loads hooks through a
+  JS/TS plugin in `.opencode/plugins/`, not a JSON hooks block, so
+  rusty-brain's JSON-writing installer would be inert.
+  `rusty-brain-install install --agents opencode` therefore fails closed with
+  `[E_INSTALL_AGENT_DEFERRED]` instead of pretending to install. The adapter
+  itself is fully functional: a plugin that pipes hook payloads to
+  `rusty-brain-hooks --agent opencode` gets capture today. The
+  fixture-recording plugin under `scripts/fixtures/opencode-logger/` shows the
+  wiring; a maintained install path is a follow-on task.
+- Retrieval — **unsupported**: no OpenCode prompt-submission event is mapped;
+  there is no recorded fixture proving one exists with a stable shape. No
+  injection channel is active for OpenCode.
+- Scorecard — **skipped** with `phase=config` (blocked on the plugin/config
+  path): `scripts/memory-scorecard.sh --agent opencode --runs 1`.
+
+## Gemini (experimental, descoped)
+
+The adapter and installer exist (`SessionStart`, `AfterTool`, `SessionEnd`,
+`PreCompress`), but Gemini is descoped from the cross-CLI terminus track
+(2026-06-27): its native `SessionEnd` stays on canonical `Stop`, so per-tool
+observations are recorded but never folded. No fixture or mapping work is
+planned. Scorecard target is skipped with `phase=scoring`.
+
+## Hermes (discovery)
+
+Discovery-gated: no hook names, config paths, or lifecycle semantics are
+hard-coded anywhere in the codebase, and no installer path exists. Known
+facts, unknowns, and next steps live in
+`docs/follow-ups/2026-06-23-hermes-discovery.md`. The scorecard target is
+skipped with `phase=config`.
+
+## Validation
+
+```bash
+cargo test -p rb-agents -p rb-hooks -p rb-install
+scripts/memory-scorecard.sh --self-test
+
+scripts/memory-scorecard.sh --agent claude-code --runs 1
+scripts/memory-scorecard.sh --agent codex --runs 1      # explicit skip
+scripts/memory-scorecard.sh --agent opencode --runs 1   # explicit skip
+scripts/memory-scorecard.sh --agent all --runs 1        # prints skips, runs Claude Code
+sh scripts/memory-scorecard.test.sh                     # agent-targeting functions
+```
+
+## Troubleshooting
+
+**Hooks don't seem to fire.** Run `rusty-brain-install status` — it reports,
+per CLI, whether the CLI was detected and whether our sentinel-marked hook
+block is present in its config. Reinstall with
+`rusty-brain-install install --agents <id>` (add `--global` for the per-user
+config). Hooks are fail-open: a broken hook degrades silently rather than
+blocking the agent, so a misconfigured binary path looks like "nothing
+happens".
+
+**`[E_INSTALL_AGENT_DEFERRED]` when installing opencode.** Expected: the
+OpenCode installer is deliberately deferred (see above). Wire a JS/TS plugin
+that invokes `rusty-brain-hooks --agent opencode` instead;
+`scripts/fixtures/opencode-logger/` demonstrates the plugin shape.
+
+**Capture is `partial` for my agent — where did my session go?** `partial`
+means per-tool observations reach the per-session scratch, but no fold event
+fires, so no session summary is written; the scratch ages out after 24h
+(`scratch::prune_stale`). This is the documented state for Codex and Gemini
+until their terminus events are fixture-verified. Existing memories still
+recall and inject normally.
+
+**Scorecard prints one line and exits 0.** That is a machine-readable skip,
+not a silent success. Fields: `agent`, `dimension`, `scenario`, `phase` (the
+earliest blocked pipeline stage: `capture`, `config`, or `scoring`),
+`status=skip`, `reason`, `detail`. A supported target that fails instead
+reports per-run failures with agent and phase.
+
+**No memories injected at prompt time.** Prompt-time retrieval is
+Claude-Code-only today (see the matrix). For Codex, injection happens at
+`SessionStart` only. For OpenCode, no injection channel is active.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -137,9 +137,10 @@ that invokes `rusty-brain-hooks --agent opencode` instead;
 **Capture is `partial` for my agent — where did my session go?** `partial`
 means per-tool observations reach the per-session scratch, but no fold event
 fires, so no session summary is written; the scratch ages out after 24h
-(`scratch::prune_stale`). This is the documented state for Codex and Gemini
-until their terminus events are fixture-verified. Existing memories still
-recall and inject normally.
+(`scratch::prune_stale`). This is the documented state for Codex (until its
+terminus event is fixture-verified) and for Gemini (deliberately descoped —
+no fixture or mapping work is planned). Existing memories still recall and
+inject normally.
 
 **Scorecard prints one line and exits 0.** That is a machine-readable skip,
 not a silent success. Fields: `agent`, `dimension`, `scenario`, `phase` (the

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,8 +1,8 @@
 # Agent Support
 
 rusty-brain is a cross-agentic memory system: the current sprint targets
-OpenCode and Codex as first-class agents alongside Claude Code, with Hermes as
-a discovery-gated candidate (see
+OpenCode and Codex as first-priority agents alongside Claude Code, with Hermes
+as a discovery-gated candidate (see
 `docs/prds/2026-06-23-cross-agentic-agent-parity.md`).
 
 The source of truth for per-agent support is the capability matrix in

--- a/docs/prds/2026-06-23-cross-agentic-agent-parity.md
+++ b/docs/prds/2026-06-23-cross-agentic-agent-parity.md
@@ -2,7 +2,16 @@
 
 ## Status
 
-New sprint task, draft. This is the task requested on 2026-06-23 after confirming the current sprint is still Claude-heavy.
+Delivered 2026-07-11 (Vikunja #380), on top of the groundwork landed via PRs #43/#45/#49/#54. All acceptance criteria are met; the items that remain open are deliberately fixture- or upstream-gated, not unfinished work:
+
+- Codex capture fold (terminus mapping): gated on a recorded Codex lifecycle fixture (`docs/plans/2026-06-26-cross-cli-terminus-mapping.md`); `apply_patch` additionally upstream-blocked ([openai/codex#16732](https://github.com/openai/codex/issues/16732)).
+- Codex/OpenCode prompt-time retrieval: no native prompt event is mapped until a recorded fixture proves its shape (CA6 "documented gap" path).
+- OpenCode installer: explicitly deferred by decision — OpenCode needs a JS/TS plugin, so the JSON installer fails closed with `[E_INSTALL_AGENT_DEFERRED]`; the adapter path is validated without it (CA2's sanctioned alternative).
+- OpenCode/Codex scorecard runs: skipped with machine-readable per-agent lines naming the blocked phase; enablement is a follow-on runner task.
+
+User-facing support levels, setup, and troubleshooting: `docs/AGENTS.md`; source of truth: `crates/rb-agents/src/capability.rs` (README table drift-guarded by `crates/rb-agents/tests/capability_docs.rs`).
+
+Originally: new sprint task requested on 2026-06-23 after confirming the current sprint was still Claude-heavy.
 
 ## Owner Area
 
@@ -224,18 +233,18 @@ Unsupported targets must produce clear skip output rather than ambiguous success
 
 ## Implementation Checklist
 
-- [ ] Audit W3.1, W3.2, and W3.5 for Claude-specific assumptions.
-- [ ] Define capability matrix.
-- [ ] Verify OpenCode capture path.
-- [ ] Verify OpenCode retrieval path or document unsupported status.
-- [ ] Verify Codex capture path.
-- [ ] Verify Codex retrieval path or document unsupported status.
-- [ ] Link Codex `apply_patch` readiness gate.
-- [ ] Decide OpenCode installer/plugin scope.
-- [ ] Extend scorecard agent target selection.
-- [ ] Add per-agent scorecard output.
-- [ ] Add or update tests for unsupported/skipped capabilities.
-- [ ] Add Hermes discovery record.
-- [ ] Update setup and troubleshooting docs.
-- [ ] Run Claude, Codex, and OpenCode validation.
-- [ ] Add board/status updates for remaining unsupported gaps.
+- [x] Audit W3.1, W3.2, and W3.5 for Claude-specific assumptions (Claude-only runner paths documented in `docs/plans/2026-06-26-cross-cli-terminus-mapping.md`).
+- [x] Define capability matrix (`crates/rb-agents/src/capability.rs`; README copy drift-guarded).
+- [x] Verify OpenCode capture path (`session.idle` → `SessionCheckpoint` fold + `apply_patch` V4A path extraction, fixture-backed; PR #54).
+- [x] Verify OpenCode retrieval path or document unsupported status (documented unsupported: no prompt event mapped; `docs/AGENTS.md`).
+- [x] Verify Codex capture path (shell capture works; terminus fold fixture-gated at `capture: Partial`).
+- [x] Verify Codex retrieval path or document unsupported status (documented unsupported; `SessionStart` injection is the closest active equivalent).
+- [x] Link Codex `apply_patch` readiness gate (`docs/follow-ups/2026-06-02-codex-apply-patch-capture.md`, openai/codex#16732).
+- [x] Decide OpenCode installer/plugin scope (deferred by decision: `[E_INSTALL_AGENT_DEFERRED]` fails closed; adapter path validated; plugin install is a follow-on).
+- [x] Extend scorecard agent target selection (`--agent claude-code|codex|opencode|gemini|hermes|all`).
+- [x] Add per-agent scorecard output (skip lines carry agent/dimension/scenario/phase/reason/detail; `phase` names the earliest blocked stage).
+- [x] Add or update tests for unsupported/skipped capabilities (`--self-test` skip assertions for all four agents; `scripts/memory-scorecard.test.sh`; `capability_docs.rs`).
+- [x] Add Hermes discovery record (`docs/follow-ups/2026-06-23-hermes-discovery.md`; no invented hook names).
+- [x] Update setup and troubleshooting docs (`docs/AGENTS.md`, README cross-agentic framing).
+- [x] Run Claude, Codex, and OpenCode validation (`cargo test -p rb-agents -p rb-hooks -p rb-install`; `--self-test`; all four skip targets; Claude live scorecard unchanged and budget-gated).
+- [x] Add board/status updates for remaining unsupported gaps (Status section above).

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -81,10 +81,24 @@ scorecard_skip_detail() { # agent
   esac
 }
 
+# The earliest blocked pipeline stage (capture|retrieval|config|scoring) for an
+# unsupported agent, so machine-readable skips triage to the real gate:
+#   codex    -> capture (terminus/apply_patch fixture-gated; see capability.rs)
+#   opencode -> config  (rb-install JS/TS plugin path deferred; adapter works)
+#   hermes   -> config  (discovery-gated; no verified config path to install)
+#   gemini   -> scoring (adapter/capture exist; scorecard support unimplemented)
+scorecard_skip_phase() { # agent
+  case "$1" in
+    codex)           printf 'capture' ;;
+    opencode|hermes) printf 'config' ;;
+    *)               printf 'scoring' ;;
+  esac
+}
+
 scorecard_skip_line() { # agent
   local agent="$1"
-  printf 'agent=%s\tdimension=all\tscenario=all\tphase=scoring\tstatus=skip\treason=%s\tdetail=%s\n' \
-    "$agent" "$(scorecard_skip_reason "$agent")" "$(scorecard_skip_detail "$agent")"
+  printf 'agent=%s\tdimension=all\tscenario=all\tphase=%s\tstatus=skip\treason=%s\tdetail=%s\n' \
+    "$agent" "$(scorecard_skip_phase "$agent")" "$(scorecard_skip_reason "$agent")" "$(scorecard_skip_detail "$agent")"
 }
 
 # ---- pure judge (P: gate's substring judge; exercised by --self-test) --------
@@ -533,12 +547,32 @@ self_test() {
     echo "BUG: reach identity layout"; fail=1
   fi
 
+  # Skip lines are a machine contract: phase names the earliest blocked pipeline
+  # stage (capture/retrieval/config/scoring), not a blanket phase=scoring.
   local skip_line
   skip_line="$(scorecard_skip_line codex)"
-  if printf '%s' "$skip_line" | grep -qF $'agent=codex\tdimension=all\tscenario=all\tphase=scoring\tstatus=skip\treason=scorecard_unsupported_codex_fixture_gated'; then
-    echo "ok: scorecard unsupported agent skip is machine-readable"
+  if printf '%s' "$skip_line" | grep -qF $'agent=codex\tdimension=all\tscenario=all\tphase=capture\tstatus=skip\treason=scorecard_unsupported_codex_fixture_gated'; then
+    echo "ok: scorecard codex skip is machine-readable and names the capture gate"
   else
-    echo "BUG: scorecard unsupported agent skip line"; printf '%s\n' "$skip_line"; fail=1
+    echo "BUG: scorecard codex skip line"; printf '%s\n' "$skip_line"; fail=1
+  fi
+  skip_line="$(scorecard_skip_line opencode)"
+  if printf '%s' "$skip_line" | grep -qF $'agent=opencode\tdimension=all\tscenario=all\tphase=config\tstatus=skip\treason=scorecard_unsupported_opencode_plugin_deferred'; then
+    echo "ok: scorecard opencode skip is machine-readable and names the config gate"
+  else
+    echo "BUG: scorecard opencode skip line"; printf '%s\n' "$skip_line"; fail=1
+  fi
+  skip_line="$(scorecard_skip_line hermes)"
+  if printf '%s' "$skip_line" | grep -qF $'agent=hermes\tdimension=all\tscenario=all\tphase=config\tstatus=skip\treason=scorecard_unsupported_hermes_discovery_gated'; then
+    echo "ok: scorecard hermes skip is machine-readable and names the config gate"
+  else
+    echo "BUG: scorecard hermes skip line"; printf '%s\n' "$skip_line"; fail=1
+  fi
+  skip_line="$(scorecard_skip_line gemini)"
+  if printf '%s' "$skip_line" | grep -qF $'agent=gemini\tdimension=all\tscenario=all\tphase=scoring\tstatus=skip\treason=scorecard_unsupported_gemini_not_first_priority'; then
+    echo "ok: scorecard gemini skip is machine-readable (scorecard itself unimplemented)"
+  else
+    echo "BUG: scorecard gemini skip line"; printf '%s\n' "$skip_line"; fail=1
   fi
   if scorecard_agent_supported claude-code && ! scorecard_agent_supported codex; then
     echo "ok: only claude-code is currently scorecard-supported"

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -550,7 +550,7 @@ self_test() {
   fi
 
   # Skip lines are a machine contract: phase names the earliest blocked pipeline
-  # stage (capture/retrieval/config/scoring), not a blanket phase=scoring.
+  # stage (capture/config/scoring), not a blanket phase=scoring.
   local skip_line
   skip_line="$(scorecard_skip_line codex)"
   if printf '%s' "$skip_line" | grep -qF $'agent=codex\tdimension=all\tscenario=all\tphase=capture\tstatus=skip\treason=scorecard_unsupported_codex_fixture_gated'; then

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -81,8 +81,10 @@ scorecard_skip_detail() { # agent
   esac
 }
 
-# The earliest blocked pipeline stage (capture|retrieval|config|scoring) for an
-# unsupported agent, so machine-readable skips triage to the real gate:
+# The earliest blocked pipeline stage (capture|config|scoring) for an
+# unsupported agent, so machine-readable skips triage to the real gate.
+# `retrieval` gaps never appear here: a missing injection channel does not stop
+# the harness from running; capture/config gaps do.
 #   codex    -> capture (terminus/apply_patch fixture-gated; see capability.rs)
 #   opencode -> config  (rb-install JS/TS plugin path deferred; adapter works)
 #   hermes   -> config  (discovery-gated; no verified config path to install)

--- a/scripts/memory-scorecard.test.sh
+++ b/scripts/memory-scorecard.test.sh
@@ -67,6 +67,7 @@ _source_pure_functions() {
   }
 
   # scorecard_skip_phase — earliest blocked pipeline stage per agent
+  # (capture|config|scoring; retrieval gaps never block the harness)
   scorecard_skip_phase() {
     case "$1" in
       codex)           printf 'capture' ;;

--- a/scripts/memory-scorecard.test.sh
+++ b/scripts/memory-scorecard.test.sh
@@ -55,7 +55,7 @@ _source_pure_functions() {
         printf 'OpenCode scorecard is blocked until the JS/TS plugin config path and lifecycle fixtures are implemented.'
         ;;
       gemini)
-        printf 'Gemini has an adapter, but the cross-agentic scorecard currently targets Claude Code, Codex, and OpenCode.'
+        printf 'Gemini has an adapter, but the cross-agentic scorecard currently supports only Claude Code; Gemini scorecard support is not yet implemented.'
         ;;
       hermes)
         printf 'Hermes is discovery-gated; no hook names, config paths, or lifecycle semantics are verified.'
@@ -66,11 +66,20 @@ _source_pure_functions() {
     esac
   }
 
-  # scorecard_skip_line — lines 84-88
+  # scorecard_skip_phase — earliest blocked pipeline stage per agent
+  scorecard_skip_phase() {
+    case "$1" in
+      codex)           printf 'capture' ;;
+      opencode|hermes) printf 'config' ;;
+      *)               printf 'scoring' ;;
+    esac
+  }
+
+  # scorecard_skip_line
   scorecard_skip_line() {
     local agent="$1"
-    printf 'agent=%s\tdimension=all\tscenario=all\tphase=scoring\tstatus=skip\treason=%s\tdetail=%s\n' \
-      "$agent" "$(scorecard_skip_reason "$agent")" "$(scorecard_skip_detail "$agent")"
+    printf 'agent=%s\tdimension=all\tscenario=all\tphase=%s\tstatus=skip\treason=%s\tdetail=%s\n' \
+      "$agent" "$(scorecard_skip_phase "$agent")" "$(scorecard_skip_reason "$agent")" "$(scorecard_skip_detail "$agent")"
   }
 }
 _source_pure_functions
@@ -161,6 +170,12 @@ pass "scorecard_skip_detail returns non-empty fallback for unknown agent"
 for agent in codex opencode gemini hermes; do
   skip_line="$(scorecard_skip_line "$agent")"
 
+  case "$agent" in
+    codex)           expected_phase="capture" ;;
+    opencode|hermes) expected_phase="config" ;;
+    *)               expected_phase="scoring" ;;
+  esac
+
   printf '%s' "$skip_line" | grep -qF "agent=$agent" \
     || fail "$agent skip line missing 'agent=$agent': $skip_line"
 
@@ -170,8 +185,8 @@ for agent in codex opencode gemini hermes; do
   printf '%s' "$skip_line" | grep -qF "scenario=all" \
     || fail "$agent skip line missing 'scenario=all': $skip_line"
 
-  printf '%s' "$skip_line" | grep -qF "phase=scoring" \
-    || fail "$agent skip line missing 'phase=scoring': $skip_line"
+  printf '%s' "$skip_line" | grep -qF "phase=$expected_phase" \
+    || fail "$agent skip line missing 'phase=$expected_phase': $skip_line"
 
   printf '%s' "$skip_line" | grep -qF "status=skip" \
     || fail "$agent skip line missing 'status=skip': $skip_line"
@@ -190,7 +205,7 @@ done
 #    (regression test matching the --self-test assertion inside the script)
 # ---------------------------------------------------------------------------
 codex_skip="$(scorecard_skip_line codex)"
-expected_codex_prefix="agent=codex	dimension=all	scenario=all	phase=scoring	status=skip	reason=scorecard_unsupported_codex_fixture_gated"
+expected_codex_prefix="agent=codex	dimension=all	scenario=all	phase=capture	status=skip	reason=scorecard_unsupported_codex_fixture_gated"
 printf '%s' "$codex_skip" | grep -qF "$expected_codex_prefix" \
   || fail "codex skip line does not match expected prefix. got: $codex_skip"
 pass "scorecard_skip_line codex matches machine-readable prefix exactly"


### PR DESCRIPTION
## Summary

Closes out the cross-agentic agent parity PRD (`docs/prds/2026-06-23-cross-agentic-agent-parity.md`, Vikunja #380). A gap analysis against the PRD's acceptance criteria showed most of it already landed via PRs #43/#45/#49/#54 (capability matrix, scorecard `--agent` selection, Hermes discovery record, OpenCode capture); this PR delivers the remainder — doc/consistency guards, CA5 skip-phase precision, and CA7 setup/troubleshooting docs — and records the deliberately gated gaps.

## What changed

- **Capability-matrix drift guard (CA1/CA7)** — the README matrix had drifted (opencode still said `partial` capture after PR #54 graduated it to `supported`). New `crates/rb-agents/tests/capability_docs.rs` parses the README table and asserts every adapter/capture/retrieval/config/scorecard cell against `capability.rs`, so docs can no longer drift silently; README rows synced (opencode capture, gemini descoped wording, codex upstream-blocker link).
- **Scorecard skip phase (CA5)** — `scorecard_skip_line` hardcoded `phase=scoring`. New `scorecard_skip_phase` names the earliest blocked pipeline stage: codex→`capture` (terminus fixture-gated), opencode/hermes→`config` (plugin deferred / discovery-gated), gemini→`scoring`. `--self-test` now asserts all four agents' skip lines (was codex-only); the vendored copies in `scripts/memory-scorecard.test.sh` were updated in lockstep (including a pre-existing drifted gemini detail string). Tab-delimited field order is unchanged.
- **Per-agent docs (CA6/CA7)** — new `docs/AGENTS.md`: per-agent setup paths (Codex `.codex/hooks.json`; OpenCode installer explicitly deferred with the `[E_INSTALL_AGENT_DEFERRED]` rationale and the plugin wiring shown by `scripts/fixtures/opencode-logger/`), closest retrieval equivalents (Codex: `SessionStart` injection only; OpenCode: none — no invented events), validation commands, and troubleshooting. README now names the agent surface cross-agentic and links the guide.
- **PRD status** — checklist completed with per-item evidence; Status section records the gated remainders.

## Design decisions

- **OpenCode installer stays deferred** (the PRD's sanctioned alternative): the adapter path is fixture-validated without it, `E_INSTALL_AGENT_DEFERRED` fails closed with a tested message, and the JS/TS plugin is a follow-on track.
- **Retrieval = documented gap, not fake parity**: no Codex/OpenCode prompt events are mapped until recorded fixtures prove their shapes.

## Still gated (by design)

Codex terminus fold (needs recorded lifecycle fixture), Codex `apply_patch` (upstream: openai/codex#16732), Codex/OpenCode prompt-time retrieval fixtures, OpenCode plugin installer, OpenCode/Codex scorecard enablement.

## Test plan

- [x] `cargo test -p rb-agents -p rb-hooks -p rb-install` — 334 passed (332 baseline + 2 new)
- [x] `cargo clippy -p rb-agents --all-targets -- -D warnings` — clean
- [x] `scripts/memory-scorecard.sh --self-test` — PASS
- [x] `scripts/memory-scorecard.sh --agent codex|opencode|gemini|hermes --runs 1` — machine-readable skips with correct phases, exit 0
- [x] `scripts/memory-scorecard.sh --agent all --runs 1` — prints all skips before the live claude-code path
- [x] `sh scripts/memory-scorecard.test.sh` — PASS
- [x] No Claude Code behavior change: no edits to capture/dispatch/adapter/runner paths; the new guard test failed RED on the stale README cell before the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a cross-agent support overview covering capture, retrieval, configuration, and scorecards.
  * Clarified fail-open hook behavior and documented setup, troubleshooting, and validation guidance.
  * Updated the capability matrix with current support and limitations for Claude Code, Codex, OpenCode, Gemini, and Hermes.

* **Improvements**
  * Scorecard skip messages now identify the earliest blocked phase, such as capture, configuration, or scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->