### PR TITLE
ci: contract-drift guard operationalizing the W5a.4 protocol-evolution policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,26 @@ jobs:
       - name: Test rb-embed local (offline only; real-model tests are #[ignore])
         run: cargo test -p rb-embed --features local
 
+  # W5a.4 protocol-evolution policy, operationalized: the wire surface
+  # (rb-proto messages + the rb-types payload shapes they embed) and the
+  # rb-store migrations are digested and compared against the checked-in
+  # contract-snapshot.toml. Any drift fails until the PR records a deliberate
+  # decision: `update --intent additive` (serde-default change, no
+  # CONTRACT_VERSION bump) or `update --intent breaking` (after bumping it).
+  contract-drift:
+    name: contract drift guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check contract surface against snapshot
+        run: cargo run -p rb-contract-guard -- check
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest
@@ -129,9 +149,9 @@ jobs:
       - name: Assert dev/measurement crates stay out of the default rusty-brain closure
         run: |
           set -euo pipefail
-          if cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install|rb-eval"; then
+          if cargo tree -e no-dev -p rusty-brain | grep -E "rb-agents|rb-hooks|rb-install|rb-eval|rb-contract-guard"; then
             echo "ERROR: a dev/measurement crate leaked into the default rusty-brain (non-dev) dependency closure." >&2
-            echo "The rusty-brain binary must NEVER depend on rb-agents/rb-hooks/rb-install/rb-eval." >&2
+            echo "The rusty-brain binary must NEVER depend on rb-agents/rb-hooks/rb-install/rb-eval/rb-contract-guard." >&2
             exit 1
           fi
-          echo "OK: rb-agents/rb-hooks/rb-install/rb-eval are absent from the default rusty-brain closure."
+          echo "OK: rb-agents/rb-hooks/rb-install/rb-eval/rb-contract-guard are absent from the default rusty-brain closure."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added — Contract-drift guard (W5a.4 operationalized)
+
+- **`rb-contract-guard` + `contract-drift` CI job**: the wire surface
+  (rb-proto messages plus the rb-types payload shapes they embed) and the
+  rb-store migrations are digested (syn-normalized item tokens: doc comments,
+  regular comments, and formatting never trip the guard) and compared against
+  the checked-in `contract-snapshot.toml`. Any drift fails CI until the PR
+  records a deliberate decision: `update --intent additive` (serde-default
+  change, no `CONTRACT_VERSION` bump — the tool refuses a bumped version) or
+  `update --intent breaking` (the tool demands the bump). The note lands in
+  the snapshot's append-only `[[log]]` so reviewers see the decision in the
+  diff. Also bound into `cargo test --workspace` and `scripts/ci-local.sh`.
+  See `docs/specs/2026-07-11-contract-drift-guard.md`.
+- **N-1 handshake fixture (W5a.4)**: rb-daemon e2e now pins version-skew
+  behavior — with no dual-support window open, an N-1 client handshake gets a
+  graceful `HandshakeAck { ok: false }` naming both versions, then a closed
+  connection.
+
 ### Added — Cross-agent capability status
 
 - **Agent capability matrix**: `rb-agents` now exposes the current support state

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-contract-guard"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "quote",
+ "rb-proto",
+ "serde",
+ "sha2",
+ "syn",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "rb-daemon"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/rb-eval",
     "crates/rb-redact",
     "crates/rb-tokens",
+    "crates/rb-contract-guard",
 ]
 
 [workspace.package]
@@ -62,6 +63,11 @@ predicates = "3"
 # true artifact path regardless of profile.
 escargot = "0.5"
 toml = "0.8"
+# Contract-drift guard (rb-contract-guard): parses the wire-shape-defining
+# sources with syn to digest type definitions, so comment/formatting-only
+# edits never trip the guard.
+syn = { version = "2", default-features = false, features = ["full", "parsing", "printing"] }
+quote = "1"
 # W3.3 token economy: a faithful BPE token counter (o200k_base) used to enforce
 # the SessionStart injection budget at runtime and to gate the token-accounting
 # CI test. Embeds its vocab (no network at runtime).

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -1,0 +1,44 @@
+# Contract-drift guard snapshot (rb-contract-guard). DO NOT EDIT BY HAND.
+# Regenerate after a deliberate contract decision (W5a.4):
+#   cargo run -p rb-contract-guard -- update --intent additive --note "..."   # serde-default addition, no bump
+#   cargo run -p rb-contract-guard -- update --intent breaking --note "..."   # after bumping CONTRACT_VERSION
+
+contract_version = 2
+
+[wire]
+"crates/rb-proto/src/messages.rs::CONTRACT_VERSION" = "3f9208b6b23ee097c0f8177f4e0c94696a2c17f0cc02d4f3db93854566d67791"
+"crates/rb-proto/src/messages.rs::ClientIdentity" = "4c817d16fbee936cf94e023e4d4ddf9330df312bc4e3bd7ce98f0b983de35fa1"
+"crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
+"crates/rb-proto/src/messages.rs::HandshakeAck" = "09b1c1de35d4a2331beeb72fce279bbc689969cffa4b0aec3226c09183120a32"
+"crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
+"crates/rb-proto/src/messages.rs::Request" = "9dfb140e260ca4098975bf3fe0831be6326a0ca4f0f037a7dc8b3bad432ce957"
+"crates/rb-proto/src/messages.rs::Response" = "824c05193069fbbeae24d95444cb02bbe359599a4fdb9047f28c59d5ebcd0210"
+"crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
+"crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
+"crates/rb-types/src/feedback_kind.rs::FeedbackKind" = "8ca2edbd8aca8e2b087ea630e10209a51a307efdf1a84b0bbccc74a06f2da7b6"
+"crates/rb-types/src/job.rs::JobKind" = "1d37fe458aaade8a2fdc2291c14e68eb54102c358e12274ea347f3645c23b986"
+"crates/rb-types/src/link.rs::MemoryLink" = "7e1c5377ec99d7e609c289b14fed82fa2a2c5275650bb688ea1afbe03fb37f4d"
+"crates/rb-types/src/link_type.rs::LinkType" = "2394c0b6dc86235d55ce3e3bb9b7d5d8b058672f07b1e57532930e897ca644f2"
+"crates/rb-types/src/memory.rs::MemoryNote" = "bc882adf4a7f6269ac42aa76d07fc2c906bab2d27eec1c9cf75b1f04c3cd0764"
+"crates/rb-types/src/memory_id.rs::MemoryId" = "688b5e41d43d9004ae80916922636c569b7dceb0e4b9ab80e1e83d9d1ed622f0"
+"crates/rb-types/src/memory_type.rs::MemoryType" = "238c3095d32261dc60d19ec7e787249c1f3a0e1bfd40917a5e670fa8e4270ac3"
+"crates/rb-types/src/namespace.rs::Namespace" = "7ba4f747be391c0b6b298ddc89b0654e92a7cd13e69f54c6debf3c01116c7c51"
+"crates/rb-types/src/query.rs::ChannelHits" = "34168a59378e913813f5c759c87925242ee72ef8a2fb107e4d460a6e87d3b298"
+"crates/rb-types/src/query.rs::MemoryUpdates" = "06e908ddd047725e8997facef27fbf79dcba980db9c0058151ffe6834ed1cd4e"
+"crates/rb-types/src/query.rs::SearchQuery" = "09cf14ba050d24ee74a6757b4b30eb8dd9baa81b6df9e5c1f50340f2b402197b"
+"crates/rb-types/src/query.rs::SearchResult" = "6553d26249a902d241e3377a24777ed772ab9ecb4451c708b3a34507a684b171"
+
+[migrations]
+"001_initial_schema.sql" = "f1c767719094a249947a56426590c95732a3ea373470dc62a5c5692e4b369731"
+"002_link_base_strength.sql" = "b09a52ddd2eb456643d65318bb5aba4ca573698faf0225ab1992b19b655293f2"
+"003_embedding_input_version.sql" = "effe50d59e6ba2a5662529ef90f77adf00e962641576fc9dd59f87c2a53f9957"
+"004_provenance.sql" = "e63d4fe90cdaaa2093b8b61d8672599ce6bdffdf0115d5f82df48e87af7e86a4"
+"005_fts_porter_tokenizer.sql" = "5733ae37f2aa52201cdf60b7c2b6823a668a5454d3ba418fdf099f5d7f436780"
+"006_narrow_mem_au.sql" = "1803fb5199302bc5e5910e870ef81b80ddb940c4b3a4df3113d6a319a3933299"
+"007_base_importance.sql" = "be04183c1209fdb8adfdcbd66dc96ecf6125b79a45cd4a65f40388b6cca6586b"
+"008_memory_feedback.sql" = "64901f555624da4b738e437877d6b2b60579dbd5051f55ab476390015a67b70b"
+
+[[log]]
+contract_version = 2
+intent = "initial"
+note = "baseline: v2 wire surface (rb-proto messages + rb-types payload shapes) and rb-store migrations 001-008"

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -11,8 +11,8 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "09b1c1de35d4a2331beeb72fce279bbc689969cffa4b0aec3226c09183120a32"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
-"crates/rb-proto/src/messages.rs::Request" = "9dfb140e260ca4098975bf3fe0831be6326a0ca4f0f037a7dc8b3bad432ce957"
-"crates/rb-proto/src/messages.rs::Response" = "824c05193069fbbeae24d95444cb02bbe359599a4fdb9047f28c59d5ebcd0210"
+"crates/rb-proto/src/messages.rs::Request" = "cbca30891389d98ab42c4778302754f1bcd9603b3eeea4b63c6ae7f2c5de2465"
+"crates/rb-proto/src/messages.rs::Response" = "383bd0e8b99c07bb4ce785c8c5cab9097a20549372cba77186d684b083a78971"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
 "crates/rb-types/src/feedback_kind.rs::FeedbackKind" = "8ca2edbd8aca8e2b087ea630e10209a51a307efdf1a84b0bbccc74a06f2da7b6"
@@ -27,6 +27,10 @@ contract_version = 2
 "crates/rb-types/src/query.rs::MemoryUpdates" = "06e908ddd047725e8997facef27fbf79dcba980db9c0058151ffe6834ed1cd4e"
 "crates/rb-types/src/query.rs::SearchQuery" = "09cf14ba050d24ee74a6757b4b30eb8dd9baa81b6df9e5c1f50340f2b402197b"
 "crates/rb-types/src/query.rs::SearchResult" = "6553d26249a902d241e3377a24777ed772ab9ecb4451c708b3a34507a684b171"
+"crates/rb-types/src/stats.rs::FeedbackTotals" = "ab6a1ea796d5866a566a9372536caed43217046b16245604cf41225963bbcd23"
+"crates/rb-types/src/stats.rs::GrowthBucket" = "552aa8d7fcb065ccc8275263b55fb0b5e1aad3493bbffa4e1c695bcd14174de6"
+"crates/rb-types/src/stats.rs::MemoryStats" = "4cf5bf4353a5783f4e9ca712060e560833e3a844547d6782c0957025058fdcf7"
+"crates/rb-types/src/stats.rs::TopRecalled" = "8d416dd284f9995cd45563cfe7d9fa56db1ca81e211dce44e09b45e850db8dd6"
 
 [migrations]
 "001_initial_schema.sql" = "f1c767719094a249947a56426590c95732a3ea373470dc62a5c5692e4b369731"
@@ -42,3 +46,8 @@ contract_version = 2
 contract_version = 2
 intent = "initial"
 note = "baseline: v2 wire surface (rb-proto messages + rb-types payload shapes) and rb-store migrations 001-008"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR #56 doctor/stats: Request::Stats/Response::Stats + rb-types MemoryStats (no bump, additive per W5a.4)"

