### PR TITLE
feat: doctor/stats observability surface (Vikunja #460)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "rb-mcp",
  "rb-proto",
  "rb-redact",
+ "rb-store",
  "rb-types",
  "serde",
  "serde_json",

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -50,6 +50,12 @@ const REEMBED_MAX_LIMIT: usize = 10_000;
 const HOOK_NEAR_DUP_THRESHOLD: f32 = 0.97;
 /// Max existing hook near-dups absorbed per write (bounds the extra reads).
 const HOOK_NEAR_DUP_LIMIT: usize = 8;
+/// Default window for the stats aggregate when a `Stats` request omits one.
+const STATS_DEFAULT_WINDOW_DAYS: u32 = 30;
+/// Hard cap on the stats window so a client cannot force an unbounded scan.
+const STATS_MAX_WINDOW_DAYS: u32 = 365;
+/// Bound on the top-recalled id list in a stats reply (ids + counts only).
+const STATS_TOP_RECALLED_LIMIT: usize = 5;
 /// Maximum number of simultaneous client connections.
 const MAX_CONNECTIONS: usize = 256;
 /// Oplog rows fetched per replay batch on a `subscribe --since` reconnect.
@@ -590,6 +596,7 @@ fn is_admin_op(req: &Request) -> bool {
         | Request::Delete { .. }
         | Request::Context
         | Request::Subscribe { .. }
+        | Request::Stats { .. }
         | Request::Ping => false,
     }
 }
@@ -668,6 +675,9 @@ async fn handle_connection(
 
     let store_for_stream = store.clone();
     let job_store = store.clone();
+    // Snapshot the provider identity before the embedder moves into the
+    // engine; the stats path reports it alongside the DB's recorded model.
+    let provider_model = embedder.model_id().to_string();
     let engine = {
         let base =
             MemoryEngine::new(store, embedder, namespace.clone()).with_fusion_mode(fusion_mode);
@@ -700,6 +710,7 @@ async fn handle_connection(
             &provenance,
             &recall_counters,
             &namespace,
+            &provider_model,
             peer,
             req,
         )
@@ -883,6 +894,7 @@ async fn dispatch<P>(
     provenance: &rb_engine::Provenance,
     recall_counters: &RecallChannelCounters,
     namespace: &rb_types::Namespace,
+    provider_model: &str,
     peer: PeerIdentity,
     req: Request,
 ) -> Response
@@ -1060,6 +1072,33 @@ where
             Ok(confidence) => Response::FeedbackRecorded { confidence },
             Err(e) => error_to_response(e),
         },
+        // Namespace-scoped read-only observability aggregate (doctor/stats
+        // PRD). Runs entirely on the read pool — zero writer ops (W1.8). The
+        // window is clamped server-side (never trusted raw); the re-embed
+        // backlog compares against the LIVE provider identity and the current
+        // input composition, mirroring the reembed scan.
+        Request::Stats { window_days } => {
+            let window = window_days
+                .unwrap_or(STATS_DEFAULT_WINDOW_DAYS)
+                .clamp(1, STATS_MAX_WINDOW_DAYS);
+            match job_store
+                .namespace_stats(
+                    namespace.clone(),
+                    window,
+                    provider_model.to_string(),
+                    rb_engine::EMBEDDING_INPUT_VERSION.to_string(),
+                    STATS_TOP_RECALLED_LIMIT,
+                )
+                .await
+            {
+                Ok(stats) => Response::Stats {
+                    stats,
+                    provider_model: provider_model.to_string(),
+                    writer_alive: job_store.writer_alive(),
+                },
+                Err(e) => error_to_response(e),
+            }
+        }
         // Admin op (peer-gated above): retroactive secret redaction across all
         // namespaces through the single writer (W2.4).
         Request::Scrub => match job_store.scrub().await {
@@ -1120,6 +1159,9 @@ mod tests {
                 tags: vec![],
                 limit: 1,
             },
+            // Stats is namespace-scoped by the handshake (read-only, W1.8),
+            // like Context — deliberately NOT peer-gated.
+            Request::Stats { window_days: None },
         ] {
             assert!(!is_admin_op(&not_admin), "{not_admin:?}");
         }
@@ -1306,6 +1348,114 @@ mod tests {
             .expect("daemon must exit its accept loop after writer death")
             .expect("run task must not panic")
             .expect("run must return Ok on writer-death shutdown");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stats_over_the_wire_reflects_seeded_feedback_and_issues_zero_writer_ops() {
+        // Daemon e2e for the PRD verification clause: a seeded feedback
+        // distribution comes back through `Request::Stats`, and serving it
+        // enqueues NOTHING on the writer thread (zero writer ops == zero FTS
+        // writes; every FTS write rides a writer op).
+        use rb_embed::DeterministicProvider;
+        use rb_types::FeedbackKind;
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let config = DaemonConfig {
+            socket_path: dir.path().join("rb.sock"),
+            db_path: dir.path().join("rb.db"),
+            read_pool_size: 2,
+            jobs_config: JobsConfig::default(),
+            request_idle_timeout: None,
+            enrich: None,
+            fusion_mode: rb_engine::FusionMode::Linear,
+        };
+        let socket = config.socket_path.clone();
+        let daemon = Daemon::bind(
+            config,
+            crate::SharedEmbedder::new(DeterministicProvider::new(8)),
+        )
+        .await
+        .unwrap();
+        let store = daemon.store.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let run = tokio::spawn(daemon.run(async {
+            let _ = shutdown_rx.await;
+        }));
+
+        let ns = Namespace::Project("stats-e2e".to_string());
+        let mut client = rb_proto::Client::connect(&socket, ns.clone())
+            .await
+            .unwrap();
+        let mut ids = Vec::new();
+        for body in ["alpha decision", "beta pattern", "gamma insight"] {
+            let id = client
+                .remember(
+                    body.to_string(),
+                    None,
+                    rb_types::MemoryType::Insight,
+                    5,
+                    vec![],
+                    vec![],
+                    vec![],
+                    None,
+                )
+                .await
+                .unwrap();
+            ids.push(id);
+        }
+        // Seeded distribution: 2 helpful, 1 wrong, 0 stale.
+        client
+            .feedback(ids[0].clone(), FeedbackKind::Helpful)
+            .await
+            .unwrap();
+        client
+            .feedback(ids[1].clone(), FeedbackKind::Helpful)
+            .await
+            .unwrap();
+        client
+            .feedback(ids[2].clone(), FeedbackKind::Wrong)
+            .await
+            .unwrap();
+
+        let ops_before = store.writer_ops_count();
+        let (stats, provider_model, writer_alive) = client.stats(Some(14)).await.unwrap();
+        assert_eq!(
+            store.writer_ops_count(),
+            ops_before,
+            "the stats path must issue ZERO writer ops (and hence zero FTS writes)"
+        );
+
+        assert_eq!(stats.namespace, ns.as_db_string());
+        assert_eq!(stats.window_days, 14);
+        assert_eq!(stats.live, 3);
+        assert_eq!(stats.archived, 0);
+        assert_eq!(stats.vectors, 3);
+        assert_eq!(stats.feedback.helpful, 2);
+        assert_eq!(stats.feedback.wrong, 1);
+        assert_eq!(stats.feedback.stale, 0);
+        assert_eq!(stats.never_recalled_live, 3, "nothing was recalled");
+        assert_eq!(stats.reembed_pending, 0, "stamps match the live provider");
+        assert_eq!(stats.db_embedding_model.as_deref(), Some("deterministic"));
+        assert_eq!(provider_model, "deterministic");
+        assert!(writer_alive);
+
+        // The window is clamped server-side, never trusted raw.
+        let (clamped, _, _) = client.stats(Some(100_000)).await.unwrap();
+        assert_eq!(
+            clamped.window_days, 365,
+            "oversized windows clamp to a year"
+        );
+        let (defaulted, _, _) = client.stats(None).await.unwrap();
+        assert_eq!(defaulted.window_days, 30, "absent window uses the default");
+
+        drop(client);
+        let _ = shutdown_tx.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(10), run)
+            .await
+            .expect("daemon must shut down")
+            .expect("run task must not panic")
+            .expect("run must return Ok");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -482,6 +482,32 @@ impl StoreHandle {
             .await
     }
 
+    /// Namespace-scoped observability aggregate (doctor/stats PRD). Goes
+    /// through the bounded read pool — the stats path issues zero writer ops
+    /// (W1.8) by construction. `model`/`input_version` are the CURRENT
+    /// embedding stamp (for the re-embed backlog count); `top_limit` bounds
+    /// the top-recalled list.
+    pub async fn namespace_stats(
+        &self,
+        namespace: Namespace,
+        window_days: u32,
+        model: String,
+        input_version: String,
+        top_limit: usize,
+    ) -> Result<rb_types::MemoryStats> {
+        self.with_read(move |store| {
+            store.namespace_stats(&namespace, window_days, &model, &input_version, top_limit)
+        })
+        .await
+    }
+
+    /// Whether the writer thread is alive (i.e. has not died ABNORMALLY).
+    /// Snapshot of the same watch [`StoreHandle::writer_died`] resolves on;
+    /// surfaced on the stats/status path so a zombie-adjacent state is visible.
+    pub fn writer_alive(&self) -> bool {
+        !*self.writer_death.borrow()
+    }
+
     /// Gracefully close the write queue and join the dedicated writer thread.
     pub async fn shutdown(self) {
         // Final access flush (W1.8): persist whatever the interval flusher has
@@ -2640,6 +2666,74 @@ mod tests {
         );
 
         handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn namespace_stats_runs_on_the_read_pool_with_zero_writer_ops() {
+        // W1.8 mirror for the stats path (doctor/stats PRD hard constraint):
+        // the whole aggregation runs on the read pool and must enqueue NOTHING
+        // on the writer thread — which also proves it triggers zero FTS writes
+        // (every FTS write rides a writer op).
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("zero-writer-stats".to_string());
+
+        let a = note(&ns, "stats aggregate over feedback");
+        let b = note(&ns, "stats aggregate over accesses");
+        let (aid, bid) = (a.id.clone(), b.id.clone());
+        handle.write(a, Some(vec![0.1f32; DIM])).await.unwrap();
+        handle.write(b, Some(vec![0.2f32; DIM])).await.unwrap();
+        handle
+            .record_feedback(ns.clone(), aid, rb_types::FeedbackKind::Helpful, None)
+            .await
+            .unwrap();
+        handle
+            .record_feedback(ns.clone(), bid.clone(), rb_types::FeedbackKind::Wrong, None)
+            .await
+            .unwrap();
+        handle
+            .record_feedback(ns.clone(), bid, rb_types::FeedbackKind::Stale, None)
+            .await
+            .unwrap();
+
+        let ops_before = handle.writer_ops_count();
+        let stats = handle
+            .namespace_stats(ns.clone(), 30, String::new(), String::new(), 5)
+            .await
+            .unwrap();
+        assert_eq!(
+            handle.writer_ops_count(),
+            ops_before,
+            "stats must issue ZERO writer-thread ops (W1.8)"
+        );
+
+        assert_eq!(stats.namespace, ns.as_db_string());
+        assert_eq!(stats.live, 2);
+        assert_eq!(stats.feedback.helpful, 1);
+        assert_eq!(stats.feedback.wrong, 1);
+        assert_eq!(stats.feedback.stale, 1);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn writer_alive_reports_liveness_and_flips_on_death() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 1).unwrap();
+        assert!(handle.writer_alive(), "a fresh handle has a live writer");
+
+        handle.kill_writer_for_test().await;
+        // The death watch flips asynchronously with the thread exit; poll.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while handle.writer_alive() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(
+            !handle.writer_alive(),
+            "an abnormally dead writer must report not-alive"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -489,6 +489,20 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
             }),
             false,
         ),
+        // Stats is a CLI observability surface (doctor/stats PRD) with no MCP
+        // tool yet; projected anyway so the mapping stays total.
+        Response::Stats {
+            stats,
+            provider_model,
+            writer_alive,
+        } => ToolContent::json(
+            json!({
+                "stats": stats,
+                "provider_model": provider_model,
+                "writer_alive": writer_alive,
+            }),
+            false,
+        ),
         Response::Error { kind, message } => ToolContent::json(
             json!({ "error": { "kind": kind, "message": message } }),
             true,

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -322,6 +322,13 @@ mod tests {
                     redacted: 0,
                     reembed_pending: 0,
                 },
+                // No MCP tool maps to the stats observability op; the arm
+                // exists only to keep this fake total over `Request`.
+                Request::Stats { .. } => Response::Stats {
+                    stats: rb_types::MemoryStats::default(),
+                    provider_model: String::new(),
+                    writer_alive: true,
+                },
             })
         }
     }

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -478,6 +478,27 @@ impl Client {
         }
     }
 
