### PR TITLE
feat: typed code anchors (--file/--commit/--symbol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added — Typed code anchors (PRD 2026-07-02)
+
+- **First-class, queryable code anchors**: a memory can now carry structured
+  `file` (+ optional 1-based line range), `commit`, and `symbol` anchors,
+  stored in the additive `memory_anchors` table (migration 009 — no ALTER on
+  `memories`, no backfill, no `CONTRACT_VERSION` bump). Capture:
+  `remember --file src/foo.rs:12-40 --commit <sha> --symbol Foo::bar`
+  (repeatable), MCP `remember` `files`/`commits`/`symbols` params, and the
+  SessionEnd hook fold now AUTO-ANCHORS the session summary to the touched
+  files (fail-open, capped like the summary's file section). Recall/list
+  filter by anchor — `--file <path>` / `--commit <sha>` / `--symbol <name>`
+  (CLI + MCP; all-of composition with each other and with the metadata
+  filters) — with normalization on both sides (`./src/a.rs` == `src/a.rs`;
+  file filters match by path, line ranges are capture-only). Anchors ride
+  `graph`/`get`/`list` output, survive `export`/`restore`, and follow a
+  `namespace rename`. v1 ships anchors as a FILTER only; ranking boosts are
+  deferred to W4.1 evidence per the PRD.
+- **`anchors` daemon capability on the handshake ack**: the additive
+  `HandshakeAck.capabilities` list lets clients distinguish an
+  anchor-evaluating daemon from an older one that would silently drop
+  `Remember.anchors` or ignore anchor filters. Typed clients (and the MCP
+  adapter's raw path) fail fast with `InvalidArgument` when anchors are used
+  against a daemon that did not advertise the capability; the hook path stays
+  fail-open and stores the summary WITHOUT anchors instead. The default MCP
+  `tools/list` stays under the W3.3 token budget (897/900) — existing
+  descriptions were tightened to make room for the anchor params.
+
 ### Added — Contract-drift guard (W5a.4 operationalized)
 
 - **`rb-contract-guard` + `contract-drift` CI job**: the wire surface

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -9,17 +9,18 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::CONTRACT_VERSION" = "3f9208b6b23ee097c0f8177f4e0c94696a2c17f0cc02d4f3db93854566d67791"
 "crates/rb-proto/src/messages.rs::ClientIdentity" = "4c817d16fbee936cf94e023e4d4ddf9330df312bc4e3bd7ce98f0b983de35fa1"
 "crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
-"crates/rb-proto/src/messages.rs::HandshakeAck" = "09b1c1de35d4a2331beeb72fce279bbc689969cffa4b0aec3226c09183120a32"
+"crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
-"crates/rb-proto/src/messages.rs::Request" = "bc95284b5f2bba84ddc6681b51c8bd9b5b1f5c0fedfec45914155817b891e40c"
+"crates/rb-proto/src/messages.rs::Request" = "68c63fba407d396d423d1fcdf12acdff8107a762b034da4cf93da2ffaebd7d7c"
 "crates/rb-proto/src/messages.rs::Response" = "383bd0e8b99c07bb4ce785c8c5cab9097a20549372cba77186d684b083a78971"
+"crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
 "crates/rb-types/src/feedback_kind.rs::FeedbackKind" = "8ca2edbd8aca8e2b087ea630e10209a51a307efdf1a84b0bbccc74a06f2da7b6"
 "crates/rb-types/src/job.rs::JobKind" = "1d37fe458aaade8a2fdc2291c14e68eb54102c358e12274ea347f3645c23b986"
 "crates/rb-types/src/link.rs::MemoryLink" = "7e1c5377ec99d7e609c289b14fed82fa2a2c5275650bb688ea1afbe03fb37f4d"
 "crates/rb-types/src/link_type.rs::LinkType" = "2394c0b6dc86235d55ce3e3bb9b7d5d8b058672f07b1e57532930e897ca644f2"
-"crates/rb-types/src/memory.rs::MemoryNote" = "bc882adf4a7f6269ac42aa76d07fc2c906bab2d27eec1c9cf75b1f04c3cd0764"
+"crates/rb-types/src/memory.rs::MemoryNote" = "87897e9d0197069a2d4a6208df5b8debb7baee9d0c28d8b1ec6a4d8af38533e8"
 "crates/rb-types/src/memory_id.rs::MemoryId" = "688b5e41d43d9004ae80916922636c569b7dceb0e4b9ab80e1e83d9d1ed622f0"
 "crates/rb-types/src/memory_type.rs::MemoryType" = "238c3095d32261dc60d19ec7e787249c1f3a0e1bfd40917a5e670fa8e4270ac3"
 "crates/rb-types/src/namespace.rs::Namespace" = "7ba4f747be391c0b6b298ddc89b0654e92a7cd13e69f54c6debf3c01116c7c51"
@@ -45,6 +46,7 @@ contract_version = 2
 "006_narrow_mem_au.sql" = "1803fb5199302bc5e5910e870ef81b80ddb940c4b3a4df3113d6a319a3933299"
 "007_base_importance.sql" = "be04183c1209fdb8adfdcbd66dc96ecf6125b79a45cd4a65f40388b6cca6586b"
 "008_memory_feedback.sql" = "64901f555624da4b738e437877d6b2b60579dbd5051f55ab476390015a67b70b"
+"009_memory_anchors.sql" = "60f223ee485e42e7b55a78027c06afdb36fcecbad136d5f995f8be2f729d3669"
 
 [[log]]
 contract_version = 2
@@ -60,3 +62,8 @@ note = "PR #56 doctor/stats: Request::Stats/Response::Stats + rb-types MemorySta
 contract_version = 2
 intent = "additive"
 note = "PR #58 recall/list filter parity: additive filter field on Request::Recall/List + rb-types RecallFilter/MemoryState/AnchorFilter/AnchorKind (no bump, additive per W5a.4)"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR: typed code anchors — memory_anchors migration (009) + anchor wire additions (MemoryNote.anchors, Remember.anchors, HandshakeAck.capabilities, rb-types MemoryAnchor); no bump, additive per W5a.4"

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -46,7 +46,7 @@ contract_version = 2
 "006_narrow_mem_au.sql" = "1803fb5199302bc5e5910e870ef81b80ddb940c4b3a4df3113d6a319a3933299"
 "007_base_importance.sql" = "be04183c1209fdb8adfdcbd66dc96ecf6125b79a45cd4a65f40388b6cca6586b"
 "008_memory_feedback.sql" = "64901f555624da4b738e437877d6b2b60579dbd5051f55ab476390015a67b70b"
-"009_memory_anchors.sql" = "60f223ee485e42e7b55a78027c06afdb36fcecbad136d5f995f8be2f729d3669"
+"009_memory_anchors.sql" = "d65aa99503a1573dfc55e65c60eb4045087e26680e2e6e426fdd6b9be1b3f6eb"
 
 [[log]]
 contract_version = 2
@@ -67,3 +67,8 @@ note = "PR #58 recall/list filter parity: additive filter field on Request::Reca
 contract_version = 2
 intent = "additive"
 note = "PR: typed code anchors — memory_anchors migration (009) + anchor wire additions (MemoryNote.anchors, Remember.anchors, HandshakeAck.capabilities, rb-types MemoryAnchor); no bump, additive per W5a.4"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR #59 review: migration 009 comment-only fix — index docs now describe the true access paths (anchor filter is a namespace-scoped semi-join over the wide indexes; memory_id index serves row_to_note); no schema change"

--- a/crates/rb-agents/src/daemon.rs
+++ b/crates/rb-agents/src/daemon.rs
@@ -75,20 +75,17 @@ impl DaemonClient {
         tags: Vec<String>,
         confidence: Option<f32>,
     ) -> Option<MemoryId> {
-        let fut = self.client.remember(
+        self.remember_anchored(
             content,
             context,
             memory_type,
             importance,
-            Vec::new(),
             tags,
-            Vec::new(),
             confidence,
-        );
-        match tokio::time::timeout(self.timeout, fut).await {
-            Ok(Ok(id)) => Some(id),
-            Ok(Err(_)) | Err(_) => None,
-        }
+            Vec::new(),
+            None,
+        )
+        .await
     }
 
     /// Best-effort `remember` that ATOMICALLY supersedes `supersedes` with the
@@ -106,7 +103,46 @@ impl DaemonClient {
         confidence: Option<f32>,
         supersedes: MemoryId,
     ) -> Option<MemoryId> {
-        let fut = self.client.remember_superseding(
+        self.remember_anchored(
+            content,
+            context,
+            memory_type,
+            importance,
+            tags,
+            confidence,
+            Vec::new(),
+            Some(supersedes),
+        )
+        .await
+    }
+
+    /// Best-effort `remember` carrying typed code anchors (PRD 2026-07-02)
+    /// and an optional atomic supersede. STRICTLY FAIL-OPEN like the rest of
+    /// the hook surface: when the daemon did not advertise anchor support,
+    /// the anchors are DROPPED (logged at debug) and the memory is stored
+    /// un-anchored — a summary must never be lost over an old daemon.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn remember_anchored(
+        &mut self,
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        tags: Vec<String>,
+        confidence: Option<f32>,
+        anchors: Vec<rb_types::MemoryAnchor>,
+        supersedes: Option<MemoryId>,
+    ) -> Option<MemoryId> {
+        let anchors = if anchors.is_empty() || self.client.supports_anchors() {
+            anchors
+        } else {
+            tracing::debug!(
+                dropped = anchors.len(),
+                "daemon lacks anchor support; storing without anchors"
+            );
+            Vec::new()
+        };
+        let fut = self.client.remember_anchored(
             content,
             context,
             memory_type,
@@ -115,6 +151,7 @@ impl DaemonClient {
             tags,
             Vec::new(),
             confidence,
+            anchors,
             supersedes,
         );
         match tokio::time::timeout(self.timeout, fut).await {
@@ -288,6 +325,36 @@ mod tests {
         // user/host were not declared: the daemon fell back to its own whoami.
         assert_eq!(note.origin_user, rb_config::current_user());
         assert_eq!(note.origin_host, rb_config::current_hostname());
+
+        // Typed code anchors: the real daemon advertises the capability, so
+        // an anchored best-effort remember persists its anchors.
+        let anchors = vec![
+            rb_types::MemoryAnchor::parse_file_spec("src/server.rs:1-9").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Server::run").unwrap(),
+        ];
+        let anchored_id = client
+            .remember_anchored(
+                "anchored session summary".to_string(),
+                None,
+                MemoryType::Insight,
+                6,
+                vec!["hook".to_string()],
+                Some(0.7),
+                anchors.clone(),
+                None,
+            )
+            .await
+            .expect("anchored remember must return an id");
+        let (recent, important, _total) = client.context().await.expect("context");
+        let anchored_note = recent
+            .iter()
+            .chain(important.iter())
+            .find(|m| m.id == anchored_id)
+            .expect("anchored memory must appear");
+        assert_eq!(
+            anchored_note.anchors, anchors,
+            "anchors must persist through the fail-open hook client"
+        );
 
         let _ = shutdown.send(());
         let _ = handle.await;

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -636,6 +636,7 @@ async fn handle_connection(
                 "contract mismatch: server {CONTRACT_VERSION}, client {}",
                 handshake.contract_version
             )),
+            capabilities: vec![],
         };
         write_frame(&mut framed, &ack).await?;
         return Ok(());
@@ -648,6 +649,7 @@ async fn handle_connection(
                 contract_version: CONTRACT_VERSION,
                 ok: false,
                 message: Some(e.to_string()),
+                capabilities: vec![],
             };
             write_frame(&mut framed, &ack).await?;
             return Ok(());
@@ -657,6 +659,11 @@ async fn handle_connection(
         contract_version: CONTRACT_VERSION,
         ok: true,
         message: None,
+        // Typed code anchors (PRD 2026-07-02): this daemon evaluates anchor
+        // payloads, so advertise the capability — clients gate anchor-bearing
+        // requests on it (pre-anchor daemons never send it). Old clients
+        // ignore the additive field.
+        capabilities: vec![rb_proto::CAP_ANCHORS.to_string()],
     };
     write_frame(&mut framed, &ack).await?;
 
@@ -929,6 +936,7 @@ where
             related_files,
             confidence,
             supersedes,
+            anchors,
         } => {
             let input = RememberInput {
                 content,
@@ -940,6 +948,7 @@ where
                 related_files,
                 confidence,
                 provenance: provenance.clone(),
+                anchors,
             };
             match engine.remember(input).await {
                 Ok(id) => {

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1230,26 +1230,89 @@ async fn recall_and_list_filters_flow_over_the_wire() {
         vec![low_conf.clone()]
     );
 
-    // Anchor filters fail fast (typed-code-anchors is not shipped yet): the
-    // client wrapper rejects them BEFORE sending (so even an old daemon that
-    // ignores the additive filter field can never return unfiltered results);
-    // the daemon-side rejection is covered by engine/store unit tests.
-    let err = cli_client
+    // Typed code anchors over a real socket (PRD 2026-07-02): the daemon
+    // advertises the `anchors` capability at handshake, an anchored remember
+    // persists its anchors, and recall/list scope by them — present under the
+    // anchored file, absent under a different one (the PRD acceptance
+    // criterion), composing with the metadata dimensions.
+    assert!(
+        cli_client.supports_anchors(),
+        "a current daemon must advertise anchor support"
+    );
+    let anchors = vec![
+        rb_types::MemoryAnchor::parse_file_spec("src/server.rs:10-40").unwrap(),
+        rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Server::run").unwrap(),
+    ];
+    let anchored_id = cli_client
+        .remember_anchored(
+            "filterable anchored decision".to_string(),
+            None,
+            MemoryType::Insight,
+            8,
+            vec![],
+            vec![],
+            vec![],
+            Some(0.9),
+            anchors.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+    let file_filter = |path: &str| RecallFilter {
+        anchors: vec![rb_types::AnchorFilter {
+            kind: rb_types::AnchorKind::File,
+            value: path.to_string(),
+        }],
+        ..Default::default()
+    };
+    let (results, _) = cli_client
+        .recall_filtered_with_status("filterable".to_string(), file_filter("src/server.rs"), 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        results
+            .iter()
+            .map(|r| r.memory.id.clone())
+            .collect::<Vec<_>>(),
+        vec![anchored_id.clone()],
+        "recall scoped to the anchored file returns ONLY the anchored memory"
+    );
+    assert_eq!(
+        results[0].memory.anchors, anchors,
+        "anchors ride the result payload"
+    );
+    let (absent, _) = cli_client
+        .recall_filtered_with_status("filterable".to_string(), file_filter("src/other.rs"), 10)
+        .await
+        .unwrap();
+    assert!(absent.is_empty(), "a different file matches nothing");
+    // List: anchor + metadata composition over the wire.
+    let listed = cli_client
         .list_filtered(
             RecallFilter {
+                min_importance: Some(7),
                 anchors: vec![rb_types::AnchorFilter {
-                    kind: rb_types::AnchorKind::File,
-                    value: "src/server.rs".to_string(),
+                    kind: rb_types::AnchorKind::Symbol,
+                    value: "Server::run".to_string(),
                 }],
                 ..Default::default()
             },
             10,
         )
         .await
+        .unwrap();
+    assert_eq!(
+        listed.iter().map(|n| n.id.clone()).collect::<Vec<_>>(),
+        vec![anchored_id.clone()]
+    );
+    // An empty anchor-filter value is a wire-visible validation error.
+    let err = cli_client
+        .list_filtered(file_filter("   "), 10)
+        .await
         .unwrap_err();
     assert!(
         matches!(err, Error::InvalidArgument(_)),
-        "anchor filter must fail fast over the wire, got {err:?}"
+        "empty anchor filter value must fail fast, got {err:?}"
     );
 
     // Old-client compatibility: a raw pre-filter frame (NO `filter` key at
@@ -1282,7 +1345,7 @@ async fn recall_and_list_filters_flow_over_the_wire() {
             let got: std::collections::HashSet<_> = memories.iter().map(|n| n.id.clone()).collect();
             assert_eq!(
                 got,
-                [high_conf, from_mcp].into_iter().collect(),
+                [high_conf, from_mcp, anchored_id].into_iter().collect(),
                 "an old frame must keep the pre-filter default (active, unfiltered)"
             );
         }

--- a/crates/rb-engine/src/backend.rs
+++ b/crates/rb-engine/src/backend.rs
@@ -46,8 +46,10 @@ pub trait MemoryBackend: Send + Sync {
     /// the SAME semantics as [`MemoryBackend::active_contradicts`] (the store
     /// pins the two with a drift test; in-memory impls delegate to their own
     /// `active_contradicts`). An error resolving contested fails the list
-    /// (fail-closed). `anchors` is NOT evaluated here — the engine rejects it
-    /// until typed code anchors land.
+    /// (fail-closed). `anchors` IS evaluated here too (all-of, the
+    /// [`RecallFilter::matches`] semantics — the SQL store probes
+    /// `memory_anchors`, in-memory impls rely on `matches` reading the
+    /// note's own anchors).
     async fn list(
         &self,
         ns: Namespace,

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -23,6 +23,10 @@ pub struct RememberInput {
     /// enricher must not override (fix #4). Hook captures send `Some(0.7)`.
     pub confidence: Option<f32>,
     pub provenance: Provenance,
+    /// Typed code anchors (PRD 2026-07-02): structured file/commit/symbol
+    /// links stored with the memory. Validated fail-closed; empty is the
+    /// pre-anchor behavior (anchors are never required).
+    pub anchors: Vec<rb_types::MemoryAnchor>,
 }
 
 /// What `recall_with_status` returns (W1.6d): the ranked results plus whether
@@ -174,19 +178,10 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
     }
 
     /// Fail-fast filter gate shared by `recall` and `list`: range/bound
-    /// validation plus the anchor rejection — the anchors TABLE ships with the
-    /// typed-code-anchors PRD, so until then a non-empty anchor filter is an
-    /// explicit error, never a silently ignored constraint.
+    /// validation, including anchor-filter values (empty-after-normalization
+    /// values are a caller mistake, rejected before any query runs).
     fn ensure_filter_supported(filter: &rb_types::RecallFilter) -> rb_types::Result<()> {
-        filter.validate()?;
-        if !filter.anchors.is_empty() {
-            return Err(rb_types::Error::InvalidArgument(
-                "anchor filters are not supported yet (the memory_anchors table ships with \
-                 typed code anchors)"
-                    .to_string(),
-            ));
-        }
-        Ok(())
+        filter.validate()
     }
 
     async fn get_scoped(&self, id: MemoryId) -> rb_types::Result<Option<MemoryNote>> {
@@ -205,6 +200,11 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         // rather than a Storage one). `None` carries no prior — valid.
         if let Some(c) = input.confidence {
             rb_types::validate_confidence(c)?;
+        }
+        // Anchor validation is fail-closed at the engine boundary (the store
+        // re-validates; the SQL CHECKs are the last backstop).
+        for anchor in &input.anchors {
+            anchor.validate()?;
         }
 
         let mut note = MemoryNote::new(
@@ -262,6 +262,7 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
                 .unwrap_or_default()
         };
         note.related_files = input.related_files;
+        note.anchors = input.anchors;
         if let Some(ctx) = input.context {
             note.context = ctx;
         }
@@ -749,12 +750,11 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
 
     /// List memories in the engine namespace, most-recent first, filtered by
     /// the unified [`rb_types::RecallFilter`] (PRD 2026-07-02 search-filter
-    /// parity). EVERY dimension — metadata AND the contested tri-state — is
-    /// honored by the backend's bounded query (SQL on the real store), so
-    /// `limit` fills with actual matches no matter how deep they sit; a
-    /// backend error under a contested filter fails the list (fail-closed —
-    /// never silently unfiltered results). Anchors are rejected until typed
-    /// code anchors land.
+    /// parity). EVERY dimension — metadata, anchors, AND the contested
+    /// tri-state — is honored by the backend's bounded query (SQL on the real
+    /// store), so `limit` fills with actual matches no matter how deep they
+    /// sit; a backend error under a contested filter fails the list
+    /// (fail-closed — never silently unfiltered results).
     pub async fn list(
         &self,
         filter: &rb_types::RecallFilter,
@@ -995,6 +995,7 @@ mod tests {
             // enricher (when present) may fill it.
             confidence: None,
             provenance: Provenance::default(),
+            anchors: Vec::new(),
         }
     }
 
@@ -1235,21 +1236,99 @@ mod tests {
         assert_eq!(all.len(), 2);
     }
 
+    fn file_anchor_filter(path: &str) -> rb_types::RecallFilter {
+        rb_types::RecallFilter {
+            anchors: vec![rb_types::AnchorFilter {
+                kind: rb_types::AnchorKind::File,
+                value: path.to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
     #[tokio::test]
-    async fn recall_rejects_anchor_filters_until_typed_anchors_land() {
+    async fn remember_persists_anchors_and_recall_filters_by_them() {
+        // The PRD acceptance criterion end-to-end at the engine layer: a
+        // memory stored with a file anchor is returned by recall filtered to
+        // that file, and absent when filtered to a different file.
+        let eng = engine();
+        let mut anchored_input = input("anchored decision about the server", 7);
+        anchored_input.anchors = vec![
+            rb_types::MemoryAnchor::parse_file_spec("src/server.rs:10-40").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Server::run").unwrap(),
+        ];
+        let anchored_id = eng.remember(anchored_input).await.unwrap();
+        let _plain_id = eng
+            .remember(input("plain decision about the server", 7))
+            .await
+            .unwrap();
+
+        let stored = eng.get(anchored_id.clone()).await.unwrap().unwrap();
+        assert_eq!(stored.anchors.len(), 2, "anchors persist through remember");
+
+        let hits = eng
+            .recall("server", 10, &file_anchor_filter("src/server.rs"))
+            .await
+            .unwrap();
+        assert_eq!(
+            hits.iter().map(|r| r.memory.id.clone()).collect::<Vec<_>>(),
+            vec![anchored_id.clone()],
+            "recall scoped to the anchored file returns ONLY the anchored memory"
+        );
+        let misses = eng
+            .recall("server", 10, &file_anchor_filter("src/other.rs"))
+            .await
+            .unwrap();
+        assert!(misses.is_empty(), "a different file matches nothing");
+    }
+
+    #[tokio::test]
+    async fn recall_composes_anchor_and_metadata_filters() {
+        let eng = engine();
+        let anchor = rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap();
+        let ids = seed_notes(&eng, 3, |i, note| {
+            if i < 2 {
+                note.anchors = vec![anchor.clone()];
+            }
+            note.importance = if i == 0 { 8 } else { 3 };
+        })
+        .await;
+        let mut filter = file_anchor_filter("./src/a.rs"); // normalization applies
+        filter.min_importance = Some(7);
+        let results = eng.recall("seeded", 10, &filter).await.unwrap();
+        assert_eq!(
+            results
+                .iter()
+                .map(|r| r.memory.id.clone())
+                .collect::<Vec<_>>(),
+            vec![ids[0].clone()],
+            "anchor + min-importance must compose (only note 0 satisfies both)"
+        );
+    }
+
+    #[tokio::test]
+    async fn remember_rejects_invalid_anchors_fail_closed() {
+        let eng = engine();
+        let mut bad = input("bad anchor", 5);
+        bad.anchors = vec![rb_types::MemoryAnchor {
+            kind: rb_types::AnchorKind::Commit,
+            value: "abc".into(),
+            start_line: Some(3), // lines are file-only
+            end_line: None,
+        }];
+        let err = eng.remember(bad).await.unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::InvalidArgument(_)),
+            "expected InvalidArgument, got {err:?}"
+        );
+        assert_eq!(eng.backend().count(), 0, "nothing may be stored");
+    }
+
+    #[tokio::test]
+    async fn recall_rejects_empty_anchor_filter_values() {
         let eng = engine();
         let err = eng
-            .recall(
-                "q",
-                10,
-                &only(rb_types::RecallFilter {
-                    anchors: vec![rb_types::AnchorFilter {
-                        kind: rb_types::AnchorKind::File,
-                        value: "src/lib.rs".into(),
-                    }],
-                    ..Default::default()
-                }),
-            )
+            .recall("q", 10, &file_anchor_filter("   "))
             .await
             .unwrap_err();
         assert!(
@@ -1406,9 +1485,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_rejects_anchor_filters_and_invalid_bounds() {
+    async fn list_honors_anchor_filters() {
         let eng = engine();
-        let err = eng
+        let symbol =
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Engine::recall").unwrap();
+        let ids = seed_notes(&eng, 2, |i, note| {
+            if i == 0 {
+                note.anchors = vec![symbol.clone()];
+            }
+        })
+        .await;
+        let listed = eng
             .list(
                 &only(rb_types::RecallFilter {
                     anchors: vec![rb_types::AnchorFilter {
@@ -1420,9 +1507,16 @@ mod tests {
                 10,
             )
             .await
-            .unwrap_err();
-        assert!(matches!(err, rb_types::Error::InvalidArgument(_)));
+            .unwrap();
+        assert_eq!(
+            listed.iter().map(|n| n.id.clone()).collect::<Vec<_>>(),
+            vec![ids[0].clone()]
+        );
+    }
 
+    #[tokio::test]
+    async fn list_rejects_invalid_bounds() {
+        let eng = engine();
         let err = eng
             .list(
                 &only(rb_types::RecallFilter {

--- a/crates/rb-engine/tests/public_api.rs
+++ b/crates/rb-engine/tests/public_api.rs
@@ -260,6 +260,7 @@ async fn full_flow_through_public_api() {
             related_files: Vec::new(),
             confidence: Some(1.0),
             provenance: Default::default(),
+            anchors: Vec::new(),
         })
         .await
         .unwrap();

--- a/crates/rb-eval/src/runner.rs
+++ b/crates/rb-eval/src/runner.rs
@@ -160,6 +160,7 @@ async fn ingest<P: EmbeddingProvider>(
                 related_files: Vec::new(),
                 confidence: None,
                 provenance: Default::default(),
+                anchors: Vec::new(),
             })
             .await?;
         // Apply the authored confidence (no-op at the 1.0 default).

--- a/crates/rb-eval/tests/score_floor_diag.rs
+++ b/crates/rb-eval/tests/score_floor_diag.rs
@@ -43,6 +43,7 @@ async fn ingest<P: EmbeddingProvider>(
                 related_files: Vec::new(),
                 confidence: None,
                 provenance: Default::default(),
+                anchors: Vec::new(),
             })
             .await
             .expect("remember");

--- a/crates/rb-hooks/src/capture.rs
+++ b/crates/rb-hooks/src/capture.rs
@@ -716,6 +716,9 @@ async fn fold_session_summary(
         return continue_only();
     };
     let content = redact(&content);
+    // Auto-anchor the summary to the touched files (typed code anchors,
+    // ANC-2): the same union the "Files touched" section lists.
+    let anchors = session_file_anchors(&data, &git_files);
 
     // Only RESET the scratch once the fold is DURABLY stored. A degraded write
     // (no daemon connection, or a store error) leaves the buffer intact so a
@@ -725,7 +728,7 @@ async fn fold_session_summary(
         return continue_only();
     };
     if let Some(new_id) =
-        store_session_summary(client, content, data.prior_summary_id.as_deref()).await
+        store_session_summary(client, content, data.prior_summary_id.as_deref(), anchors).await
     {
         let new_id = new_id.to_string();
         match mode {
@@ -740,13 +743,43 @@ async fn fold_session_summary(
     continue_only()
 }
 
+/// The touched-file union the summary reports AND the auto-anchors mirror:
+/// tool-tracked edits (scratch) first, then working-tree changes (git) not
+/// already listed, first-seen order.
+fn union_touched_files(data: &ScratchData, git_files: &[String]) -> Vec<String> {
+    let mut files = data.files.clone();
+    for f in git_files {
+        if !files.iter().any(|e| e == f) {
+            files.push(f.clone());
+        }
+    }
+    files
+}
+
+/// Derive the summary's file anchors (typed code anchors, ANC-2 auto-anchor):
+/// one `file` anchor per touched file, capped at [`SUMMARY_SECTION_LIMIT`] so
+/// the anchor set mirrors exactly what the "Files touched" section lists.
+/// FAIL-OPEN like the whole hook path: a path that fails anchor validation is
+/// skipped, never an error.
+fn session_file_anchors(data: &ScratchData, git_files: &[String]) -> Vec<rb_types::MemoryAnchor> {
+    union_touched_files(data, git_files)
+        .iter()
+        .take(SUMMARY_SECTION_LIMIT)
+        .filter_map(|f| rb_types::MemoryAnchor::new(rb_types::AnchorKind::File, f).ok())
+        .collect()
+}
+
 /// Store the folded summary, superseding the session's prior summary when one
 /// exists and parses (update-as-supersede); a bad stored id degrades to a plain
-/// store. Returns the new memory id, or `None` on any best-effort failure.
+/// store. The summary is auto-anchored to `anchors` (the touched files) on a
+/// best-effort basis — `DaemonClient` drops them against a daemon without
+/// anchor support rather than losing the summary. Returns the new memory id,
+/// or `None` on any best-effort failure.
 async fn store_session_summary(
     client: &mut DaemonClient,
     content: String,
     prior_summary_id: Option<&str>,
+    anchors: Vec<rb_types::MemoryAnchor>,
 ) -> Option<MemoryId> {
     let tags = vec!["hook".to_string(), "session-summary".to_string()];
     // A non-None id that fails to parse is a (rare) corrupt scratch: log it and
@@ -759,33 +792,18 @@ async fn store_session_summary(
             })
             .ok()
     });
-    match prior {
-        Some(old) => {
-            client
-                .remember_superseding(
-                    content,
-                    None,
-                    MemoryType::Insight,
-                    SESSION_SUMMARY_IMPORTANCE,
-                    tags,
-                    Some(HOOK_CONFIDENCE),
-                    old,
-                )
-                .await
-        }
-        None => {
-            client
-                .remember(
-                    content,
-                    None,
-                    MemoryType::Insight,
-                    SESSION_SUMMARY_IMPORTANCE,
-                    tags,
-                    Some(HOOK_CONFIDENCE),
-                )
-                .await
-        }
-    }
+    client
+        .remember_anchored(
+            content,
+            None,
+            MemoryType::Insight,
+            SESSION_SUMMARY_IMPORTANCE,
+            tags,
+            Some(HOOK_CONFIDENCE),
+            anchors,
+            prior,
+        )
+        .await
 }
 
 /// Assemble a decision-grade session summary from the scratch + transcript +
@@ -802,12 +820,7 @@ fn build_session_summary(
     if data.is_empty() && git_files.is_empty() && transcript.is_empty() {
         return None;
     }
-    let mut files = data.files.clone();
-    for f in git_files {
-        if !files.iter().any(|e| e == f) {
-            files.push(f.clone());
-        }
-    }
+    let files = union_touched_files(data, git_files);
     let mut out = String::from("Session summary.\n");
     if let Some(goal) = transcript.user_prompts.first() {
         out.push_str(&format!("\nGoal: {goal}\n"));
@@ -866,7 +879,7 @@ mod tests {
     /// supersedes) it received, and the id it issued back, in order.
     #[derive(Default)]
     struct MockObserved {
-        remembers: Vec<(String, Option<MemoryId>)>,
+        remembers: Vec<(String, Option<MemoryId>, Vec<rb_types::MemoryAnchor>)>,
         issued: Vec<MemoryId>,
     }
 
@@ -888,6 +901,10 @@ mod tests {
                 contract_version: CONTRACT_VERSION,
                 ok: true,
                 message: None,
+                // The mock plays a CURRENT daemon: advertise anchor support
+                // so the fail-open DaemonClient forwards anchors and the
+                // auto-anchor e2e below can assert them.
+                capabilities: vec![rb_proto::CAP_ANCHORS.to_string()],
             },
         )
         .await;
@@ -896,11 +913,12 @@ mod tests {
                 Request::Remember {
                     content,
                     supersedes,
+                    anchors,
                     ..
                 } => {
                     let id = MemoryId::new();
                     let mut s = state.lock().unwrap();
-                    s.remembers.push((content, supersedes));
+                    s.remembers.push((content, supersedes, anchors));
                     s.issued.push(id.clone());
                     Response::Remembered { id }
                 }
@@ -1922,5 +1940,85 @@ mod tests {
         let result = session_end(None, Some(&scratch), tmp.path(), None).await;
         assert!(result.continue_execution);
         assert!(scratch.read().is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_end_auto_anchors_the_summary_to_touched_files() {
+        // PRD acceptance (typed code anchors, ANC-2): the SessionEnd fold
+        // attaches the touched files to the summary memory as file anchors —
+        // asserted end-to-end over a live (mock) daemon connection whose ack
+        // advertises anchor support.
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let state = Arc::new(Mutex::new(MockObserved::default()));
+        let server = tokio::spawn(serve_remembers(listener, Arc::clone(&state)));
+
+        let mut client = DaemonClient::connect(
+            &socket,
+            Namespace::Project("rb-anchor-test".into()),
+            Duration::from_secs(5),
+            None,
+            None,
+        )
+        .await
+        .expect("connect to the mock daemon");
+
+        let scratch = scratch_at(tmp.path());
+        scratch.append(scratch::Kind::File, "src/server.rs");
+        scratch.append(scratch::Kind::File, "src/lib.rs");
+        scratch.append(scratch::Kind::Command, "cargo test");
+
+        let result = session_end(Some(&mut client), Some(&scratch), tmp.path(), None).await;
+        assert!(result.continue_execution);
+
+        let observed = state.lock().unwrap();
+        assert_eq!(observed.remembers.len(), 1, "one summary Remember");
+        let anchors = &observed.remembers[0].2;
+        let values: Vec<&str> = anchors.iter().map(|a| a.value.as_str()).collect();
+        assert_eq!(
+            values,
+            vec!["src/server.rs", "src/lib.rs"],
+            "the summary must be anchored to the touched files"
+        );
+        assert!(
+            anchors.iter().all(|a| a.kind == rb_types::AnchorKind::File),
+            "auto-anchors are file anchors"
+        );
+
+        server.abort();
+    }
+
+    #[test]
+    fn session_file_anchors_mirror_the_listed_section_and_fail_open() {
+        // The anchor set mirrors the "Files touched" union (scratch first,
+        // then git-only files), capped at SUMMARY_SECTION_LIMIT, skipping
+        // unanchorable paths instead of erroring (fail-open).
+        let data = ScratchData {
+            files: vec!["src/a.rs".to_string(), "  ".to_string()],
+            ..Default::default()
+        };
+        let git = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+        let anchors = session_file_anchors(&data, &git);
+        let values: Vec<&str> = anchors.iter().map(|a| a.value.as_str()).collect();
+        assert_eq!(
+            values,
+            vec!["src/a.rs", "src/b.rs"],
+            "deduped union, blank path skipped (fail-open)"
+        );
+
+        // The cap binds: more touched files than the section limit yields
+        // exactly SUMMARY_SECTION_LIMIT anchors.
+        let many = ScratchData {
+            files: (0..SUMMARY_SECTION_LIMIT + 5)
+                .map(|i| format!("src/f{i}.rs"))
+                .collect(),
+            ..Default::default()
+        };
+        assert_eq!(
+            session_file_anchors(&many, &[]).len(),
+            SUMMARY_SECTION_LIMIT,
+            "anchors are bounded like the listed section"
+        );
     }
 }

--- a/crates/rb-hooks/tests/integration.rs
+++ b/crates/rb-hooks/tests/integration.rs
@@ -151,6 +151,7 @@ struct RememberObs {
     content: String,
     supersedes: Option<String>,
     issued_id: String,
+    anchors: Vec<rb_types::MemoryAnchor>,
 }
 
 /// Record one request into `observed` and build the mock's response. A Remember
@@ -164,6 +165,7 @@ fn record_and_respond(req: Request, observed: &mut Observed) -> Response {
             content,
             context,
             supersedes,
+            anchors,
             ..
         } => {
             let id = MemoryId::new();
@@ -177,6 +179,7 @@ fn record_and_respond(req: Request, observed: &mut Observed) -> Response {
                 content,
                 supersedes: supersedes.map(|m| m.to_string()),
                 issued_id: id.to_string(),
+                anchors,
             });
             Response::Remembered { id }
         }
@@ -245,6 +248,9 @@ async fn serve_remembers(
                 contract_version: CONTRACT_VERSION,
                 ok: true,
                 message: None,
+                // The mock plays a CURRENT daemon: advertise anchor support
+                // so hook-forwarded anchors can be observed by the e2e tests.
+                capabilities: vec![rb_proto::CAP_ANCHORS.to_string()],
             },
         )
         .await;
@@ -536,6 +542,15 @@ fn opencode_apply_patch_file_edit_folds_into_checkpoint_summary() {
     assert!(
         content.contains("Files touched"),
         "the summary must carry a files section: {content}"
+    );
+    // Typed code anchors (ANC-2): the summary is auto-anchored to the touched
+    // file, not just listing it in prose — the queryable link recall filters on.
+    let anchors = &observed.remembers[0].anchors;
+    assert!(
+        anchors
+            .iter()
+            .any(|a| a.kind == rb_types::AnchorKind::File && a.value.contains("notes.txt")),
+        "the summary must carry a file anchor for the touched file: {anchors:?}"
     );
 }
 

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -171,6 +171,52 @@ fn opt_sources(args: &Value, key: &str) -> Result<Vec<String>, ToolError> {
     Ok(sources)
 }
 
+/// Parse the optional anchor FILTER params shared by `recall` and `list`
+/// (PRD 2026-07-02 typed-code-anchors): `file` (path only — line ranges are
+/// a clean error, shared rule with the CLI via
+/// `rb_types::parse_file_filter`), `commit`, `symbol`. Each is a single
+/// string; multiple anchor kinds compose all-of.
+fn parse_anchor_filters(args: &Value) -> Result<Vec<rb_types::AnchorFilter>, ToolError> {
+    let mut anchors = Vec::new();
+    if let Some(spec) = opt_string(args, "file")? {
+        anchors.push(rb_types::parse_file_filter(&spec).map_err(|e| invalid(e.to_string()))?);
+    }
+    for (key, kind) in [
+        ("commit", rb_types::AnchorKind::Commit),
+        ("symbol", rb_types::AnchorKind::Symbol),
+    ] {
+        if let Some(value) = opt_string(args, key)? {
+            let filter = rb_types::AnchorFilter { kind, value };
+            filter.validate().map_err(|e| invalid(e.to_string()))?;
+            anchors.push(filter);
+        }
+    }
+    Ok(anchors)
+}
+
+/// Parse the anchor CAPTURE params on `remember` (PRD 2026-07-02): `files`
+/// (`PATH[:LINE[-END]]` specs), `commits`, `symbols` — optional string
+/// arrays, each entry validated fail-closed.
+fn parse_capture_anchors(args: &Value) -> Result<Vec<rb_types::MemoryAnchor>, ToolError> {
+    let mut anchors = Vec::new();
+    for spec in opt_string_vec(args, "files")? {
+        anchors.push(
+            rb_types::MemoryAnchor::parse_file_spec(&spec).map_err(|e| invalid(e.to_string()))?,
+        );
+    }
+    for (key, kind) in [
+        ("commits", rb_types::AnchorKind::Commit),
+        ("symbols", rb_types::AnchorKind::Symbol),
+    ] {
+        for value in opt_string_vec(args, key)? {
+            anchors.push(
+                rb_types::MemoryAnchor::new(kind, &value).map_err(|e| invalid(e.to_string()))?,
+            );
+        }
+    }
+    Ok(anchors)
+}
+
 /// Parse the unified filter dimensions shared by the `recall` and `list` tools
 /// (PRD 2026-07-02 search-filter parity). Does NOT read `type`/`tags` — the
 /// callers route those (legacy wire slots for recall; filter fields for list).
@@ -189,6 +235,7 @@ fn parse_filter(args: &Value) -> Result<rb_types::RecallFilter, ToolError> {
         } else {
             rb_types::MemoryState::Active
         },
+        anchors: parse_anchor_filters(args)?,
         ..Default::default()
     };
     // Fail fast on inverted ranges at the tool boundary (the daemon would
@@ -220,6 +267,7 @@ pub fn build_request(name: &str, args: &Value) -> Result<Request, ToolError> {
                 // The MCP `remember` tool stores plainly; update-as-supersede
                 // (W3.1) is driven by the hook capture path, not this tool.
                 supersedes: None,
+                anchors: parse_capture_anchors(args)?,
             })
         }
         "recall" => Ok(Request::Recall {
@@ -796,6 +844,90 @@ mod tests {
             ("recall", json!({ "query": "q", "archived": 1 })),
             ("list", json!({ "until": 12345 })),
             ("list", json!({ "max_importance": 0 })),
+        ] {
+            let err = build_request(tool, &args).unwrap_err();
+            assert_eq!(
+                err.code, INVALID_PARAMS,
+                "{tool} {args} must fail closed, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_remember_request_parses_anchor_capture_params() {
+        let req = build_request(
+            "remember",
+            &json!({
+                "content": "c",
+                "files": ["src/a.rs:12-40", "./src/b.rs"],
+                "commits": ["abc123"],
+                "symbols": ["Foo::bar"]
+            }),
+        )
+        .unwrap();
+        match req {
+            Request::Remember { anchors, .. } => {
+                assert_eq!(anchors.len(), 4);
+                assert_eq!(anchors[0].kind, rb_types::AnchorKind::File);
+                assert_eq!(anchors[0].value, "src/a.rs");
+                assert_eq!(
+                    (anchors[0].start_line, anchors[0].end_line),
+                    (Some(12), Some(40))
+                );
+                assert_eq!(anchors[1].value, "src/b.rs", "paths normalize");
+                assert_eq!(anchors[2].kind, rb_types::AnchorKind::Commit);
+                assert_eq!(anchors[2].value, "abc123");
+                assert_eq!(anchors[3].kind, rb_types::AnchorKind::Symbol);
+                assert_eq!(anchors[3].value, "Foo::bar");
+            }
+            other => panic!("expected Remember, got {other:?}"),
+        }
+        // Absent params -> no anchors (the pre-anchor behavior).
+        match build_request("remember", &json!({ "content": "c" })).unwrap() {
+            Request::Remember { anchors, .. } => assert!(anchors.is_empty()),
+            other => panic!("expected Remember, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recall_and_list_map_anchor_filter_params() {
+        for tool in ["recall", "list"] {
+            let mut args = json!({
+                "file": "./src/server.rs",
+                "commit": "abc123",
+                "symbol": "Engine::recall"
+            });
+            if tool == "recall" {
+                args["query"] = json!("q");
+            }
+            let req = build_request(tool, &args).unwrap();
+            let filter = match req {
+                Request::Recall { filter, .. } | Request::List { filter, .. } => filter,
+                other => panic!("expected Recall/List, got {other:?}"),
+            };
+            assert_eq!(filter.anchors.len(), 3, "{tool}");
+            assert_eq!(filter.anchors[0].kind, rb_types::AnchorKind::File);
+            assert_eq!(filter.anchors[0].value, "src/server.rs", "normalized");
+            assert_eq!(filter.anchors[1].kind, rb_types::AnchorKind::Commit);
+            assert_eq!(filter.anchors[2].kind, rb_types::AnchorKind::Symbol);
+        }
+    }
+
+    #[test]
+    fn anchor_params_fail_closed_on_garbage() {
+        for (tool, args) in [
+            // Capture: bad line ranges and empty values are clean errors.
+            ("remember", json!({ "content": "c", "files": ["a.rs:12-"] })),
+            ("remember", json!({ "content": "c", "files": ["a.rs:0"] })),
+            ("remember", json!({ "content": "c", "files": [""] })),
+            ("remember", json!({ "content": "c", "commits": ["  "] })),
+            ("remember", json!({ "content": "c", "symbols": [42] })),
+            // Filters: line ranges are capture-only; empty values rejected.
+            ("recall", json!({ "query": "q", "file": "a.rs:12-40" })),
+            ("recall", json!({ "query": "q", "file": "" })),
+            ("recall", json!({ "query": "q", "commit": " " })),
+            ("list", json!({ "file": "a.rs:3" })),
+            ("list", json!({ "symbol": ["not-a-string"] })),
         ] {
             let err = build_request(tool, &args).unwrap_err();
             assert_eq!(

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -77,11 +77,13 @@ pub fn tool_definitions() -> Vec<ToolDef> {
     vec![
         ToolDef {
             name: "remember",
-            description: "Store a durable memory in the shared store. Use when the user \
-                          states a decision, preference, constraint, or correction worth \
-                          recalling in a future session (e.g. \"we use X because Y\", \
-                          \"always do Z\", \"never touch W\") — capture the decision and its \
-                          rationale, not transient chatter. Returns the new memory id.",
+            // Deliberately TERSE (W3.3): remember is in the default advertised
+            // set, so every description byte counts against the token budget
+            // (trimmed to make room for the typed-code-anchor params).
+            description: "Store a durable memory. Use when the user states a decision, \
+                          preference, constraint, or correction worth recalling later — \
+                          capture the decision and its rationale, not transient chatter. \
+                          Returns the new memory id.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -92,7 +94,13 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "importance": { "type": "integer", "minimum": 1, "maximum": 10,
                                     "description": "Importance 1-10 (default: 5)." },
                     "tags": { "type": "array", "items": { "type": "string" },
-                              "description": "Optional tags." }
+                              "description": "Optional tags." },
+                    "files": { "type": "array", "items": { "type": "string" },
+                               "description": "Anchor to files: PATH[:LINE[-END]]." },
+                    "commits": { "type": "array", "items": { "type": "string" },
+                                 "description": "Anchor to commit SHAs." },
+                    "symbols": { "type": "array", "items": { "type": "string" },
+                                 "description": "Anchor to symbols." }
                 },
                 "required": ["content"]
             }),
@@ -100,9 +108,8 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ToolDef {
             name: "recall",
             description: "Hybrid (keyword + vector + graph) recall of stored memories. Use \
-                          BEFORE starting a task, or whenever the user references a past \
-                          decision, prior work, or \"how we do X here\", to retrieve relevant \
-                          prior context. Returns ranked memories.",
+                          BEFORE starting a task, or when the user references a past \
+                          decision or prior work. Returns ranked memories.",
             // The unified filter params (PRD 2026-07-02 search-filter parity)
             // are deliberately TERSE: recall is in the default advertised set,
             // so every schema byte counts against the W3.3 token budget.
@@ -125,7 +132,11 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "source": { "type": "array",
                                 "items": { "enum": ["hook", "mcp", "cli", "job"] } },
                     "contested": { "type": "boolean" },
-                    "archived": { "type": "boolean" }
+                    "archived": { "type": "boolean" },
+                    "file": { "type": "string",
+                              "description": "Only memories anchored to this file path." },
+                    "commit": { "type": "string" },
+                    "symbol": { "type": "string" }
                 },
                 "required": ["query"]
             }),
@@ -133,8 +144,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ToolDef {
             name: "get",
             description: "Fetch one memory's full content + links by id. Use to expand a \
-                          memory surfaced by recall/list when you need its complete text or \
-                          its linked memories.",
+                          recall/list hit.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -173,7 +183,13 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                                    "description": "true: only contested; false: only \
                                                    uncontested." },
                     "archived": { "type": "boolean",
-                                  "description": "List archived memories instead of active." }
+                                  "description": "List archived memories instead of active." },
+                    "file": { "type": "string",
+                              "description": "Only memories anchored to this file path." },
+                    "commit": { "type": "string",
+                                "description": "Only memories anchored to this commit SHA." },
+                    "symbol": { "type": "string",
+                                "description": "Only memories anchored to this symbol." }
                 }
             }),
         },
@@ -208,7 +224,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "context": { "type": "string" },
                     "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0,
                                     "description": "Trust prior 0.0-1.0; lower it when a \
-                                                    memory looks unreliable or outdated." }
+                                                    memory looks unreliable." }
                 },
                 "required": ["id"]
             }),
@@ -247,8 +263,7 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ToolDef {
             name: "context",
             description: "Project memory digest: recent + important memories and a total \
-                          count for the current namespace. Use at the start of work to load \
-                          standing context before the user's first specific request.",
+                          count for the current namespace. Use at the start of work.",
             input_schema: json!({
                 "type": "object",
                 "properties": {}
@@ -257,10 +272,8 @@ pub fn tool_definitions() -> Vec<ToolDef> {
         ToolDef {
             name: "memory_feedback",
             description: "Report whether a recalled memory was actually useful. Use AFTER \
-                          acting on a memory recall surfaced: 'helpful' if it helped, \
-                          'wrong' if it was incorrect, 'stale' if it was once right but is \
-                          now outdated. This is the usefulness signal access counts cannot \
-                          capture; it adjusts the memory's trust so future recalls improve.",
+                          acting on one: 'helpful', 'wrong', or 'stale'. Adjusts the \
+                          memory's trust so future recalls improve.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -359,8 +372,9 @@ mod tests {
     #[test]
     fn recall_and_list_schemas_expose_the_unified_filter_params() {
         // SRH-3 (PRD 2026-07-02): recall and list advertise the SAME optional
-        // filter params, so the MCP surface reaches parity with the CLI flags.
-        const FILTER_PARAMS: [&str; 11] = [
+        // filter params, so the MCP surface reaches parity with the CLI flags
+        // (incl. the typed-code-anchor filters file/commit/symbol).
+        const FILTER_PARAMS: [&str; 14] = [
             "type",
             "tags",
             "min_importance",
@@ -372,6 +386,9 @@ mod tests {
             "source",
             "contested",
             "archived",
+            "file",
+            "commit",
+            "symbol",
         ];
         for tool_name in ["recall", "list"] {
             let t = tool_definitions()
@@ -529,7 +546,16 @@ mod tests {
             .collect();
         assert_eq!(required, vec!["content"]);
         let props = t.input_schema["properties"].as_object().unwrap();
-        for opt in ["context", "type", "importance", "tags"] {
+        for opt in [
+            "context",
+            "type",
+            "importance",
+            "tags",
+            // Typed-code-anchor capture params (PRD 2026-07-02).
+            "files",
+            "commits",
+            "symbols",
+        ] {
             assert!(
                 props.contains_key(opt),
                 "remember should accept optional {opt}"

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -16,6 +16,12 @@ use tokio_util::codec::{Framed, LengthDelimitedCodec};
 #[derive(Debug)]
 pub struct Client {
     framed: Framed<UnixStream, LengthDelimitedCodec>,
+    /// Whether the daemon advertised [`crate::CAP_ANCHORS`] at handshake —
+    /// i.e. it evaluates typed code anchors instead of silently dropping
+    /// (`Remember.anchors`) or ignoring (pre-filter daemons) them. Gates the
+    /// anchor-bearing wrappers so the fail-fast anchor guarantee holds across
+    /// daemon versions.
+    supports_anchors: bool,
 }
 
 /// One item yielded by a live subscribe stream: either a change event or a
@@ -71,7 +77,22 @@ impl Client {
             return Err(Error::Storage(format!("handshake rejected: {detail}")));
         }
 
-        Ok(Client { framed })
+        // A pre-anchor daemon sends no capabilities (serde default: empty),
+        // so `supports_anchors` correctly degrades to false against it.
+        let supports_anchors = ack.capabilities.iter().any(|c| c == crate::CAP_ANCHORS);
+        Ok(Client {
+            framed,
+            supports_anchors,
+        })
+    }
+
+    /// Whether the daemon advertised typed-code-anchor support
+    /// ([`crate::CAP_ANCHORS`]) at handshake. Raw-`Request` callers (the MCP
+    /// adapter) combine this with [`crate::request_uses_anchors`] to fail
+    /// fast instead of letting an old daemon silently drop/ignore anchors.
+    #[must_use]
+    pub fn supports_anchors(&self) -> bool {
+        self.supports_anchors
     }
 
     /// Send one request frame WITHOUT reading the response. Split from
@@ -180,7 +201,47 @@ impl Client {
             tags,
             related_files,
             confidence,
+            Vec::new(),
             None,
+        )
+        .await
+    }
+
+    /// [`Client::remember`] carrying typed code anchors (PRD 2026-07-02) and
+    /// an optional atomic supersede. Fails fast with
+    /// [`Error::InvalidArgument`] when `anchors` is non-empty but the daemon
+    /// did NOT advertise anchor support at handshake — a pre-anchor daemon
+    /// would silently DROP the additive `anchors` field, storing an
+    /// un-anchored memory the caller believes is anchored.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn remember_anchored(
+        &mut self,
+        content: String,
+        context: Option<String>,
+        memory_type: MemoryType,
+        importance: u8,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+        related_files: Vec<String>,
+        confidence: Option<f32>,
+        anchors: Vec<rb_types::MemoryAnchor>,
+        supersedes: Option<MemoryId>,
+    ) -> Result<MemoryId> {
+        self.ensure_anchor_capable(!anchors.is_empty())?;
+        for anchor in &anchors {
+            anchor.validate()?;
+        }
+        self.remember_inner(
+            content,
+            context,
+            memory_type,
+            importance,
+            keywords,
+            tags,
+            related_files,
+            confidence,
+            anchors,
+            supersedes,
         )
         .await
     }
@@ -212,6 +273,7 @@ impl Client {
             tags,
             related_files,
             confidence,
+            Vec::new(),
             Some(supersedes),
         )
         .await
@@ -228,6 +290,7 @@ impl Client {
         tags: Vec<String>,
         related_files: Vec<String>,
         confidence: Option<f32>,
+        anchors: Vec<rb_types::MemoryAnchor>,
         supersedes: Option<MemoryId>,
     ) -> Result<MemoryId> {
         // Mirrors the engine-side check so a bad EXPLICIT value fails fast and
@@ -251,6 +314,7 @@ impl Client {
                 related_files,
                 confidence,
                 supersedes,
+                anchors,
             })
             .await?;
         match resp {
@@ -290,21 +354,30 @@ impl Client {
         self.recall_filtered_with_status(query, filter, limit).await
     }
 
-    /// Fail-fast gate shared by the filtered wrappers: anchor filters are not
-    /// evaluable anywhere yet (the `memory_anchors` table ships with typed
-    /// code anchors), and an OLD contract-v2 daemon silently IGNORES the
-    /// additive `filter` field — so a frame carrying anchors could come back
-    /// unfiltered instead of erroring. Rejecting locally keeps the anchor
+    /// Fail-fast anchor-capability gate: anchor payloads may only ride the
+    /// wire when the daemon advertised [`crate::CAP_ANCHORS`] at handshake.
+    /// A PRE-ANCHOR contract-v2 daemon either silently IGNORES the additive
+    /// `filter` field (pre-parity daemons — anchor-filtered recall would come
+    /// back unfiltered) or rejects it server-side; a pre-anchor daemon
+    /// silently DROPS `Remember.anchors`. Rejecting locally keeps the
     /// fail-fast guarantee independent of the daemon version.
-    fn ensure_filter_sendable(filter: &rb_types::RecallFilter) -> Result<()> {
-        if !filter.anchors.is_empty() {
+    fn ensure_anchor_capable(&self, uses_anchors: bool) -> Result<()> {
+        if uses_anchors && !self.supports_anchors {
             return Err(Error::InvalidArgument(
-                "anchor filters are not supported yet (the memory_anchors table ships with \
-                 typed code anchors)"
+                "this daemon does not support typed code anchors (no `anchors` capability \
+                 in its handshake); upgrade and restart the daemon to use anchor \
+                 filters/anchored memories"
                     .to_string(),
             ));
         }
         Ok(())
+    }
+
+    /// Fail-fast gate shared by the filtered wrappers: non-empty anchor
+    /// filters require the daemon's advertised anchor capability (see
+    /// [`Client::ensure_anchor_capable`]).
+    fn ensure_filter_sendable(&self, filter: &rb_types::RecallFilter) -> Result<()> {
+        self.ensure_anchor_capable(!filter.anchors.is_empty())
     }
 
     /// [`Client::recall_with_status`] over the unified [`rb_types::RecallFilter`]
@@ -313,14 +386,15 @@ impl Client {
     /// legacy request slots so an old daemon still honors them; only the new
     /// dimensions ride the additive `filter` field (which an old daemon
     /// ignores — graceful degradation to the legacy subset). Non-empty anchor
-    /// filters are rejected BEFORE sending (see `ensure_filter_sendable`).
+    /// filters are rejected BEFORE sending unless the daemon advertised
+    /// anchor support (see `ensure_filter_sendable`).
     pub async fn recall_filtered_with_status(
         &mut self,
         query: String,
         filter: rb_types::RecallFilter,
         limit: usize,
     ) -> Result<(Vec<SearchResult>, bool)> {
-        Self::ensure_filter_sendable(&filter)?;
+        self.ensure_filter_sendable(&filter)?;
         let (memory_type, tags, filter) = filter.split_recall_legacy();
         let resp = self
             .request(Request::Recall {
@@ -360,13 +434,14 @@ impl Client {
     /// legacy-slot split as [`Client::recall_filtered_with_status`]:
     /// `min_importance` rides the pre-filter wire slot (old daemons honor it),
     /// the new dimensions ride the additive `filter` field. Non-empty anchor
-    /// filters are rejected BEFORE sending (see `ensure_filter_sendable`).
+    /// filters are rejected BEFORE sending unless the daemon advertised
+    /// anchor support (see `ensure_filter_sendable`).
     pub async fn list_filtered(
         &mut self,
         filter: rb_types::RecallFilter,
         limit: usize,
     ) -> Result<Vec<MemoryNote>> {
-        Self::ensure_filter_sendable(&filter)?;
+        self.ensure_filter_sendable(&filter)?;
         let (min_importance, filter) = filter.split_list_legacy();
         let resp = self
             .request(Request::List {
@@ -608,6 +683,7 @@ mod tests {
             } else {
                 Some("version mismatch".into())
             },
+            capabilities: vec![],
         };
         write_frame(&mut framed, &ack).await.unwrap();
         if !ok {
@@ -682,6 +758,7 @@ mod tests {
                     contract_version: CONTRACT_VERSION,
                     ok: true,
                     message: None,
+                    capabilities: vec![],
                 },
             )
             .await
@@ -760,9 +837,20 @@ mod wrapper_tests {
         )
     }
 
-    // Accept one connection, handshake, then answer each incoming Request with a
+    // Accept one connection, handshake (advertising NO capabilities — the
+    // pre-anchor daemon shape), then answer each incoming Request with a
     // matching canned Response until the client disconnects.
     async fn serve(listener: UnixListener, fixed_id: MemoryId) {
+        serve_with_capabilities(listener, fixed_id, vec![]).await;
+    }
+
+    // `serve` with an explicit advertised-capability list, so tests cover both
+    // the old-daemon (empty) and anchor-capable daemon shapes.
+    async fn serve_with_capabilities(
+        listener: UnixListener,
+        fixed_id: MemoryId,
+        capabilities: Vec<String>,
+    ) {
         let (stream, _addr) = listener.accept().await.unwrap();
         let mut framed: Framed<UnixStream, LengthDelimitedCodec> =
             Framed::new(stream, LengthDelimitedCodec::new());
@@ -774,6 +862,7 @@ mod wrapper_tests {
                 contract_version: CONTRACT_VERSION,
                 ok: true,
                 message: None,
+                capabilities,
             },
         )
         .await
@@ -785,9 +874,20 @@ mod wrapper_tests {
                 Err(_) => break, // client closed
             };
             let resp = match req {
-                Request::Remember { .. } => Response::Remembered {
-                    id: fixed_id.clone(),
-                },
+                Request::Remember {
+                    content, anchors, ..
+                } => {
+                    if content == "anchored-probe" {
+                        // The anchored-remember test: prove the anchors rode
+                        // the frame (a panic here fails the joined task).
+                        assert_eq!(anchors.len(), 2, "anchors must ride the wire");
+                        assert_eq!(anchors[0].value, "src/a.rs");
+                        assert_eq!(anchors[0].start_line, Some(3));
+                    }
+                    Response::Remembered {
+                        id: fixed_id.clone(),
+                    }
+                }
                 Request::Recall {
                     query,
                     memory_type,
@@ -820,6 +920,17 @@ mod wrapper_tests {
                             if memory_type.is_none()
                                 && filter.min_confidence == Some(0.9)
                                 && filter.sources == vec!["hook".to_string()]
+                            {
+                                hit()
+                            } else {
+                                Vec::new()
+                            }
+                        }
+                        "probe-anchors" => {
+                            // Anchor filters ride the ADDITIVE filter field.
+                            if filter.anchors.len() == 1
+                                && filter.anchors[0].kind == rb_types::AnchorKind::File
+                                && filter.anchors[0].value == "src/a.rs"
                             {
                                 hit()
                             } else {
@@ -922,19 +1033,24 @@ mod wrapper_tests {
     }
 
     #[tokio::test]
-    async fn filtered_wrappers_reject_anchor_filters_before_sending() {
-        // An OLD contract-v2 daemon ignores the additive `filter` field, so a
-        // frame carrying an anchor filter would come back silently UNFILTERED
-        // — violating the fail-fast anchor guarantee across daemon versions.
-        // The client must reject non-empty anchors LOCALLY, before any frame
-        // is sent. (The fake server here would happily return a hit for any
-        // recall/list, so an Err proves the request never round-tripped.)
+    async fn anchor_payloads_are_rejected_against_a_daemon_without_the_capability() {
+        // Old-daemon compatibility: a pre-anchor daemon advertises no
+        // `anchors` capability. It would silently IGNORE anchor filters on
+        // the additive `filter` field (pre-parity daemons) and silently DROP
+        // `Remember.anchors` — so the client must reject anchor-bearing calls
+        // LOCALLY, before any frame is sent. (The fake server here — acking
+        // with NO capabilities — would happily return a hit/ack for any
+        // request, so an Err proves the request never round-tripped.)
         use rb_types::{AnchorFilter, AnchorKind, RecallFilter};
         let (_dir, path) = socket_path();
         let listener = UnixListener::bind(&path).unwrap();
         let server = tokio::spawn(serve(listener, MemoryId::new()));
 
         let mut c = connect(&path).await;
+        assert!(
+            !c.supports_anchors(),
+            "a capability-less ack must read as unsupported"
+        );
         let anchored = RecallFilter {
             anchors: vec![AnchorFilter {
                 kind: AnchorKind::File,
@@ -957,6 +1073,132 @@ mod wrapper_tests {
             matches!(err, rb_types::Error::InvalidArgument(_)),
             "list must fail fast client-side, got {err:?}"
         );
+
+        let err = c
+            .remember_anchored(
+                "anchored body".into(),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap()],
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::InvalidArgument(_)),
+            "anchored remember must fail fast client-side, got {err:?}"
+        );
+
+        // Anchor-FREE calls still work against the old daemon (graceful
+        // degradation, not a hard cut).
+        let listed = c.list_filtered(RecallFilter::default(), 5).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        let id = c
+            .remember_anchored(
+                "plain body".into(),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(id.to_string().len(), 36);
+
+        drop(c);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn anchor_payloads_flow_when_the_daemon_advertises_the_capability() {
+        use rb_types::{AnchorFilter, AnchorKind, RecallFilter};
+        let (_dir, path) = socket_path();
+        let listener = UnixListener::bind(&path).unwrap();
+        let fixed_id = MemoryId::new();
+        let server = tokio::spawn(serve_with_capabilities(
+            listener,
+            fixed_id.clone(),
+            vec![crate::CAP_ANCHORS.to_string()],
+        ));
+
+        let mut c = connect(&path).await;
+        assert!(
+            c.supports_anchors(),
+            "the capability must be read off the ack"
+        );
+
+        // Anchored remember: the fake server ASSERTS the anchors rode the
+        // frame for this content (a mismatch panics the joined task).
+        let id = c
+            .remember_anchored(
+                "anchored-probe".into(),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                vec![
+                    rb_types::MemoryAnchor::parse_file_spec("src/a.rs:3-9").unwrap(),
+                    rb_types::MemoryAnchor::new(AnchorKind::Symbol, "Foo::bar").unwrap(),
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(id, fixed_id);
+
+        // Anchor filters ride the additive filter field: a hit comes back
+        // ONLY when the fake server saw them there.
+        let (results, _) = c
+            .recall_filtered_with_status(
+                "probe-anchors".into(),
+                RecallFilter {
+                    anchors: vec![AnchorFilter {
+                        kind: AnchorKind::File,
+                        value: "src/a.rs".into(),
+                    }],
+                    ..Default::default()
+                },
+                5,
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1, "anchor filter must ride the wire");
+
+        // An invalid anchor is still rejected locally (validation before send).
+        let err = c
+            .remember_anchored(
+                "bad".into(),
+                None,
+                MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                vec![rb_types::MemoryAnchor {
+                    kind: AnchorKind::Commit,
+                    value: "abc".into(),
+                    start_line: Some(1),
+                    end_line: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::InvalidArgument(_)));
 
         drop(c);
         server.await.unwrap();
@@ -1171,6 +1413,7 @@ mod wrapper_tests {
                 contract_version: CONTRACT_VERSION,
                 ok: true,
                 message: None,
+                capabilities: vec![],
             },
         )
         .await
@@ -1226,6 +1469,7 @@ mod subscribe_tests {
                 contract_version: CONTRACT_VERSION,
                 ok: true,
                 message: None,
+                capabilities: vec![],
             },
         )
         .await

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -15,6 +15,6 @@ pub use codec::{bounded_codec, bounded_framed, MAX_FRAME_BYTES};
 pub use error::{error_to_response, response_error_to_error};
 pub use frame::{read_frame, write_frame};
 pub use messages::{
-    ClientIdentity, Handshake, HandshakeAck, RecallChannelTotals, Request, Response,
-    CONTRACT_VERSION,
+    request_uses_anchors, ClientIdentity, Handshake, HandshakeAck, RecallChannelTotals, Request,
+    Response, CAP_ANCHORS, CONTRACT_VERSION,
 };

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -45,12 +45,28 @@ pub struct ClientIdentity {
     pub source: Option<String>,
 }
 
+/// Capability string a daemon advertises when it evaluates typed code
+/// anchors (the `memory_anchors` table + anchor filters, PRD 2026-07-02).
+/// Pre-anchor daemons never send it, so clients can distinguish "this daemon
+/// evaluates anchors" from "this daemon would silently drop/ignore them"
+/// WITHOUT a CONTRACT_VERSION bump.
+pub const CAP_ANCHORS: &str = "anchors";
+
 /// Daemon reply to a `Handshake`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HandshakeAck {
     pub contract_version: u32,
     pub ok: bool,
     pub message: Option<String>,
+    /// Feature capabilities this daemon supports beyond the bare contract
+    /// version (first: [`CAP_ANCHORS`]). Additive + `#[serde(default,
+    /// skip_serializing_if)]`: an old daemon's ack (no key) decodes to an
+    /// empty list — the client then treats anchor-bearing requests as
+    /// unsupported and fails fast locally — and an empty list serializes to
+    /// nothing, byte-identical to the pre-capability ack (the
+    /// `Handshake.identity` precedent; NO CONTRACT_VERSION bump).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
 }
 
 /// One request per engine operation. Internally tagged on `op`.
@@ -91,6 +107,16 @@ pub enum Request {
         /// frame, so NO CONTRACT_VERSION bump (the `confidence` precedent).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         supersedes: Option<MemoryId>,
+        /// Typed code anchors to store with the memory (PRD 2026-07-02).
+        /// Additive + `#[serde(default, skip_serializing_if)]`: an old
+        /// client's frame (no key) decodes to no anchors, and an empty list
+        /// serializes to nothing — byte-identical to the pre-anchor frame,
+        /// so NO CONTRACT_VERSION bump. A PRE-ANCHOR daemon would silently
+        /// DROP this field, so new clients gate on the daemon's advertised
+        /// [`CAP_ANCHORS`] capability before sending non-empty anchors
+        /// (see `Client::remember_anchored`).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        anchors: Vec<rb_types::MemoryAnchor>,
     },
     Recall {
         query: String,
@@ -222,6 +248,20 @@ pub enum Request {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         window_days: Option<u32>,
     },
+}
+
+/// True when `req` carries a typed-code-anchor payload that a PRE-ANCHOR
+/// daemon would silently DROP (`Remember.anchors`) or, on a pre-filter
+/// daemon, silently IGNORE (`Recall`/`List` filter anchors). Raw-`Request`
+/// callers (the MCP adapter) gate on this plus the daemon's advertised
+/// [`CAP_ANCHORS`]; the typed `Client` wrappers gate internally.
+#[must_use]
+pub fn request_uses_anchors(req: &Request) -> bool {
+    match req {
+        Request::Remember { anchors, .. } => !anchors.is_empty(),
+        Request::Recall { filter, .. } | Request::List { filter, .. } => !filter.anchors.is_empty(),
+        _ => false,
+    }
 }
 
 /// Aggregate per-channel recall hit-contribution totals (W1.0), surfaced on
@@ -460,6 +500,7 @@ mod tests {
             related_files: vec![],
             confidence: Some(0.3),
             supersedes: None,
+            anchors: vec![],
         };
         // Some(x) serializes the key and round-trips back to Some(x).
         let json = serde_json::to_value(&explicit).unwrap();
@@ -496,6 +537,7 @@ mod tests {
             related_files: vec![],
             confidence: None,
             supersedes: None,
+            anchors: vec![],
         };
         let json = serde_json::to_value(&none).unwrap();
         assert!(
@@ -520,6 +562,7 @@ mod tests {
             related_files: vec![],
             confidence: None,
             supersedes: Some(old.clone()),
+            anchors: vec![],
         };
         // Some(id) serializes the key and round-trips back to the same id.
         let json = serde_json::to_value(&explicit).unwrap();
@@ -553,6 +596,7 @@ mod tests {
             related_files: vec![],
             confidence: None,
             supersedes: None,
+            anchors: vec![],
         };
         let json = serde_json::to_value(&none).unwrap();
         assert!(
@@ -567,11 +611,162 @@ mod tests {
             contract_version: CONTRACT_VERSION,
             ok: false,
             message: Some("version mismatch".into()),
+            capabilities: vec![],
         };
         let json = serde_json::to_string(&ack).unwrap();
         let back: HandshakeAck = serde_json::from_str(&json).unwrap();
         assert!(!back.ok);
         assert_eq!(back.message.as_deref(), Some("version mismatch"));
+    }
+
+    #[test]
+    fn handshake_ack_capabilities_are_additive_in_both_directions() {
+        // OLD daemon -> NEW client: an ack without the `capabilities` key
+        // decodes to an empty list (the client then treats anchors as
+        // unsupported and fails fast locally).
+        let old = serde_json::json!({
+            "contract_version": CONTRACT_VERSION, "ok": true, "message": null
+        });
+        let back: HandshakeAck = serde_json::from_value(old).unwrap();
+        assert!(back.capabilities.is_empty());
+
+        // An empty capabilities list serializes to NOTHING — byte-identical
+        // to the pre-capability ack shape.
+        let bare = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: true,
+            message: None,
+            capabilities: vec![],
+        };
+        let json = serde_json::to_value(&bare).unwrap();
+        assert!(
+            json.as_object().unwrap().get("capabilities").is_none(),
+            "empty capabilities must not serialize: {json}"
+        );
+
+        // NEW daemon -> OLD client: a decoder that does not know the field
+        // must still accept the ack (serde ignores unknown fields).
+        #[derive(serde::Deserialize)]
+        struct OldAck {
+            contract_version: u32,
+            ok: bool,
+            #[allow(dead_code)]
+            message: Option<String>,
+        }
+        let new = HandshakeAck {
+            contract_version: CONTRACT_VERSION,
+            ok: true,
+            message: None,
+            capabilities: vec![CAP_ANCHORS.to_string()],
+        };
+        let json = serde_json::to_string(&new).unwrap();
+        let back: OldAck = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.contract_version, CONTRACT_VERSION);
+        assert!(back.ok);
+    }
+
+    #[test]
+    fn remember_without_anchors_decodes_to_empty_and_empty_omits_the_key() {
+        // Wire compat (typed code anchors): an old payload with no `anchors`
+        // decodes to an empty list, and an empty list serializes WITHOUT the
+        // key — byte-identical to the pre-anchor frame, so no
+        // CONTRACT_VERSION bump (the `confidence`/`supersedes` precedent).
+        let explicit = Request::Remember {
+            content: "c".into(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance: 5,
+            keywords: vec![],
+            tags: vec![],
+            related_files: vec![],
+            confidence: None,
+            supersedes: None,
+            anchors: vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs:2-4").unwrap()],
+        };
+        let json = serde_json::to_value(&explicit).unwrap();
+        assert!(
+            json.get("anchors").is_some(),
+            "non-empty anchors must serialize the key: {json}"
+        );
+        match serde_json::from_value::<Request>(json.clone()).unwrap() {
+            Request::Remember { anchors, .. } => {
+                assert_eq!(anchors.len(), 1);
+                assert_eq!(anchors[0].value, "src/a.rs");
+                assert_eq!(anchors[0].start_line, Some(2));
+            }
+            other => panic!("expected Remember, got {other:?}"),
+        }
+
+        // Removing the key decodes to an empty list (old client).
+        let mut value = json;
+        value.as_object_mut().unwrap().remove("anchors");
+        match serde_json::from_value::<Request>(value).unwrap() {
+            Request::Remember { anchors, .. } => assert!(anchors.is_empty()),
+            other => panic!("expected Remember, got {other:?}"),
+        }
+
+        // Empty anchors serialize to nothing (no key) — pre-anchor shape.
+        let none = Request::Remember {
+            content: "c".into(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance: 5,
+            keywords: vec![],
+            tags: vec![],
+            related_files: vec![],
+            confidence: None,
+            supersedes: None,
+            anchors: vec![],
+        };
+        let json = serde_json::to_value(&none).unwrap();
+        assert!(
+            json.as_object().unwrap().get("anchors").is_none(),
+            "empty anchors must not serialize: {json}"
+        );
+    }
+
+    #[test]
+    fn request_uses_anchors_flags_exactly_the_anchor_bearing_frames() {
+        let anchored_filter = rb_types::RecallFilter {
+            anchors: vec![rb_types::AnchorFilter {
+                kind: rb_types::AnchorKind::File,
+                value: "src/a.rs".into(),
+            }],
+            ..Default::default()
+        };
+        assert!(request_uses_anchors(&Request::Recall {
+            query: "q".into(),
+            memory_type: None,
+            tags: vec![],
+            limit: 5,
+            filter: anchored_filter.clone(),
+        }));
+        assert!(request_uses_anchors(&Request::List {
+            min_importance: None,
+            limit: 5,
+            filter: anchored_filter,
+        }));
+        assert!(request_uses_anchors(&Request::Remember {
+            content: "c".into(),
+            context: None,
+            memory_type: MemoryType::Insight,
+            importance: 5,
+            keywords: vec![],
+            tags: vec![],
+            related_files: vec![],
+            confidence: None,
+            supersedes: None,
+            anchors: vec![rb_types::MemoryAnchor::parse_file_spec("a.rs").unwrap()],
+        }));
+        // Anchor-free frames are never flagged.
+        assert!(!request_uses_anchors(&Request::Recall {
+            query: "q".into(),
+            memory_type: None,
+            tags: vec![],
+            limit: 5,
+            filter: rb_types::RecallFilter::default(),
+        }));
+        assert!(!request_uses_anchors(&Request::Ping));
     }
 
     fn all_requests() -> Vec<Request> {
@@ -587,6 +782,7 @@ mod tests {
                 related_files: vec!["src/lib.rs".into()],
                 confidence: Some(0.7),
                 supersedes: Some(id.clone()),
+                anchors: vec![rb_types::MemoryAnchor::parse_file_spec("src/lib.rs:3-9").unwrap()],
             },
             Request::Recall {
                 query: "q".into(),

--- a/crates/rb-proto/tests/public_api.rs
+++ b/crates/rb-proto/tests/public_api.rs
@@ -28,6 +28,7 @@ fn public_surface_is_reachable_and_stable() {
         contract_version: CONTRACT_VERSION,
         ok: true,
         message: None,
+        capabilities: vec![],
     };
     let _req = Request::Remember {
         content: "c".into(),
@@ -39,6 +40,7 @@ fn public_surface_is_reachable_and_stable() {
         related_files: vec![],
         confidence: Some(0.7),
         supersedes: Some(MemoryId::new()),
+        anchors: vec![],
     };
 
     // Error mapping helpers, round-tripping through the wire form.

--- a/crates/rb-store/migrations/009_memory_anchors.sql
+++ b/crates/rb-store/migrations/009_memory_anchors.sql
@@ -1,0 +1,50 @@
+-- 009_memory_anchors.sql (PRD 2026-07-02 typed-code-anchors, ANC-1)
+--
+-- First-class, queryable code anchors: a structured link from a memory to a
+-- file path (+ optional 1-based line range), a commit SHA, or a symbol name.
+-- Multiple anchors per memory. Purely additive (new table only — no ALTER on
+-- `memories`, so the FTS triggers are untouched and no backfill UPDATE runs
+-- on existing rows); anchors decode alongside the row in `row_to_note` like
+-- `memory_links`, and pre-anchor rows simply load an empty list.
+--
+-- Value placement mirrors the anchor kind (enforced by the CHECK below):
+--   kind='file'            -> `path` holds the normalized file path, `ref` NULL
+--   kind='commit'|'symbol' -> `ref` holds the SHA / symbol name, `path` NULL
+-- `start_line`/`end_line` are 1-based, inclusive, and only meaningful for
+-- file anchors (`rb_types::MemoryAnchor::validate` is the authoritative
+-- boundary check; the CHECKs here are the storage backstop).
+--
+-- `namespace` mirrors memories.namespace (denormalized like memory_vectors'
+-- partition key) so anchor lookups never need a join for scoping and the PRD's
+-- path-drift mitigation (repo-relative path + namespace) holds. Any path that
+-- mutates a memory's namespace MUST re-key its anchors in the same
+-- transaction — `rename_namespace` (the only such path today) does.
+--
+-- FK to memories(memory_id): anchors are relational row attributes (like
+-- memory_links), not an append-only event log (unlike memory_feedback), and
+-- memories are only ever soft-deleted (archived), so the FK cannot block a
+-- delete path today.
+CREATE TABLE memory_anchors (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  memory_id  TEXT NOT NULL REFERENCES memories(memory_id),
+  namespace  TEXT NOT NULL,
+  kind       TEXT NOT NULL CHECK (kind IN ('file', 'commit', 'symbol')),  -- rb_types::anchor_kind_str
+  path       TEXT,     -- normalized file path (kind='file' only)
+  start_line INTEGER,  -- 1-based, file anchors only
+  end_line   INTEGER,  -- 1-based inclusive, file anchors only
+  ref        TEXT,     -- commit SHA / symbol name (kind='commit'|'symbol' only)
+  CHECK (
+    (kind = 'file' AND path IS NOT NULL AND ref IS NULL)
+    OR (kind IN ('commit', 'symbol') AND ref IS NOT NULL AND path IS NULL
+        AND start_line IS NULL AND end_line IS NULL)
+  ),
+  CHECK (start_line IS NULL OR start_line >= 1),
+  CHECK (end_line IS NULL OR (start_line IS NOT NULL AND end_line >= start_line))
+);
+
+-- Per-memory load (row_to_note) and the anchor-filter EXISTS probes.
+CREATE INDEX idx_memory_anchors_memory ON memory_anchors(memory_id);
+-- Namespace-scoped anchor lookups by kind+path (file filters).
+CREATE INDEX idx_memory_anchors_path ON memory_anchors(namespace, kind, path);
+-- Namespace-scoped anchor lookups by kind+ref (commit/symbol filters).
+CREATE INDEX idx_memory_anchors_ref ON memory_anchors(namespace, kind, ref);

--- a/crates/rb-store/migrations/009_memory_anchors.sql
+++ b/crates/rb-store/migrations/009_memory_anchors.sql
@@ -42,9 +42,13 @@ CREATE TABLE memory_anchors (
   CHECK (end_line IS NULL OR (start_line IS NOT NULL AND end_line >= start_line))
 );
 
--- Per-memory load (row_to_note) and the anchor-filter EXISTS probes.
+-- Per-memory anchor load (row_to_note, alongside load_links).
 CREATE INDEX idx_memory_anchors_memory ON memory_anchors(memory_id);
--- Namespace-scoped anchor lookups by kind+path (file filters).
+-- The anchor-filter semi-join probes (list_filtered builds
+-- `m.memory_id IN (SELECT memory_id FROM memory_anchors WHERE namespace = ?
+-- AND kind = ? AND path|ref = ?)`), so a selective anchor lookup costs
+-- O(matching anchors), not O(active memories) — EXPLAIN-pinned by the
+-- `anchor_filters_probe_the_wide_anchor_indexes` test. Their leading
+-- `namespace` column also serves rename_namespace's re-key UPDATE.
 CREATE INDEX idx_memory_anchors_path ON memory_anchors(namespace, kind, path);
--- Namespace-scoped anchor lookups by kind+ref (commit/symbol filters).
 CREATE INDEX idx_memory_anchors_ref ON memory_anchors(namespace, kind, ref);

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -54,13 +54,14 @@ pub trait Store {
     /// SQL query — the metadata dimensions (types, tags, importance/
     /// confidence ranges, created-at window, sources, archived state) with
     /// the same inclusive/any-of/all-of semantics as
-    /// [`RecallFilter::matches`], AND the contested tri-state, expressed as
+    /// [`RecallFilter::matches`], the contested tri-state, expressed as
     /// the SQL form of [`Store::active_contradicts`] so `limit` fills with
     /// real matches no matter how deep they sit (the two expressions are
     /// pinned together by the `contested_filter_agrees_with_active_contradicts`
-    /// drift test). Ordered newest first. A non-empty `anchors` filter is
-    /// rejected fail-closed with `InvalidArgument` until the
-    /// typed-code-anchors table lands.
+    /// drift test), AND anchors (all-of EXISTS probes over `memory_anchors`,
+    /// pinned to `RecallFilter::matches` by the
+    /// `anchor_filter_agrees_with_recall_filter_matches` drift test).
+    /// Ordered newest first.
     fn list_filtered(
         &self,
         ns: &Namespace,

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -487,7 +487,9 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
         row.get::<_, Option<String>>(c)
             .map_err(|e| Error::Storage(e.to_string()))
     };
-    // TODO(P1): batch link loading (avoid N+1 load_links per row in list/get_memory).
+    // TODO(P1): batch relation loading — BOTH load_links and load_anchors are
+    // per-row queries (N+1 in list/get_many paths) and candidates for a single
+    // batched IN-list fetch per page of rows.
     let links = load_links(conn, &id)?;
     let anchors = load_anchors(conn, &id)?;
     Ok(MemoryNote {
@@ -596,6 +598,223 @@ fn escape_fts5_query(query: &str) -> String {
     }
     expr
 }
+/// Build the filtered-list SELECT — the exact SQL + positional params
+/// `list_filtered` executes — for `ns`, `filter`, `limit`. Split out so
+/// tests can `EXPLAIN QUERY PLAN` the real query (the anchor semi-join
+/// index guarantee). Every fragment is a FIXED literal (no caller data is
+/// ever interpolated); caller values ride numbered parameters exclusively.
+/// Performs the same defense-in-depth `filter.validate()` as the execution
+/// path (this also rejects empty anchor-filter values fail-closed).
+#[allow(clippy::vec_box)]
+fn build_list_filtered_query(
+    ns: &Namespace,
+    filter: &rb_types::RecallFilter,
+    limit: usize,
+) -> Result<(String, Vec<Box<dyn rusqlite::ToSql>>)> {
+    filter.validate()?;
+
+    let mut sql = String::from(
+        "SELECT memory_id, namespace, created_at, updated_at, content, summary,
+                keywords, tags, context, memory_type, importance, confidence,
+                related_files, access_count, last_accessed_at, archived_at,
+                superseded_by, embedding_model, embedding_input_version,
+                origin_user, origin_host, origin_agent, origin_source, session_id
+         FROM memories m
+         WHERE m.namespace = ?1",
+    );
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(ns.as_db_string())];
+    fn push(
+        sql: &mut String,
+        params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+        clause: &str,
+        value: Box<dyn rusqlite::ToSql>,
+    ) {
+        params.push(value);
+        sql.push_str(" AND ");
+        sql.push_str(clause);
+        sql.push_str(&format!("?{}", params.len()));
+    }
+
+    match filter.state {
+        rb_types::MemoryState::Active => sql.push_str(" AND m.archived_at IS NULL"),
+        rb_types::MemoryState::Archived => sql.push_str(" AND m.archived_at IS NOT NULL"),
+        rb_types::MemoryState::All => {}
+    }
+    if let Some(min) = filter.min_importance {
+        push(
+            &mut sql,
+            &mut params,
+            "m.importance >= ",
+            Box::new(min as i64),
+        );
+    }
+    if let Some(max) = filter.max_importance {
+        push(
+            &mut sql,
+            &mut params,
+            "m.importance <= ",
+            Box::new(max as i64),
+        );
+    }
+    if let Some(min) = filter.min_confidence {
+        push(
+            &mut sql,
+            &mut params,
+            "m.confidence >= ",
+            Box::new(f64::from(min)),
+        );
+    }
+    if let Some(max) = filter.max_confidence {
+        push(
+            &mut sql,
+            &mut params,
+            "m.confidence <= ",
+            Box::new(f64::from(max)),
+        );
+    }
+    if let Some(since) = filter.since {
+        // `created_at` is stored whole-second, so a FRACTIONAL lower bound
+        // rounds UP: flooring 12:00:00.5 would wrongly admit a row created
+        // at 12:00:00 (which `RecallFilter::matches` rejects).
+        let bound = since.timestamp() + i64::from(since.timestamp_subsec_nanos() > 0);
+        push(&mut sql, &mut params, "m.created_at >= ", Box::new(bound));
+    }
+    if let Some(until) = filter.until {
+        // Flooring the UPPER bound is exact for whole-second storage: a
+        // stored second <= floor(until) is <= until, and floor(until)+1
+        // is > until whenever `until` carries a fraction.
+        push(
+            &mut sql,
+            &mut params,
+            "m.created_at <= ",
+            Box::new(until.timestamp()),
+        );
+    }
+    if !filter.types.is_empty() {
+        // Any-of over the canonical db strings, one placeholder per type.
+        let start = params.len() + 1;
+        let placeholders: Vec<String> = (0..filter.types.len())
+            .map(|i| format!("?{}", start + i))
+            .collect();
+        sql.push_str(&format!(
+            " AND m.memory_type IN ({})",
+            placeholders.join(", ")
+        ));
+        for t in &filter.types {
+            params.push(Box::new(t.as_str().to_string()));
+        }
+    }
+    if !filter.sources.is_empty() {
+        // Any-of; a NULL origin_source never matches an IN list, so
+        // pre-provenance rows are correctly excluded.
+        let start = params.len() + 1;
+        let placeholders: Vec<String> = (0..filter.sources.len())
+            .map(|i| format!("?{}", start + i))
+            .collect();
+        sql.push_str(&format!(
+            " AND m.origin_source IN ({})",
+            placeholders.join(", ")
+        ));
+        for s in &filter.sources {
+            params.push(Box::new(s.clone()));
+        }
+    }
+    for tag in &filter.tags {
+        // All-of: one EXISTS per required tag over the JSON tags array
+        // (json1 ships with the bundled SQLite).
+        push(
+            &mut sql,
+            &mut params,
+            "EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ",
+            Box::new(tag.clone()),
+        );
+        sql.push(')');
+    }
+    for anchor in &filter.anchors {
+        // All-of (like tags): one namespace-scoped IN semi-join per
+        // anchor constraint, probing the kind-matched value column
+        // (`path` for file anchors, `ref` for commit/symbol — the same
+        // split insert_memory writes). A semi-join, NOT a correlated
+        // EXISTS (PR #59 review, EXPLAIN-verified at 100k rows): the
+        // correlated form was always planned as a full `memories` scan
+        // with a per-row idx_memory_anchors_memory probe, so a selective
+        // anchor filter cost O(active memories); the IN subquery is
+        // evaluated once via idx_memory_anchors_path / _ref — O(matching
+        // anchors) — which is what the wide indexes exist for (pinned by
+        // `anchor_filters_probe_the_wide_anchor_indexes`). Scoping the
+        // subquery on `a.namespace` (which mirrors memories.namespace;
+        // rename re-keys both) is what makes the leading index column
+        // usable and never changes the result set. Values compare by
+        // plain equality because BOTH sides are normalized: stored
+        // values at insert, the filter value here. Semantics are pinned
+        // to `RecallFilter::matches` by the
+        // `anchor_filter_agrees_with_recall_filter_matches` drift test.
+        let value_col = if anchor.kind == rb_types::AnchorKind::File {
+            "path"
+        } else {
+            "ref"
+        };
+        params.push(Box::new(ns.as_db_string()));
+        let ns_param = params.len();
+        params.push(Box::new(rb_types::anchor_kind_str(anchor.kind).to_string()));
+        let kind_param = params.len();
+        params.push(Box::new(rb_types::normalize_anchor_value(
+            anchor.kind,
+            &anchor.value,
+        )));
+        let value_param = params.len();
+        sql.push_str(&format!(
+            " AND m.memory_id IN (SELECT a.memory_id FROM memory_anchors a
+                   WHERE a.namespace = ?{ns_param}
+                     AND a.kind = ?{kind_param}
+                     AND a.{value_col} = ?{value_param})"
+        ));
+    }
+    if let Some(want_contested) = filter.contested {
+        // Contested is resolved INSIDE the bounded query (PR #58 review):
+        // post-filtering a fetch window silently drops matches past the
+        // window, so `limit` could under-fill despite more matches
+        // existing. The predicate is the SQL expression of
+        // `active_contradicts` (an active `contradicts` edge whose far
+        // endpoint is active AND in-namespace, and whose LOCAL endpoint is
+        // active — an archived memory is never contested, so under
+        // `contested=false` archived rows count as uncontested). Kept in
+        // lockstep by the `contested_filter_agrees_with_active_contradicts`
+        // drift test; change one without the other and that test fails.
+        params.push(Box::new(ns.as_db_string()));
+        let ns_param = params.len();
+        let contested_expr = format!(
+            "(m.archived_at IS NULL AND (EXISTS (
+                     SELECT 1 FROM memory_links l
+                       JOIN memories far ON far.memory_id = l.target_id
+                     WHERE l.link_type = 'contradicts'
+                       AND l.source_id = m.memory_id
+                       AND far.archived_at IS NULL
+                       AND far.namespace = ?{ns_param}
+                 ) OR EXISTS (
+                     SELECT 1 FROM memory_links l
+                       JOIN memories far ON far.memory_id = l.source_id
+                     WHERE l.link_type = 'contradicts'
+                       AND l.target_id = m.memory_id
+                       AND far.archived_at IS NULL
+                       AND far.namespace = ?{ns_param}
+                 )))"
+        );
+        if want_contested {
+            sql.push_str(&format!(" AND {contested_expr}"));
+        } else {
+            sql.push_str(&format!(" AND NOT {contested_expr}"));
+        }
+    }
+
+    params.push(Box::new(i64::try_from(limit).unwrap_or(i64::MAX)));
+    sql.push_str(&format!(
+        " ORDER BY m.created_at DESC LIMIT ?{}",
+        params.len()
+    ));
+    Ok((sql, params))
+}
+
 impl Store for SqliteStore {
     fn insert_memory(&self, note: &MemoryNote, embedding: Option<&[f32]>) -> Result<()> {
         // Defense-in-depth validation before touching the DB. The SQL CHECK
@@ -670,9 +889,23 @@ impl Store for SqliteStore {
             // (`path` for file anchors, `ref` for commit/symbol — the 009
             // CHECK pins the split). Values are stored NORMALIZED
             // (rb_types::normalize_anchor_value) so the anchor-filter SQL can
-            // compare by plain equality.
+            // compare by plain equality. Exact duplicates (post-normalization,
+            // incl. the line range) collapse to ONE row here — repeated CLI
+            // flags / `--batch` fan-out must not accumulate copies, and a
+            // UNIQUE constraint cannot do it (SQLite treats the NULL
+            // path/ref/line columns as pairwise distinct). First-seen order
+            // is preserved.
+            let mut seen_anchors = std::collections::HashSet::new();
             for anchor in &note.anchors {
                 let value = rb_types::normalize_anchor_value(anchor.kind, &anchor.value);
+                if !seen_anchors.insert((
+                    rb_types::anchor_kind_str(anchor.kind),
+                    value.clone(),
+                    anchor.start_line,
+                    anchor.end_line,
+                )) {
+                    continue;
+                }
                 let is_file = anchor.kind == rb_types::AnchorKind::File;
                 self.conn
                     .execute(
@@ -981,200 +1214,7 @@ impl Store for SqliteStore {
         filter: &rb_types::RecallFilter,
         limit: usize,
     ) -> Result<Vec<MemoryNote>> {
-        // Defense-in-depth boundary validation, consistent with insert/update
-        // (this also rejects empty anchor-filter values fail-closed).
-        filter.validate()?;
-
-        // Build the WHERE clause dynamically: every fragment below is a FIXED
-        // literal (no caller data is ever interpolated); caller values ride
-        // numbered parameters exclusively.
-        let mut sql = String::from(
-            "SELECT memory_id, namespace, created_at, updated_at, content, summary,
-                    keywords, tags, context, memory_type, importance, confidence,
-                    related_files, access_count, last_accessed_at, archived_at,
-                    superseded_by, embedding_model, embedding_input_version,
-                    origin_user, origin_host, origin_agent, origin_source, session_id
-             FROM memories m
-             WHERE m.namespace = ?1",
-        );
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(ns.as_db_string())];
-        fn push(
-            sql: &mut String,
-            params: &mut Vec<Box<dyn rusqlite::ToSql>>,
-            clause: &str,
-            value: Box<dyn rusqlite::ToSql>,
-        ) {
-            params.push(value);
-            sql.push_str(" AND ");
-            sql.push_str(clause);
-            sql.push_str(&format!("?{}", params.len()));
-        }
-
-        match filter.state {
-            rb_types::MemoryState::Active => sql.push_str(" AND m.archived_at IS NULL"),
-            rb_types::MemoryState::Archived => sql.push_str(" AND m.archived_at IS NOT NULL"),
-            rb_types::MemoryState::All => {}
-        }
-        if let Some(min) = filter.min_importance {
-            push(
-                &mut sql,
-                &mut params,
-                "m.importance >= ",
-                Box::new(min as i64),
-            );
-        }
-        if let Some(max) = filter.max_importance {
-            push(
-                &mut sql,
-                &mut params,
-                "m.importance <= ",
-                Box::new(max as i64),
-            );
-        }
-        if let Some(min) = filter.min_confidence {
-            push(
-                &mut sql,
-                &mut params,
-                "m.confidence >= ",
-                Box::new(f64::from(min)),
-            );
-        }
-        if let Some(max) = filter.max_confidence {
-            push(
-                &mut sql,
-                &mut params,
-                "m.confidence <= ",
-                Box::new(f64::from(max)),
-            );
-        }
-        if let Some(since) = filter.since {
-            // `created_at` is stored whole-second, so a FRACTIONAL lower bound
-            // rounds UP: flooring 12:00:00.5 would wrongly admit a row created
-            // at 12:00:00 (which `RecallFilter::matches` rejects).
-            let bound = since.timestamp() + i64::from(since.timestamp_subsec_nanos() > 0);
-            push(&mut sql, &mut params, "m.created_at >= ", Box::new(bound));
-        }
-        if let Some(until) = filter.until {
-            // Flooring the UPPER bound is exact for whole-second storage: a
-            // stored second <= floor(until) is <= until, and floor(until)+1
-            // is > until whenever `until` carries a fraction.
-            push(
-                &mut sql,
-                &mut params,
-                "m.created_at <= ",
-                Box::new(until.timestamp()),
-            );
-        }
-        if !filter.types.is_empty() {
-            // Any-of over the canonical db strings, one placeholder per type.
-            let start = params.len() + 1;
-            let placeholders: Vec<String> = (0..filter.types.len())
-                .map(|i| format!("?{}", start + i))
-                .collect();
-            sql.push_str(&format!(
-                " AND m.memory_type IN ({})",
-                placeholders.join(", ")
-            ));
-            for t in &filter.types {
-                params.push(Box::new(t.as_str().to_string()));
-            }
-        }
-        if !filter.sources.is_empty() {
-            // Any-of; a NULL origin_source never matches an IN list, so
-            // pre-provenance rows are correctly excluded.
-            let start = params.len() + 1;
-            let placeholders: Vec<String> = (0..filter.sources.len())
-                .map(|i| format!("?{}", start + i))
-                .collect();
-            sql.push_str(&format!(
-                " AND m.origin_source IN ({})",
-                placeholders.join(", ")
-            ));
-            for s in &filter.sources {
-                params.push(Box::new(s.clone()));
-            }
-        }
-        for tag in &filter.tags {
-            // All-of: one EXISTS per required tag over the JSON tags array
-            // (json1 ships with the bundled SQLite).
-            push(
-                &mut sql,
-                &mut params,
-                "EXISTS (SELECT 1 FROM json_each(m.tags) WHERE json_each.value = ",
-                Box::new(tag.clone()),
-            );
-            sql.push(')');
-        }
-        for anchor in &filter.anchors {
-            // All-of (like tags): one EXISTS per anchor constraint, probing
-            // the kind-matched value column (`path` for file anchors, `ref`
-            // for commit/symbol — the same split insert_memory writes).
-            // Values compare by plain equality because BOTH sides are
-            // normalized: stored values at insert, the filter value here.
-            // Semantics are pinned to `RecallFilter::matches` by the
-            // `anchor_filter_agrees_with_recall_filter_matches` drift test.
-            let value_col = if anchor.kind == rb_types::AnchorKind::File {
-                "path"
-            } else {
-                "ref"
-            };
-            params.push(Box::new(rb_types::anchor_kind_str(anchor.kind).to_string()));
-            let kind_param = params.len();
-            params.push(Box::new(rb_types::normalize_anchor_value(
-                anchor.kind,
-                &anchor.value,
-            )));
-            let value_param = params.len();
-            sql.push_str(&format!(
-                " AND EXISTS (SELECT 1 FROM memory_anchors a
-                   WHERE a.memory_id = m.memory_id
-                     AND a.kind = ?{kind_param}
-                     AND a.{value_col} = ?{value_param})"
-            ));
-        }
-        if let Some(want_contested) = filter.contested {
-            // Contested is resolved INSIDE the bounded query (PR #58 review):
-            // post-filtering a fetch window silently drops matches past the
-            // window, so `limit` could under-fill despite more matches
-            // existing. The predicate is the SQL expression of
-            // `active_contradicts` (an active `contradicts` edge whose far
-            // endpoint is active AND in-namespace, and whose LOCAL endpoint is
-            // active — an archived memory is never contested, so under
-            // `contested=false` archived rows count as uncontested). Kept in
-            // lockstep by the `contested_filter_agrees_with_active_contradicts`
-            // drift test; change one without the other and that test fails.
-            params.push(Box::new(ns.as_db_string()));
-            let ns_param = params.len();
-            let contested_expr = format!(
-                "(m.archived_at IS NULL AND (EXISTS (
-                     SELECT 1 FROM memory_links l
-                       JOIN memories far ON far.memory_id = l.target_id
-                     WHERE l.link_type = 'contradicts'
-                       AND l.source_id = m.memory_id
-                       AND far.archived_at IS NULL
-                       AND far.namespace = ?{ns_param}
-                 ) OR EXISTS (
-                     SELECT 1 FROM memory_links l
-                       JOIN memories far ON far.memory_id = l.source_id
-                     WHERE l.link_type = 'contradicts'
-                       AND l.target_id = m.memory_id
-                       AND far.archived_at IS NULL
-                       AND far.namespace = ?{ns_param}
-                 )))"
-            );
-            if want_contested {
-                sql.push_str(&format!(" AND {contested_expr}"));
-            } else {
-                sql.push_str(&format!(" AND NOT {contested_expr}"));
-            }
-        }
-
-        params.push(Box::new(i64::try_from(limit).unwrap_or(i64::MAX)));
-        sql.push_str(&format!(
-            " ORDER BY m.created_at DESC LIMIT ?{}",
-            params.len()
-        ));
-
+        let (sql, params) = build_list_filtered_query(ns, filter, limit)?;
         let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
         let mut stmt = self
             .conn
@@ -3120,6 +3160,87 @@ mod list_filtered_tests {
         assert!(
             matches!(err, Error::InvalidArgument(_)),
             "expected InvalidArgument, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn anchor_filters_probe_the_wide_anchor_indexes() {
+        // Reviewer finding (PR #59, verified with EXPLAIN QUERY PLAN at 100k
+        // rows): the original correlated-EXISTS anchor probe was ALWAYS
+        // planned as a full `memories` SCAN plus a per-row
+        // idx_memory_anchors_memory lookup — the wide (namespace, kind,
+        // path|ref) indexes were never chosen, so a selective anchor filter
+        // cost O(active memories), not O(matching anchors). The filter is a
+        // namespace-scoped IN semi-join precisely so those indexes drive it;
+        // this test EXPLAINs the EXACT query `list_filtered` executes and
+        // pins the index choice for every anchor kind.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let _ = insert(&store, |m| {
+            m.anchors = vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap()];
+        });
+        for (filter, index) in [
+            (
+                anchor_only(rb_types::AnchorKind::File, "src/a.rs"),
+                "idx_memory_anchors_path",
+            ),
+            (
+                anchor_only(rb_types::AnchorKind::Commit, "abc123"),
+                "idx_memory_anchors_ref",
+            ),
+            (
+                anchor_only(rb_types::AnchorKind::Symbol, "Foo::bar"),
+                "idx_memory_anchors_ref",
+            ),
+        ] {
+            let (sql, params) = build_list_filtered_query(&ns(), &filter, 10).unwrap();
+            let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+            let mut stmt = store
+                .conn
+                .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+                .unwrap();
+            let plan: Vec<String> = stmt
+                .query_map(refs.as_slice(), |row| row.get::<_, String>(3))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            let plan = plan.join("\n");
+            assert!(
+                plan.contains(index),
+                "the anchor subquery must be served by {index}; plan:\n{plan}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_anchors_collapse_to_one_row() {
+        // Repeated identical anchors (repeated CLI flags, `--batch` fan-out)
+        // must not accumulate duplicate rows. Dedup is normalization-aware
+        // (`./src/a.rs` == `src/a.rs`) and exact otherwise: a different line
+        // range is a DISTINCT anchor and is kept.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ranged = rb_types::MemoryAnchor::parse_file_spec("src/a.rs:3-9").unwrap();
+        // Same anchor spelled with a `./` prefix, bypassing parse-time
+        // normalization (a raw wire payload could carry this).
+        let ranged_dotted = rb_types::MemoryAnchor {
+            kind: rb_types::AnchorKind::File,
+            value: "./src/a.rs".to_string(),
+            start_line: Some(3),
+            end_line: Some(9),
+        };
+        let rangeless = rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap();
+        let id = insert(&store, |m| {
+            m.anchors = vec![
+                ranged.clone(),
+                ranged_dotted,
+                ranged.clone(),
+                rangeless.clone(),
+            ];
+        });
+        let got = store.get_memory(&id).unwrap().unwrap();
+        assert_eq!(
+            got.anchors,
+            vec![ranged, rangeless],
+            "exact duplicates (post-normalization) collapse; distinct ranges stay"
         );
     }
 

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -416,6 +416,52 @@ fn load_links(conn: &rusqlite::Connection, id: &MemoryId) -> Result<Vec<MemoryLi
     }
     Ok(links)
 }
+/// Load a memory's typed code anchors (PRD 2026-07-02), decoded from the
+/// kind-split columns: `path` carries a file anchor's value, `ref` a
+/// commit/symbol's. Ordered by insertion (rowid) so round-trips preserve the
+/// caller's anchor order.
+fn load_anchors(conn: &rusqlite::Connection, id: &MemoryId) -> Result<Vec<rb_types::MemoryAnchor>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT kind, path, start_line, end_line, ref
+             FROM memory_anchors WHERE memory_id = ?1 ORDER BY id",
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+    let rows = stmt
+        .query_map(rusqlite::params![id.to_string()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })
+        .map_err(|e| Error::Storage(e.to_string()))?;
+
+    let mut anchors = Vec::new();
+    for r in rows {
+        let (kind, path, start, end, reference) = r.map_err(|e| Error::Storage(e.to_string()))?;
+        let kind = rb_types::parse_anchor_kind(&kind)?;
+        let value = path.or(reference).ok_or_else(|| {
+            Error::Storage("memory_anchors row carries neither path nor ref".to_string())
+        })?;
+        let to_line = |v: Option<i64>| -> Result<Option<u32>> {
+            v.map(|n| {
+                u32::try_from(n)
+                    .map_err(|_| Error::Storage("anchor line out of range in DB".to_string()))
+            })
+            .transpose()
+        };
+        anchors.push(rb_types::MemoryAnchor {
+            kind,
+            value,
+            start_line: to_line(start)?,
+            end_line: to_line(end)?,
+        });
+    }
+    Ok(anchors)
+}
 fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<MemoryNote> {
     let id = parse_id(
         &row.get::<_, String>("memory_id")
@@ -443,6 +489,7 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
     };
     // TODO(P1): batch link loading (avoid N+1 load_links per row in list/get_memory).
     let links = load_links(conn, &id)?;
+    let anchors = load_anchors(conn, &id)?;
     Ok(MemoryNote {
         id,
         namespace,
@@ -493,6 +540,7 @@ fn row_to_note(conn: &rusqlite::Connection, row: &rusqlite::Row<'_>) -> Result<M
         origin_agent: go("origin_agent")?,
         origin_source: go("origin_source")?,
         session_id: go("session_id")?,
+        anchors,
     })
 }
 /// Build a safe FTS5 MATCH expression from raw user text (W1.2).
@@ -557,6 +605,12 @@ impl Store for SqliteStore {
         // must be validation-class (InvalidArgument travels verbatim over the
         // wire; Storage is replaced with an opaque "internal error").
         rb_types::validate_confidence(note.confidence)?;
+        // Anchors are validated fail-closed BEFORE the transaction opens (the
+        // SQL CHECKs are the backstop); the engine already validated, but the
+        // store is its own boundary.
+        for anchor in &note.anchors {
+            anchor.validate()?;
+        }
 
         // Take the write lock at BEGIN (IMMEDIATE) instead of deferring it to the
         // first write. This avoids a deferred-transaction upgrade racing another
@@ -611,6 +665,32 @@ impl Store for SqliteStore {
                 .map_err(|e| Error::Storage(e.to_string()))?;
 
             append_oplog(&self.conn, &self.site_id, "insert", &note.id, "")?;
+
+            // Typed code anchors (PRD 2026-07-02): kind-split value columns
+            // (`path` for file anchors, `ref` for commit/symbol — the 009
+            // CHECK pins the split). Values are stored NORMALIZED
+            // (rb_types::normalize_anchor_value) so the anchor-filter SQL can
+            // compare by plain equality.
+            for anchor in &note.anchors {
+                let value = rb_types::normalize_anchor_value(anchor.kind, &anchor.value);
+                let is_file = anchor.kind == rb_types::AnchorKind::File;
+                self.conn
+                    .execute(
+                        "INSERT INTO memory_anchors
+                            (memory_id, namespace, kind, path, start_line, end_line, ref)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        rusqlite::params![
+                            note.id.to_string(),
+                            note.namespace.as_db_string(),
+                            rb_types::anchor_kind_str(anchor.kind),
+                            is_file.then_some(value.as_str()),
+                            anchor.start_line.map(i64::from),
+                            anchor.end_line.map(i64::from),
+                            (!is_file).then_some(value.as_str()),
+                        ],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            }
 
             if let Some(emb) = embedding {
                 // The namespace partition key MUST mirror memories.namespace
@@ -901,16 +981,8 @@ impl Store for SqliteStore {
         filter: &rb_types::RecallFilter,
         limit: usize,
     ) -> Result<Vec<MemoryNote>> {
-        // Anchors need the typed-code-anchors table (PRD 2026-07-02); until it
-        // lands, fail fast rather than silently returning unfiltered rows.
-        if !filter.anchors.is_empty() {
-            return Err(Error::InvalidArgument(
-                "anchor filters are not supported yet (the memory_anchors table ships with \
-                 typed code anchors)"
-                    .to_string(),
-            ));
-        }
-        // Defense-in-depth boundary validation, consistent with insert/update.
+        // Defense-in-depth boundary validation, consistent with insert/update
+        // (this also rejects empty anchor-filter values fail-closed).
         filter.validate()?;
 
         // Build the WHERE clause dynamically: every fragment below is a FIXED
@@ -1032,6 +1104,33 @@ impl Store for SqliteStore {
                 Box::new(tag.clone()),
             );
             sql.push(')');
+        }
+        for anchor in &filter.anchors {
+            // All-of (like tags): one EXISTS per anchor constraint, probing
+            // the kind-matched value column (`path` for file anchors, `ref`
+            // for commit/symbol — the same split insert_memory writes).
+            // Values compare by plain equality because BOTH sides are
+            // normalized: stored values at insert, the filter value here.
+            // Semantics are pinned to `RecallFilter::matches` by the
+            // `anchor_filter_agrees_with_recall_filter_matches` drift test.
+            let value_col = if anchor.kind == rb_types::AnchorKind::File {
+                "path"
+            } else {
+                "ref"
+            };
+            params.push(Box::new(rb_types::anchor_kind_str(anchor.kind).to_string()));
+            let kind_param = params.len();
+            params.push(Box::new(rb_types::normalize_anchor_value(
+                anchor.kind,
+                &anchor.value,
+            )));
+            let value_param = params.len();
+            sql.push_str(&format!(
+                " AND EXISTS (SELECT 1 FROM memory_anchors a
+                   WHERE a.memory_id = m.memory_id
+                     AND a.kind = ?{kind_param}
+                     AND a.{value_col} = ?{value_param})"
+            ));
         }
         if let Some(want_contested) = filter.contested {
             // Contested is resolved INSIDE the bounded query (PR #58 review):
@@ -2805,29 +2904,287 @@ mod list_filtered_tests {
         );
     }
 
+    fn anchor_only(kind: rb_types::AnchorKind, value: &str) -> RecallFilter {
+        RecallFilter {
+            anchors: vec![rb_types::AnchorFilter {
+                kind,
+                value: value.to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
     #[test]
-    fn rejects_anchor_filters_until_typed_anchors_land() {
-        // Fail fast, never silently unfiltered: the anchors table belongs to
-        // the typed-code-anchors PRD; until it lands a non-empty anchor filter
-        // is an InvalidArgument, not an ignored constraint.
+    fn anchors_round_trip_through_insert_get_and_get_many() {
         let store = SqliteStore::open_in_memory(8).unwrap();
-        let err = store
+        let anchors = vec![
+            rb_types::MemoryAnchor::parse_file_spec("src/server.rs:12-40").unwrap(),
+            rb_types::MemoryAnchor::parse_file_spec("src/lib.rs").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, "abc123").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Engine::recall").unwrap(),
+        ];
+        let with = insert(&store, |m| m.anchors = anchors.clone());
+        let without = insert(&store, |m| m.created_at -= chrono::Duration::seconds(1));
+
+        let got = store.get_memory(&with).unwrap().unwrap();
+        assert_eq!(got.anchors, anchors, "get must load anchors with the row");
+        let bare = store.get_memory(&without).unwrap().unwrap();
+        assert!(
+            bare.anchors.is_empty(),
+            "pre-anchor rows load an empty list"
+        );
+
+        let many = store
+            .get_many(&ns(), &[with.clone(), without.clone()])
+            .unwrap();
+        assert_eq!(many[0].anchors, anchors, "get_many loads anchors too");
+        assert!(many[1].anchors.is_empty());
+    }
+
+    #[test]
+    fn insert_rejects_invalid_anchors_fail_closed() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let mut m = MemoryNote::new(ns(), "bad anchor".into(), MemoryType::Insight, 5);
+        m.anchors = vec![rb_types::MemoryAnchor {
+            kind: rb_types::AnchorKind::File,
+            value: String::new(),
+            start_line: None,
+            end_line: None,
+        }];
+        let err = store.insert_memory(&m, None).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidArgument(_)),
+            "expected InvalidArgument, got {err:?}"
+        );
+        assert!(
+            store.get_memory(&m.id).unwrap().is_none(),
+            "a rejected insert must write nothing"
+        );
+    }
+
+    #[test]
+    fn anchor_filters_scope_by_kind_and_value() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let on_server = insert(&store, |m| {
+            m.anchors = vec![rb_types::MemoryAnchor::parse_file_spec("src/server.rs").unwrap()];
+        });
+        let on_commit = insert(&store, |m| {
+            m.created_at -= chrono::Duration::seconds(1);
+            m.anchors =
+                vec![rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, "abc123").unwrap()];
+        });
+        let on_symbol = insert(&store, |m| {
+            m.created_at -= chrono::Duration::seconds(2);
+            m.anchors =
+                vec![
+                    rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Engine::recall")
+                        .unwrap(),
+                ];
+        });
+        let _bare = insert(&store, |m| m.created_at -= chrono::Duration::seconds(3));
+
+        // The PRD acceptance criterion: present under its own file, absent
+        // under a different file.
+        let hits = store
             .list_filtered(
                 &ns(),
-                &RecallFilter {
-                    anchors: vec![rb_types::AnchorFilter {
-                        kind: rb_types::AnchorKind::File,
-                        value: "src/lib.rs".into(),
-                    }],
-                    ..Default::default()
-                },
+                &anchor_only(rb_types::AnchorKind::File, "src/server.rs"),
                 10,
             )
+            .unwrap();
+        assert_eq!(ids(&hits), vec![on_server.clone()]);
+        let miss = store
+            .list_filtered(
+                &ns(),
+                &anchor_only(rb_types::AnchorKind::File, "src/other.rs"),
+                10,
+            )
+            .unwrap();
+        assert!(miss.is_empty());
+
+        let hits = store
+            .list_filtered(
+                &ns(),
+                &anchor_only(rb_types::AnchorKind::Commit, "abc123"),
+                10,
+            )
+            .unwrap();
+        assert_eq!(ids(&hits), vec![on_commit.clone()]);
+
+        let hits = store
+            .list_filtered(
+                &ns(),
+                &anchor_only(rb_types::AnchorKind::Symbol, "Engine::recall"),
+                10,
+            )
+            .unwrap();
+        assert_eq!(ids(&hits), vec![on_symbol.clone()]);
+
+        // Kinds never cross-match on an equal value.
+        let cross = store
+            .list_filtered(
+                &ns(),
+                &anchor_only(rb_types::AnchorKind::Symbol, "abc123"),
+                10,
+            )
+            .unwrap();
+        assert!(cross.is_empty(), "commit value must not match as a symbol");
+    }
+
+    #[test]
+    fn anchor_filter_normalizes_values_and_ignores_line_ranges() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        // Stored WITH a line range and a ./ prefix in the filter: still one
+        // path-level anchor (normalization on both sides; v1 matches by path).
+        let ranged = insert(&store, |m| {
+            m.anchors = vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs:12-40").unwrap()];
+        });
+        let hits = store
+            .list_filtered(
+                &ns(),
+                &anchor_only(rb_types::AnchorKind::File, "./src/a.rs"),
+                10,
+            )
+            .unwrap();
+        assert_eq!(ids(&hits), vec![ranged]);
+    }
+
+    #[test]
+    fn anchor_filters_compose_all_of_and_with_metadata() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let both = insert(&store, |m| {
+            m.importance = 8;
+            m.tags = vec!["infra".to_string()];
+            m.anchors = vec![
+                rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap(),
+                rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Foo::bar").unwrap(),
+            ];
+        });
+        let file_only = insert(&store, |m| {
+            m.created_at -= chrono::Duration::seconds(1);
+            m.importance = 8;
+            m.tags = vec!["infra".to_string()];
+            m.anchors = vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap()];
+        });
+        let _low = insert(&store, |m| {
+            m.created_at -= chrono::Duration::seconds(2);
+            m.importance = 2;
+            m.anchors = vec![
+                rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap(),
+                rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Foo::bar").unwrap(),
+            ];
+        });
+
+        // All-of over multiple anchor filters.
+        let filter = RecallFilter {
+            anchors: vec![
+                rb_types::AnchorFilter {
+                    kind: rb_types::AnchorKind::File,
+                    value: "src/a.rs".to_string(),
+                },
+                rb_types::AnchorFilter {
+                    kind: rb_types::AnchorKind::Symbol,
+                    value: "Foo::bar".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let hits = store.list_filtered(&ns(), &filter, 10).unwrap();
+        assert_eq!(
+            ids(&hits),
+            vec![both.clone(), _low.clone()],
+            "every anchor filter must match (all-of)"
+        );
+
+        // Anchors compose with --type/--tags/--min-importance (PRD acceptance).
+        let composed = RecallFilter {
+            types: vec![MemoryType::Insight],
+            tags: vec!["infra".to_string()],
+            min_importance: Some(7),
+            anchors: vec![rb_types::AnchorFilter {
+                kind: rb_types::AnchorKind::File,
+                value: "src/a.rs".to_string(),
+            }],
+            ..Default::default()
+        };
+        let hits = store.list_filtered(&ns(), &composed, 10).unwrap();
+        assert_eq!(ids(&hits), vec![both, file_only]);
+    }
+
+    #[test]
+    fn anchor_filter_rejects_empty_values_fail_closed() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let err = store
+            .list_filtered(&ns(), &anchor_only(rb_types::AnchorKind::File, "  "), 10)
             .unwrap_err();
         assert!(
             matches!(err, Error::InvalidArgument(_)),
             "expected InvalidArgument, got {err:?}"
         );
+    }
+
+    #[test]
+    fn anchor_filter_agrees_with_recall_filter_matches() {
+        // Drift guard (the `contested_filter_agrees_with_active_contradicts`
+        // pattern): the SQL anchor predicate in `list_filtered` and
+        // `RecallFilter::matches` are two expressions of ONE semantics
+        // (all-of, kind-scoped, normalized-value equality, path-level for
+        // files). If either changes alone, this fails.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let mut inserted = Vec::new();
+        let variants: Vec<Vec<rb_types::MemoryAnchor>> = vec![
+            vec![],
+            vec![rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap()],
+            vec![rb_types::MemoryAnchor::parse_file_spec("./src/a.rs:3-9").unwrap()],
+            vec![rb_types::MemoryAnchor::parse_file_spec("src/b.rs").unwrap()],
+            vec![
+                rb_types::MemoryAnchor::parse_file_spec("src/a.rs").unwrap(),
+                rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, "abc123").unwrap(),
+            ],
+            vec![rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "abc123").unwrap()],
+        ];
+        for (i, anchors) in variants.into_iter().enumerate() {
+            let mut m = MemoryNote::new(ns(), format!("variant {i}"), MemoryType::Insight, 5);
+            m.created_at -= chrono::Duration::seconds(i as i64);
+            m.anchors = anchors;
+            store.insert_memory(&m, None).unwrap();
+            inserted.push(m);
+        }
+
+        let filters = [
+            anchor_only(rb_types::AnchorKind::File, "src/a.rs"),
+            anchor_only(rb_types::AnchorKind::File, "./src/a.rs"),
+            anchor_only(rb_types::AnchorKind::Commit, "abc123"),
+            anchor_only(rb_types::AnchorKind::Symbol, "abc123"),
+            RecallFilter {
+                anchors: vec![
+                    rb_types::AnchorFilter {
+                        kind: rb_types::AnchorKind::File,
+                        value: "src/a.rs".to_string(),
+                    },
+                    rb_types::AnchorFilter {
+                        kind: rb_types::AnchorKind::Commit,
+                        value: "abc123".to_string(),
+                    },
+                ],
+                ..Default::default()
+            },
+        ];
+        for filter in filters {
+            let sql_ids: std::collections::HashSet<_> =
+                ids(&store.list_filtered(&ns(), &filter, 100).unwrap())
+                    .into_iter()
+                    .collect();
+            let matches_ids: std::collections::HashSet<_> = inserted
+                .iter()
+                .filter(|m| filter.matches(m))
+                .map(|m| m.id.clone())
+                .collect();
+            assert_eq!(
+                sql_ids, matches_ids,
+                "SQL anchor predicate must agree with RecallFilter::matches for {filter:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rb-store/src/store/rename.rs
+++ b/crates/rb-store/src/store/rename.rs
@@ -23,6 +23,9 @@ impl SqliteStore {
     ///   have no vector (W1.7 hygiene), so `vectors <= memories`.
     /// - `memory_links` — carries no namespace column; edges key on memory ids
     ///   and survive untouched.
+    /// - `memory_anchors` — namespace mirrors memories.namespace (the 009
+    ///   migration's scoping column for anchor-filter lookups), so it is
+    ///   re-keyed with a plain UPDATE in the same transaction.
     /// - `memory_oplog` — ONE `namespace_rename` row recording old, new and
     ///   the row counts; historical oplog rows keep their original namespace
     ///   (the log is history, not state).
@@ -107,6 +110,16 @@ impl SqliteStore {
                 .conn
                 .execute(
                     "UPDATE memories SET namespace = ?1 WHERE namespace = ?2",
+                    rusqlite::params![new_str, old_str],
+                )
+                .map_err(storage_err)?;
+
+            // Re-key the anchor scoping column in the same transaction (it
+            // mirrors memories.namespace; a stranded old-namespace anchor
+            // would silently drop out of anchor-filter lookups).
+            self.conn
+                .execute(
+                    "UPDATE memory_anchors SET namespace = ?1 WHERE namespace = ?2",
                     rusqlite::params![new_str, old_str],
                 )
                 .map_err(storage_err)?;
@@ -323,6 +336,47 @@ mod namespace_rename_tests {
         assert_eq!(v["moved"], 3);
         assert_eq!(v["vectors"], 2);
         assert_eq!(v["merged_into"], 0);
+    }
+
+    #[test]
+    fn rename_rekeys_anchor_namespace_and_anchor_filters_follow() {
+        // memory_anchors.namespace mirrors memories.namespace; a rename must
+        // re-key it in the same transaction so anchors stay attached AND the
+        // anchor-filter list keeps finding the memory under the new namespace.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let old = Namespace::Project("anchored-old".into());
+        let new = Namespace::Project("anchored-new".into());
+
+        let mut m = MemoryNote::new(old.clone(), "anchored".into(), MemoryType::Insight, 5);
+        m.anchors = vec![rb_types::MemoryAnchor::parse_file_spec("src/server.rs:1-3").unwrap()];
+        store.insert_memory(&m, None).unwrap();
+
+        store.rename_namespace(&old, &new, false).unwrap();
+
+        let stranded: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_anchors WHERE namespace = ?1",
+                rusqlite::params![old.as_db_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stranded, 0, "no anchor may stay under the old namespace");
+
+        let filter = rb_types::RecallFilter {
+            anchors: vec![rb_types::AnchorFilter {
+                kind: rb_types::AnchorKind::File,
+                value: "src/server.rs".into(),
+            }],
+            ..Default::default()
+        };
+        let hits = store.list_filtered(&new, &filter, 10).unwrap();
+        assert_eq!(
+            hits.iter().map(|n| n.id.clone()).collect::<Vec<_>>(),
+            vec![m.id.clone()],
+            "the anchor filter must find the memory in the NEW namespace"
+        );
+        assert_eq!(hits[0].anchors, m.anchors, "anchors stay attached");
     }
 
     #[test]

--- a/crates/rb-store/tests/migration_reproducibility.rs
+++ b/crates/rb-store/tests/migration_reproducibility.rs
@@ -46,6 +46,13 @@ fn fresh_db_exercises_every_query_path() {
     b.summary = "sqlite-vec knn".to_string();
     b.keywords = vec!["sqlite".to_string(), "vector".to_string()];
     b.tags = vec!["db".to_string(), "search".to_string()];
+    // Typed code anchors (migration 009): populated so the anchor
+    // insert/load/filter paths are all exercised by this gate.
+    b.anchors = vec![
+        rb_types::MemoryAnchor::parse_file_spec("src/store/core.rs:10-20").unwrap(),
+        rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, "abc123def").unwrap(),
+        rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "SqliteStore::open").unwrap(),
+    ];
     let emb_b: [f32; DIM] = [0.0, 1.0, 0.0, 0.0];
     store.insert_memory(&b, Some(&emb_b)).unwrap();
 
@@ -103,6 +110,32 @@ fn fresh_db_exercises_every_query_path() {
     assert!(
         neighbors.contains(&(b.id.clone(), 1)),
         "graph_neighbors must reach b from a at hop distance 1"
+    );
+
+    // --- anchors (migration 009): round-trip through get + the filter path
+    let got_b = store.get_memory(&b.id).unwrap().unwrap();
+    assert_eq!(got_b.anchors, b.anchors, "anchors must round-trip");
+    assert!(
+        got.anchors.is_empty(),
+        "an anchor-less row loads an empty list (no backfill)"
+    );
+    let anchored = store
+        .list_filtered(
+            &ns,
+            &rb_types::RecallFilter {
+                anchors: vec![rb_types::AnchorFilter {
+                    kind: rb_types::AnchorKind::File,
+                    value: "src/store/core.rs".to_string(),
+                }],
+                ..Default::default()
+            },
+            10,
+        )
+        .unwrap();
+    assert_eq!(
+        anchored.iter().map(|m| m.id.clone()).collect::<Vec<_>>(),
+        vec![b.id.clone()],
+        "anchor-filtered list must reach the anchored row"
     );
 
     // --- list: active only, ORDER BY created_at DESC

--- a/crates/rb-types/src/anchor.rs
+++ b/crates/rb-types/src/anchor.rs
@@ -1,0 +1,405 @@
+//! Typed code anchors (PRD 2026-07-02): a structured, queryable link from a
+//! memory to a code location — a file path (+ optional line range), a commit
+//! SHA, or a symbol/identifier. Anchors are caller-supplied strings, never
+//! resolved AST (PRD non-goal), and multiple anchors per memory are allowed.
+
+use crate::query::AnchorKind;
+use serde::{Deserialize, Serialize};
+
+/// One code anchor attached to a memory.
+///
+/// `value` is the normalized anchor payload for `kind`: a file path (`file`),
+/// a commit SHA (`commit`), or a symbol name (`symbol`). `start_line`/
+/// `end_line` are 1-based and only meaningful for `file` anchors.
+///
+/// Wire-compat: both line fields are `#[serde(default, skip_serializing_if)]`
+/// so a line-less anchor serializes to `{kind, value}` only, and
+/// `MemoryNote.anchors` itself is `#[serde(default)]` — pre-anchor payloads
+/// (and old daemons/clients) decode to an empty list (the `contested`
+/// additive-field precedent).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryAnchor {
+    pub kind: AnchorKind,
+    /// Normalized file path / commit SHA / symbol name (see
+    /// [`normalize_anchor_value`]).
+    pub value: String,
+    /// First line of the anchored range (1-based; `file` anchors only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
+    /// Last line of the anchored range (inclusive, 1-based; `file` only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
+}
+
+/// Normalize a raw anchor value for storage and matching: trim surrounding
+/// whitespace and, for `file` anchors, strip any leading `./` segments so
+/// `./src/foo.rs` and `src/foo.rs` are the same anchor. Paths are stored as
+/// given otherwise (repo-relative by convention — the daemon cannot resolve a
+/// repo root; path drift across machines is a documented PRD limitation).
+/// May return an empty string; [`MemoryAnchor::validate`] rejects that.
+#[must_use]
+pub fn normalize_anchor_value(kind: AnchorKind, raw: &str) -> String {
+    let mut v = raw.trim();
+    if kind == AnchorKind::File {
+        while let Some(rest) = v.strip_prefix("./") {
+            v = rest.trim_start();
+        }
+    }
+    v.to_string()
+}
+
+impl MemoryAnchor {
+    /// Build a line-less anchor from a raw value: normalize, then validate
+    /// (fail-closed on an empty value).
+    pub fn new(kind: AnchorKind, raw_value: &str) -> crate::error::Result<Self> {
+        let anchor = MemoryAnchor {
+            kind,
+            value: normalize_anchor_value(kind, raw_value),
+            start_line: None,
+            end_line: None,
+        };
+        anchor.validate()?;
+        Ok(anchor)
+    }
+
+    /// Parse a CLI/MCP `--file` capture spec: `PATH`, `PATH:LINE`, or
+    /// `PATH:START-END` (1-based, inclusive). The suffix after the LAST `:`
+    /// is treated as a line range ONLY when it starts with an ASCII digit —
+    /// and then it MUST parse (garbage like `foo.rs:12-` is a clean error,
+    /// never silently part of the path). Paths whose last segment does not
+    /// start with a digit keep their colons (`C:\proj\a.rs` stays a path).
+    pub fn parse_file_spec(spec: &str) -> crate::error::Result<Self> {
+        if let Some((path, suffix)) = spec.rsplit_once(':') {
+            if suffix.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                let (start, end) = parse_line_range(suffix)?;
+                let mut anchor = Self::new(AnchorKind::File, path)?;
+                anchor.start_line = Some(start);
+                anchor.end_line = Some(end);
+                anchor.validate()?;
+                return Ok(anchor);
+            }
+        }
+        Self::new(AnchorKind::File, spec)
+    }
+
+    /// Fail-fast boundary validation: a non-empty normalized value; line
+    /// fields only on `file` anchors, 1-based, with `start <= end` and never
+    /// an end without a start.
+    pub fn validate(&self) -> crate::error::Result<()> {
+        let invalid = |msg: String| crate::error::Error::InvalidArgument(msg);
+        if self.value.trim().is_empty() {
+            return Err(invalid(format!(
+                "{} anchor value must not be empty",
+                kind_str(self.kind)
+            )));
+        }
+        if self.kind != AnchorKind::File && (self.start_line.is_some() || self.end_line.is_some()) {
+            return Err(invalid(format!(
+                "line ranges are only valid on file anchors, not {}",
+                kind_str(self.kind)
+            )));
+        }
+        if self.end_line.is_some() && self.start_line.is_none() {
+            return Err(invalid("anchor end_line requires a start_line".to_string()));
+        }
+        for line in [self.start_line, self.end_line].into_iter().flatten() {
+            if line == 0 {
+                return Err(invalid(
+                    "anchor lines are 1-based; 0 is invalid".to_string(),
+                ));
+            }
+        }
+        if let (Some(start), Some(end)) = (self.start_line, self.end_line) {
+            if start > end {
+                return Err(invalid(format!(
+                    "anchor line range {start}-{end} is inverted"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for MemoryAnchor {
+    /// Compact human label: `file:src/a.rs:12-40`, `file:src/a.rs:12`,
+    /// `commit:abc123`, `symbol:Foo::bar`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", kind_str(self.kind), self.value)?;
+        match (self.start_line, self.end_line) {
+            (Some(s), Some(e)) if s == e => write!(f, ":{s}"),
+            (Some(s), Some(e)) => write!(f, ":{s}-{e}"),
+            (Some(s), None) => write!(f, ":{s}"),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Parse a recall/list `--file` FILTER value into an [`crate::AnchorFilter`]
+/// (shared by the CLI and MCP so the surfaces agree). Filters match by PATH
+/// only in v1, so a `:LINE`/`:START-END` suffix is a clean error — silently
+/// stripping it would widen the query behind the caller's back, and treating
+/// it as part of the path would silently match nothing.
+pub fn parse_file_filter(spec: &str) -> crate::error::Result<crate::AnchorFilter> {
+    let anchor = MemoryAnchor::parse_file_spec(spec)?;
+    if anchor.start_line.is_some() || anchor.end_line.is_some() {
+        return Err(crate::error::Error::InvalidArgument(format!(
+            "file filters match by path only; drop the line range from '{spec}' \
+             (line ranges are for capture, e.g. `remember --file {spec}`)"
+        )));
+    }
+    let filter = crate::AnchorFilter {
+        kind: AnchorKind::File,
+        value: anchor.value,
+    };
+    filter.validate()?;
+    Ok(filter)
+}
+
+/// The canonical db/display string for an anchor kind (mirrors the serde
+/// `snake_case` rename on [`AnchorKind`]; pinned by a test).
+#[must_use]
+pub fn kind_str(kind: AnchorKind) -> &'static str {
+    match kind {
+        AnchorKind::File => "file",
+        AnchorKind::Commit => "commit",
+        AnchorKind::Symbol => "symbol",
+    }
+}
+
+/// Parse `kind_str` back to an [`AnchorKind`] (store decode path).
+pub fn parse_kind(s: &str) -> crate::error::Result<AnchorKind> {
+    match s {
+        "file" => Ok(AnchorKind::File),
+        "commit" => Ok(AnchorKind::Commit),
+        "symbol" => Ok(AnchorKind::Symbol),
+        other => Err(crate::error::Error::InvalidArgument(format!(
+            "unknown anchor kind '{other}': expected file, commit, or symbol"
+        ))),
+    }
+}
+
+/// Parse the `LINE` / `START-END` suffix of a file spec. The caller has
+/// already established the suffix starts with a digit, so anything that does
+/// not fully parse is a hard error (fail fast, never a silent path).
+fn parse_line_range(suffix: &str) -> crate::error::Result<(u32, u32)> {
+    let invalid = || {
+        crate::error::Error::InvalidArgument(format!(
+            "invalid line range '{suffix}': expected LINE or START-END (1-based)"
+        ))
+    };
+    let (start_raw, end_raw) = match suffix.split_once('-') {
+        Some((s, e)) => (s, e),
+        None => (suffix, suffix),
+    };
+    let start: u32 = start_raw.parse().map_err(|_| invalid())?;
+    let end: u32 = end_raw.parse().map_err(|_| invalid())?;
+    if start == 0 || end == 0 {
+        return Err(crate::error::Error::InvalidArgument(format!(
+            "invalid line range '{suffix}': lines are 1-based"
+        )));
+    }
+    if start > end {
+        return Err(crate::error::Error::InvalidArgument(format!(
+            "invalid line range '{suffix}': start exceeds end"
+        )));
+    }
+    Ok((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn new_normalizes_and_validates() {
+        let a = MemoryAnchor::new(AnchorKind::File, "  ./src/foo.rs  ").unwrap();
+        assert_eq!(a.value, "src/foo.rs");
+        assert_eq!(a.start_line, None);
+        assert_eq!(a.end_line, None);
+
+        let c = MemoryAnchor::new(AnchorKind::Commit, " abc123 ").unwrap();
+        assert_eq!(c.value, "abc123");
+
+        let s = MemoryAnchor::new(AnchorKind::Symbol, "Foo::bar").unwrap();
+        assert_eq!(s.value, "Foo::bar");
+    }
+
+    #[test]
+    fn new_rejects_empty_values() {
+        for kind in [AnchorKind::File, AnchorKind::Commit, AnchorKind::Symbol] {
+            for raw in ["", "   ", "./", "././"] {
+                let res = MemoryAnchor::new(kind, raw);
+                if kind == AnchorKind::File || raw.trim().is_empty() {
+                    assert!(res.is_err(), "{kind:?} anchor {raw:?} must be rejected");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn normalize_strips_leading_dot_slash_for_files_only() {
+        assert_eq!(
+            normalize_anchor_value(AnchorKind::File, "././src/a.rs"),
+            "src/a.rs"
+        );
+        // Non-file kinds keep the raw (trimmed) value.
+        assert_eq!(
+            normalize_anchor_value(AnchorKind::Symbol, "./looks::weird"),
+            "./looks::weird"
+        );
+    }
+
+    #[test]
+    fn parse_file_spec_plain_path() {
+        let a = MemoryAnchor::parse_file_spec("src/server.rs").unwrap();
+        assert_eq!(a.value, "src/server.rs");
+        assert_eq!((a.start_line, a.end_line), (None, None));
+    }
+
+    #[test]
+    fn parse_file_spec_single_line_and_range() {
+        let single = MemoryAnchor::parse_file_spec("src/a.rs:12").unwrap();
+        assert_eq!(single.value, "src/a.rs");
+        assert_eq!((single.start_line, single.end_line), (Some(12), Some(12)));
+
+        let range = MemoryAnchor::parse_file_spec("src/a.rs:12-40").unwrap();
+        assert_eq!((range.start_line, range.end_line), (Some(12), Some(40)));
+    }
+
+    #[test]
+    fn parse_file_spec_keeps_non_numeric_colon_suffixes_as_path() {
+        // A Windows-style or otherwise colon-bearing path whose final segment
+        // does not start with a digit stays a path.
+        let a = MemoryAnchor::parse_file_spec("C:\\proj\\a.rs").unwrap();
+        assert_eq!(a.value, "C:\\proj\\a.rs");
+        assert_eq!((a.start_line, a.end_line), (None, None));
+    }
+
+    #[test]
+    fn parse_file_spec_rejects_garbage_ranges_cleanly() {
+        // Once the suffix starts with a digit it MUST be a valid range —
+        // trailing dashes, inverted ranges, zero lines, overflow, and junk are
+        // clean errors (never a panic, never silently part of the path).
+        for bad in [
+            "a.rs:12-",
+            "a.rs:12-9",
+            "a.rs:0",
+            "a.rs:0-4",
+            "a.rs:12-40-2",
+            "a.rs:12x",
+            "a.rs:99999999999999999999",
+            "a.rs:1-99999999999999999999",
+            ":12",
+        ] {
+            let res = MemoryAnchor::parse_file_spec(bad);
+            assert!(res.is_err(), "{bad:?} must be rejected, got {res:?}");
+            assert!(
+                matches!(res, Err(crate::error::Error::InvalidArgument(_))),
+                "{bad:?} must be InvalidArgument"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_lines_on_non_file_kinds_and_bad_ranges() {
+        let mut commit = MemoryAnchor::new(AnchorKind::Commit, "abc").unwrap();
+        commit.start_line = Some(1);
+        assert!(commit.validate().is_err(), "lines on a commit anchor");
+
+        let mut file = MemoryAnchor::new(AnchorKind::File, "a.rs").unwrap();
+        file.end_line = Some(4);
+        assert!(file.validate().is_err(), "end without start");
+
+        file.start_line = Some(9);
+        assert!(file.validate().is_err(), "inverted range");
+
+        file.start_line = Some(0);
+        file.end_line = None;
+        assert!(file.validate().is_err(), "0 is not a 1-based line");
+    }
+
+    #[test]
+    fn open_ended_start_line_is_valid() {
+        let mut file = MemoryAnchor::new(AnchorKind::File, "a.rs").unwrap();
+        file.start_line = Some(3);
+        assert!(file.validate().is_ok(), "start-only range is allowed");
+    }
+
+    #[test]
+    fn serde_round_trip_and_lineless_shape_is_minimal() {
+        let a = MemoryAnchor::parse_file_spec("src/a.rs:3-9").unwrap();
+        let json = serde_json::to_value(&a).unwrap();
+        assert_eq!(json["kind"], "file");
+        assert_eq!(json["value"], "src/a.rs");
+        assert_eq!(json["start_line"], 3);
+        assert_eq!(json["end_line"], 9);
+        let back: MemoryAnchor = serde_json::from_value(json).unwrap();
+        assert_eq!(back, a);
+
+        // A line-less anchor serializes WITHOUT the line keys (additive shape).
+        let c = MemoryAnchor::new(AnchorKind::Commit, "abc123").unwrap();
+        let json = serde_json::to_value(&c).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.contains_key("start_line"), "{json}");
+        assert!(!obj.contains_key("end_line"), "{json}");
+
+        // A payload without the line keys decodes (serde defaults).
+        let old = serde_json::json!({ "kind": "symbol", "value": "Foo::bar" });
+        let back: MemoryAnchor = serde_json::from_value(old).unwrap();
+        assert_eq!(back.start_line, None);
+        assert_eq!(back.end_line, None);
+    }
+
+    #[test]
+    fn parse_file_filter_takes_paths_and_rejects_line_ranges() {
+        let f = parse_file_filter("./src/a.rs").unwrap();
+        assert_eq!(f.kind, AnchorKind::File);
+        assert_eq!(f.value, "src/a.rs", "filter values normalize like anchors");
+
+        for bad in ["src/a.rs:12", "src/a.rs:12-40", "", "  ", "a.rs:0"] {
+            let res = parse_file_filter(bad);
+            assert!(res.is_err(), "{bad:?} must be rejected, got {res:?}");
+        }
+    }
+
+    #[test]
+    fn kind_str_round_trips_and_matches_serde_snake_case() {
+        for kind in [AnchorKind::File, AnchorKind::Commit, AnchorKind::Symbol] {
+            let s = kind_str(kind);
+            assert_eq!(parse_kind(s).unwrap(), kind);
+            // The db string must equal the serde wire string so the two
+            // representations can never disagree.
+            assert_eq!(serde_json::to_value(kind).unwrap(), serde_json::json!(s));
+        }
+        assert!(parse_kind("branch").is_err());
+    }
+
+    #[test]
+    fn display_is_compact() {
+        assert_eq!(
+            MemoryAnchor::parse_file_spec("src/a.rs:12-40")
+                .unwrap()
+                .to_string(),
+            "file:src/a.rs:12-40"
+        );
+        assert_eq!(
+            MemoryAnchor::parse_file_spec("src/a.rs:12")
+                .unwrap()
+                .to_string(),
+            "file:src/a.rs:12"
+        );
+        assert_eq!(
+            MemoryAnchor::new(AnchorKind::Commit, "abc123")
+                .unwrap()
+                .to_string(),
+            "commit:abc123"
+        );
+        assert_eq!(
+            MemoryAnchor::new(AnchorKind::Symbol, "Foo::bar")
+                .unwrap()
+                .to_string(),
+            "symbol:Foo::bar"
+        );
+    }
+}

--- a/crates/rb-types/src/lib.rs
+++ b/crates/rb-types/src/lib.rs
@@ -5,6 +5,7 @@
 //! `MemoryLink`, `SearchQuery`, `SearchResult`, `MemoryUpdates`, `Error`) used
 //! across the engine, store, daemon, and binary.
 
+mod anchor;
 mod change;
 mod error;
 mod feedback_kind;
@@ -19,6 +20,10 @@ mod query;
 mod stats;
 mod validate;
 
+pub use anchor::{
+    kind_str as anchor_kind_str, normalize_anchor_value, parse_file_filter,
+    parse_kind as parse_anchor_kind, MemoryAnchor,
+};
 pub use change::{ChangeKind, MemoryChanged};
 pub use error::{Error, Result};
 pub use feedback_kind::FeedbackKind;

--- a/crates/rb-types/src/memory.rs
+++ b/crates/rb-types/src/memory.rs
@@ -1,3 +1,4 @@
+use crate::anchor::MemoryAnchor;
 use crate::link::MemoryLink;
 use crate::memory_id::MemoryId;
 use crate::memory_type::MemoryType;
@@ -57,6 +58,14 @@ pub struct MemoryNote {
     pub origin_source: Option<String>,
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Typed code anchors (PRD 2026-07-02): structured file/commit/symbol
+    /// links, loaded from `memory_anchors` alongside the row (like `links`).
+    /// Additive + `#[serde(default, skip_serializing_if)]`: pre-anchor
+    /// payloads decode to an empty list, and an anchor-less note serializes
+    /// byte-identical to the pre-anchor shape (the `contested` precedent) —
+    /// NO CONTRACT_VERSION bump.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub anchors: Vec<MemoryAnchor>,
 }
 
 impl MemoryNote {
@@ -97,6 +106,7 @@ impl MemoryNote {
             origin_agent: None,
             origin_source: None,
             session_id: None,
+            anchors: Vec::new(),
         }
     }
 }
@@ -203,6 +213,32 @@ mod tests {
         assert!(back.origin_agent.is_none());
         assert!(back.origin_source.is_none());
         assert!(back.session_id.is_none());
+    }
+
+    #[test]
+    fn anchors_default_empty_absent_from_wire_and_round_trip() {
+        // Pre-anchor payload (no `anchors` key) decodes to an empty list, and
+        // an anchor-less note serializes WITHOUT the key — byte-identical to
+        // the pre-anchor shape (the `contested` additive-field precedent).
+        let m = sample();
+        assert!(m.anchors.is_empty());
+        let value = serde_json::to_value(&m).unwrap();
+        assert!(
+            value.as_object().unwrap().get("anchors").is_none(),
+            "empty anchors must not serialize: {value}"
+        );
+        let back: MemoryNote = serde_json::from_value(value).unwrap();
+        assert!(back.anchors.is_empty());
+
+        // A note WITH anchors round-trips them.
+        let mut anchored = sample();
+        anchored.anchors = vec![
+            crate::MemoryAnchor::parse_file_spec("src/a.rs:3-9").unwrap(),
+            crate::MemoryAnchor::new(crate::AnchorKind::Commit, "abc123").unwrap(),
+        ];
+        let json = serde_json::to_string(&anchored).unwrap();
+        let back: MemoryNote = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, anchored);
     }
 
     #[test]

--- a/crates/rb-types/src/query.rs
+++ b/crates/rb-types/src/query.rs
@@ -86,15 +86,41 @@ pub enum AnchorKind {
 /// One anchor constraint: scope results to memories anchored to `value`
 /// (a file path, commit SHA, or symbol name, per `kind`).
 ///
-/// Wire plumbing only for now: the filter MODEL ships with search-filter
-/// parity (PRD 2026-07-02) so the contract needs no second change, but
-/// evaluating it requires the `memory_anchors` table from the typed-code-anchors
-/// PRD — until that lands, engines/stores reject a non-empty anchor filter
-/// with `Error::InvalidArgument` (fail fast, never silently unfiltered).
+/// The MODEL shipped with search-filter parity (PRD 2026-07-02); evaluation
+/// shipped with typed code anchors: the value is compared against a memory's
+/// [`crate::MemoryAnchor`]s under the same normalization
+/// ([`crate::normalize_anchor_value`]) on both sides, so `./src/a.rs` and
+/// `src/a.rs` are the same file anchor. Multiple anchor filters compose
+/// all-of (like tags): every listed anchor must match. File filters match by
+/// PATH only — a stored line range never narrows a filter in v1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AnchorFilter {
     pub kind: AnchorKind,
     pub value: String,
+}
+
+impl AnchorFilter {
+    /// Whether `anchor` satisfies this constraint: same kind, same normalized
+    /// value (file line ranges are ignored — path-level matching in v1).
+    #[must_use]
+    pub fn matches_anchor(&self, anchor: &crate::MemoryAnchor) -> bool {
+        self.kind == anchor.kind
+            && crate::normalize_anchor_value(self.kind, &self.value)
+                == crate::normalize_anchor_value(anchor.kind, &anchor.value)
+    }
+
+    /// Fail-fast boundary validation: the value must be non-empty after
+    /// normalization (an empty anchor filter can never match and is a caller
+    /// mistake, not an empty result set).
+    pub fn validate(&self) -> crate::error::Result<()> {
+        if crate::normalize_anchor_value(self.kind, &self.value).is_empty() {
+            return Err(crate::error::Error::InvalidArgument(format!(
+                "{} anchor filter value must not be empty",
+                crate::anchor_kind_str(self.kind)
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// The unified recall/list filter model (PRD 2026-07-02 search-filter parity):
@@ -108,11 +134,12 @@ pub struct AnchorFilter {
 ///   field), keeping frames byte-identical to the pre-filter shape — additive,
 ///   NO CONTRACT_VERSION bump (the `contested` precedent).
 ///
-/// Semantics: `types`/`sources` are any-of; `tags` is all-of; numeric and time
-/// ranges are inclusive; `contested` is tri-state (`None` = no constraint);
-/// `state` defaults to active-only. `contested` and `anchors` are NOT decided
-/// by [`RecallFilter::matches`] (they need link/anchor lookups) — callers
-/// evaluate those dimensions where the data lives.
+/// Semantics: `types`/`sources` are any-of; `tags` and `anchors` are all-of;
+/// numeric and time ranges are inclusive; `contested` is tri-state (`None` =
+/// no constraint); `state` defaults to active-only. `contested` is NOT
+/// decided by [`RecallFilter::matches`] (it needs a link lookup) — callers
+/// evaluate that dimension where the data lives. `anchors` IS decided by
+/// `matches` (the note carries its anchors since typed code anchors).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RecallFilter {
     /// Restrict to any of these memory types (empty = no constraint).
@@ -147,8 +174,9 @@ pub struct RecallFilter {
     /// Archived-state scope (default: active-only, the pre-filter behavior).
     #[serde(default, skip_serializing_if = "MemoryState::is_active")]
     pub state: MemoryState,
-    /// Code-anchor constraints (see [`AnchorFilter`]): wire plumbing shipped
-    /// with search-filter parity; evaluation lands with typed code anchors.
+    /// Code-anchor constraints (see [`AnchorFilter`]; all-of, like `tags`):
+    /// wire plumbing shipped with search-filter parity; evaluation shipped
+    /// with typed code anchors (PRD 2026-07-02).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub anchors: Vec<AnchorFilter>,
 }
@@ -200,15 +228,21 @@ impl RecallFilter {
                 )));
             }
         }
+        for anchor in &self.anchors {
+            anchor.validate()?;
+        }
         Ok(())
     }
 
-    /// Whether `note` satisfies every metadata dimension of this filter:
+    /// Whether `note` satisfies every note-decidable dimension of this filter:
     /// types (any-of), tags (all-of), importance/confidence ranges
-    /// (inclusive), created-at window (inclusive), sources (any-of), and
-    /// archived state. `contested` and `anchors` are intentionally NOT
-    /// evaluated here — they require link/anchor lookups the note does not
-    /// carry, so callers handle those dimensions where the data lives.
+    /// (inclusive), created-at window (inclusive), sources (any-of), archived
+    /// state, and anchors (all-of over `note.anchors`, normalized on both
+    /// sides — kept in lockstep with the store's SQL by the
+    /// `anchor_filter_agrees_with_recall_filter_matches` drift test).
+    /// `contested` is intentionally NOT evaluated here — it requires a link
+    /// lookup the note does not carry, so callers handle it where the data
+    /// lives.
     #[must_use]
     pub fn matches(&self, note: &MemoryNote) -> bool {
         if !self.types.is_empty() && !self.types.contains(&note.memory_type) {
@@ -240,6 +274,15 @@ impl RecallFilter {
                 .origin_source
                 .as_ref()
                 .is_some_and(|s| self.sources.contains(s))
+        {
+            return false;
+        }
+        // All-of (like tags): every anchor constraint must be satisfied by
+        // at least one of the note's anchors.
+        if !self
+            .anchors
+            .iter()
+            .all(|af| note.anchors.iter().any(|a| af.matches_anchor(a)))
         {
             return false;
         }
@@ -625,15 +668,103 @@ mod tests {
     }
 
     #[test]
-    fn matches_ignores_contested_and_anchors_dimensions() {
-        // `contested` needs a link lookup and `anchors` needs the (PRD 4)
-        // anchors table; neither is decidable from the note alone, so
-        // `matches` must not reject on them — callers handle those dimensions.
+    fn matches_ignores_the_contested_dimension() {
+        // `contested` needs a link lookup the note does not carry, so
+        // `matches` must not reject on it — callers handle that dimension.
         let filter = RecallFilter {
             contested: Some(true),
             ..Default::default()
         };
         assert!(filter.matches(&note_with(|_| {})));
+    }
+
+    fn anchor_filter(kind: AnchorKind, value: &str) -> RecallFilter {
+        RecallFilter {
+            anchors: vec![AnchorFilter {
+                kind,
+                value: value.to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn matches_filters_by_anchor_per_kind() {
+        let anchored = note_with(|n| {
+            n.anchors = vec![
+                crate::MemoryAnchor::parse_file_spec("src/server.rs:10-20").unwrap(),
+                crate::MemoryAnchor::new(AnchorKind::Commit, "abc123").unwrap(),
+                crate::MemoryAnchor::new(AnchorKind::Symbol, "Engine::recall").unwrap(),
+            ];
+        });
+        let bare = note_with(|_| {});
+
+        // Acceptance criterion (PRD): anchored memory matches its file filter
+        // and is absent under a different file.
+        assert!(anchor_filter(AnchorKind::File, "src/server.rs").matches(&anchored));
+        assert!(!anchor_filter(AnchorKind::File, "src/other.rs").matches(&anchored));
+        assert!(!anchor_filter(AnchorKind::File, "src/server.rs").matches(&bare));
+
+        assert!(anchor_filter(AnchorKind::Commit, "abc123").matches(&anchored));
+        assert!(!anchor_filter(AnchorKind::Commit, "def456").matches(&anchored));
+        assert!(anchor_filter(AnchorKind::Symbol, "Engine::recall").matches(&anchored));
+
+        // Kinds never cross-match, even on an equal value.
+        assert!(!anchor_filter(AnchorKind::Symbol, "abc123").matches(&anchored));
+    }
+
+    #[test]
+    fn matches_normalizes_anchor_values_on_both_sides() {
+        // `./src/a.rs` (filter) matches `src/a.rs` (stored) and vice versa;
+        // a stored line range never narrows a path-level filter (v1).
+        let anchored = note_with(|n| {
+            n.anchors = vec![crate::MemoryAnchor::parse_file_spec("./src/a.rs:5").unwrap()];
+        });
+        assert!(anchor_filter(AnchorKind::File, "src/a.rs").matches(&anchored));
+        assert!(anchor_filter(AnchorKind::File, " ./src/a.rs ").matches(&anchored));
+    }
+
+    #[test]
+    fn matches_requires_every_anchor_filter() {
+        // All-of composition (like tags): both constraints must be satisfied.
+        let filter = RecallFilter {
+            anchors: vec![
+                AnchorFilter {
+                    kind: AnchorKind::File,
+                    value: "src/a.rs".to_string(),
+                },
+                AnchorFilter {
+                    kind: AnchorKind::Symbol,
+                    value: "Foo::bar".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let both = note_with(|n| {
+            n.anchors = vec![
+                crate::MemoryAnchor::new(AnchorKind::File, "src/a.rs").unwrap(),
+                crate::MemoryAnchor::new(AnchorKind::Symbol, "Foo::bar").unwrap(),
+            ];
+        });
+        let file_only = note_with(|n| {
+            n.anchors = vec![crate::MemoryAnchor::new(AnchorKind::File, "src/a.rs").unwrap()];
+        });
+        assert!(filter.matches(&both));
+        assert!(!filter.matches(&file_only));
+    }
+
+    #[test]
+    fn validate_rejects_empty_anchor_filter_values() {
+        for value in ["", "   ", "./"] {
+            let filter = anchor_filter(AnchorKind::File, value);
+            assert!(
+                filter.validate().is_err(),
+                "empty-after-normalization anchor value {value:?} must be rejected"
+            );
+        }
+        assert!(anchor_filter(AnchorKind::File, "src/a.rs")
+            .validate()
+            .is_ok());
     }
 
     #[test]

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -91,6 +91,50 @@ fn parse_time_bound(s: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
     ))
 }
 
+/// Parse a `remember --file` anchor spec: `PATH`, `PATH:LINE`, or
+/// `PATH:START-END` (1-based, inclusive). Garbage ranges (`a.rs:12-`,
+/// `a.rs:0`, inverted, overflow) fail at parse time — argv must never panic
+/// the process (the `parse_time_bound` precedent).
+fn parse_file_anchor(s: &str) -> Result<rb_types::MemoryAnchor, String> {
+    rb_types::MemoryAnchor::parse_file_spec(s).map_err(|e| e.to_string())
+}
+
+/// Parse a `remember --commit` anchor value (a commit SHA string).
+fn parse_commit_anchor(s: &str) -> Result<rb_types::MemoryAnchor, String> {
+    rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, s).map_err(|e| e.to_string())
+}
+
+/// Parse a `remember --symbol` anchor value (a symbol/identifier string).
+fn parse_symbol_anchor(s: &str) -> Result<rb_types::MemoryAnchor, String> {
+    rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, s).map_err(|e| e.to_string())
+}
+
+/// Parse a recall/list `--file` FILTER (path only — filters match by path,
+/// so a `:LINE` range is a clean parse error pointing at capture).
+fn parse_file_filter(s: &str) -> Result<rb_types::AnchorFilter, String> {
+    rb_types::parse_file_filter(s).map_err(|e| e.to_string())
+}
+
+/// Parse a recall/list `--commit` FILTER value.
+fn parse_commit_filter(s: &str) -> Result<rb_types::AnchorFilter, String> {
+    let filter = rb_types::AnchorFilter {
+        kind: rb_types::AnchorKind::Commit,
+        value: s.to_string(),
+    };
+    filter.validate().map_err(|e| e.to_string())?;
+    Ok(filter)
+}
+
+/// Parse a recall/list `--symbol` FILTER value.
+fn parse_symbol_filter(s: &str) -> Result<rb_types::AnchorFilter, String> {
+    let filter = rb_types::AnchorFilter {
+        kind: rb_types::AnchorKind::Symbol,
+        value: s.to_string(),
+    };
+    filter.validate().map_err(|e| e.to_string())?;
+    Ok(filter)
+}
+
 /// Parse a `--source` producer surface; the daemon only ever stamps these four.
 fn parse_source(s: &str) -> Result<String, String> {
     const SOURCES: [&str; 4] = ["hook", "mcp", "cli", "job"];
@@ -269,6 +313,18 @@ pub enum Command {
         /// is the UUID of the memory being replaced.
         #[arg(long)]
         supersedes: Option<String>,
+        /// Anchor this memory to a file (repeatable): PATH, PATH:LINE, or
+        /// PATH:START-END (1-based, inclusive). Recall can then filter with
+        /// `recall --file PATH`.
+        #[arg(long = "file", value_parser = parse_file_anchor)]
+        file: Vec<rb_types::MemoryAnchor>,
+        /// Anchor this memory to a commit SHA (repeatable).
+        #[arg(long = "commit", value_parser = parse_commit_anchor)]
+        commit: Vec<rb_types::MemoryAnchor>,
+        /// Anchor this memory to a symbol/identifier, e.g. `Foo::bar`
+        /// (repeatable). A caller-supplied string, not resolved AST.
+        #[arg(long = "symbol", value_parser = parse_symbol_anchor)]
+        symbol: Vec<rb_types::MemoryAnchor>,
         /// Bulk mode: read one fact per line from stdin and store them all over
         /// a SINGLE daemon connection. The `--type`/`--importance`/`--tags`/
         /// `--context` flags apply uniformly to every fact; blank lines are
@@ -324,6 +380,17 @@ pub enum Command {
         /// only: archived vectors are pruned).
         #[arg(long)]
         archived: bool,
+        /// Only memories anchored to this file path (repeatable; every
+        /// listed anchor must match). Path only — line ranges are for
+        /// capture (`remember --file`).
+        #[arg(long = "file", value_parser = parse_file_filter)]
+        file: Vec<rb_types::AnchorFilter>,
+        /// Only memories anchored to this commit SHA (repeatable).
+        #[arg(long = "commit", value_parser = parse_commit_filter)]
+        commit: Vec<rb_types::AnchorFilter>,
+        /// Only memories anchored to this symbol (repeatable).
+        #[arg(long = "symbol", value_parser = parse_symbol_filter)]
+        symbol: Vec<rb_types::AnchorFilter>,
     },
 
     /// Fetch a single memory by id.
@@ -373,6 +440,17 @@ pub enum Command {
         /// List archived memories instead of active ones.
         #[arg(long)]
         archived: bool,
+        /// Only memories anchored to this file path (repeatable; every
+        /// listed anchor must match). Path only — line ranges are for
+        /// capture (`remember --file`).
+        #[arg(long = "file", value_parser = parse_file_filter)]
+        file: Vec<rb_types::AnchorFilter>,
+        /// Only memories anchored to this commit SHA (repeatable).
+        #[arg(long = "commit", value_parser = parse_commit_filter)]
+        commit: Vec<rb_types::AnchorFilter>,
+        /// Only memories anchored to this symbol (repeatable).
+        #[arg(long = "symbol", value_parser = parse_symbol_filter)]
+        symbol: Vec<rb_types::AnchorFilter>,
     },
 
     /// Show memories connected to an id by graph links.
@@ -938,6 +1016,124 @@ mod tests {
             Cli::try_parse_from(["rusty-brain", "remember", "a fact", "--batch"]).is_err(),
             "--batch must conflict with a positional content argument"
         );
+    }
+
+    #[test]
+    fn remember_parses_anchor_capture_flags() {
+        let cli = Cli::parse_from([
+            "rusty-brain",
+            "remember",
+            "we chose tokio here",
+            "--file",
+            "src/server.rs:12-40",
+            "--file",
+            "./src/lib.rs",
+            "--commit",
+            "abc123",
+            "--symbol",
+            "Server::run",
+        ]);
+        match cli.command {
+            Command::Remember {
+                file,
+                commit,
+                symbol,
+                ..
+            } => {
+                assert_eq!(file.len(), 2);
+                assert_eq!(file[0].value, "src/server.rs");
+                assert_eq!((file[0].start_line, file[0].end_line), (Some(12), Some(40)));
+                assert_eq!(file[1].value, "src/lib.rs", "paths normalize");
+                assert_eq!(commit.len(), 1);
+                assert_eq!(commit[0].kind, rb_types::AnchorKind::Commit);
+                assert_eq!(commit[0].value, "abc123");
+                assert_eq!(symbol.len(), 1);
+                assert_eq!(symbol[0].kind, rb_types::AnchorKind::Symbol);
+                assert_eq!(symbol[0].value, "Server::run");
+            }
+            other => panic!("expected Remember, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remember_anchor_flags_reject_garbage_at_parse_time() {
+        // Clean parse errors, never a panic (the parse_time_bound precedent) —
+        // incl. line-number overflow past u32.
+        for bad in [
+            "a.rs:12-",
+            "a.rs:0",
+            "a.rs:40-12",
+            "a.rs:99999999999999999999",
+            "",
+            "./",
+        ] {
+            assert!(
+                Cli::try_parse_from(["rusty-brain", "remember", "c", "--file", bad]).is_err(),
+                "remember --file {bad:?} must be rejected at parse time"
+            );
+        }
+        for flag in ["--commit", "--symbol"] {
+            assert!(
+                Cli::try_parse_from(["rusty-brain", "remember", "c", flag, "  "]).is_err(),
+                "remember {flag} with a blank value must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn recall_and_list_parse_anchor_filters() {
+        for cmd in [
+            vec!["rusty-brain", "recall", "q"],
+            vec!["rusty-brain", "list"],
+        ] {
+            let mut argv = cmd.clone();
+            argv.extend([
+                "--file",
+                "./src/server.rs",
+                "--commit",
+                "abc123",
+                "--symbol",
+                "Engine::recall",
+            ]);
+            let cli = Cli::parse_from(argv);
+            let (file, commit, symbol) = match cli.command {
+                Command::Recall {
+                    file,
+                    commit,
+                    symbol,
+                    ..
+                }
+                | Command::List {
+                    file,
+                    commit,
+                    symbol,
+                    ..
+                } => (file, commit, symbol),
+                other => panic!("expected Recall/List, got {other:?}"),
+            };
+            assert_eq!(file.len(), 1);
+            assert_eq!(file[0].kind, rb_types::AnchorKind::File);
+            assert_eq!(file[0].value, "src/server.rs", "filter values normalize");
+            assert_eq!(commit[0].kind, rb_types::AnchorKind::Commit);
+            assert_eq!(symbol[0].kind, rb_types::AnchorKind::Symbol);
+        }
+    }
+
+    #[test]
+    fn recall_file_filter_rejects_line_ranges_and_blanks() {
+        // Filters match by path only: a line range is a clean parse error
+        // pointing at capture, never a silently-widened (or never-matching)
+        // query.
+        for bad in ["src/a.rs:12", "src/a.rs:12-40", "", "  "] {
+            assert!(
+                Cli::try_parse_from(["rusty-brain", "recall", "q", "--file", bad]).is_err(),
+                "recall --file {bad:?} must be rejected at parse time"
+            );
+            assert!(
+                Cli::try_parse_from(["rusty-brain", "list", "--file", bad]).is_err(),
+                "list --file {bad:?} must be rejected at parse time"
+            );
+        }
     }
 
     #[test]

--- a/crates/rusty-brain/src/export.rs
+++ b/crates/rusty-brain/src/export.rs
@@ -158,6 +158,10 @@ fn format_markdown(memories: &[MemoryNote]) -> String {
         if m.contested {
             out.push_str("- **Contested:** yes\n");
         }
+        if !m.anchors.is_empty() {
+            let labels: Vec<String> = m.anchors.iter().map(ToString::to_string).collect();
+            out.push_str(&format!("- **Anchors:** {}\n", labels.join(", ")));
+        }
         if !m.context.is_empty() {
             out.push_str(&format!("- **Context:** {}\n", m.context));
         }
@@ -329,6 +333,9 @@ pub fn parse_restore(text: &str) -> anyhow::Result<Vec<ImportItem>> {
             importance: m.importance,
             source: format!("restore:{}", m.id),
             tags: m.tags,
+            // Anchors survive export/restore (ANC-4): carried verbatim into
+            // the re-remember.
+            anchors: m.anchors,
         });
     }
     Ok(items)
@@ -388,6 +395,7 @@ mod tests {
             origin_agent: Some("cli".to_string()),
             origin_source: Some("cli".to_string()),
             session_id: None,
+            anchors: Vec::new(),
         }
     }
 
@@ -422,6 +430,29 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].summary, "Decision A");
         assert_eq!(items[1].memory_type, MemoryType::ArchitectureDecision);
+    }
+
+    #[test]
+    fn anchors_survive_json_export_and_parse_restore() {
+        // ANC-4: anchors are included in export and round-trip through
+        // restore (carried onto the ImportItem the re-remember consumes).
+        let mut anchored = sample_note("Anchored", "Body", MemoryType::Insight, 6);
+        anchored.anchors = vec![
+            rb_types::MemoryAnchor::parse_file_spec("src/server.rs:12-40").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Commit, "abc123").unwrap(),
+        ];
+        let json = format_json(&[anchored.clone()], "project:test").unwrap();
+        assert!(json.contains("src/server.rs"), "{json}");
+
+        let items = parse_restore(&json).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].anchors, anchored.anchors);
+
+        // Markdown lists them for the human reader.
+        let md = format_markdown(&[anchored]);
+        assert!(md.contains("**Anchors:**"), "{md}");
+        assert!(md.contains("file:src/server.rs:12-40"), "{md}");
+        assert!(md.contains("commit:abc123"), "{md}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/import.rs
+++ b/crates/rusty-brain/src/import.rs
@@ -42,6 +42,10 @@ pub struct ImportItem {
     /// Per-item tags merged with the batch tag at store time. Empty for file
     /// imports; populated by restore from the original memory's tags.
     pub tags: Vec<String>,
+    /// Typed code anchors (PRD 2026-07-02). Empty for file imports; populated
+    /// by restore from the original memory's anchors so they survive the
+    /// export/restore round-trip (ANC-4).
+    pub anchors: Vec<rb_types::MemoryAnchor>,
 }
 
 /// Counts for an import run.
@@ -181,6 +185,7 @@ pub fn extract_text(
         importance,
         source: label.to_string(),
         tags: Vec::new(),
+        anchors: Vec::new(),
     }
 }
 
@@ -388,6 +393,7 @@ fn recent_decision_commits(root: &Path, limit: usize) -> Vec<ImportItem> {
             importance: 4,
             source: format!("git log {hash}"),
             tags: Vec::new(),
+            anchors: Vec::new(),
         });
     }
     items
@@ -435,7 +441,7 @@ pub async fn store_items(
         tags.extend(item.tags.iter().cloned());
         tags.extend(extra_tags.iter().cloned());
         match client
-            .remember(
+            .remember_anchored(
                 content,
                 Some(context),
                 item.memory_type,
@@ -443,6 +449,8 @@ pub async fn store_items(
                 Vec::new(),
                 tags,
                 Vec::new(),
+                None,
+                item.anchors.clone(),
                 None,
             )
             .await

--- a/crates/rusty-brain/src/mcp.rs
+++ b/crates/rusty-brain/src/mcp.rs
@@ -169,6 +169,18 @@ impl DaemonProxy for ClientProxy {
     async fn call(&mut self, request: Request) -> rb_types::Result<Response> {
         let failure = {
             let client = self.ensure_connected().await?;
+            // Anchor-capability gate (typed code anchors): this raw path
+            // bypasses the typed Client wrappers, so it must apply the same
+            // fail-fast rule — a daemon that did not advertise the `anchors`
+            // capability would silently DROP `Remember.anchors` / IGNORE
+            // anchor filters instead of erroring.
+            if rb_proto::request_uses_anchors(&request) && !client.supports_anchors() {
+                return Err(rb_types::Error::InvalidArgument(
+                    "this daemon does not support typed code anchors (no `anchors` \
+                     capability in its handshake); upgrade and restart the daemon"
+                        .to_string(),
+                ));
+            }
             match attempt_call(client, &request).await {
                 Ok(resp) => return Ok(resp),
                 Err(f) => f,
@@ -404,6 +416,7 @@ mod tests {
         }
         for req in [
             Request::Remember {
+                anchors: vec![],
                 content: "c".into(),
                 context: None,
                 memory_type: rb_types::MemoryType::Insight,

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -42,6 +42,17 @@ pub fn render_recall(results: &[SearchResult], json: bool) -> String {
     out.trim_end().to_string()
 }
 
+/// Compact one-line anchor suffix for human renderings (typed code anchors,
+/// ANC-4: `graph <id>` and friends list anchors): ` [anchors: file:src/a.rs,
+/// commit:abc123]`, or empty when the note has none.
+fn anchors_suffix(n: &MemoryNote) -> String {
+    if n.anchors.is_empty() {
+        return String::new();
+    }
+    let labels: Vec<String> = n.anchors.iter().map(ToString::to_string).collect();
+    format!(" [anchors: {}]", labels.join(", "))
+}
+
 /// Render a list of notes (used by `list`, `graph`, and the `context` halves).
 pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
     if json {
@@ -63,12 +74,13 @@ pub fn render_notes(notes: &[MemoryNote], json: bool) -> String {
         // Surface the contested flag (Feature C) inline for the human reader.
         let contested = if n.contested { " [contested]" } else { "" };
         out.push_str(&format!(
-            "{} (imp {}, {}){} {}\n",
+            "{} (imp {}, {}){} {}{}\n",
             n.id,
             n.importance,
             n.memory_type.as_str(),
             contested,
-            summary
+            summary,
+            anchors_suffix(n)
         ));
     }
     out.trim_end().to_string()
@@ -87,13 +99,20 @@ pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
             // Surface the contested flag (Feature C) on the get read path too, so
             // every human surface (recall/list/context/get) marks a contradicted note.
             let contested = if n.contested { " [contested]" } else { "" };
+            let anchors = if n.anchors.is_empty() {
+                String::new()
+            } else {
+                let labels: Vec<String> = n.anchors.iter().map(ToString::to_string).collect();
+                format!("\nanchors: {}", labels.join(", "))
+            };
             format!(
-                "{}{}\nnamespace: {}\ntype: {}\nimportance: {}\n\n{}",
+                "{}{}\nnamespace: {}\ntype: {}\nimportance: {}{}\n\n{}",
                 n.id,
                 contested,
                 n.namespace.as_db_string(),
                 n.memory_type.as_str(),
                 n.importance,
+                anchors,
                 n.content
             )
         }
@@ -703,6 +722,7 @@ mod tests {
             importance: 8,
             source: "docs/adr.md".to_string(),
             tags: Vec::new(),
+            anchors: Vec::new(),
         }];
 
         let human = render_import_plan(&items, false);
@@ -727,6 +747,7 @@ mod tests {
             importance: 5,
             source: format!("docs/{token}.md"),
             tags: Vec::new(),
+            anchors: Vec::new(),
         }];
 
         let human = render_import_plan(&items, false);
@@ -797,6 +818,31 @@ mod tests {
         assert!(none.to_lowercase().contains("not found"));
         let json_none = render_get(&None, true);
         assert_eq!(json_none.trim(), "null");
+    }
+
+    #[test]
+    fn render_surfaces_anchors_on_get_and_notes() {
+        // ANC-4: `graph <id>`/`list`/`get` list a memory's anchors.
+        let mut n = note("anchored body", 5);
+        n.anchors = vec![
+            rb_types::MemoryAnchor::parse_file_spec("src/a.rs:3-9").unwrap(),
+            rb_types::MemoryAnchor::new(rb_types::AnchorKind::Symbol, "Foo::bar").unwrap(),
+        ];
+        let got = render_get(&Some(n.clone()), false);
+        assert!(
+            got.contains("anchors: file:src/a.rs:3-9, symbol:Foo::bar"),
+            "{got}"
+        );
+
+        let listed = render_notes(&[n], false);
+        assert!(
+            listed.contains("[anchors: file:src/a.rs:3-9, symbol:Foo::bar]"),
+            "{listed}"
+        );
+
+        // Anchor-less notes render exactly as before (no empty suffix).
+        let plain = render_notes(&[note("plain", 5)], false);
+        assert!(!plain.contains("anchors"), "{plain}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -42,6 +42,13 @@ pub fn render_recall(results: &[SearchResult], json: bool) -> String {
     out.trim_end().to_string()
 }
 
+/// Comma-joined anchor labels (`file:src/a.rs:3-9, commit:abc123`) — the one
+/// formatting shared by every human surface that lists anchors.
+fn anchor_labels(n: &MemoryNote) -> String {
+    let labels: Vec<String> = n.anchors.iter().map(ToString::to_string).collect();
+    labels.join(", ")
+}
+
 /// Compact one-line anchor suffix for human renderings (typed code anchors,
 /// ANC-4: `graph <id>` and friends list anchors): ` [anchors: file:src/a.rs,
 /// commit:abc123]`, or empty when the note has none.
@@ -49,8 +56,7 @@ fn anchors_suffix(n: &MemoryNote) -> String {
     if n.anchors.is_empty() {
         return String::new();
     }
-    let labels: Vec<String> = n.anchors.iter().map(ToString::to_string).collect();
-    format!(" [anchors: {}]", labels.join(", "))
+    format!(" [anchors: {}]", anchor_labels(n))
 }
 
 /// Render a list of notes (used by `list`, `graph`, and the `context` halves).
@@ -102,8 +108,7 @@ pub fn render_get(memory: &Option<MemoryNote>, json: bool) -> String {
             let anchors = if n.anchors.is_empty() {
                 String::new()
             } else {
-                let labels: Vec<String> = n.anchors.iter().map(ToString::to_string).collect();
-                format!("\nanchors: {}", labels.join(", "))
+                format!("\nanchors: {}", anchor_labels(n))
             };
             format!(
                 "{}{}\nnamespace: {}\ntype: {}\nimportance: {}{}\n\n{}",

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -47,6 +47,7 @@ fn build_recall_filter(
     source: Vec<String>,
     contested: Option<bool>,
     archived: bool,
+    anchors: Vec<rb_types::AnchorFilter>,
 ) -> rb_types::RecallFilter {
     rb_types::RecallFilter {
         types: memory_type.into_iter().collect(),
@@ -64,8 +65,19 @@ fn build_recall_filter(
         } else {
             rb_types::MemoryState::Active
         },
-        anchors: Vec::new(),
+        anchors,
     }
+}
+
+/// Concatenate the per-kind anchor filter flags (`--file`/`--commit`/
+/// `--symbol`, each already parse-validated by clap) into the single
+/// [`rb_types::RecallFilter::anchors`] list (all-of composition).
+fn collect_anchor_filters(
+    file: Vec<rb_types::AnchorFilter>,
+    commit: Vec<rb_types::AnchorFilter>,
+    symbol: Vec<rb_types::AnchorFilter>,
+) -> Vec<rb_types::AnchorFilter> {
+    file.into_iter().chain(commit).chain(symbol).collect()
 }
 
 /// Execute the parsed CLI with a pre-resolved `namespace` (resolved OFF the
@@ -335,8 +347,15 @@ async fn run_client(
             context,
             tags,
             supersedes,
+            file,
+            commit,
+            symbol,
             batch,
         } => {
+            // Typed code anchors: parse-validated per flag; one flat list on
+            // the wire. Applied uniformly in --batch mode (like --tags).
+            let anchors: Vec<rb_types::MemoryAnchor> =
+                file.into_iter().chain(commit).chain(symbol).collect();
             // CLI `remember` declares no explicit prior: the daemon applies the
             // 1.0 baseline (and an enricher may fill it).
             if batch {
@@ -353,7 +372,7 @@ async fn run_client(
                         continue;
                     }
                     client
-                        .remember(
+                        .remember_anchored(
                             fact.to_string(),
                             context.clone(),
                             memory_type,
@@ -361,6 +380,8 @@ async fn run_client(
                             Vec::new(),
                             tags.clone(),
                             Vec::new(),
+                            None,
+                            anchors.clone(),
                             None,
                         )
                         .await
@@ -381,38 +402,24 @@ async fn run_client(
             } else {
                 let content = content
                     .context("remember requires a content argument unless --batch is set")?;
-                let id = match supersedes {
-                    Some(old) => {
-                        let old = parse_id(&old).context("--supersedes must be a memory UUID")?;
-                        client
-                            .remember_superseding(
-                                content,
-                                context,
-                                memory_type,
-                                importance,
-                                Vec::new(),
-                                tags,
-                                Vec::new(),
-                                None,
-                                old,
-                            )
-                            .await
-                            .context("remember --supersedes failed")?
-                    }
-                    None => client
-                        .remember(
-                            content,
-                            context,
-                            memory_type,
-                            importance,
-                            Vec::new(),
-                            tags,
-                            Vec::new(),
-                            None,
-                        )
-                        .await
-                        .context("remember failed")?,
-                };
+                let supersedes = supersedes
+                    .map(|old| parse_id(&old).context("--supersedes must be a memory UUID"))
+                    .transpose()?;
+                let id = client
+                    .remember_anchored(
+                        content,
+                        context,
+                        memory_type,
+                        importance,
+                        Vec::new(),
+                        tags,
+                        Vec::new(),
+                        None,
+                        anchors,
+                        supersedes,
+                    )
+                    .await
+                    .context("remember failed")?;
                 println!("{}", output::render_remembered(&id, json));
             }
         }
@@ -430,6 +437,9 @@ async fn run_client(
             source,
             contested,
             archived,
+            file,
+            commit,
+            symbol,
         } => {
             let filter = build_recall_filter(
                 memory_type,
@@ -443,6 +453,7 @@ async fn run_client(
                 source,
                 contested,
                 archived,
+                collect_anchor_filters(file, commit, symbol),
             );
             let (results, degraded) = client
                 .recall_filtered_with_status(query, filter, limit)
@@ -477,6 +488,9 @@ async fn run_client(
             source,
             contested,
             archived,
+            file,
+            commit,
+            symbol,
         } => {
             let filter = build_recall_filter(
                 memory_type,
@@ -490,6 +504,7 @@ async fn run_client(
                 source,
                 contested,
                 archived,
+                collect_anchor_filters(file, commit, symbol),
             );
             let notes = client
                 .list_filtered(filter, limit)

--- a/docs/prds/2026-07-02-typed-code-anchors.md
+++ b/docs/prds/2026-07-02-typed-code-anchors.md
@@ -2,10 +2,23 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review. Today memories attach
-only to freeform `context`; the highest-value coding memories are decisions
-about *code locations*, and there is no structured, queryable link from a
-memory to a file/line/commit/symbol.
+Delivered 2026-07-11 (branch `claude/typed-code-anchors`). From the
+2026-07-02 senior-PM product review. Before this, memories attached only to
+freeform `context`; now a memory carries structured, queryable
+file/line/commit/symbol anchors.
+
+Delivery notes:
+
+- The anchor filter MODEL/wire plumbing shipped earlier with search-parity
+  (PR #58); this delivery replaced the three fail-fast stubs (engine, store,
+  client) with real evaluation.
+- Old-daemon compatibility: the daemon advertises an additive `anchors`
+  capability on the handshake ack. Typed clients and the MCP adapter fail
+  fast when anchors are used against a daemon that did not advertise it (a
+  pre-anchor daemon would silently drop/ignore them); the hook path stays
+  fail-open and stores the summary without anchors instead.
+- ANC-3's prompt-time recall BOOST is deferred with the ranking weights to
+  W4.1 evidence, per the Non-Goals/Risks sections (v1 = filter only).
 
 ## Owner Area
 
@@ -118,12 +131,12 @@ Plus a migration-reproducibility test against a populated v-prior fixture.
 
 ## Implementation Checklist
 
-- [ ] Add `memory_anchors` migration + type + decode.
-- [ ] Add anchor params to CLI/MCP `remember`.
-- [ ] Add anchor filters to recall (CLI/MCP).
-- [ ] Auto-anchor SessionEnd summaries to touched files.
-- [ ] Include anchors in `graph` and export/restore.
-- [ ] Migration-reproducibility + recall filter e2e tests.
+- [x] Add `memory_anchors` migration + type + decode.
+- [x] Add anchor params to CLI/MCP `remember`.
+- [x] Add anchor filters to recall (CLI/MCP).
+- [x] Auto-anchor SessionEnd summaries to touched files.
+- [x] Include anchors in `graph` and export/restore.
+- [x] Migration-reproducibility + recall filter e2e tests.
 
 ## Roadmap Fit
 

--- a/docs/prds/2026-07-02-typed-code-anchors.md
+++ b/docs/prds/2026-07-02-typed-code-anchors.md
@@ -84,9 +84,11 @@ per memory. Decoded by name in `row_to_note` with serde defaults (the
 
 - Recall filters: `--file <path>`, `--commit <sha>`, `--symbol <name>`
   (CLI + MCP), scoping candidates before ranking.
-- When the hook performs prompt-time recall (W3.2 channel a), an anchor
-  derived from the active file/context boosts anchor-matching memories (a
-  documented, bounded boost; exact weight deferred to W4.1).
+- DEFERRED (roadmap, not v1 — consistent with Non-Goals/Risks and the Status
+  note): when the hook performs prompt-time recall (W3.2 channel a), an
+  anchor derived from the active file/context boosts anchor-matching
+  memories (a documented, bounded boost). Ships with the W4.1
+  ranking-weight evidence; v1 delivers anchors as a filter only.
 
 ### ANC-4. Graph + provenance parity
 


### PR DESCRIPTION
Implements PRD `docs/prds/2026-07-02-typed-code-anchors.md` (Vikunja #464, PM-review Tier 2): first-class, structured, queryable links from a memory to a **file path (+ optional 1-based line range), commit SHA, or symbol** — replacing the three fail-fast anchor stubs PR #58 left in the engine, store, and client with real evaluation.

## What changed

### Data model + store
- **Additive `memory_anchors` migration (009)** — kind-split value columns (`path` for file anchors, `ref` for commit/symbol, pinned by CHECKs), no ALTER on `memories`, no backfill. Anchors load with the row in `row_to_note` (the `links` pattern) and insert in the same transaction, values stored **normalized** (`./src/a.rs` → `src/a.rs`).
- `list_filtered` evaluates anchor filters **inside the bounded SQL query** (one parameterized EXISTS per constraint, all-of like tags), pinned to `RecallFilter::matches` by a new drift test `anchor_filter_agrees_with_recall_filter_matches` (the `contested_filter_agrees_with_active_contradicts` precedent).
- `namespace rename` re-keys `memory_anchors.namespace` in the same transaction.

### Engine + filter semantics
- `RecallFilter::matches` now decides the anchors dimension from the note's own anchors (normalized on both sides; file filters match by **path** — line ranges never narrow a filter in v1). Anchor filters compose all-of with each other and with `--type`/`--tags`/`--min-importance` (PRD acceptance).
- `RememberInput.anchors`, validated fail-closed at the engine AND store boundaries (SQL CHECKs as backstop).

### Wire + old-daemon compat (the key design decision)
- Additive, serde-default fields only — **no CONTRACT_VERSION bump**: `Request::Remember.anchors`, `MemoryNote.anchors`, and `HandshakeAck.capabilities`.
- A **pre-anchor daemon would silently DROP `Remember.anchors` and (pre-parity) silently IGNORE anchor filters** — so the daemon now advertises an `anchors` capability on the handshake ack. Typed `Client` wrappers (`remember_anchored`, `recall_filtered_with_status`, `list_filtered`) and the MCP adapter's raw-request path fail fast with `InvalidArgument` when anchors are used against a daemon that did not advertise it; anchor-free calls degrade gracefully. Old clients ignore the additive ack field. The **hook path stays fail-open**: `DaemonClient` drops anchors (debug log) rather than losing a session summary to an old daemon.
- Compat pinned by tests in both directions: capability-less ack ⇒ local rejection + anchor-free calls still work; capability ack ⇒ anchors ride the wire (fake-server assertions); old frames without `anchors`/`capabilities` keys decode to defaults; empty values serialize to nothing (byte-identical pre-anchor shapes).

### Surfaces
- **CLI**: `remember --file src/foo.rs:12-40 --commit <sha> --symbol Foo::bar` (repeatable; garbage ranges like `a.rs:12-`, `a.rs:0`, overflow are clean parse errors — the `parse_time_bound` precedent); `recall`/`list` `--file/--commit/--symbol` filters (path only; a line range errors with guidance instead of silently widening/never matching). Anchors render on `get`/`list`/`graph` output, in markdown export, and **survive `export` → `restore`**.
- **MCP**: `remember` gains `files`/`commits`/`symbols`; `recall`/`list` gain `file`/`commit`/`symbol`. **Token budget arithmetic (W3.3 hard constraint)**: adding the params put the default `tools/list` at 994/900; existing descriptions in the default-advertised set were tightened (trigger-condition phrases pinned by tests kept intact) to land at **897/900**. The guard test is unweakened and the budget unchanged.
- **Hooks (ANC-2 auto-anchor)**: the SessionEnd/checkpoint fold anchors the summary to the touched-file union (scratch ∪ git), capped at the same limit as the summary's "Files touched" section, skipping unanchorable paths (fail-open). Asserted by hook e2e over a live mock daemon and by the OpenCode apply_patch integration test.

### Deferred (by PRD design)
- ANC-3's prompt-time recall **boost** is deferred with ranking weights to W4.1 evidence — the PRD's Non-Goals/Risks pin v1 as *filter only*.

## Contract guard
`memory_anchors` migration + wire additions recorded via `rb-contract-guard -- update --intent additive` (`[[log]]` entry in `contract-snapshot.toml`); `check` green: 30 wire items, 9 migrations, CONTRACT_VERSION 2.

## Test plan
- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace` ✓ (1464 passed, 9 ignored)
- `cargo deny check` ✓
- `cargo run -p rb-contract-guard -- check` ✓

Key new/updated tests:
- store: `anchors_round_trip_through_insert_get_and_get_many`, `anchor_filters_scope_by_kind_and_value`, `anchor_filters_compose_all_of_and_with_metadata`, `anchor_filter_agrees_with_recall_filter_matches` (drift), `rename_rekeys_anchor_namespace_and_anchor_filters_follow`, migration-reproducibility gate extended with populated anchors
- engine: `remember_persists_anchors_and_recall_filters_by_them` (PRD acceptance), `recall_composes_anchor_and_metadata_filters`, `remember_rejects_invalid_anchors_fail_closed`
- proto: `anchor_payloads_are_rejected_against_a_daemon_without_the_capability`, `anchor_payloads_flow_when_the_daemon_advertises_the_capability`, `handshake_ack_capabilities_are_additive_in_both_directions`, `remember_without_anchors_decodes_to_empty_and_empty_omits_the_key`
- daemon e2e: `recall_and_list_filters_flow_over_the_wire` extended with real anchored remember → anchored recall/list over a real socket (present under its file, absent under another), plus the old-frame raw-client check
- hooks: `session_end_auto_anchors_the_summary_to_touched_files` (PRD acceptance e2e), `session_file_anchors_mirror_the_listed_section_and_fail_open`, OpenCode apply_patch integration anchor assertion
- MCP: budget guard green at 897/900, recall/list filter-parity params extended, capture/filter parsing incl. fail-closed garbage tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed code anchors for files, commits, and symbols.
  * Use anchors with `remember`, `recall`, and `list` through the CLI and MCP tools.
  * Session summaries can automatically capture touched-file anchors.
  * Anchor filters support normalized paths, symbols, commits, and line ranges.
  * Anchors are displayed in human-readable output and preserved through export/import.

* **Compatibility**
  * Clients and daemons negotiate anchor support; older daemons safely store unanchored memories.

* **Documentation**
  * Updated release documentation and marked typed code anchors as delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review follow-up (d8c7e47)

### Anchor-filter index decision: semi-join, wide indexes kept (option a)
The review's MEDIUM finding was verified: the original correlated-EXISTS anchor probe never used `idx_memory_anchors_path`/`idx_memory_anchors_ref`. EXPLAIN QUERY PLAN on the real DDL at 100k memories / 5k anchors:

```
-- correlated EXISTS (before)
SCAN m
CORRELATED SCALAR SUBQUERY 1
  SEARCH a USING INDEX idx_memory_anchors_memory (memory_id=?)   -- ~20.1 ms/query

-- namespace-scoped IN semi-join (after)
SEARCH m USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
LIST SUBQUERY 1
  SEARCH a USING INDEX idx_memory_anchors_path (namespace=? AND kind=? AND path=?)  -- ~0.016 ms/query
```

Chosen on the evidence: anchors are the differentiator feature and "memories touching this file" is expected to be selective, so O(matching anchors) beats O(active memories) as stores grow (~1250x at 100k rows). The wide indexes now do the work their comments claim; their leading `namespace` column also serves `rename_namespace`'s re-key UPDATE (`SEARCH memory_anchors USING INDEX ... (namespace=?)`), so no extra index is needed. Pinned in-repo by `anchor_filters_probe_the_wide_anchor_indexes`, which EXPLAINs the exact query `list_filtered` executes (via the extracted `build_list_filtered_query`) and asserts the index per anchor kind; `anchor_filter_agrees_with_recall_filter_matches` still pins SQL ↔ `matches` semantics. Migration 009's index comments were corrected to the true access paths (comment-only; recorded as an additive snapshot entry — schema unchanged).

### Duplicate anchors
Exact duplicates (post-normalization, including the line range) now collapse to one row at `insert_memory` — repeated CLI flags / `--batch` fan-out no longer accumulate copies. Rust-side dedup rather than a UNIQUE constraint because SQLite treats the NULL `path`/`ref`/line columns as pairwise distinct, so a UNIQUE index could never fire for commit/symbol or line-less file anchors. First-seen order preserved; test: `duplicate_anchors_collapse_to_one_row`.

### Precision note on migration testing
The migration-reproducibility gate builds a **fresh** DB from the committed migrations and exercises every query path incl. populated anchors (the 008 precedent). It is not a populated pre-009-then-upgrade replay: 009 is purely additive — a new table with zero `ALTER`/backfill on existing rows — so there is no pre-existing-data transformation to replay; pre-anchor rows simply load an empty anchor list (asserted in the gate).