--- a/crates/rb-contract-guard/Cargo.toml
+++ b/crates/rb-contract-guard/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "rb-contract-guard"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "CI contract-drift guard: detects wire-shape (rb-proto/rb-types) and rb-store migration drift and requires a deliberate CONTRACT_VERSION decision (W5a.4)."
+
+[lib]
+name = "rb_contract_guard"
+path = "src/lib.rs"
+
+[[bin]]
+name = "rb-contract-guard"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
+syn = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = { workspace = true }
+# Integrity check only: the snapshot's recorded contract_version must equal the
+# const rb-proto actually compiles (catches a hand-edited snapshot).
+rb-proto = { path = "../rb-proto" }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rb-contract-guard/src/check.rs
+++ b/crates/rb-contract-guard/src/check.rs
@@ -1,0 +1,185 @@
+//! Compare the observed contract surface against the checked-in snapshot.
+
+use crate::snapshot::Snapshot;
+use crate::Observed;
+use std::collections::BTreeMap;
+
+/// Result of a drift check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Observed surface matches the snapshot exactly.
+    Clean,
+    /// One human-readable line per divergence, each naming the drifted item.
+    Drift(Vec<String>),
+}
+
+fn diff_maps(
+    kind: &str,
+    observed: &BTreeMap<String, String>,
+    recorded: &BTreeMap<String, String>,
+    drift: &mut Vec<String>,
+) {
+    for (key, digest) in observed {
+        match recorded.get(key) {
+            None => drift.push(format!("{kind} added: {key}")),
+            Some(rec) if rec != digest => drift.push(format!("{kind} changed: {key}")),
+            Some(_) => {}
+        }
+    }
+    for key in recorded.keys() {
+        if !observed.contains_key(key) {
+            drift.push(format!("{kind} removed: {key}"));
+        }
+    }
+}
+
+/// Compare `observed` against `snapshot`.
+pub fn check(observed: &Observed, snapshot: &Snapshot) -> Outcome {
+    let mut drift = Vec::new();
+    if observed.contract_version != snapshot.contract_version {
+        drift.push(format!(
+            "CONTRACT_VERSION changed: snapshot records {}, code declares {}",
+            snapshot.contract_version, observed.contract_version
+        ));
+    }
+    diff_maps("wire item", &observed.wire, &snapshot.wire, &mut drift);
+    diff_maps(
+        "migration",
+        &observed.migrations,
+        &snapshot.migrations,
+        &mut drift,
+    );
+    if drift.is_empty() {
+        Outcome::Clean
+    } else {
+        Outcome::Drift(drift)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapshot::{Intent, LogEntry};
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn observed() -> Observed {
+        Observed {
+            contract_version: 2,
+            wire: map(&[("m.rs::Request", "aaa"), ("m.rs::Response", "bbb")]),
+            migrations: map(&[("001_init.sql", "ccc")]),
+        }
+    }
+
+    fn snapshot_matching(obs: &Observed) -> Snapshot {
+        Snapshot {
+            contract_version: obs.contract_version,
+            wire: obs.wire.clone(),
+            migrations: obs.migrations.clone(),
+            log: vec![LogEntry {
+                contract_version: obs.contract_version,
+                intent: Intent::Initial,
+                note: "baseline".to_string(),
+            }],
+        }
+    }
+
+    fn drift_lines(outcome: Outcome) -> Vec<String> {
+        match outcome {
+            Outcome::Drift(lines) => lines,
+            Outcome::Clean => panic!("expected drift"),
+        }
+    }
+
+    #[test]
+    fn matching_surface_is_clean() {
+        let obs = observed();
+        let snap = snapshot_matching(&obs);
+        assert_eq!(check(&obs, &snap), Outcome::Clean);
+    }
+
+    #[test]
+    fn changed_wire_item_is_named() {
+        let obs = observed();
+        let mut snap = snapshot_matching(&obs);
+        snap.wire
+            .insert("m.rs::Request".to_string(), "OLD".to_string());
+        let lines = drift_lines(check(&obs, &snap));
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains("m.rs::Request") && lines[0].contains("changed"),
+            "line names the changed item: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn added_and_removed_wire_items_are_named() {
+        let obs = observed();
+        let mut snap = snapshot_matching(&obs);
+        snap.wire.remove("m.rs::Response"); // observed has it -> "added"
+        snap.wire
+            .insert("m.rs::Gone".to_string(), "ddd".to_string()); // only snapshot -> "removed"
+        let lines = drift_lines(check(&obs, &snap));
+        assert_eq!(lines.len(), 2);
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("m.rs::Response") && l.contains("added")));
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("m.rs::Gone") && l.contains("removed")));
+    }
+
+    #[test]
+    fn version_change_alone_is_drift() {
+        let obs = observed();
+        let mut snap = snapshot_matching(&obs);
+        snap.contract_version = 1;
+        let lines = drift_lines(check(&obs, &snap));
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains("CONTRACT_VERSION")
+                && lines[0].contains('1')
+                && lines[0].contains('2'),
+            "line names both versions: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn migration_drift_is_named() {
+        let mut obs = observed();
+        let snap = snapshot_matching(&obs);
+        obs.migrations
+            .insert("009_new.sql".to_string(), "eee".to_string());
+        obs.migrations
+            .insert("001_init.sql".to_string(), "TAMPERED".to_string());
+        let lines = drift_lines(check(&obs, &snap));
+        assert_eq!(lines.len(), 2);
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("009_new.sql") && l.contains("added")));
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("001_init.sql") && l.contains("changed")));
+    }
+
+    #[test]
+    fn multiple_drifts_all_reported() {
+        let mut obs = observed();
+        obs.contract_version = 3;
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        obs.migrations
+            .insert("009_new.sql".to_string(), "eee".to_string());
+        let snap = {
+            let base = observed();
+            snapshot_matching(&base)
+        };
+        let lines = drift_lines(check(&obs, &snap));
+        assert_eq!(lines.len(), 3, "version + wire + migration: {lines:?}");
+    }
+}