+    /// Namespace-scoped observability aggregate (doctor/stats PRD). Returns
+    /// `(stats, provider_model, writer_alive)`: the read-pool aggregate for
+    /// this connection's namespace, the daemon's running embedding-model
+    /// identity, and writer-thread liveness. `window_days` bounds the windowed
+    /// fields (`None` = daemon default). Read-only server-side: the stats path
+    /// issues zero writer ops (W1.8).
+    pub async fn stats(
+        &mut self,
+        window_days: Option<u32>,
+    ) -> Result<(rb_types::MemoryStats, String, bool)> {
+        let resp = self.request(Request::Stats { window_days }).await?;
+        match resp {
+            Resp::Stats {
+                stats,
+                provider_model,
+                writer_alive,
+            } => Ok((stats, provider_model, writer_alive)),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
     /// One-time namespace rename (W0.3 carryover): re-scope every memory from
     /// `old` to `new` in one daemon writer transaction. Refused with
     /// `Error::InvalidArgument` when `new` already has rows unless `merge` is
@@ -770,6 +791,17 @@ mod wrapper_tests {
                     redacted: 0,
                     reembed_pending: 0,
                 },
+                // Canned payload keyed on `window_days` so the typed-wrapper
+                // test can prove the window rides the wire.
+                Request::Stats { window_days } => Response::Stats {
+                    stats: rb_types::MemoryStats {
+                        window_days: window_days.unwrap_or(30),
+                        live: 5,
+                        ..Default::default()
+                    },
+                    provider_model: "deterministic".to_string(),
+                    writer_alive: true,
+                },
             };
             write_frame(&mut framed, &resp).await.unwrap();
         }
@@ -869,6 +901,16 @@ mod wrapper_tests {
             .await
             .unwrap();
         assert_eq!((moved, vectors), (7, 2));
+
+        // The fake server echoes the window into the payload, proving the
+        // window rides the wire and the payload comes back typed.
+        let (stats, provider_model, writer_alive) = c.stats(Some(7)).await.unwrap();
+        assert_eq!(stats.window_days, 7);
+        assert_eq!(stats.live, 5);
+        assert_eq!(provider_model, "deterministic");
+        assert!(writer_alive);
+        let (stats, _, _) = c.stats(None).await.unwrap();
+        assert_eq!(stats.window_days, 30, "None uses the daemon default");
 
         drop(c);
         server.await.unwrap();

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -190,6 +190,20 @@ pub enum Request {
         id: MemoryId,
         kind: FeedbackKind,
     },
+    /// Namespace-scoped observability aggregate (doctor/stats PRD): recall
+    /// volume, feedback ratios, top/never-recalled, contested count, corpus
+    /// growth, re-embed backlog. Scoped to the connection's handshake
+    /// namespace like `Context` (NOT an admin op); computed entirely on the
+    /// daemon's read pool — the stats path issues ZERO writer ops (W1.8).
+    /// `window_days` bounds the windowed fields; `None` uses the daemon
+    /// default. Additive variant per the `Feedback` precedent: an old daemon
+    /// fails to decode it and closes the connection (no CONTRACT_VERSION
+    /// bump), and the `#[serde(default)]`/`skip_serializing_if` pair keeps a
+    /// window-less frame byte-identical to a bare unit variant.
+    Stats {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window_days: Option<u32>,
+    },
 }
 
 /// Aggregate per-channel recall hit-contribution totals (W1.0), surfaced on
@@ -286,6 +300,19 @@ pub enum Response {
     /// send the request.
     FeedbackRecorded {
         confidence: f32,
+    },
+    /// Reply to `Request::Stats`: the namespace-scoped aggregate plus two
+    /// daemon-side health facts the store cannot know — the running embedding
+    /// provider's model identity and writer-thread liveness (both
+    /// `#[serde(default)]` so the payload stays additive). Counts and ids
+    /// only, never memory content. Additive variant; old clients never see it
+    /// because they never send the request.
+    Stats {
+        stats: rb_types::MemoryStats,
+        #[serde(default)]
+        provider_model: String,
+        #[serde(default)]
+        writer_alive: bool,
     },
     Error {
         kind: String,
@@ -590,6 +617,10 @@ mod tests {
                 id: MemoryId::new(),
                 kind: rb_types::FeedbackKind::Wrong,
             },
+            Request::Stats { window_days: None },
+            Request::Stats {
+                window_days: Some(14),
+            },
         ]
     }
 
@@ -685,6 +716,24 @@ mod tests {
                 scanned: 200,
                 redacted: 3,
                 reembed_pending: 2,
+            },
+            Response::Stats {
+                stats: rb_types::MemoryStats {
+                    namespace: "global".to_string(),
+                    window_days: 30,
+                    live: 2,
+                    top_recalled: vec![rb_types::TopRecalled {
+                        id: MemoryId::new(),
+                        access_count: 4,
+                    }],
+                    created_per_day: vec![rb_types::GrowthBucket {
+                        day: "2026-07-10".to_string(),
+                        count: 1,
+                    }],
+                    ..Default::default()
+                },
+                provider_model: "deterministic".to_string(),
+                writer_alive: true,
             },
         ]
     }