--- a/crates/rb-contract-guard/src/extract.rs
+++ b/crates/rb-contract-guard/src/extract.rs
@@ -1,0 +1,307 @@
+//! Wire-shape extraction: parse a Rust source file and digest the items that
+//! define the serialized contract.
+//!
+//! What counts as shape-defining (and is digested):
+//! - `struct` and `enum` definitions, including all their attributes — serde
+//!   attrs (`tag`, `default`, `skip_serializing_if`, `rename_all`, ...) ARE the
+//!   wire shape;
+//! - explicit `impl Serialize/Deserialize for T` blocks (none exist today; the
+//!   guard must not go blind if one appears);
+//! - the `CONTRACT_VERSION` const.
+//!
+//! What is normalized away (never trips the guard):
+//! - doc comments (`///`, `#[doc = ...]`) anywhere on/inside an item;
+//! - regular comments and formatting (dropped by parsing + token printing);
+//! - functions, inherent impls, other consts, `use` items, `#[cfg(test)]` items.
+
+use anyhow::{bail, Result};
+use quote::ToTokens;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use syn::{Attribute, Fields, ImplItem, Item, ItemImpl};
+
+/// Hex-encoded sha256 of `bytes`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn is_doc(attr: &Attribute) -> bool {
+    attr.path().is_ident("doc")
+}
+
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|a| a.path().is_ident("cfg") && a.to_token_stream().to_string().contains("test"))
+}
+
+fn strip_docs(attrs: &mut Vec<Attribute>) {
+    attrs.retain(|a| !is_doc(a));
+}
+
+fn strip_docs_in_fields(fields: &mut Fields) {
+    for field in fields.iter_mut() {
+        strip_docs(&mut field.attrs);
+    }
+}
+
+/// The trait name when `imp` is an explicit serde impl (`Serialize` or
+/// `Deserialize`), else `None`.
+fn serde_impl_trait(imp: &ItemImpl) -> Option<String> {
+    let (_, path, _) = imp.trait_.as_ref()?;
+    let last = path.segments.last()?.ident.to_string();
+    (last == "Serialize" || last == "Deserialize").then_some(last)
+}
+
+fn digest_tokens(tokens: &impl ToTokens) -> String {
+    sha256_hex(tokens.to_token_stream().to_string().as_bytes())
+}
+
+/// Extract `"<rel_path>::<item name>"` -> digest for every shape-defining item
+/// in `source`.
+pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<String, String>> {
+    let file: syn::File = match syn::parse_file(source) {
+        Ok(f) => f,
+        Err(e) => bail!("failed to parse {rel_path} as Rust: {e}"),
+    };
+
+    let mut out = BTreeMap::new();
+    for item in file.items {
+        match item {
+            Item::Struct(mut s) => {
+                if is_cfg_test(&s.attrs) {
+                    continue;
+                }
+                strip_docs(&mut s.attrs);
+                strip_docs_in_fields(&mut s.fields);
+                out.insert(format!("{rel_path}::{}", s.ident), digest_tokens(&s));
+            }
+            Item::Enum(mut e) => {
+                if is_cfg_test(&e.attrs) {
+                    continue;
+                }
+                strip_docs(&mut e.attrs);
+                for variant in &mut e.variants {
+                    strip_docs(&mut variant.attrs);
+                    strip_docs_in_fields(&mut variant.fields);
+                }
+                out.insert(format!("{rel_path}::{}", e.ident), digest_tokens(&e));
+            }
+            Item::Const(mut c) => {
+                if is_cfg_test(&c.attrs) || c.ident != "CONTRACT_VERSION" {
+                    continue;
+                }
+                strip_docs(&mut c.attrs);
+                out.insert(format!("{rel_path}::{}", c.ident), digest_tokens(&c));
+            }
+            Item::Impl(mut imp) => {
+                if is_cfg_test(&imp.attrs) {
+                    continue;
+                }
+                let Some(trait_name) = serde_impl_trait(&imp) else {
+                    continue;
+                };
+                strip_docs(&mut imp.attrs);
+                for inner in &mut imp.items {
+                    if let ImplItem::Fn(f) = inner {
+                        strip_docs(&mut f.attrs);
+                    }
+                }
+                let ty = imp.self_ty.to_token_stream().to_string();
+                out.insert(
+                    format!("{rel_path}::impl {trait_name} for {ty}"),
+                    digest_tokens(&imp),
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+/// Parse the integer value of `const CONTRACT_VERSION: u32 = N;` in `source`.
+pub fn parse_contract_version(source: &str) -> Result<u32> {
+    let file: syn::File = match syn::parse_file(source) {
+        Ok(f) => f,
+        Err(e) => bail!("failed to parse version file as Rust: {e}"),
+    };
+    for item in file.items {
+        let Item::Const(c) = item else { continue };
+        if c.ident != "CONTRACT_VERSION" {
+            continue;
+        }
+        let syn::Expr::Lit(lit) = c.expr.as_ref() else {
+            bail!("CONTRACT_VERSION is not a literal expression");
+        };
+        let syn::Lit::Int(int) = &lit.lit else {
+            bail!("CONTRACT_VERSION is not an integer literal");
+        };
+        return Ok(int.base10_parse::<u32>()?);
+    }
+    bail!("no `const CONTRACT_VERSION` found in version file")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = r#"
+        /// Wire contract version.
+        pub const CONTRACT_VERSION: u32 = 2;
+
+        /// First frame the client sends.
+        #[derive(Serialize, Deserialize)]
+        pub struct Handshake {
+            /// Negotiated version.
+            pub contract_version: u32,
+            #[serde(default)]
+            pub identity: Option<String>,
+        }
+
+        /// One request per op.
+        #[derive(Serialize, Deserialize)]
+        #[serde(tag = "op")]
+        pub enum Request {
+            Ping,
+            Get { id: String },
+        }
+
+        pub const SOME_TUNING_KNOB: f32 = 0.18;
+
+        pub fn helper() {}
+
+        impl Handshake {
+            pub fn inherent(&self) {}
+        }
+
+        #[cfg(test)]
+        mod tests {
+            pub struct NotWire;
+        }
+    "#;
+
+    fn items(src: &str) -> BTreeMap<String, String> {
+        extract_wire_items("f.rs", src).unwrap()
+    }
+
+    #[test]
+    fn extracts_structs_enums_and_contract_version_only() {
+        let map = items(BASE);
+        let keys: Vec<&str> = map.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            vec!["f.rs::CONTRACT_VERSION", "f.rs::Handshake", "f.rs::Request"],
+            "only shape-defining items are digested"
+        );
+        for digest in map.values() {
+            assert_eq!(digest.len(), 64, "sha256 hex digest");
+            assert!(digest.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn doc_comments_and_formatting_do_not_change_digests() {
+        let reworded = r#"
+        // A regular comment the parser drops.
+        pub const CONTRACT_VERSION: u32 = 2;
+        #[derive(Serialize, Deserialize)]
+        pub struct Handshake {
+                pub contract_version: u32,
+            #[serde(default)] pub identity: Option<String>,
+        }
+        /// Entirely different documentation prose.
+        #[derive(Serialize, Deserialize)]
+        #[serde(tag = "op")]
+        pub enum Request { Ping, Get { id: String }, }
+        pub const SOME_TUNING_KNOB: f32 = 0.18;
+        pub fn helper() {}
+        impl Handshake { pub fn inherent(&self) {} }
+        #[cfg(test)]
+        mod tests { pub struct NotWire; }
+        "#;
+        assert_eq!(
+            items(BASE),
+            items(reworded),
+            "docs/comments/whitespace are not part of the wire shape"
+        );
+    }
+
+    #[test]
+    fn adding_a_field_changes_the_digest() {
+        let added = BASE.replace(
+            "pub identity: Option<String>,",
+            "pub identity: Option<String>,\n pub extra: Option<u8>,",
+        );
+        let before = items(BASE);
+        let after = items(&added);
+        assert_ne!(
+            before.get("f.rs::Handshake"),
+            after.get("f.rs::Handshake"),
+            "a new field must change the item digest"
+        );
+        assert_eq!(
+            before.get("f.rs::Request"),
+            after.get("f.rs::Request"),
+            "unrelated items keep their digest"
+        );
+    }
+
+    #[test]
+    fn changing_a_serde_attribute_changes_the_digest() {
+        let retagged = BASE.replace("#[serde(tag = \"op\")]", "#[serde(tag = \"operation\")]");
+        assert_ne!(
+            items(BASE).get("f.rs::Request"),
+            items(&retagged).get("f.rs::Request"),
+            "serde attrs are part of the wire shape"
+        );
+    }
+
+    #[test]
+    fn adding_an_enum_variant_changes_the_digest() {
+        let grown = BASE.replace("Get { id: String },", "Get { id: String },\n Stats,");
+        assert_ne!(
+            items(BASE).get("f.rs::Request"),
+            items(&grown).get("f.rs::Request"),
+            "a new variant must change the enum digest"
+        );
+    }
+
+    #[test]
+    fn custom_serde_impls_are_digested_but_inherent_impls_are_not() {
+        let with_custom = r#"
+            pub struct Weird;
+            impl serde::Serialize for Weird {
+                fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error> { s.serialize_unit() }
+            }
+            impl Weird { pub fn helper(&self) {} }
+        "#;
+        let map = items(with_custom);
+        assert!(
+            map.contains_key("f.rs::impl Serialize for Weird"),
+            "explicit serde impls define wire shape; keys: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(map.len(), 2, "struct + serde impl, no inherent impl");
+    }
+
+    #[test]
+    fn contract_version_value_is_parsed() {
+        assert_eq!(parse_contract_version(BASE).unwrap(), 2);
+    }
+
+    #[test]
+    fn missing_contract_version_errors() {
+        let err = parse_contract_version("pub struct X;").unwrap_err();
+        assert!(err.to_string().contains("CONTRACT_VERSION"));
+    }
+
+    #[test]
+    fn invalid_rust_errors() {
+        assert!(extract_wire_items("f.rs", "not rust at all {{{").is_err());
+    }
+}

--- a/crates/rb-contract-guard/src/extract.rs
+++ b/crates/rb-contract-guard/src/extract.rs
@@ -5,9 +5,17 @@
 //! - `struct` and `enum` definitions, including all their attributes — serde
 //!   attrs (`tag`, `default`, `skip_serializing_if`, `rename_all`, ...) ARE the
 //!   wire shape;
+//! - `type` aliases (a wire field can reference one; retargeting it changes
+//!   the serialized shape while the struct digest stays put);
 //! - explicit `impl Serialize/Deserialize for T` blocks (none exist today; the
 //!   guard must not go blind if one appears);
 //! - the `CONTRACT_VERSION` const.
+//!
+//! Inline modules (`pub mod v2 { ... }`) are recursed into, with
+//! module-qualified keys; `#[cfg(test)]` modules and items are skipped. Only
+//! the exact `#[cfg(test)]` predicate is treated as test-only — `not(test)`,
+//! `feature = "..."`, `all(...)`, etc. stay in the digest (conservative
+//! inclusion: the guard must never silently drop a real wire item).
 //!
 //! What is normalized away (never trips the guard):
 //! - doc comments (`///`, `#[doc = ...]`) anywhere on/inside an item;
@@ -34,10 +42,16 @@ fn is_doc(attr: &Attribute) -> bool {
     attr.path().is_ident("doc")
 }
 
+/// True only for the exact `#[cfg(test)]` attribute. Anything else —
+/// `cfg(not(test))`, `cfg(feature = "latest")`, `cfg(all(test, ...))` — is
+/// treated as live wire surface: excluding on a substring match silently
+/// dropped real items (`"latest"` contains `"test"`), and over-inclusion is
+/// the safe direction for a drift guard.
 fn is_cfg_test(attrs: &[Attribute]) -> bool {
-    attrs
-        .iter()
-        .any(|a| a.path().is_ident("cfg") && a.to_token_stream().to_string().contains("test"))
+    attrs.iter().any(|a| {
+        a.path().is_ident("cfg")
+            && matches!(a.parse_args::<syn::Meta>(), Ok(syn::Meta::Path(p)) if p.is_ident("test"))
+    })
 }
 
 fn strip_docs(attrs: &mut Vec<Attribute>) {
@@ -62,8 +76,8 @@ fn digest_tokens(tokens: &impl ToTokens) -> String {
     sha256_hex(tokens.to_token_stream().to_string().as_bytes())
 }
 
-/// Extract `"<rel_path>::<item name>"` -> digest for every shape-defining item
-/// in `source`.
+/// Extract `"<rel_path>::<module path>::<item name>"` -> digest for every
+/// shape-defining item in `source`, recursing into inline modules.
 pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<String, String>> {
     let file: syn::File = match syn::parse_file(source) {
         Ok(f) => f,
@@ -71,7 +85,19 @@ pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<Strin
     };
 
     let mut out = BTreeMap::new();
-    for item in file.items {
+    collect_items(rel_path, "", file.items, &mut out);
+    Ok(out)
+}
+
+/// Walk `items` (one inline-module level; `prefix` is the `"mod::"`-style
+/// module path accumulated so far), digesting the shape-defining ones.
+fn collect_items(
+    rel_path: &str,
+    prefix: &str,
+    items: Vec<Item>,
+    out: &mut BTreeMap<String, String>,
+) {
+    for item in items {
         match item {
             Item::Struct(mut s) => {
                 if is_cfg_test(&s.attrs) {
@@ -79,7 +105,10 @@ pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<Strin
                 }
                 strip_docs(&mut s.attrs);
                 strip_docs_in_fields(&mut s.fields);
-                out.insert(format!("{rel_path}::{}", s.ident), digest_tokens(&s));
+                out.insert(
+                    format!("{rel_path}::{prefix}{}", s.ident),
+                    digest_tokens(&s),
+                );
             }
             Item::Enum(mut e) => {
                 if is_cfg_test(&e.attrs) {
@@ -90,14 +119,30 @@ pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<Strin
                     strip_docs(&mut variant.attrs);
                     strip_docs_in_fields(&mut variant.fields);
                 }
-                out.insert(format!("{rel_path}::{}", e.ident), digest_tokens(&e));
+                out.insert(
+                    format!("{rel_path}::{prefix}{}", e.ident),
+                    digest_tokens(&e),
+                );
+            }
+            Item::Type(mut t) => {
+                if is_cfg_test(&t.attrs) {
+                    continue;
+                }
+                strip_docs(&mut t.attrs);
+                out.insert(
+                    format!("{rel_path}::{prefix}{}", t.ident),
+                    digest_tokens(&t),
+                );
             }
             Item::Const(mut c) => {
                 if is_cfg_test(&c.attrs) || c.ident != "CONTRACT_VERSION" {
                     continue;
                 }
                 strip_docs(&mut c.attrs);
-                out.insert(format!("{rel_path}::{}", c.ident), digest_tokens(&c));
+                out.insert(
+                    format!("{rel_path}::{prefix}{}", c.ident),
+                    digest_tokens(&c),
+                );
             }
             Item::Impl(mut imp) => {
                 if is_cfg_test(&imp.attrs) {
@@ -114,14 +159,26 @@ pub fn extract_wire_items(rel_path: &str, source: &str) -> Result<BTreeMap<Strin
                 }
                 let ty = imp.self_ty.to_token_stream().to_string();
                 out.insert(
-                    format!("{rel_path}::impl {trait_name} for {ty}"),
+                    format!("{rel_path}::{prefix}impl {trait_name} for {ty}"),
                     digest_tokens(&imp),
                 );
+            }
+            // Inline modules are recursed into (the module-axis analogue of
+            // scanning whole directories): a wire type wrapped in `pub mod v2`
+            // must not vanish from the digest. `mod foo;` declarations have no
+            // inline content to visit — their bodies live in separate files,
+            // which the directory scan already observes.
+            Item::Mod(m) => {
+                if is_cfg_test(&m.attrs) {
+                    continue;
+                }
+                if let Some((_, inner)) = m.content {
+                    collect_items(rel_path, &format!("{prefix}{}::", m.ident), inner, out);
+                }
             }
             _ => {}
         }
     }
-    Ok(out)
 }
 
 /// Parse the integer value of `const CONTRACT_VERSION: u32 = N;` in `source`.
@@ -287,6 +344,89 @@ mod tests {
             map.keys().collect::<Vec<_>>()
         );
         assert_eq!(map.len(), 2, "struct + serde impl, no inherent impl");
+    }
+
+    #[test]
+    fn cfg_not_test_and_feature_gated_items_are_extracted() {
+        // Reviewer-reproduced bug: substring matching on the cfg tokens
+        // misclassified #[cfg(not(test))] and #[cfg(feature = "latest")]
+        // ("latest" contains "test") as test-only, silently dropping REAL
+        // wire items from the digest.
+        let src = r#"
+            #[cfg(not(test))]
+            pub struct ProdOnly { pub a: u8 }
+            #[cfg(feature = "latest")]
+            pub struct Gated { pub b: u8 }
+            #[cfg(test)]
+            pub struct TestOnly { pub c: u8 }
+        "#;
+        let map = items(src);
+        assert!(
+            map.contains_key("f.rs::ProdOnly"),
+            "cfg(not(test)) items are wire shape: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            map.contains_key("f.rs::Gated"),
+            "cfg(feature = \"latest\") items are wire shape: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !map.contains_key("f.rs::TestOnly"),
+            "item-level cfg(test) items are still excluded"
+        );
+    }
+
+    #[test]
+    fn items_inside_inline_modules_are_extracted() {
+        // The module-axis variant of the new-file blind spot: a wire type
+        // wrapped in `pub mod v2 { ... }` must not vanish from the digest.
+        let src = r#"
+            pub mod v2 {
+                pub struct Wrapped { pub a: u8 }
+                pub mod deeper {
+                    pub enum Inner { A, B }
+                }
+            }
+            #[cfg(test)]
+            mod tests {
+                pub struct NotWire;
+            }
+        "#;
+        let map = items(src);
+        assert!(
+            map.contains_key("f.rs::v2::Wrapped"),
+            "inline-module items are digested under a module-qualified key: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            map.contains_key("f.rs::v2::deeper::Inner"),
+            "nesting recurses: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !map.keys().any(|k| k.contains("NotWire")),
+            "cfg(test) modules stay excluded"
+        );
+    }
+
+    #[test]
+    fn type_aliases_are_digested() {
+        // A wire struct field can reference an alias; retargeting the alias
+        // changes the serialized shape while the struct digest stays put.
+        let with_alias = "pub type Tags = Vec<String>;\npub struct Note { pub tags: Tags }";
+        let map = items(with_alias);
+        assert!(
+            map.contains_key("f.rs::Tags"),
+            "type aliases are digested: {:?}",
+            map.keys().collect::<Vec<_>>()
+        );
+        let changed = items("pub type Tags = Vec<u64>;\npub struct Note { pub tags: Tags }");
+        assert_ne!(
+            map.get("f.rs::Tags"),
+            changed.get("f.rs::Tags"),
+            "an alias retarget changes the digest"
+        );
     }
 
     #[test]

--- a/crates/rb-contract-guard/src/lib.rs
+++ b/crates/rb-contract-guard/src/lib.rs
@@ -27,11 +27,26 @@ use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::Path;
 
+/// A directory whose `.rs` files are ALL wire-shape-defining unless excluded.
+///
+/// Scanning a directory instead of listing files guards NEW files by default —
+/// the PR #56 lesson: `MemoryStats` landed in a brand-new `rb-types/src/stats.rs`
+/// that an explicit file list would have silently missed.
+#[derive(Debug, Clone)]
+pub struct WireDir {
+    /// Directory relative to the repo root (scanned non-recursively).
+    pub dir: String,
+    /// File names within `dir` that are NOT part of the wire surface.
+    pub exclude: Vec<String>,
+}
+
 /// Which files define the contract surface, relative to the repo root.
 #[derive(Debug, Clone)]
 pub struct SurfaceConfig {
     /// Rust sources whose type definitions shape the wire contract.
     pub wire_files: Vec<String>,
+    /// Directories whose `.rs` files are wire-shape-defining unless excluded.
+    pub wire_dirs: Vec<WireDir>,
     /// The file declaring `CONTRACT_VERSION` (also listed in `wire_files`).
     pub version_file: String,
     /// Directory of on-disk schema migrations (`NNN_*.sql`).
@@ -44,21 +59,17 @@ impl SurfaceConfig {
     /// The rusty-brain contract surface: rb-proto wire messages, the rb-types
     /// payload shapes they embed (the v2 bump — `MemoryNote.contested` — lived
     /// in rb-types, so rb-proto alone is not enough), and rb-store migrations.
+    /// rb-types is scanned as a whole directory so new payload files (e.g. the
+    /// PR #56 `stats.rs`) are guarded by default; only `error.rs` is excluded
+    /// (its enum maps to wire error strings in rb-daemon, it is not serialized
+    /// itself).
     pub fn default_paths() -> Self {
         Self {
-            wire_files: vec![
-                "crates/rb-proto/src/messages.rs".to_string(),
-                "crates/rb-types/src/change.rs".to_string(),
-                "crates/rb-types/src/feedback_kind.rs".to_string(),
-                "crates/rb-types/src/job.rs".to_string(),
-                "crates/rb-types/src/link.rs".to_string(),
-                "crates/rb-types/src/link_type.rs".to_string(),
-                "crates/rb-types/src/memory.rs".to_string(),
-                "crates/rb-types/src/memory_id.rs".to_string(),
-                "crates/rb-types/src/memory_type.rs".to_string(),
-                "crates/rb-types/src/namespace.rs".to_string(),
-                "crates/rb-types/src/query.rs".to_string(),
-            ],
+            wire_files: vec!["crates/rb-proto/src/messages.rs".to_string()],
+            wire_dirs: vec![WireDir {
+                dir: "crates/rb-types/src".to_string(),
+                exclude: vec!["error.rs".to_string()],
+            }],
             version_file: "crates/rb-proto/src/messages.rs".to_string(),
             migrations_dir: "crates/rb-store/migrations".to_string(),
             snapshot_file: "contract-snapshot.toml".to_string(),
@@ -88,6 +99,23 @@ pub fn observe(root: &Path, cfg: &SurfaceConfig) -> Result<Observed> {
         let source = std::fs::read_to_string(&path)
             .with_context(|| format!("reading wire file {}", path.display()))?;
         wire.extend(extract::extract_wire_items(rel, &source)?);
+    }
+
+    for wire_dir in &cfg.wire_dirs {
+        let dir_path = root.join(&wire_dir.dir);
+        let entries = std::fs::read_dir(&dir_path)
+            .with_context(|| format!("reading wire dir {}", dir_path.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| format!("listing {}", dir_path.display()))?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !name.ends_with(".rs") || wire_dir.exclude.iter().any(|e| e == &name) {
+                continue;
+            }
+            let rel = format!("{}/{name}", wire_dir.dir);
+            let source = std::fs::read_to_string(entry.path())
+                .with_context(|| format!("reading wire file {}", entry.path().display()))?;
+            wire.extend(extract::extract_wire_items(&rel, &source)?);
+        }
     }
 
     let version_path = root.join(&cfg.version_file);
@@ -132,6 +160,7 @@ mod tests {
     fn tiny_config() -> SurfaceConfig {
         SurfaceConfig {
             wire_files: vec!["src/messages.rs".to_string()],
+            wire_dirs: vec![],
             version_file: "src/messages.rs".to_string(),
             migrations_dir: "migrations".to_string(),
             snapshot_file: "contract-snapshot.toml".to_string(),
@@ -183,6 +212,73 @@ mod tests {
         assert!(
             err.to_string().contains("migrations"),
             "error names the missing dir, got: {err:#}"
+        );
+    }
+
+    fn dir_config() -> SurfaceConfig {
+        SurfaceConfig {
+            wire_dirs: vec![WireDir {
+                dir: "types/src".to_string(),
+                exclude: vec!["error.rs".to_string()],
+            }],
+            ..tiny_config()
+        }
+    }
+
+    #[test]
+    fn observe_scans_wire_dirs_so_new_files_are_guarded_by_default() {
+        // The PR #56 lesson: MemoryStats landed in a brand-new rb-types file
+        // (stats.rs). An explicit file list silently misses new files; a
+        // scanned directory guards them by default.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/messages.rs", MESSAGES);
+        write(
+            dir.path(),
+            "migrations/001_init.sql",
+            "CREATE TABLE t (id);",
+        );
+        write(dir.path(), "types/src/memory.rs", "pub struct MemoryNote;");
+        write(
+            dir.path(),
+            "types/src/error.rs",
+            "pub enum Error { Io(String) }",
+        );
+        write(dir.path(), "types/src/notes.txt", "not rust");
+
+        let obs = observe(dir.path(), &dir_config()).unwrap();
+        assert!(
+            obs.wire.contains_key("types/src/memory.rs::MemoryNote"),
+            "scanned-dir items observed: {:?}",
+            obs.wire.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !obs.wire.keys().any(|k| k.contains("error.rs")),
+            "excluded files are not observed"
+        );
+
+        // A NEW file appearing later is picked up without a config change.
+        write(dir.path(), "types/src/stats.rs", "pub struct MemoryStats;");
+        let after = observe(dir.path(), &dir_config()).unwrap();
+        assert!(
+            after.wire.contains_key("types/src/stats.rs::MemoryStats"),
+            "new wire file guarded by default: {:?}",
+            after.wire.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn observe_fails_closed_on_missing_wire_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/messages.rs", MESSAGES);
+        write(
+            dir.path(),
+            "migrations/001_init.sql",
+            "CREATE TABLE t (id);",
+        );
+        let err = observe(dir.path(), &dir_config()).unwrap_err();
+        assert!(
+            err.to_string().contains("types/src"),
+            "error names the missing wire dir, got: {err:#}"
         );
     }
 }

--- a/crates/rb-contract-guard/src/lib.rs
+++ b/crates/rb-contract-guard/src/lib.rs
@@ -1,0 +1,188 @@
+//! `rb-contract-guard`: the CI contract-drift guard (Road-to-Tens W5a.4).
+//!
+//! The W5a.4 protocol-evolution policy — additive serde-default fields never
+//! bump `CONTRACT_VERSION`; breaking changes bump it — used to be enforced by
+//! reviewer diligence only. This crate operationalizes it: the shape-defining
+//! items of the wire surface (rb-proto messages + the rb-types payload types
+//! they embed) and the rb-store on-disk migrations are digested and compared
+//! against a checked-in snapshot (`contract-snapshot.toml`). Any drift fails
+//! CI until the author records a deliberate decision:
+//!
+//! - additive, serde-default change (no bump):
+//!   `cargo run -p rb-contract-guard -- update --intent additive --note "..."`
+//! - breaking change (bump `CONTRACT_VERSION` first):
+//!   `cargo run -p rb-contract-guard -- update --intent breaking --note "..."`
+//!
+//! Detection parses the sources with `syn` and digests normalized item tokens
+//! (doc comments stripped, `cfg(test)` items skipped), so comment- and
+//! formatting-only edits never trip the guard.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
+
+pub mod check;
+pub mod extract;
+pub mod snapshot;
+pub mod update;
+
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Which files define the contract surface, relative to the repo root.
+#[derive(Debug, Clone)]
+pub struct SurfaceConfig {
+    /// Rust sources whose type definitions shape the wire contract.
+    pub wire_files: Vec<String>,
+    /// The file declaring `CONTRACT_VERSION` (also listed in `wire_files`).
+    pub version_file: String,
+    /// Directory of on-disk schema migrations (`NNN_*.sql`).
+    pub migrations_dir: String,
+    /// The checked-in snapshot the observed surface is compared against.
+    pub snapshot_file: String,
+}
+
+impl SurfaceConfig {
+    /// The rusty-brain contract surface: rb-proto wire messages, the rb-types
+    /// payload shapes they embed (the v2 bump — `MemoryNote.contested` — lived
+    /// in rb-types, so rb-proto alone is not enough), and rb-store migrations.
+    pub fn default_paths() -> Self {
+        Self {
+            wire_files: vec![
+                "crates/rb-proto/src/messages.rs".to_string(),
+                "crates/rb-types/src/change.rs".to_string(),
+                "crates/rb-types/src/feedback_kind.rs".to_string(),
+                "crates/rb-types/src/job.rs".to_string(),
+                "crates/rb-types/src/link.rs".to_string(),
+                "crates/rb-types/src/link_type.rs".to_string(),
+                "crates/rb-types/src/memory.rs".to_string(),
+                "crates/rb-types/src/memory_id.rs".to_string(),
+                "crates/rb-types/src/memory_type.rs".to_string(),
+                "crates/rb-types/src/namespace.rs".to_string(),
+                "crates/rb-types/src/query.rs".to_string(),
+            ],
+            version_file: "crates/rb-proto/src/messages.rs".to_string(),
+            migrations_dir: "crates/rb-store/migrations".to_string(),
+            snapshot_file: "contract-snapshot.toml".to_string(),
+        }
+    }
+}
+
+/// The contract surface as observed from the working tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Observed {
+    /// Value of `rb_proto::CONTRACT_VERSION` parsed from the version file.
+    pub contract_version: u32,
+    /// `"<file>::<item>"` -> sha256 of the item's normalized tokens.
+    pub wire: BTreeMap<String, String>,
+    /// Migration file name -> sha256 of its bytes.
+    pub migrations: BTreeMap<String, String>,
+}
+
+/// Read and digest the configured contract surface under `root`.
+///
+/// Fails closed: a missing wire file or migrations directory is an error, not
+/// an empty observation — a silently unobserved surface would defeat the guard.
+pub fn observe(root: &Path, cfg: &SurfaceConfig) -> Result<Observed> {
+    let mut wire = BTreeMap::new();
+    for rel in &cfg.wire_files {
+        let path = root.join(rel);
+        let source = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading wire file {}", path.display()))?;
+        wire.extend(extract::extract_wire_items(rel, &source)?);
+    }
+
+    let version_path = root.join(&cfg.version_file);
+    let version_source = std::fs::read_to_string(&version_path)
+        .with_context(|| format!("reading version file {}", version_path.display()))?;
+    let contract_version = extract::parse_contract_version(&version_source)
+        .with_context(|| format!("parsing CONTRACT_VERSION from {}", cfg.version_file))?;
+
+    let mig_dir = root.join(&cfg.migrations_dir);
+    let mut migrations = BTreeMap::new();
+    let entries = std::fs::read_dir(&mig_dir)
+        .with_context(|| format!("reading migrations dir {}", mig_dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("listing {}", mig_dir.display()))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.ends_with(".sql") {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path())
+            .with_context(|| format!("reading migration {}", entry.path().display()))?;
+        migrations.insert(name, extract::sha256_hex(&bytes));
+    }
+
+    Ok(Observed {
+        contract_version,
+        wire,
+        migrations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(root: &Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    fn tiny_config() -> SurfaceConfig {
+        SurfaceConfig {
+            wire_files: vec!["src/messages.rs".to_string()],
+            version_file: "src/messages.rs".to_string(),
+            migrations_dir: "migrations".to_string(),
+            snapshot_file: "contract-snapshot.toml".to_string(),
+        }
+    }
+
+    const MESSAGES: &str = "pub const CONTRACT_VERSION: u32 = 2;\n\
+                            pub struct Handshake { pub contract_version: u32 }\n";
+
+    #[test]
+    fn observe_reads_wire_items_version_and_migrations() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/messages.rs", MESSAGES);
+        write(
+            dir.path(),
+            "migrations/001_init.sql",
+            "CREATE TABLE t (id);",
+        );
+        write(dir.path(), "migrations/README.md", "not sql");
+
+        let obs = observe(dir.path(), &tiny_config()).unwrap();
+        assert_eq!(obs.contract_version, 2);
+        assert!(obs.wire.contains_key("src/messages.rs::Handshake"));
+        assert!(obs.wire.contains_key("src/messages.rs::CONTRACT_VERSION"));
+        assert_eq!(obs.migrations.len(), 1, "non-.sql files are ignored");
+        assert!(obs.migrations.contains_key("001_init.sql"));
+    }
+
+    #[test]
+    fn observe_fails_closed_on_missing_wire_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "migrations/001_init.sql",
+            "CREATE TABLE t (id);",
+        );
+        let err = observe(dir.path(), &tiny_config()).unwrap_err();
+        assert!(
+            err.to_string().contains("messages.rs"),
+            "error names the missing file, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn observe_fails_closed_on_missing_migrations_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/messages.rs", MESSAGES);
+        let err = observe(dir.path(), &tiny_config()).unwrap_err();
+        assert!(
+            err.to_string().contains("migrations"),
+            "error names the missing dir, got: {err:#}"
+        );
+    }
+}

--- a/crates/rb-contract-guard/src/main.rs
+++ b/crates/rb-contract-guard/src/main.rs
@@ -1,0 +1,169 @@
+//! CLI entry point for the contract-drift guard.
+//!
+//! Exit codes: 0 = surface matches the snapshot; 1 = contract drift without a
+//! recorded decision; 2 = usage/configuration error (missing snapshot, rejected
+//! intent, unreadable surface).
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use rb_contract_guard::check::{check, Outcome};
+use rb_contract_guard::snapshot::{self, Intent};
+use rb_contract_guard::{observe, update, SurfaceConfig};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+#[derive(Parser)]
+#[command(
+    name = "rb-contract-guard",
+    about = "Contract-drift guard for the rusty-brain wire protocol and rb-store migrations (W5a.4)"
+)]
+struct Cli {
+    /// Repo root containing crates/ and the snapshot file.
+    #[arg(long, global = true, default_value = ".")]
+    root: PathBuf,
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Compare the observed contract surface against the checked-in snapshot.
+    Check,
+    /// Write the baseline snapshot (first-time bootstrap only).
+    Init {
+        /// Short description recorded in the snapshot log.
+        #[arg(long)]
+        note: String,
+    },
+    /// Regenerate the snapshot, recording a deliberate contract decision.
+    Update {
+        /// additive = serde-default-compatible, no CONTRACT_VERSION bump;
+        /// breaking = CONTRACT_VERSION was bumped.
+        #[arg(long)]
+        intent: CliIntent,
+        /// Short description recorded in the snapshot log.
+        #[arg(long)]
+        note: String,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum CliIntent {
+    Additive,
+    Breaking,
+}
+
+impl From<CliIntent> for Intent {
+    fn from(value: CliIntent) -> Self {
+        match value {
+            CliIntent::Additive => Intent::Additive,
+            CliIntent::Breaking => Intent::Breaking,
+        }
+    }
+}
+
+fn drift_report(lines: &[String], cfg: &SurfaceConfig) -> String {
+    let mut out = String::from(
+        "contract drift detected — the wire/persistence contract surface changed \
+         without a recorded decision (W5a.4 protocol-evolution policy):\n",
+    );
+    for line in lines {
+        out.push_str("  - ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(&format!(
+        "\nDecide and record the change:\n\
+         * additive, serde-default-compatible change (old frames still decode; \
+         NO CONTRACT_VERSION bump):\n\
+         \x20   cargo run -p rb-contract-guard -- update --intent additive --note \"<what changed>\"\n\
+         * breaking change: bump CONTRACT_VERSION in {version_file} first, then:\n\
+         \x20   cargo run -p rb-contract-guard -- update --intent breaking --note \"<what changed>\"\n\
+         Then commit the regenerated {snapshot}.",
+        version_file = cfg.version_file,
+        snapshot = cfg.snapshot_file,
+    ));
+    out
+}
+
+fn run(cli: &Cli) -> Result<ExitCode> {
+    let cfg = SurfaceConfig::default_paths();
+    let snap_path = cli.root.join(&cfg.snapshot_file);
+    let observed = observe(&cli.root, &cfg)?;
+
+    match &cli.cmd {
+        Cmd::Check => {
+            if !snap_path.is_file() {
+                bail!(
+                    "no {} found under {} — bootstrap it once with \
+                     `cargo run -p rb-contract-guard -- init --note \"baseline\"`",
+                    cfg.snapshot_file,
+                    cli.root.display()
+                );
+            }
+            let snap = snapshot::load(&snap_path)?;
+            match check(&observed, &snap) {
+                Outcome::Clean => {
+                    println!(
+                        "contract surface matches {} (CONTRACT_VERSION {}, {} wire items, {} migrations)",
+                        cfg.snapshot_file,
+                        observed.contract_version,
+                        observed.wire.len(),
+                        observed.migrations.len()
+                    );
+                    Ok(ExitCode::SUCCESS)
+                }
+                Outcome::Drift(lines) => {
+                    eprintln!("{}", drift_report(&lines, &cfg));
+                    Ok(ExitCode::from(1))
+                }
+            }
+        }
+        Cmd::Init { note } => {
+            if snap_path.is_file() {
+                bail!(
+                    "{} already exists — record changes with `update`, not `init`",
+                    cfg.snapshot_file
+                );
+            }
+            let snap = update::init_snapshot(&observed, note)?;
+            snapshot::save(&snap_path, &snap)?;
+            println!(
+                "wrote baseline {} (CONTRACT_VERSION {})",
+                cfg.snapshot_file, snap.contract_version
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        Cmd::Update { intent, note } => {
+            let prev = snapshot::load(&snap_path).with_context(|| {
+                format!(
+                    "no usable {} — bootstrap it once with `init --note ...`",
+                    cfg.snapshot_file
+                )
+            })?;
+            let snap = update::apply_update(&observed, &prev, (*intent).into(), note)?;
+            snapshot::save(&snap_path, &snap)?;
+            println!(
+                "recorded {} contract change in {} (CONTRACT_VERSION {})",
+                match intent {
+                    CliIntent::Additive => "additive",
+                    CliIntent::Breaking => "breaking",
+                },
+                cfg.snapshot_file,
+                snap.contract_version
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(&cli) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("rb-contract-guard error: {e:#}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/crates/rb-contract-guard/src/snapshot.rs
+++ b/crates/rb-contract-guard/src/snapshot.rs
@@ -1,0 +1,124 @@
+//! The checked-in snapshot (`contract-snapshot.toml`): recorded contract
+//! version, per-item wire digests, migration digests, and an append-only log
+//! of deliberate contract decisions (the reviewable "intent markers").
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// The deliberate decision recorded with a snapshot update.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Intent {
+    /// Baseline snapshot (only ever written by `init`).
+    Initial,
+    /// Additive, serde-default-compatible change: NO `CONTRACT_VERSION` bump.
+    Additive,
+    /// Breaking wire change: `CONTRACT_VERSION` was bumped.
+    Breaking,
+}
+
+/// One append-only log entry: the marker reviewers see in the PR diff.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct LogEntry {
+    pub contract_version: u32,
+    pub intent: Intent,
+    pub note: String,
+}
+
+/// The full checked-in snapshot.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    pub contract_version: u32,
+    pub wire: BTreeMap<String, String>,
+    pub migrations: BTreeMap<String, String>,
+    #[serde(default)]
+    pub log: Vec<LogEntry>,
+}
+
+/// Header prepended to the generated file so nobody edits it by hand.
+const HEADER: &str = "\
+# Contract-drift guard snapshot (rb-contract-guard). DO NOT EDIT BY HAND.\n\
+# Regenerate after a deliberate contract decision (W5a.4):\n\
+#   cargo run -p rb-contract-guard -- update --intent additive --note \"...\"   # serde-default addition, no bump\n\
+#   cargo run -p rb-contract-guard -- update --intent breaking --note \"...\"   # after bumping CONTRACT_VERSION\n";
+
+/// Load a snapshot from `path`.
+pub fn load(path: &Path) -> Result<Snapshot> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading snapshot {}", path.display()))?;
+    toml::from_str(&text).with_context(|| format!("parsing snapshot {}", path.display()))
+}
+
+/// Write `snap` to `path` with the generated-file header.
+pub fn save(path: &Path, snap: &Snapshot) -> Result<()> {
+    let body = toml::to_string_pretty(snap)
+        .with_context(|| format!("serializing snapshot {}", path.display()))?;
+    std::fs::write(path, format!("{HEADER}\n{body}"))
+        .with_context(|| format!("writing snapshot {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Snapshot {
+        let mut wire = BTreeMap::new();
+        wire.insert(
+            "crates/rb-proto/src/messages.rs::Request".to_string(),
+            "ab".repeat(32),
+        );
+        let mut migrations = BTreeMap::new();
+        migrations.insert("001_init.sql".to_string(), "cd".repeat(32));
+        Snapshot {
+            contract_version: 2,
+            wire,
+            migrations,
+            log: vec![LogEntry {
+                contract_version: 2,
+                intent: Intent::Initial,
+                note: "baseline".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contract-snapshot.toml");
+        let snap = sample();
+        save(&path, &snap).unwrap();
+        assert_eq!(load(&path).unwrap(), snap);
+    }
+
+    #[test]
+    fn saved_file_carries_do_not_edit_header_and_update_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contract-snapshot.toml");
+        save(&path, &sample()).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.starts_with("# Contract-drift guard snapshot"));
+        assert!(text.contains("--intent additive"));
+        assert!(text.contains("--intent breaking"));
+    }
+
+    #[test]
+    fn load_missing_file_errors_with_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.toml");
+        let err = load(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("nope.toml"),
+            "error names the file, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn load_rejects_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "contract_version = \"not a number\"").unwrap();
+        assert!(load(&path).is_err());
+    }
+}

--- a/crates/rb-contract-guard/src/update.rs
+++ b/crates/rb-contract-guard/src/update.rs
@@ -1,0 +1,215 @@
+//! Snapshot regeneration with an enforced, deliberate intent (the W5a.4
+//! decision): `additive` must NOT bump `CONTRACT_VERSION`, `breaking` MUST.
+
+use crate::check::{check, Outcome};
+use crate::snapshot::{Intent, LogEntry, Snapshot};
+use crate::Observed;
+use anyhow::{bail, Result};
+
+fn require_note(note: &str) -> Result<String> {
+    let trimmed = note.trim();
+    if trimmed.is_empty() {
+        bail!("a non-empty --note describing the contract change is required");
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Build the baseline snapshot (first ever generation).
+pub fn init_snapshot(observed: &Observed, note: &str) -> Result<Snapshot> {
+    let note = require_note(note)?;
+    Ok(Snapshot {
+        contract_version: observed.contract_version,
+        wire: observed.wire.clone(),
+        migrations: observed.migrations.clone(),
+        log: vec![LogEntry {
+            contract_version: observed.contract_version,
+            intent: Intent::Initial,
+            note,
+        }],
+    })
+}
+
+/// Regenerate the snapshot from `observed`, recording `intent` + `note` in the
+/// append-only log. Enforces the version rule for the declared intent.
+pub fn apply_update(
+    observed: &Observed,
+    prev: &Snapshot,
+    intent: Intent,
+    note: &str,
+) -> Result<Snapshot> {
+    let note = require_note(note)?;
+    if check(observed, prev) == Outcome::Clean {
+        bail!("snapshot is already current; nothing to record");
+    }
+    match intent {
+        Intent::Initial => bail!("intent `initial` is reserved for `init`"),
+        Intent::Additive => {
+            if observed.contract_version != prev.contract_version {
+                bail!(
+                    "--intent additive requires an unchanged CONTRACT_VERSION \
+                     (snapshot {}, code {}): a bumped version is a breaking \
+                     change — use --intent breaking",
+                    prev.contract_version,
+                    observed.contract_version
+                );
+            }
+        }
+        Intent::Breaking => {
+            if observed.contract_version <= prev.contract_version {
+                bail!(
+                    "--intent breaking requires a CONTRACT_VERSION bump \
+                     (snapshot {}, code {}): bump the const in rb-proto \
+                     messages.rs first",
+                    prev.contract_version,
+                    observed.contract_version
+                );
+            }
+        }
+    }
+    let mut log = prev.log.clone();
+    log.push(LogEntry {
+        contract_version: observed.contract_version,
+        intent,
+        note,
+    });
+    Ok(Snapshot {
+        contract_version: observed.contract_version,
+        wire: observed.wire.clone(),
+        migrations: observed.migrations.clone(),
+        log,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn observed(version: u32) -> Observed {
+        Observed {
+            contract_version: version,
+            wire: map(&[("m.rs::Request", "aaa")]),
+            migrations: map(&[("001_init.sql", "bbb")]),
+        }
+    }
+
+    fn baseline() -> Snapshot {
+        init_snapshot(&observed(2), "baseline").unwrap()
+    }
+
+    #[test]
+    fn init_records_baseline_with_initial_intent() {
+        let snap = baseline();
+        assert_eq!(snap.contract_version, 2);
+        assert_eq!(snap.wire, observed(2).wire);
+        assert_eq!(snap.migrations, observed(2).migrations);
+        assert_eq!(snap.log.len(), 1);
+        assert_eq!(snap.log[0].intent, Intent::Initial);
+        assert_eq!(snap.log[0].note, "baseline");
+    }
+
+    #[test]
+    fn init_rejects_empty_note() {
+        assert!(init_snapshot(&observed(2), "  ").is_err());
+    }
+
+    #[test]
+    fn additive_update_with_same_version_appends_log() {
+        let prev = baseline();
+        let mut obs = observed(2);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        let snap = apply_update(&obs, &prev, Intent::Additive, "add Stats variant").unwrap();
+        assert_eq!(snap.contract_version, 2);
+        assert_eq!(
+            snap.wire.get("m.rs::Request").map(String::as_str),
+            Some("NEW")
+        );
+        assert_eq!(snap.log.len(), 2, "log is append-only");
+        assert_eq!(snap.log[1].intent, Intent::Additive);
+        assert_eq!(snap.log[1].contract_version, 2);
+    }
+
+    #[test]
+    fn additive_update_rejects_a_version_bump() {
+        let prev = baseline();
+        let mut obs = observed(3);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        let err = apply_update(&obs, &prev, Intent::Additive, "oops").unwrap_err();
+        assert!(
+            err.to_string().contains("breaking"),
+            "error points at --intent breaking, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn breaking_update_requires_a_version_bump() {
+        let prev = baseline();
+        let mut obs = observed(2);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        let err = apply_update(&obs, &prev, Intent::Breaking, "shape change").unwrap_err();
+        assert!(
+            err.to_string().contains("bump"),
+            "error demands a CONTRACT_VERSION bump, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn breaking_update_with_bump_succeeds() {
+        let prev = baseline();
+        let mut obs = observed(3);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        let snap = apply_update(&obs, &prev, Intent::Breaking, "retag Request").unwrap();
+        assert_eq!(snap.contract_version, 3);
+        assert_eq!(snap.log.len(), 2);
+        assert_eq!(snap.log[1].intent, Intent::Breaking);
+        assert_eq!(snap.log[1].contract_version, 3);
+    }
+
+    #[test]
+    fn breaking_update_rejects_a_version_decrease() {
+        let prev = baseline();
+        let mut obs = observed(1);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        assert!(apply_update(&obs, &prev, Intent::Breaking, "downgrade").is_err());
+    }
+
+    #[test]
+    fn update_rejects_empty_note() {
+        let prev = baseline();
+        let mut obs = observed(2);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        assert!(apply_update(&obs, &prev, Intent::Additive, "").is_err());
+    }
+
+    #[test]
+    fn update_rejects_initial_intent() {
+        let prev = baseline();
+        let mut obs = observed(2);
+        obs.wire
+            .insert("m.rs::Request".to_string(), "NEW".to_string());
+        assert!(apply_update(&obs, &prev, Intent::Initial, "nope").is_err());
+    }
+
+    #[test]
+    fn update_when_already_current_is_rejected() {
+        let prev = baseline();
+        let err = apply_update(&observed(2), &prev, Intent::Additive, "noise").unwrap_err();
+        assert!(
+            err.to_string().contains("current"),
+            "error says the snapshot is already current, got: {err:#}"
+        );
+    }
+}

--- a/crates/rb-contract-guard/tests/guard_matrix.rs
+++ b/crates/rb-contract-guard/tests/guard_matrix.rs
@@ -1,0 +1,329 @@
+//! End-to-end pass/fail matrix for the contract-drift guard CLI, exercised
+//! against fixture repos that mirror the real surface paths.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+const MESSAGES: &str = "\
+pub const CONTRACT_VERSION: u32 = 2;
+
+pub struct Handshake {
+    pub contract_version: u32,
+}
+
+pub enum Request {
+    Ping,
+    Get { id: String },
+}
+
+pub enum Response {
+    Pong,
+    Error { message: String },
+}
+";
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn edit(root: &Path, rel: &str, from: &str, to: &str) {
+    let path = root.join(rel);
+    let text = fs::read_to_string(&path).unwrap();
+    assert!(text.contains(from), "fixture edit anchor missing: {from}");
+    fs::write(&path, text.replace(from, to)).unwrap();
+}
+
+/// A fixture repo laid out on the same relative paths as the real one.
+fn fixture_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "crates/rb-proto/src/messages.rs", MESSAGES);
+    for f in [
+        "change.rs",
+        "feedback_kind.rs",
+        "job.rs",
+        "link.rs",
+        "link_type.rs",
+        "memory_id.rs",
+        "memory_type.rs",
+        "namespace.rs",
+        "query.rs",
+    ] {
+        write(root, &format!("crates/rb-types/src/{f}"), "");
+    }
+    write(
+        root,
+        "crates/rb-types/src/memory.rs",
+        "pub struct MemoryNote {\n    pub content: String,\n}\n",
+    );
+    write(
+        root,
+        "crates/rb-store/migrations/001_init.sql",
+        "CREATE TABLE memories (id TEXT PRIMARY KEY);\n",
+    );
+    dir
+}
+
+fn guard(root: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut cmd = Command::cargo_bin("rb-contract-guard").unwrap();
+    cmd.arg("--root").arg(root).args(args);
+    cmd.assert()
+}
+
+fn init(root: &Path) {
+    guard(root, &["init", "--note", "baseline"]).success();
+}
+
+fn check_ok(root: &Path) {
+    guard(root, &["check"]).success();
+}
+
+fn check_drifts(root: &Path, expect_in_output: &[&str]) {
+    let assert = guard(root, &["check"]).code(1);
+    let out = String::from_utf8_lossy(&assert.get_output().stderr).to_string()
+        + &String::from_utf8_lossy(&assert.get_output().stdout);
+    for needle in expect_in_output {
+        assert!(
+            out.contains(needle),
+            "check output should mention {needle:?}, got:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn init_then_check_passes_and_snapshot_is_written() {
+    let repo = fixture_repo();
+    init(repo.path());
+    assert!(repo.path().join("contract-snapshot.toml").is_file());
+    check_ok(repo.path());
+}
+
+#[test]
+fn check_without_snapshot_fails_with_init_guidance() {
+    let repo = fixture_repo();
+    let assert = guard(repo.path(), &["check"]).code(2);
+    let err = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(err.contains("init"), "guidance points at init, got:\n{err}");
+}
+
+#[test]
+fn comment_only_and_unrelated_changes_pass_without_a_marker() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "pub struct Handshake {",
+        "/// New documentation, still the same wire shape.\npub struct Handshake {",
+    );
+    write(
+        repo.path(),
+        "crates/rb-engine/src/lib.rs",
+        "pub fn unrelated() {}\n",
+    );
+    check_ok(repo.path());
+}
+
+#[test]
+fn silent_shape_change_fails_naming_the_item_and_the_marker_path() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "    Ping,",
+        "    Ping,\n    Stats,",
+    );
+    check_drifts(
+        repo.path(),
+        &[
+            "crates/rb-proto/src/messages.rs::Request",
+            "--intent additive",
+            "--intent breaking",
+        ],
+    );
+}
+
+#[test]
+fn additive_marker_unblocks_an_additive_change() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "    Ping,",
+        "    Ping,\n    Stats,",
+    );
+    guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "additive",
+            "--note",
+            "Request::Stats variant",
+        ],
+    )
+    .success();
+    check_ok(repo.path());
+    let snap = fs::read_to_string(repo.path().join("contract-snapshot.toml")).unwrap();
+    assert!(
+        snap.contains("Request::Stats variant"),
+        "the note is the reviewable marker:\n{snap}"
+    );
+}
+
+#[test]
+fn rb_types_payload_shape_change_is_also_guarded() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-types/src/memory.rs",
+        "pub content: String,",
+        "pub content: String,\n    pub contested: bool,",
+    );
+    check_drifts(repo.path(), &["crates/rb-types/src/memory.rs::MemoryNote"]);
+}
+
+#[test]
+fn silent_migration_addition_fails_then_marker_unblocks() {
+    let repo = fixture_repo();
+    init(repo.path());
+    write(
+        repo.path(),
+        "crates/rb-store/migrations/002_add_column.sql",
+        "ALTER TABLE memories ADD COLUMN contested INTEGER;\n",
+    );
+    check_drifts(repo.path(), &["002_add_column.sql"]);
+    guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "additive",
+            "--note",
+            "add contested column",
+        ],
+    )
+    .success();
+    check_ok(repo.path());
+}
+
+#[test]
+fn silent_version_bump_fails_and_needs_a_breaking_marker() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "pub const CONTRACT_VERSION: u32 = 2;",
+        "pub const CONTRACT_VERSION: u32 = 3;",
+    );
+    check_drifts(repo.path(), &["CONTRACT_VERSION"]);
+    guard(
+        repo.path(),
+        &["update", "--intent", "breaking", "--note", "v3 handshake"],
+    )
+    .success();
+    check_ok(repo.path());
+}
+
+#[test]
+fn breaking_change_cannot_hide_behind_an_additive_marker() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "pub const CONTRACT_VERSION: u32 = 2;",
+        "pub const CONTRACT_VERSION: u32 = 3;",
+    );
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "Error { message: String },",
+        "Error { kind: String, message: String },",
+    );
+    let assert = guard(
+        repo.path(),
+        &["update", "--intent", "additive", "--note", "sneaky"],
+    )
+    .code(2);
+    let err = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        err.contains("breaking"),
+        "additive marker with a bump must be rejected, got:\n{err}"
+    );
+    // The guard stays red until the right marker is recorded.
+    check_drifts(repo.path(), &["Response"]);
+    guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "breaking",
+            "--note",
+            "Error carries kind",
+        ],
+    )
+    .success();
+    check_ok(repo.path());
+}
+
+#[test]
+fn breaking_marker_without_a_bump_is_rejected() {
+    let repo = fixture_repo();
+    init(repo.path());
+    edit(
+        repo.path(),
+        "crates/rb-proto/src/messages.rs",
+        "Error { message: String },",
+        "Error { kind: String, message: String },",
+    );
+    let assert = guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "breaking",
+            "--note",
+            "forgot the bump",
+        ],
+    )
+    .code(2);
+    let err = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        err.contains("bump"),
+        "breaking without a bump must demand one, got:\n{err}"
+    );
+}
+
+#[test]
+fn init_twice_is_rejected() {
+    let repo = fixture_repo();
+    init(repo.path());
+    guard(repo.path(), &["init", "--note", "again"]).code(2);
+}
+
+#[test]
+fn update_without_snapshot_points_at_init() {
+    let repo = fixture_repo();
+    let assert = guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "additive",
+            "--note",
+            "no baseline yet",
+        ],
+    )
+    .code(2);
+    let err = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(err.contains("init"), "guidance points at init, got:\n{err}");
+}