@@ -824,6 +873,85 @@ mod tests {
         assert_eq!(json, r#"{"result":"Lagged","dropped":7}"#);
         let back: Response = serde_json::from_str(&json).unwrap();
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    #[test]
+    fn stats_request_uses_op_tag_and_window_days_is_additive() {
+        // A window-less Stats request stays byte-identical to a bare
+        // unit-variant frame (the `Subscribe.since` precedent), and the bare
+        // frame decodes to `None` — no CONTRACT_VERSION bump.
+        let json = serde_json::to_string(&Request::Stats { window_days: None }).unwrap();
+        assert_eq!(json, r#"{"op":"Stats"}"#);
+        let back: Request = serde_json::from_str(r#"{"op":"Stats"}"#).unwrap();
+        assert!(matches!(back, Request::Stats { window_days: None }));
+
+        let json = serde_json::to_string(&Request::Stats {
+            window_days: Some(7),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"op":"Stats","window_days":7}"#);
+        let back: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            back,
+            Request::Stats {
+                window_days: Some(7)
+            }
+        ));
+    }
+
+    #[test]
+    fn stats_response_round_trips_with_result_tag() {
+        let resp = Response::Stats {
+            stats: rb_types::MemoryStats {
+                namespace: "project:rusty-brain".to_string(),
+                window_days: 30,
+                live: 10,
+                feedback: rb_types::FeedbackTotals {
+                    helpful: 3,
+                    wrong: 1,
+                    stale: 0,
+                },
+                ..Default::default()
+            },
+            provider_model: "deterministic".to_string(),
+            writer_alive: true,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["result"], "Stats");
+        let back: Response = serde_json::from_str(&json).unwrap();
+        match back {
+            Response::Stats {
+                stats,
+                provider_model,
+                writer_alive,
+            } => {
+                assert_eq!(stats.live, 10);
+                assert_eq!(stats.feedback.helpful, 3);
+                assert_eq!(provider_model, "deterministic");
+                assert!(writer_alive);
+            }
+            other => panic!("expected Stats, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stats_response_daemon_fields_are_additive() {
+        // A frame carrying only the stats payload (a peer predating the
+        // daemon-side fields) must decode with zero-valued defaults.
+        let back: Response = serde_json::from_str(r#"{"result":"Stats","stats":{}}"#).unwrap();
+        match back {
+            Response::Stats {
+                stats,
+                provider_model,
+                writer_alive,
+            } => {
+                assert_eq!(stats, rb_types::MemoryStats::default());
+                assert_eq!(provider_model, "");
+                assert!(!writer_alive);
+            }
+            other => panic!("expected Stats, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rb-store/src/lib.rs
+++ b/crates/rb-store/src/lib.rs
@@ -11,6 +11,6 @@ mod store;
 
 pub use migrations::run_migrations;
 pub use store::{
-    AccessBump, ConsolidationCandidate, LinkRow, NamespaceRenameOutcome, OplogReplayPage, RecalRow,
-    ScrubOutcome, SqliteStore, Store,
+    read_meta_embedding_model, AccessBump, ConsolidationCandidate, LinkRow, NamespaceRenameOutcome,
+    OplogReplayPage, RecalRow, ScrubOutcome, SqliteStore, Store,
 };

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -8,6 +8,7 @@ mod oplog;
 mod reembed;
 mod rename;
 mod scrub;
+mod stats;
 
 use rb_types::{
     Error, MemoryId, MemoryLink, MemoryNote, MemoryType, MemoryUpdates, Namespace, Result,
@@ -164,3 +165,4 @@ pub use link_decay::LinkRow;
 pub use oplog::OplogReplayPage;
 pub use rename::NamespaceRenameOutcome;
 pub use scrub::ScrubOutcome;
+pub use stats::read_meta_embedding_model;

--- a/crates/rb-store/src/store/stats.rs
+++ b/crates/rb-store/src/store/stats.rs
@@ -1,0 +1,507 @@
+//! Read-only observability aggregation (doctor/stats PRD): the queries behind
+//! `rusty-brain stats`/`status`. Inherent-impl module like `oplog.rs` — these
+//! run on the daemon's READ pool, never through the `Store` trait the engine
+//! writes with, so the stats path issues zero writer ops (W1.8) by
+//! construction. Counts and ids only — never memory content.
+
+use super::internal::*;
+use super::*;
+use rb_types::{FeedbackTotals, GrowthBucket, MemoryStats, TopRecalled};
+
+/// Read `meta.embedding_model` from `db_path` over a plain READ-ONLY SQLite
+/// open — no migrations, no writer, no file creation — so `rusty-brain doctor`
+/// can compare the DB's recorded model identity against the configured
+/// provider even while a daemon owns the DB, or when the daemon refuses to
+/// start on a model mismatch (the W0.2 fail-closed contract this check
+/// diagnoses). A missing or unreadable database is an error; a database
+/// without the stamp (legacy) is `Ok(None)`.
+pub fn read_meta_embedding_model(db_path: &std::path::Path) -> Result<Option<String>> {
+    let conn =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| Error::Storage(format!("read-only open {}: {e}", db_path.display())))?;
+    meta_value(&conn, "embedding_model")
+}
+
+/// Decode one `(count_a, count_b)` aggregate row.
+fn two_counts(row: &rusqlite::Row<'_>) -> rusqlite::Result<(u64, u64)> {
+    Ok((
+        row.get::<_, i64>(0)?.max(0) as u64,
+        row.get::<_, i64>(1)?.max(0) as u64,
+    ))
+}
+
+fn count_query(
+    conn: &rusqlite::Connection,
+    sql: &str,
+    params: impl rusqlite::Params,
+) -> Result<u64> {
+    conn.query_row(sql, params, |r| r.get::<_, i64>(0))
+        .map(|n| n.max(0) as u64)
+        .map_err(|e| Error::Storage(e.to_string()))
+}
+
+impl SqliteStore {
+    /// Compute the namespace-scoped value/health aggregate for `ns`
+    /// (doctor/stats PRD). Pure reads — safe on a read-pool connection; the
+    /// caller supplies the bounded `window_days`, the CURRENT
+    /// `(model, input_version)` embedding stamp (for the re-embed backlog),
+    /// and the `top_limit` bound on the top-recalled list.
+    pub fn namespace_stats(
+        &self,
+        ns: &Namespace,
+        window_days: u32,
+        model: &str,
+        input_version: &str,
+        top_limit: usize,
+    ) -> Result<MemoryStats> {
+        let ns_str = ns.as_db_string();
+        let cutoff = chrono::Utc::now().timestamp() - i64::from(window_days) * 86_400;
+
+        let (live, archived) = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FILTER (WHERE archived_at IS NULL),
+                        COUNT(*) FILTER (WHERE archived_at IS NOT NULL)
+                 FROM memories WHERE namespace = ?1",
+                rusqlite::params![ns_str],
+                two_counts,
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        // The vec0 index is one table for the whole DB (DOC-1 ops number).
+        let vectors = count_query(&self.conn, "SELECT COUNT(*) FROM memory_vectors", [])?;
+
+        let (helpful, wrong, stale) = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FILTER (WHERE kind = 'helpful'),
+                        COUNT(*) FILTER (WHERE kind = 'wrong'),
+                        COUNT(*) FILTER (WHERE kind = 'stale')
+                 FROM memory_feedback WHERE namespace = ?1",
+                rusqlite::params![ns_str],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?.max(0) as u64,
+                        row.get::<_, i64>(1)?.max(0) as u64,
+                        row.get::<_, i64>(2)?.max(0) as u64,
+                    ))
+                },
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let (total_accesses, accessed_in_window) = self
+            .conn
+            .query_row(
+                "SELECT COALESCE(SUM(access_count), 0),
+                        COUNT(*) FILTER (WHERE archived_at IS NULL
+                                           AND last_accessed_at >= ?2)
+                 FROM memories WHERE namespace = ?1",
+                rusqlite::params![ns_str, cutoff],
+                two_counts,
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let top_recalled = {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT memory_id, access_count FROM memories
+                     WHERE namespace = ?1 AND archived_at IS NULL AND access_count > 0
+                     ORDER BY access_count DESC, memory_id ASC
+                     LIMIT ?2",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query(rusqlite::params![
+                    ns_str,
+                    i64::try_from(top_limit).unwrap_or(i64::MAX)
+                ])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+                let id: String = row.get(0).map_err(|e| Error::Storage(e.to_string()))?;
+                let count: i64 = row.get(1).map_err(|e| Error::Storage(e.to_string()))?;
+                out.push(TopRecalled {
+                    id: parse_id(&id)?,
+                    access_count: count.max(0) as u64,
+                });
+            }
+            out
+        };
+
+        let never_recalled_live = count_query(
+            &self.conn,
+            "SELECT COUNT(*) FROM memories
+             WHERE namespace = ?1 AND archived_at IS NULL AND access_count = 0",
+            rusqlite::params![ns_str],
+        )?;
+
+        // Distinct memories with an active contradicts link whose BOTH
+        // endpoints are active and in `ns` — the aggregate twin of
+        // `active_contradicts` (Feature C), with the same namespace-purity
+        // reasoning: `memory_links` carries no namespace and permits
+        // cross-namespace edges, so both endpoints are scoped explicitly.
+        let contested = count_query(
+            &self.conn,
+            "SELECT COUNT(*) FROM (
+               SELECT l.source_id AS local FROM memory_links l
+                 JOIN memories far ON far.memory_id = l.target_id
+                 JOIN memories loc ON loc.memory_id = l.source_id
+               WHERE l.link_type = 'contradicts'
+                 AND far.archived_at IS NULL AND loc.archived_at IS NULL
+                 AND far.namespace = ?1 AND loc.namespace = ?1
+               UNION
+               SELECT l.target_id AS local FROM memory_links l
+                 JOIN memories far ON far.memory_id = l.source_id
+                 JOIN memories loc ON loc.memory_id = l.target_id
+               WHERE l.link_type = 'contradicts'
+                 AND far.archived_at IS NULL AND loc.archived_at IS NULL
+                 AND far.namespace = ?1 AND loc.namespace = ?1
+             )",
+            rusqlite::params![ns_str],
+        )?;
+
+        let created_per_day = {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT strftime('%Y-%m-%d', created_at, 'unixepoch') AS day, COUNT(*)
+                     FROM memories
+                     WHERE namespace = ?1 AND created_at >= ?2
+                     GROUP BY day ORDER BY day ASC",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query(rusqlite::params![ns_str, cutoff])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+                let day: String = row.get(0).map_err(|e| Error::Storage(e.to_string()))?;
+                let count: i64 = row.get(1).map_err(|e| Error::Storage(e.to_string()))?;
+                out.push(GrowthBucket {
+                    day,
+                    count: count.max(0) as u64,
+                });
+            }
+            out
+        };
+
+        // Namespace-scoped re-embed backlog: same staleness predicate as the
+        // cross-namespace `memories_for_reembed` scan (P5 Feature A).
+        let reembed_pending = count_query(
+            &self.conn,
+            "SELECT COUNT(*) FROM memories
+             WHERE namespace = ?1 AND archived_at IS NULL
+               AND (embedding_model <> ?2 OR embedding_input_version <> ?3)",
+            rusqlite::params![ns_str, model, input_version],
+        )?;
+
+        let db_path = self.conn.path().unwrap_or("").to_string();
+        let wal_bytes = if db_path.is_empty() {
+            0
+        } else {
+            std::fs::metadata(format!("{db_path}-wal"))
+                .map(|m| m.len())
+                .unwrap_or(0)
+        };
+
+        Ok(MemoryStats {
+            namespace: ns_str,
+            window_days,
+            db_path,
+            live,
+            archived,
+            vectors,
+            wal_bytes,
+            db_embedding_model: meta_value(&self.conn, "embedding_model")?,
+            feedback: FeedbackTotals {
+                helpful,
+                wrong,
+                stale,
+            },
+            total_accesses,
+            accessed_in_window,
+            top_recalled,
+            never_recalled_live,
+            contested,
+            created_per_day,
+            reembed_pending,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use crate::store::Store as _;
+    use crate::SqliteStore;
+    use rb_types::{FeedbackKind, LinkType, MemoryLink, MemoryNote, MemoryType, Namespace};
+
+    const DIM: usize = 8;
+    const MODEL: &str = "deterministic";
+    const INPUT_VERSION: &str = "v2-composite";
+
+    fn open(path: &std::path::Path) -> SqliteStore {
+        SqliteStore::open_with_model(path, DIM, MODEL).unwrap()
+    }
+
+    /// Insert one active memory stamped with the CURRENT (model, input
+    /// version) pair, returning its id.
+    fn seed(store: &SqliteStore, ns: &Namespace, content: &str) -> rb_types::MemoryId {
+        let mut note = MemoryNote::new(ns.clone(), content.to_string(), MemoryType::Insight, 5);
+        note.embedding_model = MODEL.to_string();
+        note.embedding_input_version = INPUT_VERSION.to_string();
+        let id = note.id.clone();
+        store.insert_memory(&note, Some(&[0.1f32; DIM])).unwrap();
+        id
+    }
+
+    #[test]
+    fn namespace_stats_aggregates_counts_feedback_and_recall_signals() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        let store = open(&path);
+        let ns = Namespace::Project("stats".to_string());
+        let other = Namespace::Project("other".to_string());
+
+        // Three live rows + one archived in `ns`.
+        let a = seed(&store, &ns, "a");
+        let b = seed(&store, &ns, "b");
+        let _c = seed(&store, &ns, "c");
+        let dead = seed(&store, &ns, "dead");
+        store.archive_memory(&dead).unwrap();
+        // A stale-stamped live row (re-embed backlog of 1).
+        let mut stale = MemoryNote::new(ns.clone(), "stale".to_string(), MemoryType::Insight, 5);
+        stale.embedding_model = MODEL.to_string();
+        stale.embedding_input_version = "v1-content".to_string();
+        store.insert_memory(&stale, Some(&[0.2f32; DIM])).unwrap();
+
+        // Cross-namespace noise that must NOT leak into `ns` aggregates.
+        let x = seed(&store, &other, "x");
+        let y = seed(&store, &other, "y");
+        store
+            .record_feedback(&x, FeedbackKind::Helpful, Some("mallory"))
+            .unwrap();
+        store
+            .add_link(&MemoryLink {
+                source_id: x.clone(),
+                target_id: y,
+                link_type: LinkType::Contradicts,
+                strength: 1.0,
+                reason: String::new(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+
+        // Feedback in `ns`: 2 helpful, 1 wrong, 1 stale.
+        store
+            .record_feedback(&a, FeedbackKind::Helpful, Some("alice"))
+            .unwrap();
+        store
+            .record_feedback(&a, FeedbackKind::Helpful, None)
+            .unwrap();
+        store
+            .record_feedback(&b, FeedbackKind::Wrong, Some("bob"))
+            .unwrap();
+        store
+            .record_feedback(&b, FeedbackKind::Stale, None)
+            .unwrap();
+
+        // Access signal: a recalled 5x, b recalled 2x; c/stale never.
+        let now = chrono::Utc::now().timestamp();
+        store
+            .record_access_bumps(&[
+                crate::AccessBump {
+                    id: a.clone(),
+                    count: 5,
+                    last_accessed_at: now,
+                },
+                crate::AccessBump {
+                    id: b.clone(),
+                    count: 2,
+                    last_accessed_at: now,
+                },
+            ])
+            .unwrap();
+
+        // One active contradicts pair in `ns` -> both endpoints contested.
+        store
+            .add_link(&MemoryLink {
+                source_id: a.clone(),
+                target_id: b.clone(),
+                link_type: LinkType::Contradicts,
+                strength: 1.0,
+                reason: "team reversed".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+
+        let stats = store
+            .namespace_stats(&ns, 30, MODEL, INPUT_VERSION, 10)
+            .unwrap();
+
+        assert_eq!(stats.namespace, ns.as_db_string());
+        assert_eq!(stats.window_days, 30);
+        assert_eq!(stats.live, 4, "3 seeded + 1 stale-stamped live rows");
+        assert_eq!(stats.archived, 1);
+        // Vector index is one table: 5 ns rows + 2 other-ns rows, minus the
+        // archived row's pruned vector.
+        assert_eq!(stats.vectors, 6);
+        // SQLite reports the resolved path (macOS: /var -> /private/var), so
+        // compare canonicalized forms.
+        assert_eq!(
+            std::path::Path::new(&stats.db_path).canonicalize().unwrap(),
+            path.canonicalize().unwrap()
+        );
+        assert_eq!(stats.db_embedding_model.as_deref(), Some(MODEL));
+        assert!(
+            stats.wal_bytes > 0,
+            "writes leave a non-empty -wal sidecar under WAL mode"
+        );
+
+        assert_eq!(stats.feedback.helpful, 2);
+        assert_eq!(stats.feedback.wrong, 1);
+        assert_eq!(stats.feedback.stale, 1);
+
+        assert_eq!(stats.total_accesses, 7);
+        assert_eq!(stats.accessed_in_window, 2);
+        assert_eq!(stats.top_recalled.len(), 2);
+        assert_eq!(stats.top_recalled[0].id, a);
+        assert_eq!(stats.top_recalled[0].access_count, 5);
+        assert_eq!(stats.top_recalled[1].id, b);
+        assert_eq!(stats.top_recalled[1].access_count, 2);
+        assert_eq!(stats.never_recalled_live, 2, "c and the stale row");
+
+        assert_eq!(stats.contested, 2, "both endpoints of the active pair");
+        assert_eq!(stats.reembed_pending, 1, "the stale-stamped row only");
+
+        // Growth: everything was created today; buckets stay in-window.
+        assert_eq!(stats.created_per_day.len(), 1);
+        assert_eq!(
+            stats.created_per_day[0].count, 5,
+            "all 5 ns rows (incl. archived) were created today"
+        );
+
+        // The other namespace sees only its own signals.
+        let other_stats = store
+            .namespace_stats(&other, 30, MODEL, INPUT_VERSION, 10)
+            .unwrap();
+        assert_eq!(other_stats.live, 2);
+        assert_eq!(other_stats.feedback.helpful, 1);
+        assert_eq!(other_stats.feedback.wrong, 0);
+        assert_eq!(other_stats.contested, 2);
+        assert_eq!(other_stats.total_accesses, 0);
+    }
+
+    #[test]
+    fn namespace_stats_windows_bound_growth_and_access_recency() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        let store = open(&path);
+        let ns = Namespace::Project("windowed".to_string());
+
+        // One row created now, one 10 days ago.
+        let fresh = seed(&store, &ns, "fresh");
+        let mut old = MemoryNote::new(ns.clone(), "old".to_string(), MemoryType::Insight, 5);
+        old.embedding_model = MODEL.to_string();
+        old.embedding_input_version = INPUT_VERSION.to_string();
+        old.created_at = chrono::Utc::now() - chrono::Duration::days(10);
+        old.updated_at = old.created_at;
+        let old_id = old.id.clone();
+        store.insert_memory(&old, Some(&[0.3f32; DIM])).unwrap();
+
+        // `old` was last accessed 10 days ago, `fresh` today.
+        let now = chrono::Utc::now().timestamp();
+        store
+            .record_access_bumps(&[
+                crate::AccessBump {
+                    id: fresh.clone(),
+                    count: 1,
+                    last_accessed_at: now,
+                },
+                crate::AccessBump {
+                    id: old_id,
+                    count: 3,
+                    last_accessed_at: now - 10 * 86_400,
+                },
+            ])
+            .unwrap();
+
+        let stats = store
+            .namespace_stats(&ns, 7, MODEL, INPUT_VERSION, 10)
+            .unwrap();
+        assert_eq!(stats.window_days, 7);
+        // Growth buckets only cover the 7-day window: the 10-day-old row is out.
+        assert_eq!(stats.created_per_day.len(), 1);
+        assert_eq!(stats.created_per_day[0].count, 1);
+        // Cumulative volume counts everything; the windowed count only `fresh`.
+        assert_eq!(stats.total_accesses, 4);
+        assert_eq!(stats.accessed_in_window, 1);
+
+        // A wider window sees both buckets, oldest first.
+        let wide = store
+            .namespace_stats(&ns, 30, MODEL, INPUT_VERSION, 10)
+            .unwrap();
+        assert_eq!(wide.created_per_day.len(), 2);
+        assert!(wide.created_per_day[0].day < wide.created_per_day[1].day);
+        assert_eq!(wide.accessed_in_window, 2);
+    }
+
+    #[test]
+    fn namespace_stats_top_recalled_is_bounded_by_the_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        let store = open(&path);
+        let ns = Namespace::Project("bounded".to_string());
+
+        let now = chrono::Utc::now().timestamp();
+        let bumps: Vec<crate::AccessBump> = (1..=3)
+            .map(|i| crate::AccessBump {
+                id: seed(&store, &ns, &format!("m{i}")),
+                count: i,
+                last_accessed_at: now,
+            })
+            .collect();
+        store.record_access_bumps(&bumps).unwrap();
+
+        let stats = store
+            .namespace_stats(&ns, 30, MODEL, INPUT_VERSION, 2)
+            .unwrap();
+        assert_eq!(stats.top_recalled.len(), 2, "LIMIT bounds the list");
+        assert_eq!(stats.top_recalled[0].access_count, 3);
+        assert_eq!(stats.top_recalled[1].access_count, 2);
+    }
+
+    #[test]
+    fn read_meta_embedding_model_reads_without_a_writable_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        {
+            let store = open(&path);
+            let ns = Namespace::Project("meta".to_string());
+            seed(&store, &ns, "seed");
+        }
+
+        // Doctor's daemon-down path: a plain read-only open, no migrations, no
+        // writer — usable while another process owns the DB.
+        let model = crate::read_meta_embedding_model(&path).unwrap();
+        assert_eq!(model.as_deref(), Some(MODEL));
+
+        // A missing database is an error (doctor checks existence first).
+        assert!(crate::read_meta_embedding_model(&dir.path().join("absent.db")).is_err());
+    }
+
+    #[test]
+    fn read_meta_embedding_model_does_not_create_or_modify_the_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+        {
+            let store = open(&path);
+            seed(&store, &Namespace::Global, "seed");
+        }
+        let before = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let _ = crate::read_meta_embedding_model(&path).unwrap();
+        let after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(before, after, "a read-only open must not touch the file");
+    }
+}

--- a/crates/rb-types/src/lib.rs
+++ b/crates/rb-types/src/lib.rs
@@ -16,6 +16,7 @@ mod memory_id;
 mod memory_type;
 mod namespace;
 mod query;
+mod stats;
 mod validate;
 
 pub use change::{ChangeKind, MemoryChanged};
@@ -29,4 +30,5 @@ pub use memory_id::MemoryId;
 pub use memory_type::MemoryType;
 pub use namespace::Namespace;
 pub use query::{ChannelHits, MemoryUpdates, SearchQuery, SearchResult};
+pub use stats::{FeedbackTotals, GrowthBucket, MemoryStats, TopRecalled};
 pub use validate::{validate_confidence, validate_importance};

--- a/crates/rb-types/src/stats.rs
+++ b/crates/rb-types/src/stats.rs
@@ -1,0 +1,188 @@
+//! Read-only observability aggregates (doctor/stats PRD). Lives in `rb-types`
+//! (the leaf crate) so `rb-store` (the aggregation queries), `rb-proto` (the
+//! wire `Response::Stats`) and the CLI (rendering) can share one definition
+//! without a dependency cycle — the `MemoryChanged` precedent.
+
+use crate::MemoryId;
+use serde::{Deserialize, Serialize};
+
+/// Namespace-scoped value/health aggregate computed on the daemon's READ pool
+/// (W1.8: the stats path issues zero writer ops). Counts and ids only — never
+/// memory content, so stats output cannot leak a stored secret.
+///
+/// Every field is `#[serde(default)]` so the payload stays additive: a peer
+/// that predates (or postdates) a field decodes the rest — the
+/// `RecallChannelTotals` precedent, no CONTRACT_VERSION bump.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct MemoryStats {
+    /// Namespace the aggregate is scoped to (db string form).
+    #[serde(default)]
+    pub namespace: String,
+    /// Bounded window, in days, for the windowed fields below.
+    #[serde(default)]
+    pub window_days: u32,
+    /// The daemon's database file path (the authoritative one — the daemon may
+    /// have been started with a different env than this client).
+    #[serde(default)]
+    pub db_path: String,
+    /// Active (non-archived) memories in the namespace.
+    #[serde(default)]
+    pub live: u64,
+    /// Archived memories in the namespace.
+    #[serde(default)]
+    pub archived: u64,
+    /// Rows in the vec0 vector index (whole DB — the index is one table).
+    #[serde(default)]
+    pub vectors: u64,
+    /// Size of the SQLite `-wal` sidecar in bytes (0 when absent).
+    #[serde(default)]
+    pub wal_bytes: u64,
+    /// `meta.embedding_model` — the DB's recorded embedding-model identity
+    /// (the W0.2 fail-closed contract). `None` on a legacy DB with no stamp.
+    #[serde(default)]
+    pub db_embedding_model: Option<String>,
+    /// All-time usefulness-feedback totals for the namespace (W3.7).
+    #[serde(default)]
+    pub feedback: FeedbackTotals,
+    /// Sum of `access_count` over the namespace's memories (recall volume,
+    /// cumulative — access bumps are the only recall-derived counter, W1.8).
+    #[serde(default)]
+    pub total_accesses: u64,
+    /// Live memories accessed within the window (`last_accessed_at` based).
+    #[serde(default)]
+    pub accessed_in_window: u64,
+    /// Most-recalled live memories (ids + counts only), bounded by the server.
+    #[serde(default)]
+    pub top_recalled: Vec<TopRecalled>,
+    /// Live memories recall has NEVER returned (`access_count = 0`).
+    #[serde(default)]
+    pub never_recalled_live: u64,
+    /// Live memories with at least one active `contradicts` link whose both
+    /// endpoints are active and in this namespace (the `contested` read flag).
+    #[serde(default)]
+    pub contested: u64,
+    /// Corpus growth: memories created per UTC day inside the window, oldest
+    /// first. Days with no writes are omitted.
+    #[serde(default)]
+    pub created_per_day: Vec<GrowthBucket>,
+    /// Active memories whose embedding stamp is stale relative to the current
+    /// `(model, input_version)` — the re-embed backlog (P5 Feature A scan).
+    #[serde(default)]
+    pub reembed_pending: u64,
+}
+
+/// All-time helpful/wrong/stale counts from the `memory_feedback` event log.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FeedbackTotals {
+    #[serde(default)]
+    pub helpful: u64,
+    #[serde(default)]
+    pub wrong: u64,
+    #[serde(default)]
+    pub stale: u64,
+}
+
+impl FeedbackTotals {
+    /// Net trust trend: helpful minus the two negative signals. Saturating on
+    /// the (absurd) overflow edge rather than panicking in a render path.
+    pub fn net(&self) -> i64 {
+        let pos = i64::try_from(self.helpful).unwrap_or(i64::MAX);
+        let neg = i64::try_from(self.wrong.saturating_add(self.stale)).unwrap_or(i64::MAX);
+        pos.saturating_sub(neg)
+    }
+
+    /// Total feedback events (drives the low-N caveat in rendering).
+    pub fn total(&self) -> u64 {
+        self.helpful
+            .saturating_add(self.wrong)
+            .saturating_add(self.stale)
+    }
+}
+
+/// One top-recalled entry: id and its cumulative access count — never content.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct TopRecalled {
+    pub id: MemoryId,
+    pub access_count: u64,
+}
+
+/// One corpus-growth bucket: memories created on `day` (UTC, `YYYY-MM-DD`).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct GrowthBucket {
+    pub day: String,
+    pub count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::MemoryId;
+
+    #[test]
+    fn memory_stats_round_trips_with_every_field() {
+        let stats = MemoryStats {
+            namespace: "project:rusty-brain".to_string(),
+            window_days: 30,
+            db_path: "/tmp/rb.db".to_string(),
+            live: 12,
+            archived: 3,
+            vectors: 12,
+            wal_bytes: 4096,
+            db_embedding_model: Some("deterministic".to_string()),
+            feedback: FeedbackTotals {
+                helpful: 5,
+                wrong: 1,
+                stale: 2,
+            },
+            total_accesses: 40,
+            accessed_in_window: 7,
+            top_recalled: vec![TopRecalled {
+                id: MemoryId::new(),
+                access_count: 9,
+            }],
+            never_recalled_live: 4,
+            contested: 1,
+            created_per_day: vec![GrowthBucket {
+                day: "2026-07-10".to_string(),
+                count: 2,
+            }],
+            reembed_pending: 3,
+        };
+        let json = serde_json::to_string(&stats).unwrap();
+        let back: MemoryStats = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, stats);
+    }
+
+    #[test]
+    fn memory_stats_decodes_from_an_empty_object() {
+        // Every field is additive + serde(default): a payload from an
+        // older/newer peer that omits fields must still decode (the
+        // RecallChannelTotals precedent), yielding the zero-valued default.
+        let back: MemoryStats = serde_json::from_str("{}").unwrap();
+        assert_eq!(back, MemoryStats::default());
+        assert_eq!(back.feedback.helpful, 0);
+        assert!(back.top_recalled.is_empty());
+        assert!(back.db_embedding_model.is_none());
+    }
+
+    #[test]
+    fn feedback_totals_net_and_total() {
+        let fb = FeedbackTotals {
+            helpful: 5,
+            wrong: 1,
+            stale: 2,
+        };
+        // Net trust trend: helpful minus the two negative signals.
+        assert_eq!(fb.net(), 2);
+        assert_eq!(fb.total(), 8);
+        // Net can go negative and must not underflow.
+        let bad = FeedbackTotals {
+            helpful: 0,
+            wrong: 3,
+            stale: 1,
+        };
+        assert_eq!(bad.net(), -4);
+        assert_eq!(FeedbackTotals::default().total(), 0);
+    }
+}

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -28,6 +28,7 @@ rb-daemon = { path = "../rb-daemon" }
 rb-embed = { path = "../rb-embed" }
 rb-mcp = { path = "../rb-mcp" }
 rb-redact = { path = "../rb-redact" }
+rb-store = { path = "../rb-store" }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -332,8 +332,23 @@ pub enum Command {
         since: Option<u64>,
     },
 
-    /// Ping the daemon and report its contract version.
+    /// Ping the daemon and report its health: contract version, writer
+    /// health, embedding model, DB path/mode, WAL size, corpus counts.
     Status,
+
+    /// Show value/health aggregates for the current namespace: recall volume,
+    /// feedback ratios, top/never-recalled memories, contested count, corpus
+    /// growth, re-embed backlog. Read-only — issues zero writer ops.
+    Stats {
+        /// Window in days for the windowed aggregates (recent accesses,
+        /// growth buckets). Server-clamped to 1-365; default 30.
+        #[arg(long = "window-days", value_parser = value_parser!(u32).range(1..=365))]
+        window_days: Option<u32>,
+    },
+
+    /// Run health checks (daemon, socket/DB permissions, embedding model vs
+    /// DB meta, WAL size) and exit non-zero if any check fails.
+    Doctor,
 
     /// Trigger one bounded evolution-job pass on the running daemon.
     Evolve {
@@ -789,6 +804,41 @@ mod tests {
         // --kind is required.
         let res = Cli::try_parse_from(["rusty-brain", "feedback", "an-id"]);
         assert!(res.is_err(), "--kind is required for feedback");
+    }
+
+    #[test]
+    fn parses_stats_with_optional_window() {
+        let cli = Cli::parse_from(["rusty-brain", "stats"]);
+        assert!(
+            matches!(cli.command, Command::Stats { window_days: None }),
+            "`rusty-brain stats` must parse with no window (daemon default)"
+        );
+        let cli = Cli::parse_from(["rusty-brain", "stats", "--window-days", "7"]);
+        assert!(matches!(
+            cli.command,
+            Command::Stats {
+                window_days: Some(7)
+            }
+        ));
+        // Global --json applies to stats.
+        let cli = Cli::parse_from(["rusty-brain", "--json", "stats"]);
+        assert!(cli.json);
+        assert!(matches!(cli.command, Command::Stats { .. }));
+    }
+
+    #[test]
+    fn stats_rejects_a_zero_window_at_parse_time() {
+        let res = Cli::try_parse_from(["rusty-brain", "stats", "--window-days", "0"]);
+        assert!(res.is_err(), "a zero-day window is meaningless");
+    }
+
+    #[test]
+    fn parses_doctor_subcommand() {
+        let cli = Cli::parse_from(["rusty-brain", "doctor"]);
+        assert!(
+            matches!(cli.command, Command::Doctor),
+            "`rusty-brain doctor` must parse to Command::Doctor"
+        );
     }
 
     #[test]

--- a/crates/rusty-brain/src/doctor.rs
+++ b/crates/rusty-brain/src/doctor.rs
@@ -1,0 +1,671 @@
+//! `rusty-brain doctor`: health checks + diagnostics (doctor/stats PRD DOC-3).
+//!
+//! Pure check functions produce a [`DoctorReport`]; `run_doctor` orchestrates
+//! them against the live system. Doctor NEVER auto-starts the daemon (it
+//! diagnoses, it does not mutate) and reads the DB only through the read-only
+//! meta helper — zero writer ops, zero side effects.
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::Path;
+
+/// WAL size above which doctor warns about checkpoint health. SQLite's
+/// default autocheckpoint is ~4 MiB of WAL; two orders of magnitude past it
+/// means checkpointing is not keeping up (e.g. a long-lived reader pinning
+/// the WAL).
+pub const WAL_WARN_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+    Skipped,
+}
+
+impl CheckStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            CheckStatus::Ok => "ok",
+            CheckStatus::Warn => "warn",
+            CheckStatus::Fail => "fail",
+            CheckStatus::Skipped => "skipped",
+        }
+    }
+
+    /// Human line marker; FAIL is loud on purpose.
+    fn marker(self) -> &'static str {
+        match self {
+            CheckStatus::Ok => "[ok]  ",
+            CheckStatus::Warn => "[warn]",
+            CheckStatus::Fail => "[FAIL]",
+            CheckStatus::Skipped => "[skip]",
+        }
+    }
+}
+
+/// One health check outcome: what was inspected, what was observed, and (for
+/// non-ok outcomes) how to fix it.
+#[derive(Debug, Clone)]
+pub struct DoctorCheck {
+    pub name: &'static str,
+    pub status: CheckStatus,
+    pub detail: String,
+    pub hint: Option<String>,
+}
+
+/// The full doctor run. `failed() > 0` drives the non-zero exit.
+#[derive(Debug, Clone)]
+pub struct DoctorReport {
+    pub checks: Vec<DoctorCheck>,
+}
+
+impl DoctorReport {
+    /// Number of hard failures (warnings and skips do not fail the run).
+    pub fn failed(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|c| c.status == CheckStatus::Fail)
+            .count()
+    }
+
+    /// Render the report (human lines or a JSON object).
+    pub fn render(&self, json: bool) -> String {
+        if json {
+            let checks: Vec<_> = self
+                .checks
+                .iter()
+                .map(|c| {
+                    serde_json::json!({
+                        "name": c.name,
+                        "status": c.status.as_str(),
+                        "detail": c.detail,
+                        "hint": c.hint,
+                    })
+                })
+                .collect();
+            return serde_json::json!({
+                "ok": self.failed() == 0,
+                "failed": self.failed(),
+                "checks": checks,
+            })
+            .to_string();
+        }
+        let mut out = String::new();
+        for c in &self.checks {
+            out.push_str(&format!("{} {}: {}\n", c.status.marker(), c.name, c.detail));
+            if let Some(hint) = &c.hint {
+                out.push_str(&format!("       hint: {hint}\n"));
+            }
+        }
+        let failed = self.failed();
+        if failed == 0 {
+            out.push_str("doctor: no problems found");
+        } else {
+            out.push_str(&format!(
+                "doctor: {failed} problem{} found",
+                if failed == 1 { "" } else { "s" }
+            ));
+        }
+        out
+    }
+}
+
+/// Check that `path` exists with exactly the expected permission bits
+/// (`expected` is the 0o777-masked mode, e.g. `0o600`).
+pub fn check_mode(name: &'static str, path: &Path, expected: u32) -> DoctorCheck {
+    match std::fs::metadata(path) {
+        Ok(meta) => {
+            let mode = meta.permissions().mode() & 0o777;
+            if mode == expected {
+                DoctorCheck {
+                    name,
+                    status: CheckStatus::Ok,
+                    detail: format!("{} is {mode:04o}", path.display()),
+                    hint: None,
+                }
+            } else {
+                DoctorCheck {
+                    name,
+                    status: CheckStatus::Fail,
+                    detail: format!("{} is {mode:04o} (expected {expected:04o})", path.display()),
+                    hint: Some(format!("chmod {expected:o} {}", path.display())),
+                }
+            }
+        }
+        Err(e) => DoctorCheck {
+            name,
+            status: CheckStatus::Fail,
+            detail: format!("cannot stat {}: {e}", path.display()),
+            hint: None,
+        },
+    }
+}
+
+/// Check the SQLite `-wal` sidecar size: absent or modest is healthy; an
+/// oversized WAL means checkpointing is not keeping up.
+pub fn check_wal(db_path: &Path) -> DoctorCheck {
+    let wal = wal_path(db_path);
+    match std::fs::metadata(&wal) {
+        Err(_) => DoctorCheck {
+            name: "wal",
+            status: CheckStatus::Ok,
+            detail: "no -wal sidecar (fully checkpointed)".to_string(),
+            hint: None,
+        },
+        Ok(meta) if meta.len() <= WAL_WARN_BYTES => DoctorCheck {
+            name: "wal",
+            status: CheckStatus::Ok,
+            detail: format!("{} bytes", meta.len()),
+            hint: None,
+        },
+        Ok(meta) => DoctorCheck {
+            name: "wal",
+            status: CheckStatus::Warn,
+            detail: format!(
+                "{} is {} bytes (over the {WAL_WARN_BYTES}-byte watermark)",
+                wal.display(),
+                meta.len()
+            ),
+            hint: Some(
+                "checkpointing is falling behind; close long-lived readers and \
+                 restart the daemon (shutdown runs a truncating checkpoint)"
+                    .to_string(),
+            ),
+        },
+    }
+}
+
+/// The SQLite WAL sidecar path for `db_path` (`<db>-wal`).
+fn wal_path(db_path: &Path) -> std::path::PathBuf {
+    let mut name = db_path.as_os_str().to_os_string();
+    name.push("-wal");
+    std::path::PathBuf::from(name)
+}
+
+/// Compare the (running or expected) embedding provider identity against the
+/// DB's recorded `meta.embedding_model` — the W0.2 fail-closed contract this
+/// check diagnoses when the daemon refuses to start.
+pub fn check_model_identity(provider: Option<&str>, meta: Option<&str>) -> DoctorCheck {
+    match (provider, meta) {
+        (Some(p), Some(m)) if p == m => DoctorCheck {
+            name: "embedding-model",
+            status: CheckStatus::Ok,
+            detail: format!("provider '{p}' matches DB meta"),
+            hint: None,
+        },
+        (Some(p), Some(m)) => DoctorCheck {
+            name: "embedding-model",
+            status: CheckStatus::Fail,
+            detail: format!("provider '{p}' does not match DB meta '{m}'"),
+            hint: Some(
+                "the daemon fails closed on a model swap; either restore the \
+                 original provider or opt in with `rusty-brain serve \
+                 --accept-model-change` and run `rusty-brain reembed` until \
+                 changed=0"
+                    .to_string(),
+            ),
+        },
+        (Some(_), None) => DoctorCheck {
+            name: "embedding-model",
+            status: CheckStatus::Warn,
+            detail: "DB has no recorded embedding model (legacy DB; it is \
+                     seeded at the next daemon start)"
+                .to_string(),
+            hint: None,
+        },
+        (None, meta) => DoctorCheck {
+            name: "embedding-model",
+            status: CheckStatus::Skipped,
+            detail: format!(
+                "provider identity unknown offline (DB meta: {})",
+                meta.unwrap_or("none")
+            ),
+            hint: None,
+        },
+    }
+}
+
+/// Warn loudly when the offline deterministic fallback is serving embeddings
+/// (recall quality is reduced and vectors are not portable to a real model).
+pub fn check_provider(provider_model: &str) -> DoctorCheck {
+    if provider_model == "deterministic" {
+        DoctorCheck {
+            name: "embedding-provider",
+            status: CheckStatus::Warn,
+            detail: "deterministic fallback active (no VOYAGE_API_KEY and no \
+                     local backend): recall quality is reduced and embeddings \
+                     are not portable to a real model"
+                .to_string(),
+            hint: Some(
+                "set VOYAGE_API_KEY or configure the local backend, then \
+                 restart the daemon"
+                    .to_string(),
+            ),
+        }
+    } else {
+        DoctorCheck {
+            name: "embedding-provider",
+            status: CheckStatus::Ok,
+            detail: format!("'{provider_model}'"),
+            hint: None,
+        }
+    }
+}
+
+/// What model would `serve` pick with the daemon DOWN, given the resolved
+/// config? Only the deterministic fallback has a knowable identity offline
+/// (`select_provider_kind` parity): a Voyage key or a local backend selects a
+/// provider whose model id is provider state we must not guess.
+pub fn expected_offline_provider_model(
+    api_key: Option<String>,
+    embed_backend: Option<&str>,
+    local_model: Option<&str>,
+) -> Option<String> {
+    match crate::serve::select_provider_kind(
+        api_key,
+        embed_backend.is_some_and(|b| b.eq_ignore_ascii_case("local")) || local_model.is_some(),
+    ) {
+        crate::serve::ProviderKind::Deterministic => Some("deterministic".to_string()),
+        crate::serve::ProviderKind::Voyage | crate::serve::ProviderKind::Local => None,
+    }
+}
+
+/// The daemon side of a doctor run: the stats payload when the daemon
+/// answered, or `None` (with the failure already recorded as a check).
+type DaemonStats = Option<(rb_types::MemoryStats, String, bool)>;
+
+/// Daemon reachability — a plain connect (NO auto-start: doctor diagnoses the
+/// system as it is). A successful connect also proves the contract version
+/// matches (the handshake fails closed on drift).
+async fn check_daemon(
+    socket_path: &Path,
+    namespace: rb_types::Namespace,
+    checks: &mut Vec<DoctorCheck>,
+) -> DaemonStats {
+    let mut client = match rb_proto::Client::connect(socket_path, namespace).await {
+        Ok(client) => client,
+        Err(e) => {
+            checks.push(DoctorCheck {
+                name: "daemon",
+                status: CheckStatus::Fail,
+                detail: format!("not reachable at {}: {e}", socket_path.display()),
+                hint: Some(
+                    "start it with `rusty-brain serve` (any client command \
+                     auto-starts it)"
+                        .to_string(),
+                ),
+            });
+            return None;
+        }
+    };
+    match client.stats(None).await {
+        Ok(payload) => {
+            checks.push(DoctorCheck {
+                name: "daemon",
+                status: CheckStatus::Ok,
+                detail: format!(
+                    "reachable at {} (contract v{})",
+                    socket_path.display(),
+                    rb_proto::CONTRACT_VERSION
+                ),
+                hint: None,
+            });
+            Some(payload)
+        }
+        Err(e) => {
+            checks.push(DoctorCheck {
+                name: "daemon",
+                status: CheckStatus::Fail,
+                detail: format!("reachable, but the stats request failed: {e}"),
+                hint: Some(
+                    "the daemon may predate the stats op; restart it so the \
+                     current binary serves the socket"
+                        .to_string(),
+                ),
+            });
+            None
+        }
+    }
+}
+
+/// Socket + socket-dir permissions (only meaningful once the socket exists;
+/// the daemon binds it 0600 in a 0700 dir, fail-closed).
+fn check_socket_permissions(socket_path: &Path, checks: &mut Vec<DoctorCheck>) {
+    if socket_path.exists() {
+        checks.push(check_mode("socket-mode", socket_path, 0o600));
+        if let Some(dir) = socket_path.parent() {
+            checks.push(check_mode("socket-dir-mode", dir, 0o700));
+        }
+    } else {
+        checks.push(DoctorCheck {
+            name: "socket-mode",
+            status: CheckStatus::Skipped,
+            detail: format!("{} does not exist (daemon down)", socket_path.display()),
+            hint: None,
+        });
+    }
+}
+
+/// DB file permissions + WAL health (rb-store tightens the file to 0600 at
+/// every open). The parent dir is deliberately NOT checked: the daemon only
+/// owns dirs it created itself, and caller-owned dirs are legitimate (W0.5).
+fn check_db_health(db_path: &Path, checks: &mut Vec<DoctorCheck>) {
+    if db_path.exists() {
+        checks.push(check_mode("db-file-mode", db_path, 0o600));
+        checks.push(check_wal(db_path));
+    } else {
+        checks.push(DoctorCheck {
+            name: "db-file-mode",
+            status: CheckStatus::Skipped,
+            detail: format!(
+                "{} does not exist yet (nothing stored so far)",
+                db_path.display()
+            ),
+            hint: None,
+        });
+    }
+}
+
+/// Writer-thread health, as the daemon reported it on the stats reply.
+fn check_writer(alive: bool) -> DoctorCheck {
+    if alive {
+        DoctorCheck {
+            name: "writer",
+            status: CheckStatus::Ok,
+            detail: "writer thread alive".to_string(),
+            hint: None,
+        }
+    } else {
+        DoctorCheck {
+            name: "writer",
+            status: CheckStatus::Fail,
+            detail: "writer thread has died; every write will fail".to_string(),
+            hint: Some("restart the daemon".to_string()),
+        }
+    }
+}
+
+/// Embedding provider + model-vs-meta identity. With the daemon up, both
+/// sides come from its stats reply; with it down, the meta side is read
+/// read-only from the DB file and the provider side is only knowable for the
+/// deterministic fallback.
+fn check_embedding_identity(
+    daemon_stats: &DaemonStats,
+    db_path: &Path,
+    embed_backend: Option<&str>,
+    local_model: Option<&str>,
+    checks: &mut Vec<DoctorCheck>,
+) {
+    match daemon_stats {
+        Some((stats, provider_model, _)) => {
+            checks.push(check_provider(provider_model));
+            checks.push(check_model_identity(
+                Some(provider_model),
+                stats.db_embedding_model.as_deref(),
+            ));
+        }
+        None if db_path.exists() => {
+            let meta = match rb_store::read_meta_embedding_model(db_path) {
+                Ok(meta) => meta,
+                Err(e) => {
+                    checks.push(DoctorCheck {
+                        name: "embedding-model",
+                        status: CheckStatus::Fail,
+                        detail: format!("cannot read DB meta: {e}"),
+                        hint: None,
+                    });
+                    None
+                }
+            };
+            if let Some(meta) = meta {
+                let expected = expected_offline_provider_model(
+                    std::env::var("VOYAGE_API_KEY").ok(),
+                    embed_backend,
+                    local_model,
+                );
+                if let Some(p) = expected.as_deref() {
+                    checks.push(check_provider(p));
+                }
+                checks.push(check_model_identity(
+                    expected.as_deref(),
+                    Some(meta.as_str()),
+                ));
+            }
+        }
+        None => {}
+    }
+}
+
+/// Run the full doctor flow and print the report; `Err` (non-zero exit) when
+/// any check FAILS. Never auto-starts the daemon and never writes.
+pub async fn run_doctor(
+    socket_path: &Path,
+    db_path: &Path,
+    namespace: rb_types::Namespace,
+    embed_backend: Option<String>,
+    local_model: Option<String>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let mut checks = Vec::new();
+
+    let daemon_stats = check_daemon(socket_path, namespace, &mut checks).await;
+    check_socket_permissions(socket_path, &mut checks);
+    check_db_health(db_path, &mut checks);
+    if let Some((_, _, alive)) = &daemon_stats {
+        checks.push(check_writer(*alive));
+    }
+    check_embedding_identity(
+        &daemon_stats,
+        db_path,
+        embed_backend.as_deref(),
+        local_model.as_deref(),
+        &mut checks,
+    );
+
+    let report = DoctorReport { checks };
+    println!("{}", report.render(json));
+    let failed = report.failed();
+    if failed > 0 {
+        anyhow::bail!(
+            "doctor found {failed} problem{}",
+            if failed == 1 { "" } else { "s" }
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn check_mode_accepts_expected_and_flags_wrong_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("rb.db");
+        std::fs::write(&file, b"x").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let ok = check_mode("db-file-mode", &file, 0o600);
+        assert_eq!(ok.status, CheckStatus::Ok, "{ok:?}");
+
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let fail = check_mode("db-file-mode", &file, 0o600);
+        assert_eq!(fail.status, CheckStatus::Fail, "{fail:?}");
+        assert!(fail.detail.contains("0644"), "observed mode: {fail:?}");
+        let hint = fail.hint.expect("a failing mode check carries guidance");
+        assert!(hint.contains("chmod 600"), "remediation: {hint}");
+    }
+
+    #[test]
+    fn check_mode_fails_on_a_missing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let check = check_mode("socket-mode", &dir.path().join("absent"), 0o600);
+        assert_eq!(check.status, CheckStatus::Fail, "{check:?}");
+    }
+
+    #[test]
+    fn check_wal_warns_only_above_the_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        std::fs::write(&db, b"x").unwrap();
+
+        // No -wal sidecar at all: healthy (fully checkpointed).
+        assert_eq!(check_wal(&db).status, CheckStatus::Ok);
+
+        // A small WAL is normal operation.
+        let wal = dir.path().join("rb.db-wal");
+        std::fs::write(&wal, b"small").unwrap();
+        assert_eq!(check_wal(&db).status, CheckStatus::Ok);
+
+        // An oversized WAL warns with a remediation hint (sparse file: set_len
+        // reports the logical size without writing the bytes).
+        let f = std::fs::OpenOptions::new().write(true).open(&wal).unwrap();
+        f.set_len(WAL_WARN_BYTES + 1).unwrap();
+        let warn = check_wal(&db);
+        assert_eq!(warn.status, CheckStatus::Warn, "{warn:?}");
+        let hint = warn.hint.expect("an oversized WAL carries guidance");
+        assert!(
+            hint.contains("checkpoint") || hint.contains("restart"),
+            "remediation: {hint}"
+        );
+    }
+
+    #[test]
+    fn check_model_identity_covers_match_mismatch_and_unknowns() {
+        let ok = check_model_identity(Some("deterministic"), Some("deterministic"));
+        assert_eq!(ok.status, CheckStatus::Ok, "{ok:?}");
+
+        let fail = check_model_identity(Some("deterministic"), Some("voyage-3"));
+        assert_eq!(fail.status, CheckStatus::Fail, "{fail:?}");
+        assert!(fail.detail.contains("voyage-3"), "{fail:?}");
+        let hint = fail.hint.expect("a model mismatch carries guidance");
+        assert!(
+            hint.contains("--accept-model-change"),
+            "remediation names the opt-in: {hint}"
+        );
+
+        // Legacy DB without a stamp: warn, not fail.
+        let legacy = check_model_identity(Some("deterministic"), None);
+        assert_eq!(legacy.status, CheckStatus::Warn, "{legacy:?}");
+
+        // Provider identity unknown (offline with a remote provider): skip.
+        let skipped = check_model_identity(None, Some("voyage-3"));
+        assert_eq!(skipped.status, CheckStatus::Skipped, "{skipped:?}");
+    }
+
+    #[test]
+    fn check_provider_warns_loudly_on_the_deterministic_fallback() {
+        let warn = check_provider("deterministic");
+        assert_eq!(warn.status, CheckStatus::Warn, "{warn:?}");
+        assert!(
+            warn.detail.to_lowercase().contains("deterministic"),
+            "{warn:?}"
+        );
+
+        let ok = check_provider("voyage-3");
+        assert_eq!(ok.status, CheckStatus::Ok, "{ok:?}");
+    }
+
+    #[test]
+    fn expected_offline_provider_model_is_known_only_for_deterministic() {
+        // No API key, no local backend: serve would pick deterministic.
+        assert_eq!(
+            expected_offline_provider_model(None, None, None).as_deref(),
+            Some("deterministic")
+        );
+        assert_eq!(
+            expected_offline_provider_model(Some("  ".to_string()), None, None).as_deref(),
+            Some("deterministic"),
+            "a blank key is not a key (select_provider_kind parity)"
+        );
+        // A Voyage key or a local backend: the model id is provider state we
+        // cannot know offline — the check must skip, not guess.
+        assert_eq!(
+            expected_offline_provider_model(Some("vk-1".to_string()), None, None),
+            None
+        );
+        assert_eq!(
+            expected_offline_provider_model(None, Some("local"), None),
+            None
+        );
+        assert_eq!(
+            expected_offline_provider_model(None, None, Some("all-MiniLM-L6-v2")),
+            None
+        );
+    }
+
+    #[test]
+    fn report_renders_statuses_hints_and_summary_in_both_modes() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck {
+                    name: "daemon",
+                    status: CheckStatus::Ok,
+                    detail: "reachable (contract v2)".to_string(),
+                    hint: None,
+                },
+                DoctorCheck {
+                    name: "db-file-mode",
+                    status: CheckStatus::Fail,
+                    detail: "/tmp/rb.db is 0644 (expected 0600)".to_string(),
+                    hint: Some("chmod 600 /tmp/rb.db".to_string()),
+                },
+                DoctorCheck {
+                    name: "embedding-provider",
+                    status: CheckStatus::Warn,
+                    detail: "deterministic fallback active".to_string(),
+                    hint: None,
+                },
+            ],
+        };
+        let human = report.render(false);
+        assert!(human.contains("[ok]"), "{human}");
+        assert!(human.contains("[FAIL]"), "{human}");
+        assert!(human.contains("[warn]"), "{human}");
+        assert!(human.contains("db-file-mode"), "{human}");
+        assert!(
+            human.contains("chmod 600 /tmp/rb.db"),
+            "hint shown: {human}"
+        );
+        assert!(human.contains("1 problem"), "summary: {human}");
+
+        let json = report.render(true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["ok"].as_bool(), Some(false));
+        assert_eq!(parsed["failed"].as_u64(), Some(1));
+        assert_eq!(parsed["checks"][1]["name"].as_str(), Some("db-file-mode"));
+        assert_eq!(parsed["checks"][1]["status"].as_str(), Some("fail"));
+        assert_eq!(
+            parsed["checks"][1]["hint"].as_str(),
+            Some("chmod 600 /tmp/rb.db")
+        );
+    }
+
+    #[test]
+    fn report_counts_failures_for_the_exit_code() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck {
+                    name: "a",
+                    status: CheckStatus::Ok,
+                    detail: String::new(),
+                    hint: None,
+                },
+                DoctorCheck {
+                    name: "b",
+                    status: CheckStatus::Warn,
+                    detail: String::new(),
+                    hint: None,
+                },
+                DoctorCheck {
+                    name: "c",
+                    status: CheckStatus::Fail,
+                    detail: String::new(),
+                    hint: None,
+                },
+            ],
+        };
+        assert_eq!(report.failed(), 1, "only Fail drives a non-zero exit");
+    }
+}