--- a/crates/rb-contract-guard/tests/guard_matrix.rs
+++ b/crates/rb-contract-guard/tests/guard_matrix.rs
@@ -178,6 +178,33 @@ fn additive_marker_unblocks_an_additive_change() {
 }
 
 #[test]
+fn brand_new_rb_types_wire_file_is_guarded_by_default() {
+    // The PR #56 lesson: doctor/stats added MemoryStats in a NEW rb-types
+    // file (stats.rs). The guard must catch shapes in files that did not
+    // exist when the snapshot was taken.
+    let repo = fixture_repo();
+    init(repo.path());
+    write(
+        repo.path(),
+        "crates/rb-types/src/stats.rs",
+        "pub struct MemoryStats {\n    pub total: u64,\n}\n",
+    );
+    check_drifts(repo.path(), &["crates/rb-types/src/stats.rs::MemoryStats"]);
+    guard(
+        repo.path(),
+        &[
+            "update",
+            "--intent",
+            "additive",
+            "--note",
+            "MemoryStats payload",
+        ],
+    )
+    .success();
+    check_ok(repo.path());
+}
+
+#[test]
 fn rb_types_payload_shape_change_is_also_guarded() {
     let repo = fixture_repo();
     init(repo.path());

--- a/crates/rb-contract-guard/tests/real_repo.rs
+++ b/crates/rb-contract-guard/tests/real_repo.rs
@@ -1,0 +1,43 @@
+//! Binds the guard to THIS repository: `cargo test --workspace` fails locally
+//! (not just in the dedicated CI job) whenever the wire surface or migrations
+//! drift from `contract-snapshot.toml` without a recorded decision.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use rb_contract_guard::check::{check, Outcome};
+use rb_contract_guard::{observe, snapshot, SurfaceConfig};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+#[test]
+fn snapshot_is_current_for_this_repo() {
+    let root = repo_root();
+    let cfg = SurfaceConfig::default_paths();
+    let observed = observe(&root, &cfg).expect("contract surface must be observable");
+    let snap = snapshot::load(&root.join(&cfg.snapshot_file))
+        .expect("contract-snapshot.toml must exist; bootstrap with `rb-contract-guard init`");
+    match check(&observed, &snap) {
+        Outcome::Clean => {}
+        Outcome::Drift(lines) => panic!(
+            "contract drift without a recorded decision (W5a.4). Run\n  \
+             cargo run -p rb-contract-guard -- update --intent additive|breaking --note \"...\"\n\
+             after deciding whether the change bumps CONTRACT_VERSION.\nDrift:\n  {}",
+            lines.join("\n  ")
+        ),
+    }
+}
+
+#[test]
+fn snapshot_version_matches_rb_proto() {
+    // The snapshot's recorded version must be the one rb-proto actually
+    // exports (guards against a hand-edited snapshot file).
+    let root = repo_root();
+    let cfg = SurfaceConfig::default_paths();
+    let snap = snapshot::load(&root.join(&cfg.snapshot_file)).unwrap();
+    assert_eq!(snap.contract_version, rb_proto::CONTRACT_VERSION);
+}

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1384,3 +1384,55 @@ async fn near_dup_suppression_never_touches_non_hook_memories() {
 
     daemon.stop().await;
 }
+
+/// W5a.4 protocol-evolution fixture: an N-1 client handshake. The daemon's
+/// CURRENT policy window is exact-match (no breaking bump is in flight, so no
+/// N/N-1 dual-support window is open) — an N-1 handshake must be REJECTED
+/// GRACEFULLY: a HandshakeAck { ok: false } that names both versions, then a
+/// closed connection. If a future bump opens a dual-support window, this test
+/// is the seam to flip: it pins the version-skew behavior either way.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn n_minus_one_handshake_is_rejected_gracefully() {
+    let daemon = RunningDaemon::start(2).await;
+
+    let stream = tokio::net::UnixStream::connect(&daemon.socket)
+        .await
+        .unwrap();
+    let mut framed = rb_proto::bounded_framed(stream);
+    rb_proto::write_frame(
+        &mut framed,
+        &rb_proto::Handshake {
+            contract_version: rb_proto::CONTRACT_VERSION - 1,
+            namespace: Namespace::Project("skew".to_string()),
+            identity: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let ack: rb_proto::HandshakeAck = rb_proto::read_frame(&mut framed).await.unwrap();
+    assert!(!ack.ok, "N-1 handshake must be refused, got ack: {ack:?}");
+    assert_eq!(
+        ack.contract_version,
+        rb_proto::CONTRACT_VERSION,
+        "the nack advertises the server's version so the client can report skew"
+    );
+    let message = ack.message.expect("nack carries a diagnostic message");
+    assert!(
+        message.contains(&rb_proto::CONTRACT_VERSION.to_string())
+            && message.contains(&(rb_proto::CONTRACT_VERSION - 1).to_string()),
+        "diagnostic names both versions: {message}"
+    );
+
+    // After the nack the daemon closes the connection: no further frame ever
+    // arrives (read yields EOF/error rather than hanging).
+    let eof = tokio::time::timeout(
+        Duration::from_secs(5),
+        rb_proto::read_frame::<_, rb_proto::HandshakeAck>(&mut framed),
+    )
+    .await
+    .expect("connection must be closed promptly after a version nack");
+    assert!(eof.is_err(), "no frames after a version nack, got: {eof:?}");
+
+    daemon.stop().await;
+}

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1393,6 +1393,9 @@ async fn near_dup_suppression_never_touches_non_hook_memories() {
 /// is the seam to flip: it pins the version-skew behavior either way.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn n_minus_one_handshake_is_rejected_gracefully() {
+    let n_minus_one = rb_proto::CONTRACT_VERSION
+        .checked_sub(1)
+        .expect("N-1 fixture requires CONTRACT_VERSION >= 1");
     let daemon = RunningDaemon::start(2).await;
 
     let stream = tokio::net::UnixStream::connect(&daemon.socket)
@@ -1402,7 +1405,7 @@ async fn n_minus_one_handshake_is_rejected_gracefully() {
     rb_proto::write_frame(
         &mut framed,
         &rb_proto::Handshake {
-            contract_version: rb_proto::CONTRACT_VERSION - 1,
+            contract_version: n_minus_one,
             namespace: Namespace::Project("skew".to_string()),
             identity: None,
         },
@@ -1420,7 +1423,7 @@ async fn n_minus_one_handshake_is_rejected_gracefully() {
     let message = ack.message.expect("nack carries a diagnostic message");
     assert!(
         message.contains(&rb_proto::CONTRACT_VERSION.to_string())
-            && message.contains(&(rb_proto::CONTRACT_VERSION - 1).to_string()),
+            && message.contains(&n_minus_one.to_string()),
         "diagnostic names both versions: {message}"
     );
 

--- a/docs/specs/2026-07-11-contract-drift-guard.md
+++ b/docs/specs/2026-07-11-contract-drift-guard.md
@@ -11,10 +11,14 @@ used to live in prose only, enforced by reviewer diligence. The
   `crates/rb-proto/src/messages.rs` (`CONTRACT_VERSION`, `Handshake`,
   `HandshakeAck`, `ClientIdentity`, `Request`, `Response`,
   `RecallChannelTotals`) plus the rb-types payload shapes those frames embed
-  (`MemoryNote`, `SearchResult`, `MemoryChanged`, `Namespace`, enums, ...).
-  rb-types is included deliberately: the v2 bump (`MemoryNote.contested`)
-  happened in rb-types, so guarding rb-proto alone would have missed the only
-  historical breaking change.
+  (`MemoryNote`, `SearchResult`, `MemoryStats`, `MemoryChanged`, `Namespace`,
+  enums, ...). rb-types is included deliberately: the v2 bump
+  (`MemoryNote.contested`) happened in rb-types, so guarding rb-proto alone
+  would have missed the only historical breaking change. The whole
+  `crates/rb-types/src` directory is scanned (only `error.rs` is excluded), so
+  a NEW payload file is guarded by default — the PR #56 lesson, where
+  `MemoryStats` landed in a brand-new `stats.rs` that an explicit file list
+  would have silently missed.
 - **Persistence surface**: every `crates/rb-store/migrations/NNN_*.sql` file
   (name + sha256).
 

--- a/docs/specs/2026-07-11-contract-drift-guard.md
+++ b/docs/specs/2026-07-11-contract-drift-guard.md
@@ -25,8 +25,14 @@ used to live in prose only, enforced by reviewer diligence. The
 `crates/rb-contract-guard` parses the sources with `syn` and digests each
 item's normalized tokens: doc comments, regular comments, and formatting are
 stripped, `#[cfg(test)]` items are skipped, and serde attributes are kept
-(they ARE the wire shape). Comment- or formatting-only edits never trip the
-guard. The digests live in the checked-in `contract-snapshot.toml`.
+(they ARE the wire shape). Structs, enums, `type` aliases, explicit serde
+impls, and `CONTRACT_VERSION` are digested; inline modules
+(`pub mod v2 { ... }`) are recursed into with module-qualified keys. Only the
+exact `#[cfg(test)]` predicate is treated as test-only — `cfg(not(test))`,
+`cfg(feature = "...")`, `cfg(all(test, ...))` etc. stay in the digest
+(conservative inclusion: the guard must never silently drop a real wire
+item). Comment- or formatting-only edits never trip the guard. The digests
+live in the checked-in `contract-snapshot.toml`.
 
 ## What happens on a PR
 
@@ -73,3 +79,8 @@ release per W5a.4), that test is the seam to flip.
 - Framing (`rb-proto/src/frame.rs`, `codec.rs`) is not digested: its wire
   behavior lives in function bodies, which would make every refactor a false
   positive; it is covered by the round-trip tests instead.
+- Non-doc attribute edits that cannot change the wire shape — e.g. rewording a
+  `#[deprecated(note = "...")]` — DO trip the guard: attributes are digested
+  whole because serde attrs must be, and special-casing "harmless" attrs is
+  not worth the complexity. The resolution is the same one-command additive
+  marker.

--- a/docs/specs/2026-07-11-contract-drift-guard.md
+++ b/docs/specs/2026-07-11-contract-drift-guard.md
@@ -1,0 +1,71 @@
+# Contract-drift guard (W5a.4, operationalized)
+
+Vikunja #492. The Road-to-Tens W5a.4 protocol-evolution policy — additive
+serde-default fields never bump `CONTRACT_VERSION`; breaking changes bump it —
+used to live in prose only, enforced by reviewer diligence. The
+`contract-drift` CI job now enforces it mechanically.
+
+## What is guarded
+
+- **Wire surface**: every shape-defining item in
+  `crates/rb-proto/src/messages.rs` (`CONTRACT_VERSION`, `Handshake`,
+  `HandshakeAck`, `ClientIdentity`, `Request`, `Response`,
+  `RecallChannelTotals`) plus the rb-types payload shapes those frames embed
+  (`MemoryNote`, `SearchResult`, `MemoryChanged`, `Namespace`, enums, ...).
+  rb-types is included deliberately: the v2 bump (`MemoryNote.contested`)
+  happened in rb-types, so guarding rb-proto alone would have missed the only
+  historical breaking change.
+- **Persistence surface**: every `crates/rb-store/migrations/NNN_*.sql` file
+  (name + sha256).
+
+`crates/rb-contract-guard` parses the sources with `syn` and digests each
+item's normalized tokens: doc comments, regular comments, and formatting are
+stripped, `#[cfg(test)]` items are skipped, and serde attributes are kept
+(they ARE the wire shape). Comment- or formatting-only edits never trip the
+guard. The digests live in the checked-in `contract-snapshot.toml`.
+
+## What happens on a PR
+
+- **No contract change**: `check` matches the snapshot, the job is green.
+- **Any shape/migration/version change without a snapshot update**: the job
+  fails, naming exactly which items drifted.
+- **Recording the decision** (this is the "explicit marker"):
+  - additive, serde-default-compatible change — old frames still decode, no
+    bump (the `Handshake.identity` / `Pong.recall_channels` precedent):
+
+        cargo run -p rb-contract-guard -- update --intent additive --note "<what changed>"
+
+  - breaking change — bump `CONTRACT_VERSION` in
+    `crates/rb-proto/src/messages.rs` first, then:
+
+        cargo run -p rb-contract-guard -- update --intent breaking --note "<what changed>"
+
+  Commit the regenerated `contract-snapshot.toml`. The tool enforces the
+  version rule for the declared intent (`additive` refuses a bumped version;
+  `breaking` demands one), and the note lands in the snapshot's append-only
+  `[[log]]`, so the decision is visible in the PR diff for reviewers.
+
+The guard is also bound into `cargo test --workspace` (the
+`rb-contract-guard` `real_repo` test), so drift fails locally before CI, and
+`scripts/ci-local.sh` runs the same `check` step.
+
+## Version-skew fixture
+
+`rb-daemon`'s `n_minus_one_handshake_is_rejected_gracefully` e2e test pins the
+N-1 handshake behavior: with no breaking bump in flight there is no N/N-1
+dual-support window, so an N-1 client gets a graceful
+`HandshakeAck { ok: false }` naming both versions, then a closed connection.
+When a future bump opens a dual-support window (hub supports N and N-1 for one
+release per W5a.4), that test is the seam to flip.
+
+## Non-goals
+
+- No general-purpose schema/OpenSpec adoption; the guard is scoped to
+  rusty-brain's `CONTRACT_VERSION` + migration surfaces.
+- No semantic additive-vs-breaking classification: the guard forces a
+  deliberate, reviewable decision; whether a change is truly serde-default
+  compatible remains a review judgment (the drift report and log entry make it
+  impossible to slip one through silently).
+- Framing (`rb-proto/src/frame.rs`, `codec.rs`) is not digested: its wire
+  behavior lives in function bodies, which would make every refactor a false
+  positive; it is covered by the round-trip tests instead.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -26,6 +26,9 @@ step "agent: build"      cargo build -p rb-agents -p rb-hooks -p rb-install
 step "agent: clippy"     cargo clippy -p rb-agents -p rb-hooks -p rb-install --all-targets -- -D warnings
 step "agent: test"       cargo test -p rb-agents -p rb-hooks -p rb-install
 
+# --- contract drift guard job (W5a.4) ---
+step "contract-drift"    cargo run -p rb-contract-guard -- check
+
 # --- cargo-deny / cargo-audit jobs ---
 step "cargo-deny"        cargo deny check
 step "cargo-audit"       cargo audit


### PR DESCRIPTION
## Summary

Operationalizes the Road-to-Tens W5a.4 protocol-evolution policy (Vikunja #492). Until now the policy — additive serde-default fields never bump `CONTRACT_VERSION`; breaking changes bump it — lived in prose and was enforced by reviewer diligence only. This PR adds a `contract-drift` CI job backed by a new `crates/rb-contract-guard` tool:

- **Wire surface**: every shape-defining item in `crates/rb-proto/src/messages.rs` (`CONTRACT_VERSION`, `Handshake`, `HandshakeAck`, `ClientIdentity`, `Request`, `Response`, `RecallChannelTotals`) plus the rb-types payload shapes those frames embed. The whole `crates/rb-types/src` directory is scanned (only `error.rs` excluded) so a NEW payload file is guarded by default. rb-types is guarded deliberately: the only historical bump (v2, `MemoryNote.contested`) happened in rb-types, so rb-proto-only path triggers would have missed it.
- **Persistence surface**: every `crates/rb-store/migrations/NNN_*.sql` (name + sha256).

Any drift fails CI (and `cargo test --workspace`, via the crate's `real_repo` binding test) until the PR records a deliberate decision in the checked-in `contract-snapshot.toml`.

## Design decisions

- **Marker mechanism: checked-in intent file over PR-description parsing.** The snapshot's append-only `[[log]]` (written by `update --intent ... --note "..."`) is the explicit marker. It is deterministic, testable locally with plain `cargo test`/`cargo run`, immune to gh API quirks, and lands in the PR diff where reviewers see it. A PR-description magic line would be invisible to local runs and easy to edit after review.
- **Detection: syn-normalized per-item digests over git-diff path triggers.** Sources are parsed and each shape-defining item's token stream is hashed with doc comments stripped and `cfg(test)` items skipped; serde attributes are kept because they are the wire shape. Comment/formatting-only edits never trip the guard, failures name the exact drifted item, and the check needs no git plumbing. Explicit `impl Serialize/Deserialize` blocks are also digested so a future custom impl cannot evade the guard.
- **Directory scanning for rb-types (added after PR #56 merged).** PR #56 landed `MemoryStats` in a brand-new `stats.rs`; the initial explicit file list would have missed it. `SurfaceConfig` now scans `crates/rb-types/src` non-recursively with an exclude list, so new payload files are guarded by default (covered by a dedicated e2e matrix test).
- **Intent enforcement**: `update --intent additive` refuses a bumped `CONTRACT_VERSION` (points at `breaking`); `update --intent breaking` demands a strictly-greater bump. A silent bump alone (digests unchanged) is also drift.
- **N-1 fixture (W5a.4 "CI handshakes an N-1 fixture client")**: the daemon currently enforces exact-match (no dual-support window is open — no breaking bump is in flight). The new rb-daemon e2e test pins the graceful rejection: `HandshakeAck { ok: false }` naming both versions, then a closed connection. When a future bump opens an N/N-1 window, that test is the seam to flip. Implementing actual N-1 acceptance would be a daemon behavior change and is out of scope here.

## Coordination with PR #56 (doctor/stats) — DONE

Rebased onto main after #56 merged (33a22186). The guard correctly flagged the drift (`Request`, `Response` changed; `stats.rs` shapes new), and the decision is recorded in this branch's snapshot as the first real marker:

    [[log]]
    contract_version = 2
    intent = "additive"
    note = "PR #56 doctor/stats: Request::Stats/Response::Stats + rb-types MemoryStats (no bump, additive per W5a.4)"

Task #458 (additive `RecallFilter` fields) will follow the same one-command flow.

Docs: `docs/specs/2026-07-11-contract-drift-guard.md` + CHANGELOG entry.

## Test plan

- [x] TDD: module stubs first, unit tests observed failing, then implemented (extract normalization, snapshot round-trip, check diffing, update intent rules, wire-dir scanning)
- [x] CLI e2e matrix (13 tests, `tests/guard_matrix.rs`, fixture repos): additive change + marker passes; silent shape change fails naming the item and both remediation commands; comment-only and unrelated changes pass without a marker; rb-types payload drift caught; brand-new rb-types wire file caught; silent migration addition fails then additive marker unblocks; silent version bump fails then breaking marker unblocks; breaking change cannot hide behind an additive marker; breaking marker without a bump rejected; init/update bootstrap errors
- [x] `real_repo` test: guard passes on this tree as-is; snapshot version cross-checked against the compiled `rb_proto::CONTRACT_VERSION`
- [x] rb-daemon e2e: `n_minus_one_handshake_is_rejected_gracefully`
- [x] Post-rebase gates: `cargo fmt --all --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `cargo test --workspace` (1348 passed, 9 ignored); `cargo deny check`; `cargo run -p rb-contract-guard -- check` green