--- a/crates/rusty-brain/src/doctor.rs
+++ b/crates/rusty-brain/src/doctor.rs
@@ -146,11 +146,23 @@ pub fn check_mode(name: &'static str, path: &Path, expected: u32) -> DoctorCheck
 pub fn check_wal(db_path: &Path) -> DoctorCheck {
     let wal = wal_path(db_path);
     match std::fs::metadata(&wal) {
-        Err(_) => DoctorCheck {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DoctorCheck {
             name: "wal",
             status: CheckStatus::Ok,
             detail: "no -wal sidecar (fully checkpointed)".to_string(),
             hint: None,
+        },
+        // Any other stat error means WAL health is unknown, not healthy: the
+        // sidecar may exist but be unreadable (e.g. a permission problem).
+        Err(e) => DoctorCheck {
+            name: "wal",
+            status: CheckStatus::Warn,
+            detail: format!("cannot stat {}: {e}", wal.display()),
+            hint: Some(
+                "WAL health is unknown; fix permissions on the DB directory \
+                 so doctor can inspect the sidecar"
+                    .to_string(),
+            ),
         },
         Ok(meta) if meta.len() <= WAL_WARN_BYTES => DoctorCheck {
             name: "wal",
@@ -414,23 +426,21 @@ fn check_embedding_identity(
                         detail: format!("cannot read DB meta: {e}"),
                         hint: None,
                     });
-                    None
+                    return;
                 }
             };
-            if let Some(meta) = meta {
-                let expected = expected_offline_provider_model(
-                    std::env::var("VOYAGE_API_KEY").ok(),
-                    embed_backend,
-                    local_model,
-                );
-                if let Some(p) = expected.as_deref() {
-                    checks.push(check_provider(p));
-                }
-                checks.push(check_model_identity(
-                    expected.as_deref(),
-                    Some(meta.as_str()),
-                ));
+            // A legacy DB without a stamp still gets an identity check —
+            // `check_model_identity` routes `None` meta to its Warn/Skipped
+            // arms, mirroring the daemon-up path.
+            let expected = expected_offline_provider_model(
+                std::env::var("VOYAGE_API_KEY").ok(),
+                embed_backend,
+                local_model,
+            );
+            if let Some(p) = expected.as_deref() {
+                checks.push(check_provider(p));
             }
+            checks.push(check_model_identity(expected.as_deref(), meta.as_deref()));
         }
         None => {}
     }
@@ -528,6 +538,56 @@ mod tests {
         assert!(
             hint.contains("checkpoint") || hint.contains("restart"),
             "remediation: {hint}"
+        );
+    }
+
+    #[test]
+    fn check_wal_flags_an_uninspectable_sidecar_instead_of_claiming_checkpointed() {
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        let db = locked.join("rb.db");
+        std::fs::write(&db, b"x").unwrap();
+        std::fs::write(locked.join("rb.db-wal"), b"wal").unwrap();
+
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Root ignores directory modes; the EACCES this test needs never fires.
+        if std::fs::metadata(locked.join("rb.db-wal")).is_ok() {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+        let check = check_wal(&db);
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(check.status, CheckStatus::Warn, "{check:?}");
+        assert!(check.detail.contains("cannot stat"), "{check:?}");
+        assert!(
+            check.hint.is_some(),
+            "an uninspectable WAL carries guidance"
+        );
+    }
+
+    #[test]
+    fn offline_identity_check_still_reports_a_legacy_db_without_a_model_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        // `open` (unlike `open_with_model`) leaves the embedding_model meta
+        // unstamped — the legacy-DB shape.
+        drop(rb_store::SqliteStore::open(&db, 8).unwrap());
+
+        let mut checks = Vec::new();
+        check_embedding_identity(&None, &db, None, None, &mut checks);
+
+        let identity = checks
+            .iter()
+            .find(|c| c.name == "embedding-model")
+            .expect("a legacy DB still gets an embedding-model check offline");
+        // Warn when the offline provider is knowable (deterministic), Skipped
+        // when it is not (VOYAGE_API_KEY present in the ambient env) — never
+        // silently absent.
+        assert!(
+            matches!(identity.status, CheckStatus::Warn | CheckStatus::Skipped),
+            "{identity:?}"
         );
     }
 

--- a/crates/rusty-brain/src/lib.rs
+++ b/crates/rusty-brain/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod cli;
 pub mod client;
+pub mod doctor;
 pub mod export;
 pub mod import;
 pub mod logging;

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -366,6 +366,164 @@ pub fn render_context(
     out
 }
 
+/// Threshold below which the feedback ratio gets a low-N caveat instead of
+/// being presented as a confident signal (doctor/stats PRD risk mitigation).
+const FEEDBACK_LOW_N: u64 = 10;
+
+/// Render the `stats` payload: value/health aggregates for one namespace.
+/// Counts and ids only — never memory content. JSON: `{stats, provider_model,
+/// writer_alive}` with a derived `feedback.net`.
+pub fn render_stats(
+    stats: &rb_types::MemoryStats,
+    provider_model: &str,
+    writer_alive: bool,
+    json: bool,
+) -> String {
+    if json {
+        let mut value = serde_json::json!({
+            "stats": stats,
+            "provider_model": provider_model,
+            "writer_alive": writer_alive,
+        });
+        // Derived net trend rides along so scripts need no client-side math.
+        if let Some(fb) = value
+            .pointer_mut("/stats/feedback")
+            .and_then(|v| v.as_object_mut())
+        {
+            fb.insert("net".to_string(), serde_json::json!(stats.feedback.net()));
+        }
+        return serde_json::to_string_pretty(&value).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render stats JSON");
+            "{}".to_string()
+        });
+    }
+
+    let mut out = format!(
+        "Memory stats for {} (last {} days)\n\n",
+        stats.namespace, stats.window_days
+    );
+    out.push_str(&format!(
+        "corpus: {} live, {} archived, {} vectors\n",
+        stats.live, stats.archived, stats.vectors
+    ));
+    out.push_str(&format!(
+        "recall: {} total accesses; {} recalled in window; {} never recalled\n",
+        stats.total_accesses, stats.accessed_in_window, stats.never_recalled_live
+    ));
+    let fb = &stats.feedback;
+    if fb.total() == 0 {
+        out.push_str(
+            "feedback: no feedback recorded yet (use `rusty-brain feedback <id> --kind ...`)\n",
+        );
+    } else {
+        out.push_str(&format!(
+            "feedback: {} helpful, {} wrong, {} stale (net {:+})\n",
+            fb.helpful,
+            fb.wrong,
+            fb.stale,
+            fb.net()
+        ));
+        if fb.total() < FEEDBACK_LOW_N {
+            out.push_str(&format!(
+                "  note: only {} feedback event(s) — low-confidence signal\n",
+                fb.total()
+            ));
+        }
+    }
+    out.push_str(&format!("contested: {}\n", stats.contested));
+    out.push_str(&format!("re-embed backlog: {}\n", stats.reembed_pending));
+    if !stats.top_recalled.is_empty() {
+        out.push_str("top recalled:\n");
+        for t in &stats.top_recalled {
+            out.push_str(&format!("  {}x {}\n", t.access_count, t.id));
+        }
+    }
+    if !stats.created_per_day.is_empty() {
+        out.push_str("growth (created per day):\n");
+        for b in &stats.created_per_day {
+            out.push_str(&format!("  {}: {}\n", b.day, b.count));
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// Everything the extended `status` line-up needs (DOC-1), gathered by the
+/// caller: the ping reply, the stats payload, and a client-side stat of the
+/// DB file mode (`None` when the file could not be inspected).
+pub struct StatusView<'a> {
+    pub contract_version: u32,
+    pub recall_channels: Option<rb_proto::RecallChannelTotals>,
+    pub stats: &'a rb_types::MemoryStats,
+    pub provider_model: &'a str,
+    pub writer_alive: bool,
+    pub db_file_mode: Option<u32>,
+}
+
+/// Render the extended `status` payload (daemon up, writer health, embedding
+/// identity, DB path/mode, WAL size, corpus counts, namespace).
+pub fn render_status(view: &StatusView<'_>, json: bool) -> String {
+    let mode_str = view.db_file_mode.map(|m| format!("{m:04o}"));
+    if json {
+        let value = serde_json::json!({
+            "ok": true,
+            "contract_version": view.contract_version,
+            "writer_alive": view.writer_alive,
+            "provider_model": view.provider_model,
+            "db": {
+                "path": view.stats.db_path,
+                "file_mode": mode_str,
+                "wal_bytes": view.stats.wal_bytes,
+                "embedding_model": view.stats.db_embedding_model,
+            },
+            "memories": {
+                "live": view.stats.live,
+                "archived": view.stats.archived,
+            },
+            "vectors": view.stats.vectors,
+            "namespace": view.stats.namespace,
+            "recall_channels": view.recall_channels.map(|c| serde_json::json!({
+                "recalls": c.recalls,
+                "fts_hits": c.fts_hits,
+                "vector_hits": c.vector_hits,
+                "graph_hits": c.graph_hits,
+            })),
+        });
+        return serde_json::to_string_pretty(&value).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render status JSON");
+            "{}".to_string()
+        });
+    }
+
+    let mut out = format!("daemon: ok (contract v{})\n", view.contract_version);
+    out.push_str(&format!(
+        "writer: {}\n",
+        if view.writer_alive { "alive" } else { "DEAD" }
+    ));
+    out.push_str(&format!(
+        "embedding: {} (db meta: {})\n",
+        view.provider_model,
+        view.stats.db_embedding_model.as_deref().unwrap_or("none")
+    ));
+    out.push_str(&format!(
+        "db: {} (mode {})\n",
+        view.stats.db_path,
+        mode_str.as_deref().unwrap_or("unknown")
+    ));
+    out.push_str(&format!("wal: {} bytes\n", view.stats.wal_bytes));
+    out.push_str(&format!(
+        "memories: {} live, {} archived (namespace {})\n",
+        view.stats.live, view.stats.archived, view.stats.namespace
+    ));
+    out.push_str(&format!("vectors: {}\n", view.stats.vectors));
+    if let Some(c) = view.recall_channels {
+        out.push_str(&format!(
+            "recalls={} fts_hits={} vector_hits={} graph_hits={}\n",
+            c.recalls, c.fts_hits, c.vector_hits, c.graph_hits
+        ));
+    }
+    out.trim_end().to_string()
+}
+
 /// Render one streamed subscribe item (a change event or a lagged notice).
 /// JSON: a flat object. Human: a single line.
 pub fn render_change(item: &rb_proto::SubscribeItem, json: bool) -> String {
@@ -664,6 +822,145 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!((parsed["confidence"].as_f64().unwrap() - 0.4).abs() < 1e-6);
         assert!(render_feedback(0.4, false).contains("0.40"));
+    }
+
+    fn sample_stats() -> rb_types::MemoryStats {
+        rb_types::MemoryStats {
+            namespace: "project:rusty-brain".to_string(),
+            window_days: 30,
+            db_path: "/tmp/rb.db".to_string(),
+            live: 42,
+            archived: 3,
+            vectors: 42,
+            wal_bytes: 12_288,
+            db_embedding_model: Some("deterministic".to_string()),
+            feedback: rb_types::FeedbackTotals {
+                helpful: 5,
+                wrong: 1,
+                stale: 2,
+            },
+            total_accesses: 120,
+            accessed_in_window: 7,
+            top_recalled: vec![rb_types::TopRecalled {
+                id: rb_types::MemoryId::new(),
+                access_count: 9,
+            }],
+            never_recalled_live: 12,
+            contested: 1,
+            created_per_day: vec![rb_types::GrowthBucket {
+                day: "2026-07-10".to_string(),
+                count: 2,
+            }],
+            reembed_pending: 3,
+        }
+    }
+
+    #[test]
+    fn human_stats_shows_value_signals_and_low_n_caveat() {
+        let stats = sample_stats();
+        let out = render_stats(&stats, "deterministic", true, false);
+        assert!(out.contains("project:rusty-brain"), "namespace: {out}");
+        assert!(out.contains("30"), "window: {out}");
+        assert!(out.contains("42"), "live count: {out}");
+        assert!(out.contains("5 helpful"), "feedback counts: {out}");
+        assert!(out.contains("1 wrong"), "{out}");
+        assert!(out.contains("2 stale"), "{out}");
+        assert!(out.contains("net +2"), "net trend: {out}");
+        assert!(out.contains("12"), "never recalled: {out}");
+        assert!(out.contains(&stats.top_recalled[0].id.to_string()), "{out}");
+        assert!(out.contains("2026-07-10"), "growth bucket: {out}");
+        // 8 total events < 10: raw counts get a low-N caveat, not a confident
+        // ratio (PRD risk mitigation).
+        assert!(
+            out.contains("low") || out.contains("few"),
+            "low-N caveat: {out}"
+        );
+        // Counts and ids only — never memory content.
+        assert!(!out.contains("content"), "{out}");
+    }
+
+    #[test]
+    fn human_stats_without_feedback_says_so() {
+        let mut stats = sample_stats();
+        stats.feedback = rb_types::FeedbackTotals::default();
+        let out = render_stats(&stats, "deterministic", true, false);
+        assert!(
+            out.to_lowercase().contains("no feedback"),
+            "empty-feedback state must be explicit: {out}"
+        );
+    }
+
+    #[test]
+    fn json_stats_is_parseable_and_carries_daemon_fields() {
+        let stats = sample_stats();
+        let out = render_stats(&stats, "deterministic", true, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["stats"]["live"].as_u64(), Some(42));
+        assert_eq!(parsed["stats"]["feedback"]["helpful"].as_u64(), Some(5));
+        assert_eq!(parsed["stats"]["feedback"]["net"].as_i64(), Some(2));
+        assert_eq!(parsed["provider_model"].as_str(), Some("deterministic"));
+        assert_eq!(parsed["writer_alive"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn status_renders_health_payload_in_both_modes() {
+        let stats = sample_stats();
+        let view = StatusView {
+            contract_version: 2,
+            recall_channels: Some(rb_proto::RecallChannelTotals {
+                recalls: 4,
+                fts_hits: 9,
+                vector_hits: 11,
+                graph_hits: 2,
+            }),
+            stats: &stats,
+            provider_model: "deterministic",
+            writer_alive: true,
+            db_file_mode: Some(0o600),
+        };
+        let human = render_status(&view, false);
+        assert!(human.contains("ok (contract v2)"), "{human}");
+        assert!(human.contains("writer: alive"), "{human}");
+        assert!(human.contains("deterministic"), "{human}");
+        assert!(human.contains("/tmp/rb.db"), "{human}");
+        assert!(human.contains("0600"), "db file mode: {human}");
+        assert!(human.contains("42 live"), "{human}");
+        assert!(human.contains("3 archived"), "{human}");
+        assert!(human.contains("project:rusty-brain"), "{human}");
+        assert!(human.contains("recalls=4"), "{human}");
+
+        let json = render_status(&view, true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["ok"].as_bool(), Some(true));
+        assert_eq!(parsed["contract_version"].as_u64(), Some(2));
+        assert_eq!(parsed["writer_alive"].as_bool(), Some(true));
+        assert_eq!(parsed["provider_model"].as_str(), Some("deterministic"));
+        assert_eq!(parsed["db"]["path"].as_str(), Some("/tmp/rb.db"));
+        assert_eq!(parsed["db"]["file_mode"].as_str(), Some("0600"));
+        assert_eq!(parsed["db"]["wal_bytes"].as_u64(), Some(12_288));
+        assert_eq!(parsed["memories"]["live"].as_u64(), Some(42));
+        assert_eq!(parsed["memories"]["archived"].as_u64(), Some(3));
+        assert_eq!(parsed["vectors"].as_u64(), Some(42));
+        assert_eq!(parsed["namespace"].as_str(), Some("project:rusty-brain"));
+        assert_eq!(parsed["recall_channels"]["recalls"].as_u64(), Some(4));
+    }
+
+    #[test]
+    fn status_marks_a_dead_writer() {
+        let stats = sample_stats();
+        let view = StatusView {
+            contract_version: 2,
+            recall_channels: None,
+            stats: &stats,
+            provider_model: "deterministic",
+            writer_alive: false,
+            db_file_mode: None,
+        };
+        let human = render_status(&view, false);
+        assert!(
+            human.contains("writer: DEAD"),
+            "a dead writer must be loud: {human}"
+        );
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -71,8 +71,30 @@ pub async fn run(cli: Cli, namespace: rb_types::Namespace) -> anyhow::Result<()>
         Command::Mcp => crate::mcp::run_mcp(&socket_path, &db_path, namespace)
             .await
             .context("mcp adapter failed"),
+        // Doctor diagnoses the system AS IT IS: it must not auto-start the
+        // daemon (run_client would), so it is dispatched before it.
+        Command::Doctor => {
+            crate::doctor::run_doctor(
+                &socket_path,
+                &db_path,
+                namespace,
+                effective.embed_backend.clone(),
+                effective.local_model.clone(),
+                cli.json,
+            )
+            .await
+        }
         other => run_client(other, cli.json, namespace, &socket_path, &db_path).await,
     }
+}
+
+/// Permission bits (0o777-masked) of `path`, or `None` when it cannot be
+/// inspected (missing file, permission error).
+fn file_mode(path: &Path) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::metadata(path)
+        .ok()
+        .map(|m| m.permissions().mode() & 0o777)
 }
 
 /// Connect to the daemon and dispatch a single client request, scoped to the
@@ -99,6 +121,7 @@ async fn run_client(
     match command {
         Command::Serve { .. } => anyhow::bail!("internal: serve must be handled before run_client"),
         Command::Mcp => anyhow::bail!("internal: mcp must be handled before run_client"),
+        Command::Doctor => anyhow::bail!("internal: doctor must be handled before run_client"),
         Command::Init {
             yes,
             dry_run,
@@ -482,23 +505,64 @@ async fn run_client(
         }
         Command::Status => {
             let (version, channels) = client.ping_stats().await.context("status/ping failed")?;
-            if json {
-                match channels {
-                    Some(c) => println!(
-                        "{{\"contract_version\":{version},\"ok\":true,\"recall_channels\":{{\"recalls\":{},\"fts_hits\":{},\"vector_hits\":{},\"graph_hits\":{}}}}}",
-                        c.recalls, c.fts_hits, c.vector_hits, c.graph_hits
-                    ),
-                    None => println!("{{\"contract_version\":{version},\"ok\":true}}"),
+            // DOC-1: one health payload — writer health, embedding identity,
+            // DB path/mode, WAL size, corpus counts. Falls back to the legacy
+            // ping-only line against a daemon that predates the stats op (it
+            // closes the connection on the unknown frame).
+            match client.stats(None).await {
+                Ok((stats, provider_model, writer_alive)) => {
+                    let view = output::StatusView {
+                        contract_version: version,
+                        recall_channels: channels,
+                        stats: &stats,
+                        provider_model: &provider_model,
+                        writer_alive,
+                        db_file_mode: file_mode(Path::new(&stats.db_path)),
+                    };
+                    println!("{}", output::render_status(&view, json));
                 }
-            } else {
-                match channels {
-                    Some(c) => println!(
-                        "ok (contract v{version}) recalls={} fts_hits={} vector_hits={} graph_hits={}",
-                        c.recalls, c.fts_hits, c.vector_hits, c.graph_hits
-                    ),
-                    None => println!("ok (contract v{version})"),
+                Err(e) => {
+                    // stderr so `--json` stdout stays machine-parseable.
+                    eprintln!(
+                        "note: daemon did not answer the stats request ({e}); \
+                         it may predate this binary — restart it for full status"
+                    );
+                    if json {
+                        let mut value = serde_json::json!({
+                            "contract_version": version,
+                            "ok": true,
+                        });
+                        if let (Some(c), Some(obj)) = (channels, value.as_object_mut()) {
+                            obj.insert(
+                                "recall_channels".to_string(),
+                                serde_json::json!({
+                                    "recalls": c.recalls,
+                                    "fts_hits": c.fts_hits,
+                                    "vector_hits": c.vector_hits,
+                                    "graph_hits": c.graph_hits,
+                                }),
+                            );
+                        }
+                        println!("{value}");
+                    } else {
+                        match channels {
+                            Some(c) => println!(
+                                "ok (contract v{version}) recalls={} fts_hits={} vector_hits={} graph_hits={}",
+                                c.recalls, c.fts_hits, c.vector_hits, c.graph_hits
+                            ),
+                            None => println!("ok (contract v{version})"),
+                        }
+                    }
                 }
             }
+        }
+        Command::Stats { window_days } => {
+            let (stats, provider_model, writer_alive) =
+                client.stats(window_days).await.context("stats failed")?;
+            println!(
+                "{}",
+                output::render_stats(&stats, &provider_model, writer_alive, json)
+            );
         }
         Command::Evolve { job } => {
             let kind = rb_types::JobKind::parse(&job)

--- a/crates/rusty-brain/tests/cli_surface.rs
+++ b/crates/rusty-brain/tests/cli_surface.rs
@@ -23,7 +23,18 @@ fn help_lists_all_subcommands() {
         .stdout(predicate::str::contains("graph"))
         .stdout(predicate::str::contains("delete"))
         .stdout(predicate::str::contains("context"))
-        .stdout(predicate::str::contains("status"));
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("stats"))
+        .stdout(predicate::str::contains("doctor"));
+}
+
+#[test]
+fn stats_help_shows_window_flag() {
+    bin()
+        .args(["stats", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--window-days"));
 }
 
 #[test]

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -542,3 +542,171 @@ fn export_then_restore_round_trips_and_redacts() {
         "backup file must not contain the secret"
     );
 }
+
+#[test]
+fn stats_and_status_report_value_signals_through_the_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(wait_for_socket(&socket, Duration::from_secs(10)));
+
+    // Seed two memories and one helpful-feedback event.
+    let remembered = cli(&exe, &socket, &db, dir.path(), "stats-e2e")
+        .args(["--json", "remember", "alpha decision"])
+        .output()
+        .expect("run remember");
+    assert!(remembered.status.success());
+    let id = serde_json::from_slice::<serde_json::Value>(&remembered.stdout).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(cli(&exe, &socket, &db, dir.path(), "stats-e2e")
+        .args(["remember", "beta pattern"])
+        .output()
+        .expect("run remember")
+        .status
+        .success());
+    assert!(cli(&exe, &socket, &db, dir.path(), "stats-e2e")
+        .args(["feedback", &id, "--kind", "helpful"])
+        .output()
+        .expect("run feedback")
+        .status
+        .success());
+
+    // `stats --json`: the seeded distribution comes back, counts + ids only.
+    let stats = cli(&exe, &socket, &db, dir.path(), "stats-e2e")
+        .args(["--json", "stats", "--window-days", "7"])
+        .output()
+        .expect("run stats");
+    assert!(
+        stats.status.success(),
+        "stats failed: stderr={:?}",
+        String::from_utf8_lossy(&stats.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&stats.stdout).unwrap();
+    assert_eq!(parsed["stats"]["live"].as_u64(), Some(2));
+    assert_eq!(parsed["stats"]["window_days"].as_u64(), Some(7));
+    assert_eq!(parsed["stats"]["feedback"]["helpful"].as_u64(), Some(1));
+    assert_eq!(parsed["stats"]["feedback"]["net"].as_i64(), Some(1));
+    assert_eq!(parsed["provider_model"].as_str(), Some("deterministic"));
+    assert_eq!(parsed["writer_alive"].as_bool(), Some(true));
+    let text = String::from_utf8_lossy(&stats.stdout);
+    assert!(
+        !text.contains("alpha decision"),
+        "stats must never leak memory content: {text}"
+    );
+
+    // Extended `status --json` (DOC-1): one health payload.
+    let status = cli(&exe, &socket, &db, dir.path(), "stats-e2e")
+        .args(["--json", "status"])
+        .output()
+        .expect("run status");
+    assert!(status.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(parsed["ok"].as_bool(), Some(true));
+    assert_eq!(parsed["writer_alive"].as_bool(), Some(true));
+    assert_eq!(parsed["provider_model"].as_str(), Some("deterministic"));
+    assert_eq!(parsed["db"]["file_mode"].as_str(), Some("0600"));
+    assert_eq!(parsed["memories"]["live"].as_u64(), Some(2));
+    assert_eq!(parsed["namespace"].as_str(), Some("project:stats-e2e"));
+}
+
+#[test]
+fn doctor_healthy_system_exits_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(wait_for_socket(&socket, Duration::from_secs(10)));
+
+    let doctor = cli(&exe, &socket, &db, dir.path(), "doctor-e2e")
+        .arg("doctor")
+        .output()
+        .expect("run doctor");
+    let stdout = String::from_utf8_lossy(&doctor.stdout);
+    assert!(
+        doctor.status.success(),
+        "doctor must exit 0 on a healthy system; stdout={stdout} stderr={:?}",
+        String::from_utf8_lossy(&doctor.stderr)
+    );
+    assert!(stdout.contains("no problems"), "{stdout}");
+    // The offline fallback is active in this test env: warned, not failed.
+    assert!(stdout.to_lowercase().contains("deterministic"), "{stdout}");
+}
+
+#[test]
+fn doctor_fails_with_guidance_on_wrong_db_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(wait_for_socket(&socket, Duration::from_secs(10)));
+
+    // A completed round trip proves the daemon is fully initialized (writer
+    // AND read pool opened — each open re-tightens the DB to 0600), so the
+    // chmod below cannot race a late open that would undo it.
+    assert!(cli(&exe, &socket, &db, dir.path(), "doctor-e2e")
+        .args(["remember", "mode probe"])
+        .output()
+        .expect("run remember")
+        .status
+        .success());
+
+    // Loosen the DB file mode behind the daemon's back.
+    std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let doctor = cli(&exe, &socket, &db, dir.path(), "doctor-e2e")
+        .arg("doctor")
+        .output()
+        .expect("run doctor");
+    let stdout = String::from_utf8_lossy(&doctor.stdout);
+    assert!(
+        !doctor.status.success(),
+        "doctor must exit non-zero on a world-readable DB; stdout={stdout}"
+    );
+    assert!(stdout.contains("db-file-mode"), "{stdout}");
+    assert!(stdout.contains("0644"), "observed mode shown: {stdout}");
+    assert!(
+        stdout.contains(&format!("chmod 600 {}", db.display())),
+        "actionable guidance shown: {stdout}"
+    );
+}
+
+#[test]
+fn doctor_fails_with_guidance_on_model_mismatch_against_db_meta() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+
+    // A DB whose meta records a real embedding model, with NO daemon running:
+    // serve would fail closed (W0.2), and doctor must diagnose exactly that.
+    // (This env has no VOYAGE_API_KEY, so the expected provider is the
+    // deterministic fallback — a mismatch with the recorded 'voyage-3'.)
+    drop(rb_store::SqliteStore::open_with_model(&db, 8, "voyage-3").unwrap());
+
+    let doctor = cli(&exe, &socket, &db, dir.path(), "doctor-e2e")
+        .arg("doctor")
+        .output()
+        .expect("run doctor");
+    let stdout = String::from_utf8_lossy(&doctor.stdout);
+    assert!(
+        !doctor.status.success(),
+        "doctor must exit non-zero on a model mismatch; stdout={stdout}"
+    );
+    assert!(stdout.contains("embedding-model"), "{stdout}");
+    assert!(
+        stdout.contains("voyage-3"),
+        "the recorded model is named: {stdout}"
+    );
+    assert!(
+        stdout.contains("--accept-model-change"),
+        "guidance names the opt-in: {stdout}"
+    );
+}

--- a/docs/prds/2026-07-02-doctor-and-stats-observability.md
+++ b/docs/prds/2026-07-02-doctor-and-stats-observability.md
@@ -76,7 +76,8 @@ actionable guidance:
 - embedding-model identity matches DB meta (the W0.2 fail-closed contract).
 - WAL checkpoint health; oversized-WAL warning with remediation hint.
 - hooks installed + wiring drift (delegates to installer `status` where
-  available).
+  available). DEFERRED: `rusty-brain-install` exposes no `status` surface
+  yet; doctor gains this check when it does.
 
 ### DOC-4. Protocol addition (additive, no CONTRACT_VERSION bump)
 
@@ -118,12 +119,14 @@ seeded feedback distribution.
 
 ## Implementation Checklist
 
-- [ ] Extend `status` payload + output.
-- [ ] Add `Stats` request/response (additive, no bump).
-- [ ] Implement read-only aggregations in the store/read pool.
-- [ ] Add `doctor` with exit codes + guidance.
-- [ ] Assert zero-writer-ops on the stats path.
-- [ ] Add JSON + human output and tests.
+- [x] Extend `status` payload + output.
+- [x] Add `Stats` request/response (additive, no bump).
+- [x] Implement read-only aggregations in the store/read pool
+      (`rb-store/src/store/stats.rs`, inherent-impl module — the store split
+      landed in PR #54, so there is no monolithic `store.rs` anymore).
+- [x] Add `doctor` with exit codes + guidance.
+- [x] Assert zero-writer-ops on the stats path.
+- [x] Add JSON + human output and tests.
 
 ## Roadmap Fit
 


### PR DESCRIPTION
## Summary

Implements the "memory is working" observability surface (Vikunja #460, PRD `docs/prds/2026-07-02-doctor-and-stats-observability.md`). Surfaces the signals `memory_feedback` (W3.7) and `access_count` already accumulate: recall volume, helpful/wrong/stale ratios with a low-N caveat, top/never-recalled memories, contested count, corpus growth, and the re-embed backlog. Counts and ids only, never memory content.

- **rb-types**: `MemoryStats` vocabulary struct (all fields serde-default).
- **rb-proto**: additive `Request::Stats`/`Response::Stats` following the Feedback precedent; no CONTRACT_VERSION bump (stays 2); `Client::stats` wrapper.
- **rb-store**: `store/stats.rs` inherent-impl aggregation module (the `oplog.rs` precedent) plus a read-only meta reader (`read_meta_embedding_model`, SQLITE_OPEN_READ_ONLY, no migrations) for doctor's daemon-down path.
- **rb-daemon**: `StoreHandle::namespace_stats` through the read pool, `writer_alive` accessor, dispatch arm with server-side window clamp.
- **rusty-brain**: new `stats`/`doctor` subcommands, extended `status` (writer health, embedding identity, DB path/mode, WAL size, corpus counts) with a legacy fallback for pre-stats daemons. `doctor` never auto-starts the daemon (dispatched before `run_client`), checks socket/DB permissions, WAL size, deterministic-fallback, and provider-vs-meta model identity (also offline via the read-only meta reader), and exits non-zero with actionable guidance on any failure.

W1.8 hard constraint (zero writer ops) proven twice: `namespace_stats_runs_on_the_read_pool_with_zero_writer_ops` (StoreHandle, mirrors the recall gate) and `stats_over_the_wire_reflects_seeded_feedback_and_issues_zero_writer_ops` (server e2e) both assert `writer_ops_count()` is unchanged across stats.

DOC-3's hooks/wiring-drift check is deferred until rusty-brain-install exposes a status surface (noted in the PRD).

## Test plan

- [x] `cargo test --workspace` green at implementation time (branch base f89c8e6)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green at implementation time
- [ ] Re-verify gates against current main (clean textual merge confirmed via merge-tree; local gate run on the merged tree in progress)
- [x] Zero-writer-ops asserted at both the StoreHandle and wire layers
- [x] `doctor` daemon-down path covered (read-only meta reader, no auto-start)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stats` command with configurable reporting windows and human-readable or JSON output.
  * Expanded `status` with memory counts, feedback, embedding model, storage, and writer health details.
  * Added `doctor` diagnostics with actionable checks for database permissions, WAL usage, model identity, daemon connectivity, and provider health.
* **Bug Fixes**
  * Stats reporting is namespace-scoped, read-only, and safely bounds requested time windows.
  * Added compatibility support for older stats payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->