### PR TITLE
feat: decision history and audit timeline (rusty-brain history)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,13 +93,18 @@ All notable changes to rusty-brain are documented here. The format is based on
   existing rows (`memories.superseded_by` + `memory_links`): no schema change,
   no new persistence, and the whole path runs on the daemon's READ pool —
   zero writer ops (W1.8), asserted at the StoreHandle level and over a real
-  socket. Cycles in user-creatable link data cannot hang the walk (visited
-  set + server depth clamp of 100 hops per direction; edge list capped at
-  200), and traversal never crosses namespaces (both chain hops and both
-  edge endpoints are namespace-scoped, the `active_contradicts` rigor).
+  socket. Each direction is one bounded recursive CTE (the `graph_neighbors`
+  shape), walked independently so an ancestor entering a supersede cycle is
+  still found; cycles in user-creatable data cannot hang the walk (SQL hop
+  bound + `MIN(hop)` dedup; server depth clamp of 100 hops per direction,
+  chain membership and edge list each capped at 200, with exact
+  depth-truncation reporting), and traversal never crosses namespaces (both
+  chain hops and both edge endpoints are namespace-scoped, the
+  `active_contradicts` rigor). A corrupt out-of-band `importance` fails
+  closed instead of decoding as 0.
 - **Additive wire op `Request::History`/`Response::History`** with
   `rb_types::{MemoryHistory, HistoryEntry, HistoryEdge}` payloads — every
-  field serde-default, no `CONTRACT_VERSION` bump (recorded in the
+  top-level field serde-default, no `CONTRACT_VERSION` bump (recorded in the
   contract-drift snapshot as an additive decision).
 - **MCP `history` tool (full-toolset-gated)**: exposed only under
   `RB_MCP_FULL_TOOLSET` per HIST-3, so the default `tools/list` token budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,29 @@ All notable changes to rusty-brain are documented here. The format is based on
   an absent `dry_run` decodes to a preview (never an execute). Deliberately
   NO MCP tool: a destructive surface stays off the model-facing toolset.
 
+### Added — Decision history and audit timeline (PRD 2026-07-02)
+
+- **`rusty-brain history <id>` (+ `--depth`, `--json`)**: read-only timeline of
+  a memory's evolution — the supersede chain in BOTH directions (prior and
+  newer versions, oldest first) plus active `contradicts`/`extends`/
+  `references` edges, each hop carrying summary, importance, confidence,
+  created-at age, and `origin_*` provenance, with `current`/`superseded`/
+  `contested` markers and a current-truth pointer. Derived entirely from
+  existing rows (`memories.superseded_by` + `memory_links`): no schema change,
+  no new persistence, and the whole path runs on the daemon's READ pool —
+  zero writer ops (W1.8), asserted at the StoreHandle level and over a real
+  socket. Cycles in user-creatable link data cannot hang the walk (visited
+  set + server depth clamp of 100 hops per direction; edge list capped at
+  200), and traversal never crosses namespaces (both chain hops and both
+  edge endpoints are namespace-scoped, the `active_contradicts` rigor).
+- **Additive wire op `Request::History`/`Response::History`** with
+  `rb_types::{MemoryHistory, HistoryEntry, HistoryEdge}` payloads — every
+  field serde-default, no `CONTRACT_VERSION` bump (recorded in the
+  contract-drift snapshot as an additive decision).
+- **MCP `history` tool (full-toolset-gated)**: exposed only under
+  `RB_MCP_FULL_TOOLSET` per HIST-3, so the default `tools/list` token budget
+  is unchanged; the tool remains routable when called directly.
+
 ### Added — Contract-drift guard (W5a.4 operationalized)
 
 - **`rb-contract-guard` + `contract-drift` CI job**: the wire surface

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ rusty-brain context
 rusty-brain update <id> --confidence 0.3
 rusty-brain link <from-id> <to-id> --type contradicts --reason "policy reversed"
 
+# audit how a decision evolved: the supersede chain in both directions plus
+# active contradicts/extends/references links, with current/superseded/
+# contested markers (read-only, zero writer ops)
+rusty-brain history <id>
+rusty-brain history <id> --depth 3 --json
+
 # retroactively redact secrets from every stored memory, then re-embed
 rusty-brain scrub
 rusty-brain reembed
@@ -254,11 +260,12 @@ MCP-capable agent at it as a stdio server, for example:
 }
 ```
 
-It exposes eleven tools: `remember`, `recall`, `get`, `list`, `graph`, `update`,
+It exposes twelve tools: `remember`, `recall`, `get`, `list`, `graph`, `update`,
 `link` (e.g. mark one memory as contradicting another), `delete`, `context`,
 `memory_feedback` (report whether a recalled memory was `helpful`/`wrong`/`stale`,
-nudging its trust prior), and `poll_changes` (drains buffered change
-notifications).
+nudging its trust prior), `history` (a memory's decision-history timeline:
+supersede chain + active contradiction links), and `poll_changes` (drains
+buffered change notifications).
 
 ### Capture hooks (optional)
 

--- a/README.md
+++ b/README.md
@@ -260,12 +260,15 @@ MCP-capable agent at it as a stdio server, for example:
 }
 ```
 
-It exposes twelve tools: `remember`, `recall`, `get`, `list`, `graph`, `update`,
-`link` (e.g. mark one memory as contradicting another), `delete`, `context`,
-`memory_feedback` (report whether a recalled memory was `helpful`/`wrong`/`stale`,
-nudging its trust prior), `history` (a memory's decision-history timeline:
-supersede chain + active contradiction links), and `poll_changes` (drains
-buffered change notifications).
+It implements twelve tools. By default `tools/list` advertises the six-tool
+token-economy subset the model pays for every turn: `remember`, `recall`,
+`get`, `context`, `update`, and `memory_feedback` (report whether a recalled
+memory was `helpful`/`wrong`/`stale`, nudging its trust prior). The remaining
+six — `list`, `graph`, `link` (e.g. mark one memory as contradicting another),
+`delete`, `history` (a memory's decision-history timeline: supersede chain +
+active contradiction links), and `poll_changes` (drains buffered change
+notifications) — are advertised only when `RB_MCP_FULL_TOOLSET` is set, though
+every tool stays routable when called directly.
 
 ### Capture hooks (optional)
 

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -11,12 +11,15 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
-"crates/rb-proto/src/messages.rs::Request" = "31921c2123297d490a311e24dba44df8d7ab76eccf7881e8461984ff0392ef00"
-"crates/rb-proto/src/messages.rs::Response" = "9c284452e2f0464eee8e3a865903273c429a6755ee0dd80f55f889757e675700"
+"crates/rb-proto/src/messages.rs::Request" = "af5a8ce05ce48088d2e862964f847e1a243095ed58c2cc53c41c1d920fefa870"
+"crates/rb-proto/src/messages.rs::Response" = "267061d0c21b7a996d9be0c70f7f753ec2c71859dcb055981a3b8ba80d98b341"
 "crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
 "crates/rb-types/src/feedback_kind.rs::FeedbackKind" = "8ca2edbd8aca8e2b087ea630e10209a51a307efdf1a84b0bbccc74a06f2da7b6"
+"crates/rb-types/src/history.rs::HistoryEdge" = "2eeaea0b396c0c0e1b4fc9d88088f34c3d701115e0d3af739b335f057c656195"
+"crates/rb-types/src/history.rs::HistoryEntry" = "01c147087fa036cb389172d86036870275dc164578edb7320666e003f3fc6abc"
+"crates/rb-types/src/history.rs::MemoryHistory" = "f87b10e75c2fbf835a6f3d1bec9d36235ec785942af85ab2241edb3ca3ddc6e1"
 "crates/rb-types/src/job.rs::JobKind" = "3a57cc7d386b30a18c67877d0e822f778a36659a4bba51dc314720dd3c84d243"
 "crates/rb-types/src/link.rs::MemoryLink" = "7e1c5377ec99d7e609c289b14fed82fa2a2c5275650bb688ea1afbe03fb37f4d"
 "crates/rb-types/src/link_type.rs::LinkType" = "2394c0b6dc86235d55ce3e3bb9b7d5d8b058672f07b1e57532930e897ca644f2"
@@ -83,3 +86,8 @@ note = "PR #59 review: migration 009 comment-only fix — index docs now describ
 contract_version = 2
 intent = "additive"
 note = "PR #60 retention/forget: Request::Forget + retention payloads (no bump, additive per W5a.4)"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR #61 decision history timeline: Request/Response::History + rb-types history payloads (no bump, additive per W5a.4)"

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -56,6 +56,14 @@ const STATS_DEFAULT_WINDOW_DAYS: u32 = 30;
 const STATS_MAX_WINDOW_DAYS: u32 = 365;
 /// Bound on the top-recalled id list in a stats reply (ids + counts only).
 const STATS_TOP_RECALLED_LIMIT: usize = 5;
+/// Hard cap on the history chain walk PER DIRECTION (PRD HIST-3: "default
+/// unbounded but capped by an internal safety limit" — an absent depth uses
+/// this cap, and a client cannot exceed it). Also the cycle-defense backstop
+/// alongside the store's visited set.
+const HISTORY_MAX_DEPTH: u32 = 100;
+/// Hard cap on the edge list in a history reply, so a heavily linked chain
+/// cannot balloon one response (the stats window-clamp convention).
+const HISTORY_EDGE_LIMIT: usize = 200;
 /// Maximum number of simultaneous client connections.
 const MAX_CONNECTIONS: usize = 256;
 /// Oplog rows fetched per replay batch on a `subscribe --since` reconnect.
@@ -614,6 +622,7 @@ fn is_admin_op(req: &Request) -> bool {
         | Request::Context
         | Request::Subscribe { .. }
         | Request::Stats { .. }
+        | Request::History { .. }
         | Request::Ping => false,
     }
 }
@@ -1188,6 +1197,23 @@ where
                 }
             }
         }
+        // Namespace-scoped read-only decision-history timeline (PRD
+        // 2026-07-02). Runs entirely on the read pool — zero writer ops
+        // (W1.8). The depth is clamped server-side (never trusted raw) and
+        // the edge list is capped; namespace purity (both chain hops and edge
+        // endpoints) is enforced inside the store query.
+        Request::History { id, depth } => {
+            let depth = depth
+                .unwrap_or(HISTORY_MAX_DEPTH)
+                .clamp(1, HISTORY_MAX_DEPTH);
+            match job_store
+                .memory_history(namespace.clone(), id, depth, HISTORY_EDGE_LIMIT)
+                .await
+            {
+                Ok(history) => Response::History { history },
+                Err(e) => error_to_response(e),
+            }
+        }
         // Admin op (peer-gated above): retroactive secret redaction across all
         // namespaces through the single writer (W2.4).
         Request::Scrub => match job_store.scrub().await {
@@ -1264,6 +1290,12 @@ mod tests {
                 policy: rb_types::RetentionPolicy::default(),
                 mode: rb_types::ForgetMode::Hard,
                 dry_run: true,
+            },
+            // History is namespace-scoped and read-only too (PRD 2026-07-02),
+            // like Get/Stats — deliberately NOT peer-gated.
+            Request::History {
+                id: rb_types::MemoryId::new(),
+                depth: None,
             },
         ] {
             assert!(!is_admin_op(&not_admin), "{not_admin:?}");
@@ -1560,6 +1592,162 @@ mod tests {
         );
         let (defaulted, _, _) = client.stats(None).await.unwrap();
         assert_eq!(defaulted.window_days, 30, "absent window uses the default");
+
+        drop(client);
+        let _ = shutdown_tx.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(10), run)
+            .await
+            .expect("daemon must shut down")
+            .expect("run task must not panic")
+            .expect("run must return Ok");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn history_over_the_wire_walks_the_chain_and_issues_zero_writer_ops() {
+        // Daemon e2e for the decision-history PRD verification clause: a
+        // 3-deep supersede chain (A -> B -> C) plus a contradiction on the
+        // head comes back through `Request::History` as the rendered
+        // timeline, and serving it enqueues NOTHING on the writer thread.
+        use rb_embed::DeterministicProvider;
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let config = DaemonConfig {
+            socket_path: dir.path().join("rb.sock"),
+            db_path: dir.path().join("rb.db"),
+            read_pool_size: 2,
+            jobs_config: JobsConfig::default(),
+            request_idle_timeout: None,
+            enrich: None,
+            fusion_mode: rb_engine::FusionMode::Linear,
+            retention_policy: None,
+        };
+        let socket = config.socket_path.clone();
+        let daemon = Daemon::bind(
+            config,
+            crate::SharedEmbedder::new(DeterministicProvider::new(8)),
+        )
+        .await
+        .unwrap();
+        let store = daemon.store.clone();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let run = tokio::spawn(daemon.run(async {
+            let _ = shutdown_rx.await;
+        }));
+
+        let ns = Namespace::Project("history-e2e".to_string());
+        let mut client = rb_proto::Client::connect(&socket, ns.clone())
+            .await
+            .unwrap();
+        let a = client
+            .remember(
+                "decision v1".to_string(),
+                None,
+                rb_types::MemoryType::ArchitectureDecision,
+                7,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            )
+            .await
+            .unwrap();
+        // B supersedes A, C supersedes B (the W3.1 update-as-supersede path).
+        let b = client
+            .remember_superseding(
+                "decision v2".to_string(),
+                None,
+                rb_types::MemoryType::ArchitectureDecision,
+                7,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                a.clone(),
+            )
+            .await
+            .unwrap();
+        let c = client
+            .remember_superseding(
+                "decision v3".to_string(),
+                None,
+                rb_types::MemoryType::ArchitectureDecision,
+                7,
+                vec![],
+                vec![],
+                vec![],
+                None,
+                b.clone(),
+            )
+            .await
+            .unwrap();
+        let rival = client
+            .remember(
+                "rival claim".to_string(),
+                None,
+                rb_types::MemoryType::Insight,
+                5,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            )
+            .await
+            .unwrap();
+        client
+            .link(
+                rival.clone(),
+                c.clone(),
+                rb_types::LinkType::Contradicts,
+                Some("disputes v3".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let ops_before = store.writer_ops_count();
+        let history = client.history(c.clone(), None).await.unwrap();
+        assert_eq!(
+            store.writer_ops_count(),
+            ops_before,
+            "the history path must issue ZERO writer ops (and hence zero FTS writes)"
+        );
+
+        // Acceptance criteria: `history C` lists A -> B -> C with C flagged
+        // current and A/B flagged superseded (archived).
+        assert_eq!(history.namespace, ns.as_db_string());
+        assert_eq!(history.depth, 100, "absent depth uses the safety cap");
+        let ids: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
+        assert_eq!(
+            ids,
+            vec![a.to_string(), b.to_string(), c.to_string()],
+            "oldest first: A -> B -> C"
+        );
+        assert!(history.chain[0].archived && history.chain[1].archived);
+        assert!(history.chain[2].current && history.chain[2].is_target);
+        assert!(!history.truncated);
+        // The contradicts edge appears with the far memory's summary and the
+        // contested marker on the head.
+        assert!(history.chain[2].contested, "the head is contested");
+        assert_eq!(history.edges.len(), 1);
+        assert_eq!(history.edges[0].other.to_string(), rival.to_string());
+        assert_eq!(history.edges[0].reason, "disputes v3");
+        assert_eq!(history.edges[0].other_summary, "rival claim");
+
+        // The depth is clamped server-side, never trusted raw.
+        let clamped = client.history(c.clone(), Some(100_000)).await.unwrap();
+        assert_eq!(clamped.depth, 100, "oversized depth clamps to the cap");
+        let bounded = client.history(c.clone(), Some(1)).await.unwrap();
+        assert_eq!(bounded.chain.len(), 2, "depth 1 keeps one ancestor hop");
+        assert!(bounded.truncated);
+
+        // A missing id errors cleanly: the daemon maps NotFound to the stable
+        // `not_found` wire kind with the message preserved (the client
+        // reconstructs unstructured kinds under Storage — the Get precedent).
+        let err = client
+            .history(rb_types::MemoryId::new(), None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"), "{err:?}");
 
         drop(client);
         let _ = shutdown_tx.send(());

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -61,6 +61,10 @@ const STATS_TOP_RECALLED_LIMIT: usize = 5;
 /// this cap, and a client cannot exceed it). Also the cycle-defense backstop
 /// alongside the store's visited set.
 const HISTORY_MAX_DEPTH: u32 = 100;
+/// Hard cap on TOTAL chain members in a history reply. Depth bounds hops, not
+/// width: near-dup fan-in can point many predecessors at one id, so one hop
+/// could otherwise balloon the response. Overflow is reported via `truncated`.
+const HISTORY_CHAIN_LIMIT: usize = 200;
 /// Hard cap on the edge list in a history reply, so a heavily linked chain
 /// cannot balloon one response (the stats window-clamp convention).
 const HISTORY_EDGE_LIMIT: usize = 200;
@@ -1200,14 +1204,20 @@ where
         // Namespace-scoped read-only decision-history timeline (PRD
         // 2026-07-02). Runs entirely on the read pool — zero writer ops
         // (W1.8). The depth is clamped server-side (never trusted raw) and
-        // the edge list is capped; namespace purity (both chain hops and edge
-        // endpoints) is enforced inside the store query.
+        // the chain/edge lists are capped; namespace purity (both chain hops
+        // and edge endpoints) is enforced inside the store query.
         Request::History { id, depth } => {
             let depth = depth
                 .unwrap_or(HISTORY_MAX_DEPTH)
                 .clamp(1, HISTORY_MAX_DEPTH);
             match job_store
-                .memory_history(namespace.clone(), id, depth, HISTORY_EDGE_LIMIT)
+                .memory_history(
+                    namespace.clone(),
+                    id,
+                    depth,
+                    HISTORY_CHAIN_LIMIT,
+                    HISTORY_EDGE_LIMIT,
+                )
                 .await
             {
                 Ok(history) => Response::History { history },

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -522,6 +522,22 @@ impl StoreHandle {
         .await
     }
 
+    /// Decision-history timeline for one memory (PRD 2026-07-02). Goes
+    /// through the bounded read pool — the history path issues zero writer
+    /// ops (W1.8) by construction. `depth` bounds the chain walk per
+    /// direction and `edge_limit` the edge list (both pre-clamped by the
+    /// caller); namespace purity is enforced inside the store query.
+    pub async fn memory_history(
+        &self,
+        namespace: Namespace,
+        id: MemoryId,
+        depth: u32,
+        edge_limit: usize,
+    ) -> Result<rb_types::MemoryHistory> {
+        self.with_read(move |store| store.memory_history(&namespace, &id, depth, edge_limit))
+            .await
+    }
+
     /// Whether the writer thread is alive (i.e. has not died ABNORMALLY).
     /// Snapshot of the same watch [`StoreHandle::writer_died`] resolves on;
     /// surfaced on the stats/status path so a zombie-adjacent state is visible.
@@ -2858,6 +2874,62 @@ mod tests {
         assert_eq!(stats.feedback.helpful, 1);
         assert_eq!(stats.feedback.wrong, 1);
         assert_eq!(stats.feedback.stale, 1);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_history_runs_on_the_read_pool_with_zero_writer_ops() {
+        // W1.8 mirror for the history path (decision-history PRD hard
+        // constraint): the whole chain+edge derivation runs on the read pool
+        // and must enqueue NOTHING on the writer thread — which also proves
+        // it triggers zero FTS writes (every FTS write rides a writer op).
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("zero-writer-history".to_string());
+
+        let old = note(&ns, "old decision");
+        let new = note(&ns, "replacement decision");
+        let rival = note(&ns, "rival claim");
+        let (old_id, new_id, rival_id) = (old.id.clone(), new.id.clone(), rival.id.clone());
+        handle.write(old, Some(vec![0.1f32; DIM])).await.unwrap();
+        handle.write(new, Some(vec![0.2f32; DIM])).await.unwrap();
+        handle.write(rival, Some(vec![0.3f32; DIM])).await.unwrap();
+        handle
+            .supersede(ns.clone(), old_id.clone(), new_id.clone())
+            .await
+            .unwrap();
+        handle
+            .add_link(rb_types::MemoryLink {
+                source_id: rival_id.clone(),
+                target_id: new_id.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 1.0,
+                reason: "disagrees".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let ops_before = handle.writer_ops_count();
+        let history = handle
+            .memory_history(ns.clone(), new_id.clone(), 100, 200)
+            .await
+            .unwrap();
+        assert_eq!(
+            handle.writer_ops_count(),
+            ops_before,
+            "history must issue ZERO writer-thread ops (W1.8)"
+        );
+
+        assert_eq!(history.namespace, ns.as_db_string());
+        assert_eq!(history.chain.len(), 2, "old -> new chain");
+        assert_eq!(history.chain[0].id, old_id);
+        assert_eq!(history.chain[1].id, new_id);
+        assert!(history.chain[1].current && history.chain[1].contested);
+        assert_eq!(history.edges.len(), 1);
+        assert_eq!(history.edges[0].other, rival_id);
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -525,17 +525,21 @@ impl StoreHandle {
     /// Decision-history timeline for one memory (PRD 2026-07-02). Goes
     /// through the bounded read pool — the history path issues zero writer
     /// ops (W1.8) by construction. `depth` bounds the chain walk per
-    /// direction and `edge_limit` the edge list (both pre-clamped by the
-    /// caller); namespace purity is enforced inside the store query.
+    /// direction, `chain_limit` the total chain membership, and `edge_limit`
+    /// the edge list (all pre-clamped by the caller); namespace purity is
+    /// enforced inside the store query.
     pub async fn memory_history(
         &self,
         namespace: Namespace,
         id: MemoryId,
         depth: u32,
+        chain_limit: usize,
         edge_limit: usize,
     ) -> Result<rb_types::MemoryHistory> {
-        self.with_read(move |store| store.memory_history(&namespace, &id, depth, edge_limit))
-            .await
+        self.with_read(move |store| {
+            store.memory_history(&namespace, &id, depth, chain_limit, edge_limit)
+        })
+        .await
     }
 
     /// Whether the writer thread is alive (i.e. has not died ABNORMALLY).
@@ -2914,7 +2918,7 @@ mod tests {
 
         let ops_before = handle.writer_ops_count();
         let history = handle
-            .memory_history(ns.clone(), new_id.clone(), 100, 200)
+            .memory_history(ns.clone(), new_id.clone(), 100, 200, 200)
             .await
             .unwrap();
         assert_eq!(

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -350,6 +350,14 @@ pub fn build_request(name: &str, args: &Value) -> Result<Request, ToolError> {
         "delete" => Ok(Request::Delete {
             id: parse_id(args)?,
         }),
+        // Full-toolset-gated (PRD 2026-07-02 decision history): not in the
+        // default advertised set, but ROUTABLE like every gated tool.
+        "history" => Ok(Request::History {
+            id: parse_id(args)?,
+            // The daemon clamps to its safety cap; opt_u8's 0..=255 range is
+            // ample (the cap is 100) and matches the `graph.depth` parsing.
+            depth: opt_u8(args, "depth")?.map(u32::from),
+        }),
         "context" => Ok(Request::Context),
         "memory_feedback" => {
             let id = parse_id(args)?;
@@ -635,6 +643,10 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
         // mapping stays total.
         Response::ForgetPlanned { plan } => ToolContent::json(json!({ "plan": plan }), false),
         Response::ForgetDone { outcome } => ToolContent::json(json!({ "outcome": outcome }), false),
+        // The decision-history timeline (full-toolset-gated `history` tool):
+        // the model fetched it deliberately, so keep the full JSON as text
+        // (the `get` convention).
+        Response::History { history } => ToolContent::json(json!({ "history": history }), false),
         Response::Error { kind, message } => ToolContent::json(
             json!({ "error": { "kind": kind, "message": message } }),
             true,
@@ -955,6 +967,74 @@ mod tests {
         }
         let d = build_request("delete", &json!({ "id": id.to_string() })).unwrap();
         assert!(matches!(d, Request::Delete { .. }));
+    }
+
+    #[test]
+    fn build_history_parses_id_and_optional_depth() {
+        let id = MemoryId::new();
+        let h = build_request("history", &json!({ "id": id.to_string() })).unwrap();
+        match h {
+            Request::History { id: got, depth } => {
+                assert_eq!(got, id);
+                assert_eq!(depth, None, "absent depth defers to the daemon cap");
+            }
+            other => panic!("expected History, got {other:?}"),
+        }
+        let h = build_request("history", &json!({ "id": id.to_string(), "depth": 3 })).unwrap();
+        match h {
+            Request::History { depth, .. } => assert_eq!(depth, Some(3)),
+            other => panic!("expected History, got {other:?}"),
+        }
+        // Bad ids and non-numeric depths fail closed with INVALID_PARAMS.
+        let err = build_request("history", &json!({ "id": "not-a-uuid" })).unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::INVALID_PARAMS);
+        let err = build_request("history", &json!({ "id": id.to_string(), "depth": "deep" }))
+            .unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::INVALID_PARAMS);
+        let err = build_request("history", &json!({})).unwrap_err();
+        assert_eq!(err.code, crate::jsonrpc::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn history_response_projects_structured_json() {
+        use rb_proto::Response;
+        let id = MemoryId::new();
+        let content = response_to_content(
+            Response::History {
+                history: rb_types::MemoryHistory {
+                    namespace: "project:p".to_string(),
+                    depth: 100,
+                    chain: vec![rb_types::HistoryEntry {
+                        id: id.clone(),
+                        summary: "we use kafka".to_string(),
+                        importance: 7,
+                        confidence: 0.9,
+                        created_at: Utc::now(),
+                        archived: false,
+                        contested: true,
+                        current: true,
+                        is_target: true,
+                        superseded_by: None,
+                        origin_user: None,
+                        origin_host: None,
+                        origin_agent: None,
+                        origin_source: None,
+                    }],
+                    edges: Vec::new(),
+                    truncated: false,
+                },
+            },
+            Utc::now(),
+        );
+        assert!(!content.is_error);
+        assert_eq!(
+            content.structured["history"]["chain"][0]["id"],
+            id.to_string()
+        );
+        assert_eq!(content.structured["history"]["chain"][0]["current"], true);
+        // Like `get`, the model text is the JSON itself (deliberate fetch).
+        let text: serde_json::Value = serde_json::from_str(&content.text).unwrap();
+        assert_eq!(text["history"]["depth"], 100);
     }
 
     #[test]

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -328,6 +328,32 @@ mod tests {
                 Request::Forget { .. } => Response::ForgetPlanned {
                     plan: rb_types::ForgetPlan::default(),
                 },
+                // The `history` tool maps here (full-toolset-gated); echo the
+                // requested id so dispatch tests can assert the payload.
+                Request::History { ref id, .. } => Response::History {
+                    history: rb_types::MemoryHistory {
+                        namespace: "project:p".to_string(),
+                        depth: 100,
+                        chain: vec![rb_types::HistoryEntry {
+                            id: id.clone(),
+                            summary: "current decision".to_string(),
+                            importance: 6,
+                            confidence: 1.0,
+                            created_at: chrono::Utc::now(),
+                            archived: false,
+                            contested: false,
+                            current: true,
+                            is_target: true,
+                            superseded_by: None,
+                            origin_user: None,
+                            origin_host: None,
+                            origin_agent: None,
+                            origin_source: None,
+                        }],
+                        edges: Vec::new(),
+                        truncated: false,
+                    },
+                },
                 // No MCP tool maps to the stats observability op; the arm
                 // exists only to keep this fake total over `Request`.
                 Request::Stats { .. } => Response::Stats {

--- a/crates/rb-mcp/src/tools.rs
+++ b/crates/rb-mcp/src/tools.rs
@@ -29,10 +29,10 @@ fn memory_type_enum() -> Value {
 }
 
 /// The default tools advertised to the model (W3.3 token economy). The rest —
-/// `list`, `graph`, `link`, `delete`, `poll_changes` — are gated behind
-/// `RB_MCP_FULL_TOOLSET` so the per-turn `tools/list` the model pays for stays
-/// small. (All tools remain ROUTABLE if called; gating only trims the advertised
-/// set.)
+/// `list`, `graph`, `link`, `delete`, `history`, `poll_changes` — are gated
+/// behind `RB_MCP_FULL_TOOLSET` so the per-turn `tools/list` the model pays for
+/// stays small. (All tools remain ROUTABLE if called; gating only trims the
+/// advertised set.)
 ///
 /// Single source of truth for the default advertised set: the installer's
 /// `permissions.allow` allowlist (rb-install) is drift-tested against this, so
@@ -288,6 +288,24 @@ pub fn tool_definitions() -> Vec<ToolDef> {
             }),
         },
         ToolDef {
+            name: "history",
+            description: "Decision-history timeline for a memory: its supersede chain \
+                          (prior and newer versions) plus active contradicts/extends/\
+                          references links, with a current-truth pointer and \
+                          archived/contested flags. Read-only. Use to audit how a \
+                          decision evolved before trusting or changing it.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "Memory id (UUID)." },
+                    "depth": { "type": "integer", "minimum": 1,
+                               "description": "Max supersede hops per direction \
+                                               (default: server cap)." }
+                },
+                "required": ["id"]
+            }),
+        },
+        ToolDef {
             name: "poll_changes",
             description: "Drain buffered change notifications for the current \
                           namespace since the last poll. Returns up to `max` events, \
@@ -313,7 +331,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn exposes_exactly_the_eleven_tools() {
+    fn exposes_exactly_the_twelve_tools() {
         let names: BTreeSet<&str> = tool_definitions().iter().map(|t| t.name).collect();
         let expected: BTreeSet<&str> = [
             "remember",
@@ -327,14 +345,39 @@ mod tests {
             "context",
             "memory_feedback",
             "poll_changes",
+            "history",
         ]
         .into_iter()
         .collect();
         assert_eq!(
             names, expected,
-            "tool set must be the 8 spine tools + link + memory_feedback + poll_changes"
+            "tool set must be the 8 spine tools + link + memory_feedback + \
+             poll_changes + history"
         );
-        assert_eq!(tool_definitions().len(), 11);
+        assert_eq!(tool_definitions().len(), 12);
+    }
+
+    #[test]
+    fn history_is_gated_out_of_the_default_toolset() {
+        // PRD 2026-07-02 HIST-3: the history tool is full-toolset-gated so the
+        // default tools/list the model pays for every turn is unchanged.
+        assert!(!DEFAULT_TOOLS.contains(&"history"));
+        let default: Vec<&str> = advertised_tool_definitions_for(false)
+            .iter()
+            .map(|t| t.name)
+            .collect();
+        assert!(!default.contains(&"history"), "{default:?}");
+        let full: Vec<&str> = advertised_tool_definitions_for(true)
+            .iter()
+            .map(|t| t.name)
+            .collect();
+        assert!(full.contains(&"history"), "{full:?}");
+        // The gated tool requires only the id; depth stays optional.
+        let t = tool_definitions()
+            .into_iter()
+            .find(|t| t.name == "history")
+            .unwrap();
+        assert_eq!(t.input_schema["required"][0], "id");
     }
 
     #[test]

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -672,6 +672,25 @@ impl Client {
         }
     }
 
+    /// Decision-history timeline for one memory (PRD 2026-07-02): the
+    /// supersede chain in both directions plus active
+    /// contradicts/extends/references edges, scoped to this connection's
+    /// namespace. `depth` bounds the chain walk per direction (`None` =
+    /// daemon safety cap). Read-only server-side: the history path issues
+    /// zero writer ops (W1.8). A missing (or foreign-namespace) id is
+    /// `Error::NotFound`.
+    pub async fn history(
+        &mut self,
+        id: rb_types::MemoryId,
+        depth: Option<u32>,
+    ) -> Result<rb_types::MemoryHistory> {
+        let resp = self.request(Request::History { id, depth }).await?;
+        match resp {
+            Resp::History { history } => Ok(history),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
     /// One-time namespace rename (W0.3 carryover): re-scope every memory from
     /// `old` to `new` in one daemon writer transaction. Refused with
     /// `Error::InvalidArgument` when `new` already has rows unless `merge` is
@@ -1067,7 +1086,6 @@ mod wrapper_tests {
                     provider_model: "deterministic".to_string(),
                     writer_alive: true,
                 },
-
                 // Canned payloads keyed on dry_run/mode so the typed-wrapper
                 // test can prove both flags ride the wire.
                 Request::Forget {
@@ -1096,6 +1114,32 @@ mod wrapper_tests {
                         }
                     }
                 }
+                // Canned payload echoing `id` and keyed on `depth` so the
+                // typed-wrapper test can prove both ride the wire.
+                Request::History { id, depth } => Response::History {
+                    history: rb_types::MemoryHistory {
+                        namespace: "global".to_string(),
+                        depth: depth.unwrap_or(100),
+                        chain: vec![rb_types::HistoryEntry {
+                            id,
+                            summary: "canned".to_string(),
+                            importance: 5,
+                            confidence: 1.0,
+                            created_at: chrono::Utc::now(),
+                            archived: false,
+                            contested: false,
+                            current: true,
+                            is_target: true,
+                            superseded_by: None,
+                            origin_user: None,
+                            origin_host: None,
+                            origin_agent: None,
+                            origin_source: None,
+                        }],
+                        edges: Vec::new(),
+                        truncated: false,
+                    },
+                },
             };
             write_frame(&mut framed, &resp).await.unwrap();
         }
@@ -1471,6 +1515,16 @@ mod wrapper_tests {
         assert!(writer_alive);
         let (stats, _, _) = c.stats(None).await.unwrap();
         assert_eq!(stats.window_days, 30, "None uses the daemon default");
+
+        // The fake server echoes the id and depth into the payload, proving
+        // both ride the wire and the timeline comes back typed.
+        let history = c.history(fixed_id.clone(), Some(3)).await.unwrap();
+        assert_eq!(history.depth, 3);
+        assert_eq!(history.chain.len(), 1);
+        assert_eq!(history.chain[0].id, fixed_id);
+        assert!(history.chain[0].is_target && history.chain[0].current);
+        let history = c.history(fixed_id.clone(), None).await.unwrap();
+        assert_eq!(history.depth, 100, "None uses the daemon safety cap");
 
         drop(c);
         server.await.unwrap();

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -266,6 +266,22 @@ pub enum Request {
         #[serde(default = "default_forget_dry_run")]
         dry_run: bool,
     },
+    /// Decision-history timeline for one memory (PRD 2026-07-02): the
+    /// supersede chain in both directions plus active
+    /// contradicts/extends/references edges, derived entirely from existing
+    /// rows. Scoped to the connection's handshake namespace like `Get`/`Stats`
+    /// (NOT an admin op); computed on the daemon's read pool — the history
+    /// path issues ZERO writer ops (W1.8). `depth` bounds the chain walk per
+    /// direction; `None` uses the daemon's safety cap. Additive variant per
+    /// the `Stats` precedent: an old daemon fails to decode it and closes the
+    /// connection (no CONTRACT_VERSION bump), and the
+    /// `#[serde(default)]`/`skip_serializing_if` pair keeps a depth-less frame
+    /// minimal.
+    History {
+        id: MemoryId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        depth: Option<u32>,
+    },
 }
 
 /// An absent `dry_run` on the wire must PREVIEW, never execute.
@@ -406,6 +422,13 @@ pub enum Response {
     /// Additive variant; old clients never see it.
     ForgetDone {
         outcome: rb_types::ForgetOutcome,
+    },
+    /// Reply to `Request::History`: the derived decision-history timeline.
+    /// Every payload field is `#[serde(default)]` (the `MemoryStats`
+    /// precedent) so the shape stays additive. Additive variant; old clients
+    /// never see it because they never send the request.
+    History {
+        history: rb_types::MemoryHistory,
     },
     Error {
         kind: String,
@@ -894,6 +917,14 @@ mod tests {
             Request::Stats {
                 window_days: Some(14),
             },
+            Request::History {
+                id: MemoryId::new(),
+                depth: None,
+            },
+            Request::History {
+                id: MemoryId::new(),
+                depth: Some(3),
+            },
         ]
     }
 
@@ -1007,6 +1038,40 @@ mod tests {
                 },
                 provider_model: "deterministic".to_string(),
                 writer_alive: true,
+            },
+            Response::History {
+                history: rb_types::MemoryHistory {
+                    namespace: "global".to_string(),
+                    depth: 100,
+                    chain: vec![rb_types::HistoryEntry {
+                        id: MemoryId::new(),
+                        summary: "we use kafka".to_string(),
+                        importance: 7,
+                        confidence: 0.9,
+                        created_at: chrono::Utc::now(),
+                        archived: false,
+                        contested: true,
+                        current: true,
+                        is_target: true,
+                        superseded_by: None,
+                        origin_user: Some("alice".to_string()),
+                        origin_host: None,
+                        origin_agent: None,
+                        origin_source: Some("cli".to_string()),
+                    }],
+                    edges: vec![rb_types::HistoryEdge {
+                        link_type: rb_types::LinkType::Contradicts,
+                        local: MemoryId::new(),
+                        other: MemoryId::new(),
+                        outbound: false,
+                        reason: "disagrees".to_string(),
+                        other_summary: "kafka too slow".to_string(),
+                        other_confidence: 0.5,
+                        other_contested: true,
+                        created_at: chrono::Utc::now(),
+                    }],
+                    truncated: false,
+                },
             },
         ]
     }
@@ -1473,6 +1538,94 @@ mod tests {
                 assert!(!writer_alive);
             }
             other => panic!("expected Stats, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn history_request_uses_op_tag_and_depth_is_additive() {
+        // A depth-less History request carries only the op tag and the id
+        // (the `Stats.window_days` precedent), and a frame without the depth
+        // key decodes to `None` — no CONTRACT_VERSION bump.
+        let id = MemoryId::new();
+        let json = serde_json::to_string(&Request::History {
+            id: id.clone(),
+            depth: None,
+        })
+        .unwrap();
+        assert_eq!(json, format!(r#"{{"op":"History","id":"{id}"}}"#));
+        let back: Request = serde_json::from_str(&json).unwrap();
+        match back {
+            Request::History { id: got, depth } => {
+                assert_eq!(got, id);
+                assert_eq!(depth, None);
+            }
+            other => panic!("expected History, got {other:?}"),
+        }
+
+        let json = serde_json::to_string(&Request::History {
+            id: id.clone(),
+            depth: Some(3),
+        })
+        .unwrap();
+        assert_eq!(json, format!(r#"{{"op":"History","id":"{id}","depth":3}}"#));
+        let back: Request = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, Request::History { depth: Some(3), .. }));
+    }
+
+    #[test]
+    fn history_response_round_trips_with_result_tag() {
+        let id = MemoryId::new();
+        let resp = Response::History {
+            history: rb_types::MemoryHistory {
+                namespace: "project:rusty-brain".to_string(),
+                depth: 100,
+                chain: vec![rb_types::HistoryEntry {
+                    id: id.clone(),
+                    summary: "we use kafka".to_string(),
+                    importance: 7,
+                    confidence: 0.9,
+                    created_at: chrono::Utc::now(),
+                    archived: false,
+                    contested: true,
+                    current: true,
+                    is_target: true,
+                    superseded_by: None,
+                    origin_user: None,
+                    origin_host: None,
+                    origin_agent: None,
+                    origin_source: None,
+                }],
+                edges: Vec::new(),
+                truncated: true,
+            },
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["result"], "History");
+        let back: Response = serde_json::from_str(&json).unwrap();
+        match back {
+            Response::History { history } => {
+                assert_eq!(history.chain.len(), 1);
+                assert_eq!(history.chain[0].id, id);
+                assert!(history.chain[0].current);
+                assert!(history.truncated);
+            }
+            other => panic!("expected History, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn history_response_payload_fields_are_additive() {
+        // A frame carrying an empty history object (a peer predating — or
+        // postdating — any field) must decode to the zero-valued default:
+        // old-daemon/new-client tolerance without a CONTRACT_VERSION bump.
+        let back: Response = serde_json::from_str(r#"{"result":"History","history":{}}"#).unwrap();
+        match back {
+            Response::History { history } => {
+                assert_eq!(history, rb_types::MemoryHistory::default());
+                assert!(history.chain.is_empty());
+            }
+            other => panic!("expected History, got {other:?}"),
         }
     }
 

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -1,6 +1,7 @@
 //! `SqliteStore`: the concrete `Store` backed by SQLite + sqlite-vec.
 
 mod core;
+mod history;
 mod internal;
 mod lifecycle;
 mod link_decay;

--- a/crates/rb-store/src/store/history.rs
+++ b/crates/rb-store/src/store/history.rs
@@ -1,0 +1,725 @@
+//! Decision-history timeline derivation (PRD 2026-07-02): the read-only
+//! queries behind `rusty-brain history`. Inherent-impl module like `stats.rs`
+//! — these run on the daemon's READ pool, never through the writer, so the
+//! history path issues zero writer ops (W1.8) by construction.
+//!
+//! Everything is derived from EXISTING rows (HIST-2): the
+//! `memories.superseded_by` pointer (the atomic supersede's artifact), the
+//! `archived_at`/`confidence`/`origin_*` columns, and `memory_links`. No new
+//! persistence, no schema change.
+
+use super::internal::{from_ts, parse_id};
+use super::*;
+use rb_types::{HistoryEdge, HistoryEntry, MemoryHistory};
+use std::collections::HashSet;
+
+/// The link types HIST-1 surfaces on the timeline. `supersedes` rides the
+/// chain itself and `implements` is out of the PRD's edge scope.
+const EDGE_TYPES: [&str; 3] = ["contradicts", "extends", "references"];
+
+/// One decoded chain-member row (pre-flag: contested/current/is_target are
+/// stamped by the caller once the whole chain is known).
+struct ChainRow {
+    entry: HistoryEntry,
+}
+
+impl SqliteStore {
+    /// Derive the decision-history timeline for `id` in `ns`: the supersede
+    /// chain in BOTH directions (each direction bounded by `depth` hops) plus
+    /// the active `contradicts`/`extends`/`references` edges touching chain
+    /// members (bounded by `edge_limit`). Pure reads — safe on a read-pool
+    /// connection.
+    ///
+    /// Semantics guarantees:
+    /// - Namespace purity: every chain member and BOTH endpoints of every edge
+    ///   live in `ns` (`memory_links` carries no namespace and cross-namespace
+    ///   pointers/edges exist, so each hop and both edge endpoints are scoped
+    ///   explicitly — the `active_contradicts` rigor). A target id living in
+    ///   another namespace is indistinguishable from a missing one: `NotFound`.
+    /// - Cycle defense: `superseded_by` is user-influencable data; a visited
+    ///   set plus the depth cap make the walk terminate on any input.
+    /// - `truncated` reports a depth- or edge-cap stop with rows remaining.
+    pub fn memory_history(
+        &self,
+        ns: &Namespace,
+        id: &MemoryId,
+        depth: u32,
+        edge_limit: usize,
+    ) -> Result<MemoryHistory> {
+        let ns_str = ns.as_db_string();
+        let target = self
+            .history_row(&ns_str, id)?
+            .ok_or_else(|| Error::NotFound(id.clone()))?;
+
+        let mut truncated = false;
+        let mut visited: HashSet<MemoryId> = HashSet::new();
+        visited.insert(id.clone());
+
+        // Forward walk: follow the superseded_by pointer (old -> new). A
+        // pointer that leaves the namespace, dangles, or closes a cycle ends
+        // the walk; only a depth stop with a live pointer marks truncation.
+        let mut successors: Vec<ChainRow> = Vec::new();
+        let mut cursor = target.entry.superseded_by.clone();
+        while let Some(next_id) = cursor {
+            if successors.len() as u32 >= depth {
+                truncated = true;
+                break;
+            }
+            if !visited.insert(next_id.clone()) {
+                break; // cycle: already on the chain
+            }
+            match self.history_row(&ns_str, &next_id)? {
+                Some(row) => {
+                    cursor = row.entry.superseded_by.clone();
+                    successors.push(row);
+                }
+                None => break, // cross-namespace or dangling pointer: never leak
+            }
+        }
+
+        // Backward walk: BFS over predecessors (rows whose superseded_by
+        // points INTO the frontier). Multiple predecessors per hop are
+        // possible (near-dup absorption fans in), so this is a level walk,
+        // not a pointer chase.
+        let mut ancestors: Vec<(u32, ChainRow)> = Vec::new();
+        let mut frontier: Vec<MemoryId> = vec![id.clone()];
+        for hop in 0..=depth {
+            if frontier.is_empty() {
+                break;
+            }
+            let rows = self.predecessor_rows(&ns_str, &frontier)?;
+            let mut next_frontier = Vec::new();
+            for row in rows {
+                if !visited.insert(row.entry.id.clone()) {
+                    continue; // cycle or already-collected member
+                }
+                if hop >= depth {
+                    // A probe level past the bound: rows remain, do not emit.
+                    truncated = true;
+                    continue;
+                }
+                next_frontier.push(row.entry.id.clone());
+                ancestors.push((hop, row));
+            }
+            frontier = next_frontier;
+        }
+        // Timeline order (HIST-1: "ordered by time"): ancestors oldest first.
+        // The hop distance is the primary key — `created_at` has one-second
+        // resolution, so a fast A->B->C chain would tie on time and shuffle;
+        // deeper ancestors are by construction older. Time then id break ties
+        // WITHIN a fan-in level (near-dup absorption).
+        ancestors.sort_by(|(ah, a), (bh, b)| {
+            bh.cmp(ah)
+                .then_with(|| a.entry.created_at.cmp(&b.entry.created_at))
+                .then_with(|| a.entry.id.to_string().cmp(&b.entry.id.to_string()))
+        });
+
+        let mut chain: Vec<HistoryEntry> = ancestors
+            .into_iter()
+            .map(|(_, r)| r.entry)
+            .chain(std::iter::once(target.entry))
+            .chain(successors.into_iter().map(|r| r.entry))
+            .collect();
+
+        // Edges: active links touching any chain member, both endpoints
+        // scoped to `ns` and non-archived (the `active_contradicts` rigor).
+        let chain_ids: Vec<MemoryId> = chain.iter().map(|e| e.id.clone()).collect();
+        let (mut edges, edges_truncated) = self.chain_edges(&ns_str, &chain_ids, edge_limit)?;
+        truncated |= edges_truncated;
+
+        // Contested flags for chain members AND far endpoints in one batch.
+        let mut flag_ids = chain_ids.clone();
+        flag_ids.extend(edges.iter().map(|e| e.other.clone()));
+        flag_ids.sort_by_key(|i| i.to_string());
+        flag_ids.dedup();
+        let contested = self.active_contradicts(ns, &flag_ids)?;
+        for entry in &mut chain {
+            entry.contested = contested.contains(&entry.id);
+            entry.is_target = entry.id == *id;
+        }
+        for edge in &mut edges {
+            edge.other_contested = contested.contains(&edge.other);
+        }
+
+        // "Current truth" pointer: the newest non-archived chain member.
+        if let Some(current) = chain.iter_mut().rev().find(|e| !e.archived) {
+            current.current = true;
+        }
+
+        Ok(MemoryHistory {
+            namespace: ns_str,
+            depth,
+            chain,
+            edges,
+            truncated,
+        })
+    }
+
+    /// Fetch one chain-member row scoped to `ns`; `Ok(None)` when the id is
+    /// missing OR lives in another namespace (indistinguishable on purpose).
+    fn history_row(&self, ns_str: &str, id: &MemoryId) -> Result<Option<ChainRow>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT memory_id, summary, content, importance, confidence, created_at,
+                        archived_at, superseded_by, origin_user, origin_host, origin_agent,
+                        origin_source
+                 FROM memories WHERE memory_id = ?1 AND namespace = ?2",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(rusqlite::params![id.to_string(), ns_str])
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        match rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+            Some(row) => Ok(Some(decode_chain_row(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Rows whose `superseded_by` points at any id in `frontier`, scoped to
+    /// `ns`, ordered deterministically.
+    fn predecessor_rows(&self, ns_str: &str, frontier: &[MemoryId]) -> Result<Vec<ChainRow>> {
+        if frontier.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: Vec<String> =
+            (0..frontier.len()).map(|i| format!("?{}", i + 2)).collect();
+        let sql = format!(
+            "SELECT memory_id, summary, content, importance, confidence, created_at,
+                    archived_at, superseded_by, origin_user, origin_host, origin_agent,
+                    origin_source
+             FROM memories
+             WHERE namespace = ?1 AND superseded_by IN ({})
+             ORDER BY created_at ASC, memory_id ASC",
+            placeholders.join(", ")
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(frontier.len() + 1);
+        params.push(Box::new(ns_str.to_string()));
+        for id in frontier {
+            params.push(Box::new(id.to_string()));
+        }
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(refs.as_slice())
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+            out.push(decode_chain_row(row)?);
+        }
+        Ok(out)
+    }
+
+    /// Active `contradicts`/`extends`/`references` edges touching any chain
+    /// member. BOTH endpoints must be non-archived and in `ns` (the
+    /// `active_contradicts` double-endpoint scoping). Returns at most
+    /// `edge_limit` edges plus a truncation flag (one extra row is probed).
+    fn chain_edges(
+        &self,
+        ns_str: &str,
+        chain_ids: &[MemoryId],
+        edge_limit: usize,
+    ) -> Result<(Vec<HistoryEdge>, bool)> {
+        if chain_ids.is_empty() || edge_limit == 0 {
+            return Ok((Vec::new(), false));
+        }
+        // ?1 = namespace; ?2..: chain ids; trailing param = LIMIT probe.
+        let placeholders: Vec<String> = (0..chain_ids.len())
+            .map(|i| format!("?{}", i + 2))
+            .collect();
+        let in_list = placeholders.join(", ");
+        let limit_param = format!("?{}", chain_ids.len() + 2);
+        let type_list = EDGE_TYPES
+            .iter()
+            .map(|t| format!("'{t}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT l.source_id, l.target_id, l.link_type, l.reason, l.created_at,
+                    s.summary, s.content, s.confidence,
+                    t.summary, t.content, t.confidence
+             FROM memory_links l
+               JOIN memories s ON s.memory_id = l.source_id
+               JOIN memories t ON t.memory_id = l.target_id
+             WHERE l.link_type IN ({type_list})
+               AND s.namespace = ?1 AND t.namespace = ?1
+               AND s.archived_at IS NULL AND t.archived_at IS NULL
+               AND (l.source_id IN ({in_list}) OR l.target_id IN ({in_list}))
+             ORDER BY l.created_at ASC, l.source_id ASC, l.target_id ASC, l.link_type ASC
+             LIMIT {limit_param}"
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(chain_ids.len() + 2);
+        params.push(Box::new(ns_str.to_string()));
+        for id in chain_ids {
+            params.push(Box::new(id.to_string()));
+        }
+        // Probe one row past the cap so truncation is reported, not silent.
+        params.push(Box::new(
+            i64::try_from(edge_limit.saturating_add(1)).unwrap_or(i64::MAX),
+        ));
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+
+        let chain_set: HashSet<&MemoryId> = chain_ids.iter().collect();
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut rows = stmt
+            .query(refs.as_slice())
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let mut edges = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
+            let source = parse_id(&row.get::<_, String>(0).map_err(storage)?)?;
+            let target = parse_id(&row.get::<_, String>(1).map_err(storage)?)?;
+            let link_type = rb_types::LinkType::parse(&row.get::<_, String>(2).map_err(storage)?)?;
+            let reason: String = row.get(3).map_err(storage)?;
+            let created_at = from_ts(row.get::<_, i64>(4).map_err(storage)?)?;
+            let source_summary = summary_or_content(
+                row.get::<_, String>(5).map_err(storage)?,
+                row.get::<_, String>(6).map_err(storage)?,
+            );
+            let source_confidence = row.get::<_, f64>(7).map_err(storage)? as f32;
+            let target_summary = summary_or_content(
+                row.get::<_, String>(8).map_err(storage)?,
+                row.get::<_, String>(9).map_err(storage)?,
+            );
+            let target_confidence = row.get::<_, f64>(10).map_err(storage)? as f32;
+
+            // `local` is the chain member; when both endpoints are chain
+            // members the source side wins (deterministic, matches `outbound`).
+            let outbound = chain_set.contains(&source);
+            let (local, other, other_summary, other_confidence) = if outbound {
+                (source, target, target_summary, target_confidence)
+            } else {
+                (target, source, source_summary, source_confidence)
+            };
+            edges.push(HistoryEdge {
+                link_type,
+                local,
+                other,
+                outbound,
+                reason,
+                other_summary,
+                other_confidence,
+                other_contested: false, // stamped by the caller in one batch
+                created_at,
+            });
+        }
+        let truncated = edges.len() > edge_limit;
+        edges.truncate(edge_limit);
+        Ok((edges, truncated))
+    }
+}
+
+fn storage(e: rusqlite::Error) -> Error {
+    Error::Storage(e.to_string())
+}
+
+/// The projection rule every read surface applies: the summary, falling back
+/// to the content when the summary is empty.
+fn summary_or_content(summary: String, content: String) -> String {
+    if summary.trim().is_empty() {
+        content
+    } else {
+        summary
+    }
+}
+
+fn decode_chain_row(row: &rusqlite::Row<'_>) -> Result<ChainRow> {
+    let id = parse_id(&row.get::<_, String>(0).map_err(storage)?)?;
+    let summary = summary_or_content(
+        row.get::<_, String>(1).map_err(storage)?,
+        row.get::<_, String>(2).map_err(storage)?,
+    );
+    let importance = u8::try_from(row.get::<_, i64>(3).map_err(storage)?).unwrap_or(0);
+    let confidence = row.get::<_, f64>(4).map_err(storage)? as f32;
+    let created_at = from_ts(row.get::<_, i64>(5).map_err(storage)?)?;
+    let archived = row.get::<_, Option<i64>>(6).map_err(storage)?.is_some();
+    let superseded_by = row
+        .get::<_, Option<String>>(7)
+        .map_err(storage)?
+        .map(|s| parse_id(&s))
+        .transpose()?;
+    Ok(ChainRow {
+        entry: HistoryEntry {
+            id,
+            summary,
+            importance,
+            confidence,
+            created_at,
+            archived,
+            contested: false,
+            current: false,
+            is_target: false,
+            superseded_by,
+            origin_user: row.get(8).map_err(storage)?,
+            origin_host: row.get(9).map_err(storage)?,
+            origin_agent: row.get(10).map_err(storage)?,
+            origin_source: row.get(11).map_err(storage)?,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use crate::store::Store as _;
+    use crate::SqliteStore;
+    use rb_types::{LinkType, MemoryId, MemoryLink, MemoryNote, MemoryType, Namespace};
+
+    const DIM: usize = 8;
+
+    fn open(path: &std::path::Path) -> SqliteStore {
+        SqliteStore::open_with_model(path, DIM, "deterministic").unwrap()
+    }
+
+    /// Insert one active memory with `summary`, returning its id.
+    fn seed(store: &SqliteStore, ns: &Namespace, summary: &str) -> MemoryId {
+        let mut note = MemoryNote::new(
+            ns.clone(),
+            format!("content for {summary}"),
+            MemoryType::ArchitectureDecision,
+            7,
+        );
+        note.summary = summary.to_string();
+        note.origin_user = Some("alice".to_string());
+        note.origin_source = Some("cli".to_string());
+        let id = note.id.clone();
+        store.insert_memory(&note, Some(&[0.1f32; DIM])).unwrap();
+        id
+    }
+
+    fn link(store: &SqliteStore, from: &MemoryId, to: &MemoryId, lt: LinkType, reason: &str) {
+        store
+            .add_link(&MemoryLink {
+                source_id: from.clone(),
+                target_id: to.clone(),
+                link_type: lt,
+                strength: 1.0,
+                reason: reason.to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+    }
+
+    /// A (superseded by) B (superseded by) C: `history B` walks BOTH
+    /// directions, orders oldest first, flags C current and A/B archived, and
+    /// carries the HIST-1 metadata.
+    #[test]
+    fn history_walks_the_supersede_chain_in_both_directions() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist".to_string());
+
+        let a = seed(&store, &ns, "use rabbitmq");
+        let b = seed(&store, &ns, "use kafka");
+        let c = seed(&store, &ns, "use kafka with kraft");
+        store.supersede(&a, &b).unwrap();
+        store.supersede(&b, &c).unwrap();
+
+        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        assert_eq!(history.namespace, ns.as_db_string());
+        assert_eq!(history.depth, 100);
+        assert!(!history.truncated);
+
+        let ids: Vec<&MemoryId> = history.chain.iter().map(|e| &e.id).collect();
+        assert_eq!(ids, vec![&a, &b, &c], "oldest first: A -> B -> C");
+
+        let [ea, eb, ec] = &history.chain[..] else {
+            panic!("expected 3 chain entries, got {}", history.chain.len());
+        };
+        assert!(
+            ea.archived && eb.archived,
+            "superseded members are archived"
+        );
+        assert!(!ec.archived);
+        assert!(ec.current, "C is the current truth");
+        assert!(!ea.current && !eb.current);
+        assert!(eb.is_target, "the requested member is flagged");
+        assert!(!ea.is_target && !ec.is_target);
+        assert_eq!(ea.superseded_by.as_ref(), Some(&b));
+        assert_eq!(eb.superseded_by.as_ref(), Some(&c));
+        assert!(ec.superseded_by.is_none());
+        // HIST-1 metadata rides each hop.
+        assert_eq!(ea.summary, "use rabbitmq");
+        assert_eq!(ea.importance, 7);
+        assert!((ea.confidence - 1.0).abs() < 1e-6);
+        assert_eq!(ea.origin_user.as_deref(), Some("alice"));
+        assert_eq!(ea.origin_source.as_deref(), Some("cli"));
+    }
+
+    /// `history C` (the chain head) still lists the full ancestry (the
+    /// acceptance-criteria direction).
+    #[test]
+    fn history_of_the_current_head_lists_ancestors() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-head".to_string());
+
+        let a = seed(&store, &ns, "v1");
+        let b = seed(&store, &ns, "v2");
+        let c = seed(&store, &ns, "v3");
+        store.supersede(&a, &b).unwrap();
+        store.supersede(&b, &c).unwrap();
+
+        let history = store.memory_history(&ns, &c, 100, 200).unwrap();
+        let ids: Vec<&MemoryId> = history.chain.iter().map(|e| &e.id).collect();
+        assert_eq!(ids, vec![&a, &b, &c]);
+        assert!(history.chain[2].current && history.chain[2].is_target);
+        assert!(
+            history.chain[0].archived && history.chain[1].archived,
+            "A and B are flagged superseded/archived"
+        );
+    }
+
+    /// Near-dup absorption fans several predecessors into one successor; all
+    /// of them appear, ordered by time.
+    #[test]
+    fn history_includes_multiple_predecessors_per_hop() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-fanin".to_string());
+
+        let a1 = seed(&store, &ns, "dup one");
+        let a2 = seed(&store, &ns, "dup two");
+        let b = seed(&store, &ns, "absorbed");
+        store.supersede(&a1, &b).unwrap();
+        store.supersede(&a2, &b).unwrap();
+
+        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        let ids: std::collections::HashSet<String> =
+            history.chain.iter().map(|e| e.id.to_string()).collect();
+        assert_eq!(history.chain.len(), 3);
+        assert!(ids.contains(&a1.to_string()) && ids.contains(&a2.to_string()));
+        assert!(history.chain[2].is_target);
+    }
+
+    /// A supersede cycle (user-influencable data) must not hang the walk: the
+    /// visited set ends it and every member appears once.
+    #[test]
+    fn history_terminates_on_a_supersede_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-cycle".to_string());
+
+        let a = seed(&store, &ns, "a");
+        let b = seed(&store, &ns, "b");
+        store.supersede(&a, &b).unwrap();
+        store.supersede(&b, &a).unwrap(); // closes the cycle A -> B -> A
+
+        for anchor in [&a, &b] {
+            let history = store.memory_history(&ns, anchor, 100, 200).unwrap();
+            let mut ids: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
+            let len_before = ids.len();
+            ids.sort();
+            ids.dedup();
+            assert_eq!(ids.len(), len_before, "no duplicate chain members");
+            assert_eq!(history.chain.len(), 2, "both cycle members, exactly once");
+        }
+    }
+
+    /// The depth bound clamps BOTH directions and reports truncation.
+    #[test]
+    fn history_depth_bounds_the_walk_and_reports_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-depth".to_string());
+
+        // Chain of five: m0 -> m1 -> m2 -> m3 -> m4.
+        let ids: Vec<MemoryId> = (0..5)
+            .map(|i| seed(&store, &ns, &format!("m{i}")))
+            .collect();
+        for w in ids.windows(2) {
+            store.supersede(&w[0], &w[1]).unwrap();
+        }
+
+        let history = store.memory_history(&ns, &ids[2], 1, 200).unwrap();
+        let got: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
+        assert_eq!(
+            got,
+            vec![ids[1].to_string(), ids[2].to_string(), ids[3].to_string()],
+            "depth 1 keeps one hop in each direction"
+        );
+        assert!(history.truncated, "rows remain past the bound");
+
+        // A bound that covers everything reports no truncation.
+        let full = store.memory_history(&ns, &ids[2], 10, 200).unwrap();
+        assert_eq!(full.chain.len(), 5);
+        assert!(!full.truncated);
+    }
+
+    /// Namespace purity: a raw cross-namespace supersede pointer is never
+    /// followed, and a foreign target id is NotFound (indistinguishable from
+    /// missing).
+    #[test]
+    fn history_never_crosses_namespaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-ns".to_string());
+        let other = Namespace::Project("hist-other".to_string());
+
+        let a = seed(&store, &ns, "in-ns decision");
+        let foreign = seed(&store, &other, "foreign successor");
+        // The raw Store::supersede has no namespace check (the daemon's
+        // StoreHandle enforces it); simulate the hostile/corrupt edge.
+        store.supersede(&a, &foreign).unwrap();
+
+        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        assert_eq!(history.chain.len(), 1, "the cross-ns successor never leaks");
+        assert_eq!(history.chain[0].id, a);
+        // The backward direction is scoped too: history of the foreign row in
+        // ITS namespace must not pull in the `ns` ancestor.
+        let foreign_history = store.memory_history(&other, &foreign, 100, 200).unwrap();
+        assert_eq!(foreign_history.chain.len(), 1);
+
+        // A target id from another namespace is NotFound, not a leak.
+        let err = store.memory_history(&ns, &foreign, 100, 200).unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "{err:?}");
+        // A missing id errors identically.
+        let err = store
+            .memory_history(&ns, &MemoryId::new(), 100, 200)
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "{err:?}");
+    }
+
+    /// Active contradicts/extends/references edges surface with the far
+    /// memory's summary/confidence/contested state; cross-namespace edges and
+    /// archived far endpoints never appear (the `active_contradicts` scoping).
+    #[test]
+    fn history_surfaces_active_edges_with_far_endpoint_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-edges".to_string());
+        let other = Namespace::Project("hist-edges-other".to_string());
+
+        let a = seed(&store, &ns, "old decision");
+        let b = seed(&store, &ns, "new decision");
+        store.supersede(&a, &b).unwrap();
+
+        let rival = seed(&store, &ns, "rival claim");
+        let extension = seed(&store, &ns, "extension note");
+        let archived_far = seed(&store, &ns, "archived far");
+        let foreign = seed(&store, &other, "foreign contradiction");
+
+        // Inbound contradicts + outbound extends on the live head B.
+        link(
+            &store,
+            &rival,
+            &b,
+            LinkType::Contradicts,
+            "benchmarks disagree",
+        );
+        link(&store, &b, &extension, LinkType::Extends, "adds detail");
+        // Noise that must NOT appear: an archived far endpoint, a
+        // cross-namespace edge, and an edge on the ARCHIVED chain member A.
+        link(&store, &archived_far, &b, LinkType::References, "");
+        store.archive_memory(&archived_far).unwrap();
+        link(&store, &foreign, &b, LinkType::Contradicts, "cross-ns");
+        link(
+            &store,
+            &rival,
+            &a,
+            LinkType::Contradicts,
+            "on archived member",
+        );
+
+        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        assert_eq!(history.edges.len(), 2, "{:?}", history.edges);
+
+        let contra = history
+            .edges
+            .iter()
+            .find(|e| e.link_type == LinkType::Contradicts)
+            .expect("contradicts edge present");
+        assert_eq!(contra.local, b);
+        assert_eq!(contra.other, rival);
+        assert!(
+            !contra.outbound,
+            "rival -> b is inbound for the chain member"
+        );
+        assert_eq!(contra.reason, "benchmarks disagree");
+        assert_eq!(contra.other_summary, "rival claim");
+        assert!((contra.other_confidence - 1.0).abs() < 1e-6);
+        assert!(
+            contra.other_contested,
+            "the rival is contested by the same active pair"
+        );
+
+        let ext = history
+            .edges
+            .iter()
+            .find(|e| e.link_type == LinkType::Extends)
+            .expect("extends edge present");
+        assert_eq!(ext.local, b);
+        assert_eq!(ext.other, extension);
+        assert!(ext.outbound);
+        assert!(!ext.other_contested);
+
+        // The chain member itself carries the contested read flag (W2.2).
+        let head = history.chain.iter().find(|e| e.id == b).unwrap();
+        assert!(
+            head.contested,
+            "an active contradicts pair contests the head"
+        );
+    }
+
+    /// The edge cap bounds the list and reports truncation.
+    #[test]
+    fn history_edge_cap_bounds_the_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-edge-cap".to_string());
+
+        let hub = seed(&store, &ns, "hub");
+        for i in 0..4 {
+            let spoke = seed(&store, &ns, &format!("spoke {i}"));
+            link(&store, &spoke, &hub, LinkType::References, "");
+        }
+
+        let history = store.memory_history(&ns, &hub, 100, 2).unwrap();
+        assert_eq!(history.edges.len(), 2, "edge cap applied");
+        assert!(history.truncated, "capped edge list reports truncation");
+
+        let full = store.memory_history(&ns, &hub, 100, 200).unwrap();
+        assert_eq!(full.edges.len(), 4);
+        assert!(!full.truncated);
+    }
+
+    /// A single memory with no supersede history and no links is a one-entry
+    /// timeline: itself, current, target.
+    #[test]
+    fn history_of_an_unversioned_memory_is_itself() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-single".to_string());
+        let a = seed(&store, &ns, "lone decision");
+
+        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        assert_eq!(history.chain.len(), 1);
+        let entry = &history.chain[0];
+        assert!(entry.current && entry.is_target && !entry.archived);
+        assert!(history.edges.is_empty());
+        assert!(!history.truncated);
+    }
+
+    /// A fully archived chain has NO current-truth member (no false pointer).
+    #[test]
+    fn history_of_a_fully_archived_chain_has_no_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-dead".to_string());
+        let a = seed(&store, &ns, "old");
+        let b = seed(&store, &ns, "newer but deleted");
+        store.supersede(&a, &b).unwrap();
+        store.archive_memory(&b).unwrap();
+
+        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        assert!(
+            history.chain.iter().all(|e| !e.current),
+            "no member of an all-archived chain may claim current truth"
+        );
+    }
+}

--- a/crates/rb-store/src/store/history.rs
+++ b/crates/rb-store/src/store/history.rs
@@ -23,12 +23,33 @@ struct ChainRow {
     entry: HistoryEntry,
 }
 
+/// Which way one supersede-chain CTE walks from the target.
+#[derive(Clone, Copy)]
+enum Direction {
+    /// Follow `superseded_by` pointers (old -> new): the successors.
+    Forward,
+    /// Follow reverse pointers (rows whose `superseded_by` reaches the
+    /// target): the ancestors, including near-dup fan-in.
+    Backward,
+}
+
+/// One direction's walk result: emit-eligible rows (with shortest hop
+/// distance), the ids discovered at the depth+1 probe (never emitted), and
+/// whether the row-budget window filled (rows beyond it exist).
+struct DirectionWalk {
+    rows: Vec<(u32, ChainRow)>,
+    dropped: Vec<MemoryId>,
+    overflow: bool,
+}
+
 impl SqliteStore {
     /// Derive the decision-history timeline for `id` in `ns`: the supersede
-    /// chain in BOTH directions (each direction bounded by `depth` hops) plus
-    /// the active `contradicts`/`extends`/`references` edges touching chain
-    /// members (bounded by `edge_limit`). Pure reads — safe on a read-pool
-    /// connection.
+    /// chain in BOTH directions (each direction bounded by `depth` hops, the
+    /// whole chain by `chain_limit` members) plus the active
+    /// `contradicts`/`extends`/`references` edges touching chain members
+    /// (bounded by `edge_limit`). Pure reads — safe on a read-pool
+    /// connection: one recursive-CTE query per direction (the
+    /// `graph_neighbors` shape), one edge query, one contested batch.
     ///
     /// Semantics guarantees:
     /// - Namespace purity: every chain member and BOTH endpoints of every edge
@@ -36,14 +57,22 @@ impl SqliteStore {
     ///   pointers/edges exist, so each hop and both edge endpoints are scoped
     ///   explicitly — the `active_contradicts` rigor). A target id living in
     ///   another namespace is indistinguishable from a missing one: `NotFound`.
-    /// - Cycle defense: `superseded_by` is user-influencable data; a visited
-    ///   set plus the depth cap make the walk terminate on any input.
-    /// - `truncated` reports a depth- or edge-cap stop with rows remaining.
+    /// - Cycle defense: `superseded_by` is user-influencable data; the CTE's
+    ///   hop bound terminates any cycle and `MIN(hop) GROUP BY id` collapses
+    ///   revisits, so each member appears once. The two directions are walked
+    ///   INDEPENDENTLY (an ancestor entering a forward cycle is still found),
+    ///   then merged with successors taking precedence for cycle overlaps.
+    /// - `truncated` is exact for depth stops: it is set only when a
+    ///   discovered-but-dropped row is genuinely absent from the final chain
+    ///   (a boundary coinciding with a dangling/cross-namespace pointer or a
+    ///   cycle revisit does NOT claim truncation). Cap overflows (chain or
+    ///   edge) always report it.
     pub fn memory_history(
         &self,
         ns: &Namespace,
         id: &MemoryId,
         depth: u32,
+        chain_limit: usize,
         edge_limit: usize,
     ) -> Result<MemoryHistory> {
         let ns_str = ns.as_db_string();
@@ -51,74 +80,91 @@ impl SqliteStore {
             .history_row(&ns_str, id)?
             .ok_or_else(|| Error::NotFound(id.clone()))?;
 
-        let mut truncated = false;
-        let mut visited: HashSet<MemoryId> = HashSet::new();
-        visited.insert(id.clone());
+        // Per-direction budget: the target always holds one chain slot.
+        let budget = chain_limit.saturating_sub(1);
+        let mut fwd = self.chain_direction(&ns_str, id, depth, budget, Direction::Forward)?;
+        let mut bwd = self.chain_direction(&ns_str, id, depth, budget, Direction::Backward)?;
 
-        // Forward walk: follow the superseded_by pointer (old -> new). A
-        // pointer that leaves the namespace, dangles, or closes a cycle ends
-        // the walk; only a depth stop with a live pointer marks truncation.
-        let mut successors: Vec<ChainRow> = Vec::new();
-        let mut cursor = target.entry.superseded_by.clone();
-        while let Some(next_id) = cursor {
-            if successors.len() as u32 >= depth {
-                truncated = true;
-                break;
-            }
-            if !visited.insert(next_id.clone()) {
-                break; // cycle: already on the chain
-            }
-            match self.history_row(&ns_str, &next_id)? {
-                Some(row) => {
-                    cursor = row.entry.superseded_by.clone();
-                    successors.push(row);
+        // Cross-direction merge: a member can only appear in both directions
+        // through a cycle; successors win so the timeline reads target-first
+        // toward the current truth, and the ancestor copy is dropped.
+        let mut member_ids: HashSet<MemoryId> = HashSet::with_capacity(fwd.rows.len() + 1);
+        member_ids.insert(id.clone());
+        member_ids.extend(fwd.rows.iter().map(|(_, r)| r.entry.id.clone()));
+        bwd.rows.retain(|(_, r)| !member_ids.contains(&r.entry.id));
+        member_ids.extend(bwd.rows.iter().map(|(_, r)| r.entry.id.clone()));
+
+        // Total chain cap: keep the members closest to the target (smallest
+        // hop; successors before ancestors on ties — the current-truth side
+        // is the more valuable half of an audit view).
+        let mut cap_dropped = false;
+        if fwd.rows.len() + bwd.rows.len() > budget {
+            cap_dropped = true;
+            let mut candidates: Vec<(u32, u8, bool, ChainRow)> = fwd
+                .rows
+                .into_iter()
+                .map(|(h, r)| (h, 0u8, true, r))
+                .chain(bwd.rows.into_iter().map(|(h, r)| (h, 1u8, false, r)))
+                .collect();
+            candidates.sort_by(|a, b| {
+                a.0.cmp(&b.0)
+                    .then_with(|| a.1.cmp(&b.1))
+                    .then_with(|| a.3.entry.created_at.cmp(&b.3.entry.created_at))
+                    .then_with(|| a.3.entry.id.as_uuid().cmp(&b.3.entry.id.as_uuid()))
+            });
+            candidates.truncate(budget);
+            let (mut kept_fwd, mut kept_bwd) = (Vec::new(), Vec::new());
+            for (h, _, is_fwd, row) in candidates {
+                if is_fwd {
+                    kept_fwd.push((h, row));
+                } else {
+                    kept_bwd.push((h, row));
                 }
-                None => break, // cross-namespace or dangling pointer: never leak
             }
+            member_ids = kept_fwd
+                .iter()
+                .chain(kept_bwd.iter())
+                .map(|(_, r)| r.entry.id.clone())
+                .collect();
+            member_ids.insert(id.clone());
+            fwd.rows = kept_fwd;
+            bwd.rows = kept_bwd;
         }
 
-        // Backward walk: BFS over predecessors (rows whose superseded_by
-        // points INTO the frontier). Multiple predecessors per hop are
-        // possible (near-dup absorption fans in), so this is a level walk,
-        // not a pointer chase.
-        let mut ancestors: Vec<(u32, ChainRow)> = Vec::new();
-        let mut frontier: Vec<MemoryId> = vec![id.clone()];
-        for hop in 0..=depth {
-            if frontier.is_empty() {
-                break;
-            }
-            let rows = self.predecessor_rows(&ns_str, &frontier)?;
-            let mut next_frontier = Vec::new();
-            for row in rows {
-                if !visited.insert(row.entry.id.clone()) {
-                    continue; // cycle or already-collected member
-                }
-                if hop >= depth {
-                    // A probe level past the bound: rows remain, do not emit.
-                    truncated = true;
-                    continue;
-                }
-                next_frontier.push(row.entry.id.clone());
-                ancestors.push((hop, row));
-            }
-            frontier = next_frontier;
-        }
+        // Exact depth-truncation: a row discovered at the depth+1 probe only
+        // counts as truncation when it is ABSENT from the final chain — a
+        // cycle revisiting an already-listed member at the boundary is
+        // completeness, not loss (PR #61 review, CodeRabbit).
+        let depth_dropped = fwd
+            .dropped
+            .iter()
+            .chain(bwd.dropped.iter())
+            .any(|d| !member_ids.contains(d));
+        let mut truncated = depth_dropped || fwd.overflow || bwd.overflow || cap_dropped;
+
         // Timeline order (HIST-1: "ordered by time"): ancestors oldest first.
         // The hop distance is the primary key — `created_at` has one-second
         // resolution, so a fast A->B->C chain would tie on time and shuffle;
         // deeper ancestors are by construction older. Time then id break ties
         // WITHIN a fan-in level (near-dup absorption).
-        ancestors.sort_by(|(ah, a), (bh, b)| {
+        bwd.rows.sort_by(|(ah, a), (bh, b)| {
             bh.cmp(ah)
                 .then_with(|| a.entry.created_at.cmp(&b.entry.created_at))
-                .then_with(|| a.entry.id.to_string().cmp(&b.entry.id.to_string()))
+                .then_with(|| a.entry.id.as_uuid().cmp(&b.entry.id.as_uuid()))
+        });
+        // Successors stay in pointer-chase order (hop ascending).
+        fwd.rows.sort_by(|(ah, a), (bh, b)| {
+            ah.cmp(bh)
+                .then_with(|| a.entry.created_at.cmp(&b.entry.created_at))
+                .then_with(|| a.entry.id.as_uuid().cmp(&b.entry.id.as_uuid()))
         });
 
-        let mut chain: Vec<HistoryEntry> = ancestors
+        let mut chain: Vec<HistoryEntry> = bwd
+            .rows
             .into_iter()
             .map(|(_, r)| r.entry)
             .chain(std::iter::once(target.entry))
-            .chain(successors.into_iter().map(|r| r.entry))
+            .chain(fwd.rows.into_iter().map(|(_, r)| r.entry))
             .collect();
 
         // Edges: active links touching any chain member, both endpoints
@@ -130,7 +176,7 @@ impl SqliteStore {
         // Contested flags for chain members AND far endpoints in one batch.
         let mut flag_ids = chain_ids.clone();
         flag_ids.extend(edges.iter().map(|e| e.other.clone()));
-        flag_ids.sort_by_key(|i| i.to_string());
+        flag_ids.sort_by_key(rb_types::MemoryId::as_uuid);
         flag_ids.dedup();
         let contested = self.active_contradicts(ns, &flag_ids)?;
         for entry in &mut chain {
@@ -176,41 +222,107 @@ impl SqliteStore {
         }
     }
 
-    /// Rows whose `superseded_by` points at any id in `frontier`, scoped to
-    /// `ns`, ordered deterministically.
-    fn predecessor_rows(&self, ns_str: &str, frontier: &[MemoryId]) -> Result<Vec<ChainRow>> {
-        if frontier.is_empty() {
-            return Ok(Vec::new());
-        }
-        let placeholders: Vec<String> =
-            (0..frontier.len()).map(|i| format!("?{}", i + 2)).collect();
+    /// Walk one supersede direction with a single bounded recursive CTE (the
+    /// `graph_neighbors` shape): every hop is namespace-scoped, `UNION`
+    /// dedups `(id, hop)` pairs, and the `hop < depth+1` bound terminates any
+    /// cycle. `MIN(hop) GROUP BY id` collapses multi-path revisits to the
+    /// shortest distance; the target itself is excluded.
+    ///
+    /// The query probes ONE hop past `depth` and ONE row past `budget`:
+    /// - rows whose shortest distance is `depth + 1` are returned as
+    ///   `dropped` ids (never emitted) so the caller can decide whether a
+    ///   genuinely-new row was cut (exact truncation semantics);
+    /// - fetching `budget + 1` rows sets `overflow` and the extra row is
+    ///   discarded (the chain cap refused to fetch further).
+    fn chain_direction(
+        &self,
+        ns_str: &str,
+        id: &MemoryId,
+        depth: u32,
+        budget: usize,
+        direction: Direction,
+    ) -> Result<DirectionWalk> {
+        // Both directions share the outer projection; only the recursive
+        // seed/step differ. Every fragment is a FIXED literal — caller data
+        // rides numbered parameters exclusively.
+        let cte = match direction {
+            Direction::Forward => {
+                "walk(id, hop) AS (
+                     SELECT nxt.memory_id, 1
+                       FROM memories cur
+                       JOIN memories nxt ON nxt.memory_id = cur.superseded_by
+                      WHERE cur.memory_id = ?1 AND cur.namespace = ?2
+                        AND nxt.namespace = ?2
+                     UNION
+                     SELECT nxt.memory_id, w.hop + 1
+                       FROM walk w
+                       JOIN memories cur ON cur.memory_id = w.id
+                       JOIN memories nxt ON nxt.memory_id = cur.superseded_by
+                      WHERE nxt.namespace = ?2 AND w.hop < ?3
+                 )"
+            }
+            Direction::Backward => {
+                "walk(id, hop) AS (
+                     SELECT p.memory_id, 1
+                       FROM memories p
+                      WHERE p.superseded_by = ?1 AND p.namespace = ?2
+                     UNION
+                     SELECT p.memory_id, w.hop + 1
+                       FROM walk w
+                       JOIN memories p ON p.superseded_by = w.id
+                      WHERE p.namespace = ?2 AND w.hop < ?3
+                 )"
+            }
+        };
         let sql = format!(
-            "SELECT memory_id, summary, content, importance, confidence, created_at,
-                    archived_at, superseded_by, origin_user, origin_host, origin_agent,
-                    origin_source
-             FROM memories
-             WHERE namespace = ?1 AND superseded_by IN ({})
-             ORDER BY created_at ASC, memory_id ASC",
-            placeholders.join(", ")
+            "WITH RECURSIVE {cte}
+             SELECT m.memory_id, m.summary, m.content, m.importance, m.confidence,
+                    m.created_at, m.archived_at, m.superseded_by, m.origin_user,
+                    m.origin_host, m.origin_agent, m.origin_source, x.hops
+               FROM (SELECT id, MIN(hop) AS hops FROM walk WHERE id <> ?1 GROUP BY id) x
+               JOIN memories m ON m.memory_id = x.id
+              ORDER BY x.hops ASC, m.created_at ASC, m.memory_id ASC
+              LIMIT ?4"
         );
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(frontier.len() + 1);
-        params.push(Box::new(ns_str.to_string()));
-        for id in frontier {
-            params.push(Box::new(id.to_string()));
+
+        let probe_depth = i64::from(depth).saturating_add(1);
+        let probe_budget = i64::try_from(budget.saturating_add(1)).unwrap_or(i64::MAX);
+        let mut stmt = self.conn.prepare(&sql).map_err(storage)?;
+        let mut db_rows = stmt
+            .query(rusqlite::params![
+                id.to_string(),
+                ns_str,
+                probe_depth,
+                probe_budget
+            ])
+            .map_err(storage)?;
+
+        let mut walk = DirectionWalk {
+            rows: Vec::new(),
+            dropped: Vec::new(),
+            overflow: false,
+        };
+        let mut fetched: i64 = 0;
+        while let Some(row) = db_rows.next().map_err(storage)? {
+            fetched += 1;
+            let hops_raw = row.get::<_, i64>(12).map_err(storage)?;
+            let hops = u32::try_from(hops_raw).unwrap_or(u32::MAX);
+            if hops > depth {
+                // Depth+1 probe row: discovered but never emitted. Ordering
+                // (hops ASC) guarantees these follow every emit-eligible row,
+                // so the emit slots below are never displaced by a probe.
+                walk.dropped
+                    .push(parse_id(&row.get::<_, String>(0).map_err(storage)?)?);
+            } else if walk.rows.len() < budget {
+                walk.rows.push((hops, decode_chain_row(row)?));
+            }
         }
-        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
-        let mut stmt = self
-            .conn
-            .prepare(&sql)
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let mut rows = stmt
-            .query(refs.as_slice())
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let mut out = Vec::new();
-        while let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? {
-            out.push(decode_chain_row(row)?);
-        }
-        Ok(out)
+        // A full window means rows beyond it exist (emit-eligible or probe —
+        // unknown either way), so the cap reports conservatively. Below the
+        // window, everything reachable was fetched and the `dropped` set is
+        // complete, keeping the caller's depth-truncation check exact.
+        walk.overflow = fetched == probe_budget;
+        Ok(walk)
     }
 
     /// Active `contradicts`/`extends`/`references` edges touching any chain
@@ -334,7 +446,15 @@ fn decode_chain_row(row: &rusqlite::Row<'_>) -> Result<ChainRow> {
         row.get::<_, String>(1).map_err(storage)?,
         row.get::<_, String>(2).map_err(storage)?,
     );
-    let importance = u8::try_from(row.get::<_, i64>(3).map_err(storage)?).unwrap_or(0);
+    // Fail closed on an out-of-band importance: the schema CHECKs 1..=10, so
+    // a value no u8 holds is corruption — surfacing 0 would mask it (PR #61
+    // review, Copilot).
+    let raw_importance = row.get::<_, i64>(3).map_err(storage)?;
+    let importance = u8::try_from(raw_importance).map_err(|_| {
+        Error::Storage(format!(
+            "corrupt importance {raw_importance} on memory {id} (schema allows 1..=10)"
+        ))
+    })?;
     let confidence = row.get::<_, f64>(4).map_err(storage)? as f32;
     let created_at = from_ts(row.get::<_, i64>(5).map_err(storage)?)?;
     let archived = row.get::<_, Option<i64>>(6).map_err(storage)?.is_some();
@@ -420,7 +540,7 @@ mod tests {
         store.supersede(&a, &b).unwrap();
         store.supersede(&b, &c).unwrap();
 
-        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &b, 100, 200, 200).unwrap();
         assert_eq!(history.namespace, ns.as_db_string());
         assert_eq!(history.depth, 100);
         assert!(!history.truncated);
@@ -465,7 +585,7 @@ mod tests {
         store.supersede(&a, &b).unwrap();
         store.supersede(&b, &c).unwrap();
 
-        let history = store.memory_history(&ns, &c, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &c, 100, 200, 200).unwrap();
         let ids: Vec<&MemoryId> = history.chain.iter().map(|e| &e.id).collect();
         assert_eq!(ids, vec![&a, &b, &c]);
         assert!(history.chain[2].current && history.chain[2].is_target);
@@ -489,7 +609,7 @@ mod tests {
         store.supersede(&a1, &b).unwrap();
         store.supersede(&a2, &b).unwrap();
 
-        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &b, 100, 200, 200).unwrap();
         let ids: std::collections::HashSet<String> =
             history.chain.iter().map(|e| e.id.to_string()).collect();
         assert_eq!(history.chain.len(), 3);
@@ -511,14 +631,206 @@ mod tests {
         store.supersede(&b, &a).unwrap(); // closes the cycle A -> B -> A
 
         for anchor in [&a, &b] {
-            let history = store.memory_history(&ns, anchor, 100, 200).unwrap();
+            let history = store.memory_history(&ns, anchor, 100, 200, 200).unwrap();
             let mut ids: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
             let len_before = ids.len();
             ids.sort();
             ids.dedup();
             assert_eq!(ids.len(), len_before, "no duplicate chain members");
             assert_eq!(history.chain.len(), 2, "both cycle members, exactly once");
+            assert!(
+                !history.truncated,
+                "a cycle stop is completeness, not truncation"
+            );
         }
+    }
+
+    /// PR #61 review (HIGH): an external ancestor that enters a supersede
+    /// cycle must still appear in the chain. With a shared cross-direction
+    /// visited set, the forward walk (B, C) poisoned the backward BFS: it hit
+    /// forward-visited C, skipped without enqueueing, and A -> C's ancestor A
+    /// silently vanished while `truncated` stayed false — an integrity defect
+    /// for an audit surface.
+    #[test]
+    fn history_backward_reaches_ancestors_that_enter_a_forward_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-cycle-entry".to_string());
+
+        let a = seed(&store, &ns, "external ancestor");
+        let b = seed(&store, &ns, "cycle b");
+        let c = seed(&store, &ns, "cycle c");
+        let d = seed(&store, &ns, "cycle d");
+        store.supersede(&b, &c).unwrap();
+        store.supersede(&c, &d).unwrap();
+        store.supersede(&d, &b).unwrap(); // closes the cycle B -> C -> D -> B
+        store.supersede(&a, &c).unwrap(); // the external entry A -> C
+
+        // From D (inside the cycle) and from A (outside, feeding in): every
+        // member appears exactly once and nothing is silently dropped.
+        for anchor in [&d, &a] {
+            let history = store.memory_history(&ns, anchor, 100, 200, 200).unwrap();
+            let mut got: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
+            let len_before = got.len();
+            got.sort();
+            got.dedup();
+            assert_eq!(got.len(), len_before, "no duplicates from {anchor}");
+            for member in [&a, &b, &c, &d] {
+                assert!(
+                    history.chain.iter().any(|e| &e.id == member),
+                    "member {member} missing from the chain anchored at {anchor}: {got:?}"
+                );
+            }
+            assert_eq!(history.chain.len(), 4);
+            assert!(
+                !history.truncated,
+                "nothing was dropped, so truncated must be false (anchor {anchor})"
+            );
+        }
+    }
+
+    /// Diamond fan-in (a1 -> b1 -> d, a2 -> b2 -> d): every branch member
+    /// appears exactly once, ordered by hop distance (deepest ancestors
+    /// first), with no cross-path duplicates.
+    #[test]
+    fn history_diamond_fan_in_lists_every_branch_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-diamond".to_string());
+
+        let a1 = seed(&store, &ns, "a1");
+        let a2 = seed(&store, &ns, "a2");
+        let b1 = seed(&store, &ns, "b1");
+        let b2 = seed(&store, &ns, "b2");
+        let d = seed(&store, &ns, "d");
+        store.supersede(&a1, &b1).unwrap();
+        store.supersede(&a2, &b2).unwrap();
+        store.supersede(&b1, &d).unwrap();
+        store.supersede(&b2, &d).unwrap();
+
+        let history = store.memory_history(&ns, &d, 100, 200, 200).unwrap();
+        assert_eq!(history.chain.len(), 5, "all branch members, exactly once");
+        let hop2: Vec<&MemoryId> = history.chain[..2].iter().map(|e| &e.id).collect();
+        let hop1: Vec<&MemoryId> = history.chain[2..4].iter().map(|e| &e.id).collect();
+        assert!(hop2.contains(&&a1) && hop2.contains(&&a2), "deepest first");
+        assert!(hop1.contains(&&b1) && hop1.contains(&&b2));
+        assert_eq!(history.chain[4].id, d);
+        assert!(history.chain[4].is_target);
+        assert!(!history.truncated);
+    }
+
+    /// A self-supersede (A -> A) terminates and yields a one-entry chain.
+    #[test]
+    fn history_self_supersede_terminates() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-self".to_string());
+        let a = seed(&store, &ns, "self-superseded");
+        store.supersede(&a, &a).unwrap();
+
+        let history = store.memory_history(&ns, &a, 100, 200, 200).unwrap();
+        assert_eq!(history.chain.len(), 1, "the self-loop adds no members");
+        assert_eq!(history.chain[0].id, a);
+        assert!(history.chain[0].archived, "supersede archived it");
+        assert!(
+            !history.chain[0].current,
+            "an archived row is never current"
+        );
+        assert!(!history.truncated);
+    }
+
+    /// PR #61 review (Copilot): depth bounds hops, not width — near-dup
+    /// fan-in can point many predecessors at one id. The total chain-member
+    /// cap bounds the response and reports the drop via `truncated`.
+    #[test]
+    fn history_chain_cap_bounds_members_and_reports_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-chain-cap".to_string());
+
+        let hub = seed(&store, &ns, "absorbing hub");
+        for i in 0..6 {
+            let dup = seed(&store, &ns, &format!("near-dup {i}"));
+            store.supersede(&dup, &hub).unwrap();
+        }
+
+        let history = store.memory_history(&ns, &hub, 100, 3, 200).unwrap();
+        assert_eq!(history.chain.len(), 3, "total chain members are capped");
+        assert!(
+            history.chain.iter().any(|e| e.id == hub),
+            "the target always survives the cap"
+        );
+        assert!(history.truncated, "the cap dropped rows: report it");
+
+        let full = store.memory_history(&ns, &hub, 100, 200, 200).unwrap();
+        assert_eq!(full.chain.len(), 7);
+        assert!(!full.truncated);
+    }
+
+    /// PR #61 review (CodeRabbit): a depth-boundary stop where the next
+    /// pointer is cross-namespace/dangling or cyclic has NO further row to
+    /// fetch — it must not claim truncation.
+    #[test]
+    fn history_depth_boundary_without_further_rows_is_not_truncated() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-boundary".to_string());
+        let other = Namespace::Project("hist-boundary-other".to_string());
+
+        // A -> B -> X where X is foreign: at depth 1 from A the boundary
+        // coincides with the cross-namespace pointer — nothing was dropped.
+        let a = seed(&store, &ns, "a");
+        let b = seed(&store, &ns, "b");
+        let x = seed(&store, &other, "foreign x");
+        store.supersede(&a, &b).unwrap();
+        store.supersede(&b, &x).unwrap();
+        let history = store.memory_history(&ns, &a, 1, 200, 200).unwrap();
+        assert_eq!(history.chain.len(), 2, "A and B; the foreign X never leaks");
+        assert!(
+            !history.truncated,
+            "a cross-namespace pointer at the boundary is not truncation"
+        );
+
+        // C -> D -> C: at depth 1 from C the boundary coincides with the
+        // cycle closing back onto the target — nothing was dropped either.
+        let c = seed(&store, &ns, "c");
+        let d = seed(&store, &ns, "d");
+        store.supersede(&c, &d).unwrap();
+        store.supersede(&d, &c).unwrap();
+        let history = store.memory_history(&ns, &c, 1, 200, 200).unwrap();
+        assert_eq!(history.chain.len(), 2);
+        assert!(
+            !history.truncated,
+            "a cycle closing at the boundary is not truncation"
+        );
+    }
+
+    /// PR #61 review (Copilot): a corrupt importance outside the schema's
+    /// CHECK range must fail closed with a storage error, not silently decode
+    /// as the impossible value 0.
+    #[test]
+    fn history_corrupt_importance_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open(&dir.path().join("rb.db"));
+        let ns = Namespace::Project("hist-corrupt".to_string());
+        let a = seed(&store, &ns, "will be corrupted");
+
+        // Simulate on-disk corruption: bypass the CHECK constraint and plant
+        // an importance no u8 (or the schema) allows.
+        store
+            .conn
+            .execute_batch(&format!(
+                "PRAGMA ignore_check_constraints = ON;
+                 UPDATE memories SET importance = 300 WHERE memory_id = '{a}';
+                 PRAGMA ignore_check_constraints = OFF;"
+            ))
+            .unwrap();
+
+        let err = store.memory_history(&ns, &a, 100, 200, 200).unwrap_err();
+        assert!(
+            matches!(err, rb_types::Error::Storage(_)),
+            "corruption must surface as a storage error, got {err:?}"
+        );
     }
 
     /// The depth bound clamps BOTH directions and reports truncation.
@@ -536,7 +848,7 @@ mod tests {
             store.supersede(&w[0], &w[1]).unwrap();
         }
 
-        let history = store.memory_history(&ns, &ids[2], 1, 200).unwrap();
+        let history = store.memory_history(&ns, &ids[2], 1, 200, 200).unwrap();
         let got: Vec<String> = history.chain.iter().map(|e| e.id.to_string()).collect();
         assert_eq!(
             got,
@@ -546,7 +858,7 @@ mod tests {
         assert!(history.truncated, "rows remain past the bound");
 
         // A bound that covers everything reports no truncation.
-        let full = store.memory_history(&ns, &ids[2], 10, 200).unwrap();
+        let full = store.memory_history(&ns, &ids[2], 10, 200, 200).unwrap();
         assert_eq!(full.chain.len(), 5);
         assert!(!full.truncated);
     }
@@ -567,20 +879,24 @@ mod tests {
         // StoreHandle enforces it); simulate the hostile/corrupt edge.
         store.supersede(&a, &foreign).unwrap();
 
-        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &a, 100, 200, 200).unwrap();
         assert_eq!(history.chain.len(), 1, "the cross-ns successor never leaks");
         assert_eq!(history.chain[0].id, a);
         // The backward direction is scoped too: history of the foreign row in
         // ITS namespace must not pull in the `ns` ancestor.
-        let foreign_history = store.memory_history(&other, &foreign, 100, 200).unwrap();
+        let foreign_history = store
+            .memory_history(&other, &foreign, 100, 200, 200)
+            .unwrap();
         assert_eq!(foreign_history.chain.len(), 1);
 
         // A target id from another namespace is NotFound, not a leak.
-        let err = store.memory_history(&ns, &foreign, 100, 200).unwrap_err();
+        let err = store
+            .memory_history(&ns, &foreign, 100, 200, 200)
+            .unwrap_err();
         assert!(matches!(err, rb_types::Error::NotFound(_)), "{err:?}");
         // A missing id errors identically.
         let err = store
-            .memory_history(&ns, &MemoryId::new(), 100, 200)
+            .memory_history(&ns, &MemoryId::new(), 100, 200, 200)
             .unwrap_err();
         assert!(matches!(err, rb_types::Error::NotFound(_)), "{err:?}");
     }
@@ -626,7 +942,7 @@ mod tests {
             "on archived member",
         );
 
-        let history = store.memory_history(&ns, &b, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &b, 100, 200, 200).unwrap();
         assert_eq!(history.edges.len(), 2, "{:?}", history.edges);
 
         let contra = history
@@ -679,11 +995,11 @@ mod tests {
             link(&store, &spoke, &hub, LinkType::References, "");
         }
 
-        let history = store.memory_history(&ns, &hub, 100, 2).unwrap();
+        let history = store.memory_history(&ns, &hub, 100, 200, 2).unwrap();
         assert_eq!(history.edges.len(), 2, "edge cap applied");
         assert!(history.truncated, "capped edge list reports truncation");
 
-        let full = store.memory_history(&ns, &hub, 100, 200).unwrap();
+        let full = store.memory_history(&ns, &hub, 100, 200, 200).unwrap();
         assert_eq!(full.edges.len(), 4);
         assert!(!full.truncated);
     }
@@ -697,7 +1013,7 @@ mod tests {
         let ns = Namespace::Project("hist-single".to_string());
         let a = seed(&store, &ns, "lone decision");
 
-        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &a, 100, 200, 200).unwrap();
         assert_eq!(history.chain.len(), 1);
         let entry = &history.chain[0];
         assert!(entry.current && entry.is_target && !entry.archived);
@@ -716,7 +1032,7 @@ mod tests {
         store.supersede(&a, &b).unwrap();
         store.archive_memory(&b).unwrap();
 
-        let history = store.memory_history(&ns, &a, 100, 200).unwrap();
+        let history = store.memory_history(&ns, &a, 100, 200, 200).unwrap();
         assert!(
             history.chain.iter().all(|e| !e.current),
             "no member of an all-archived chain may claim current truth"

--- a/crates/rb-types/src/history.rs
+++ b/crates/rb-types/src/history.rs
@@ -1,0 +1,222 @@
+//! Decision-history timeline payloads (PRD 2026-07-02 decision-history
+//! timeline). Lives in `rb-types` (the leaf crate) so `rb-store` (the
+//! derivation queries), `rb-proto` (the wire `Response::History`) and the CLI
+//! (rendering) share one definition without a dependency cycle — the
+//! `MemoryStats` precedent.
+
+use crate::{LinkType, MemoryId};
+use serde::{Deserialize, Serialize};
+
+/// A memory's evolution derived ENTIRELY from existing rows (HIST-2: the
+/// `memories.superseded_by` pointer, `archived_at`/`confidence`/`origin_*`
+/// columns, and `memory_links`) — no new persistence. Computed on the daemon's
+/// READ pool: the history path issues zero writer ops (W1.8).
+///
+/// Every field is `#[serde(default)]` so the payload stays additive: a peer
+/// that predates (or postdates) a field decodes the rest — the `MemoryStats`
+/// precedent, no CONTRACT_VERSION bump.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct MemoryHistory {
+    /// Namespace the timeline is scoped to (db string form). Both endpoints of
+    /// every hop and edge live here — the walk never crosses namespaces.
+    #[serde(default)]
+    pub namespace: String,
+    /// The applied per-direction chain-walk bound (post server clamp).
+    #[serde(default)]
+    pub depth: u32,
+    /// The supersede chain ordered oldest first: ancestors (what led to the
+    /// requested memory), the requested memory itself (`is_target`), then its
+    /// successors. Never empty on success — the target is always present.
+    #[serde(default)]
+    pub chain: Vec<HistoryEntry>,
+    /// Active `contradicts`/`extends`/`references` edges touching a chain
+    /// member. "Active" mirrors the `contested` semantics: BOTH endpoints
+    /// non-archived and in this namespace.
+    #[serde(default)]
+    pub edges: Vec<HistoryEdge>,
+    /// `true` when the chain walk stopped at the depth bound (or the edge list
+    /// at the server's edge cap) with more rows remaining.
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+/// One supersede-chain member with the metadata the timeline renders (HIST-1:
+/// summary, importance, confidence, created_at, origin_*) plus its read-side
+/// flags. The supersede op records no reason in v1 storage, so hops carry none.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HistoryEntry {
+    pub id: MemoryId,
+    /// The memory's summary, falling back to its content when the summary is
+    /// empty (the projection rule every other read surface applies).
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub importance: u8,
+    #[serde(default)]
+    pub confidence: f32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// `archived_at IS NOT NULL` — a superseded/deleted chain member.
+    #[serde(default)]
+    pub archived: bool,
+    /// At least one ACTIVE in-namespace `contradicts` edge touches this member
+    /// (the same predicate as the `MemoryNote.contested` read flag).
+    #[serde(default)]
+    pub contested: bool,
+    /// The "current truth" pointer: the newest non-archived chain member.
+    /// At most one entry carries it; none when the whole chain is archived.
+    #[serde(default)]
+    pub current: bool,
+    /// The chain member the caller asked about.
+    #[serde(default)]
+    pub is_target: bool,
+    /// Raw supersede pointer (`None` for the chain head). May name a memory
+    /// outside this namespace or beyond the depth bound; the walk itself never
+    /// follows a cross-namespace pointer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<MemoryId>,
+    #[serde(default)]
+    pub origin_user: Option<String>,
+    #[serde(default)]
+    pub origin_host: Option<String>,
+    #[serde(default)]
+    pub origin_agent: Option<String>,
+    #[serde(default)]
+    pub origin_source: Option<String>,
+}
+
+/// One active link edge touching a chain member. `local` is the chain member;
+/// `other` is the far endpoint, carried with the summary/confidence/contested
+/// state HIST-1 asks for so the timeline reads without a second fetch.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HistoryEdge {
+    pub link_type: LinkType,
+    /// The chain member this edge touches (the link's source when both
+    /// endpoints are chain members).
+    pub local: MemoryId,
+    /// The far endpoint (active and in-namespace by construction).
+    pub other: MemoryId,
+    /// `true` when `local` is the link's source (`local -> other`); `false`
+    /// for an inbound edge (`other -> local`).
+    #[serde(default)]
+    pub outbound: bool,
+    /// Why the link exists (stored on the edge at link time).
+    #[serde(default)]
+    pub reason: String,
+    /// The far endpoint's summary (content fallback, like `HistoryEntry`).
+    #[serde(default)]
+    pub other_summary: String,
+    #[serde(default)]
+    pub other_confidence: f32,
+    #[serde(default)]
+    pub other_contested: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+    use crate::MemoryId;
+
+    fn entry(summary: &str) -> HistoryEntry {
+        HistoryEntry {
+            id: MemoryId::new(),
+            summary: summary.to_string(),
+            importance: 7,
+            confidence: 0.8,
+            created_at: chrono::Utc::now(),
+            archived: false,
+            contested: true,
+            current: true,
+            is_target: true,
+            superseded_by: None,
+            origin_user: Some("alice".to_string()),
+            origin_host: Some("devbox".to_string()),
+            origin_agent: Some("claude-code".to_string()),
+            origin_source: Some("cli".to_string()),
+        }
+    }
+
+    #[test]
+    fn memory_history_round_trips_with_every_field() {
+        let mut old = entry("we use rabbitmq");
+        old.archived = true;
+        old.contested = false;
+        old.current = false;
+        old.is_target = false;
+        let current = entry("we use kafka");
+        old.superseded_by = Some(current.id.clone());
+        let history = MemoryHistory {
+            namespace: "project:rusty-brain".to_string(),
+            depth: 100,
+            chain: vec![old, current.clone()],
+            edges: vec![HistoryEdge {
+                link_type: LinkType::Contradicts,
+                local: current.id.clone(),
+                other: MemoryId::new(),
+                outbound: false,
+                reason: "bench results disagree".to_string(),
+                other_summary: "kafka too slow for us".to_string(),
+                other_confidence: 0.6,
+                other_contested: true,
+                created_at: chrono::Utc::now(),
+            }],
+            truncated: true,
+        };
+        let json = serde_json::to_string(&history).unwrap();
+        let back: MemoryHistory = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, history);
+    }
+
+    #[test]
+    fn memory_history_decodes_from_an_empty_object() {
+        // Every field is additive + serde(default): a payload from an
+        // older/newer peer that omits fields must still decode (the
+        // MemoryStats precedent), yielding the zero-valued default.
+        let back: MemoryHistory = serde_json::from_str("{}").unwrap();
+        assert_eq!(back, MemoryHistory::default());
+        assert!(back.chain.is_empty());
+        assert!(back.edges.is_empty());
+        assert!(!back.truncated);
+    }
+
+    #[test]
+    fn history_entry_tolerates_absent_optional_fields() {
+        // A minimal entry (id + created_at only) decodes with defaulted flags
+        // and provenance — the additive-payload tolerance the wire relies on.
+        let id = MemoryId::new();
+        let json = format!("{{\"id\":\"{id}\",\"created_at\":\"2026-07-01T00:00:00Z\"}}");
+        let back: HistoryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, id);
+        assert_eq!(back.summary, "");
+        assert_eq!(back.importance, 0);
+        assert!(!back.archived && !back.contested && !back.current && !back.is_target);
+        assert!(back.superseded_by.is_none());
+        assert!(back.origin_user.is_none());
+    }
+
+    #[test]
+    fn history_entry_omits_a_none_supersede_pointer() {
+        // skip_serializing_if keeps a chain-head entry free of a null pointer
+        // key (the `Remember.supersedes` wire-frugality precedent).
+        let e = entry("head");
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(!json.contains("superseded_by"), "{json}");
+    }
+
+    #[test]
+    fn history_edge_round_trips_and_defaults() {
+        let id = MemoryId::new();
+        let other = MemoryId::new();
+        let json = format!(
+            "{{\"link_type\":\"Contradicts\",\"local\":\"{id}\",\"other\":\"{other}\",\
+             \"created_at\":\"2026-07-01T00:00:00Z\"}}"
+        );
+        let back: HistoryEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.link_type, LinkType::Contradicts);
+        assert!(!back.outbound);
+        assert_eq!(back.reason, "");
+        assert_eq!(back.other_summary, "");
+        assert!(!back.other_contested);
+    }
+}

--- a/crates/rb-types/src/history.rs
+++ b/crates/rb-types/src/history.rs
@@ -12,9 +12,13 @@ use serde::{Deserialize, Serialize};
 /// columns, and `memory_links`) — no new persistence. Computed on the daemon's
 /// READ pool: the history path issues zero writer ops (W1.8).
 ///
-/// Every field is `#[serde(default)]` so the payload stays additive: a peer
-/// that predates (or postdates) a field decodes the rest — the `MemoryStats`
-/// precedent, no CONTRACT_VERSION bump.
+/// Additive-payload guarantee: every field of THIS struct is
+/// `#[serde(default)]`, so a peer that predates (or postdates) a top-level
+/// field decodes the rest — the `MemoryStats` precedent, no CONTRACT_VERSION
+/// bump. The nested [`HistoryEntry`]/[`HistoryEdge`] items keep their
+/// identity fields (`id`, `local`/`other`, `link_type`, `created_at`)
+/// REQUIRED — no payload version has ever omitted them, and an item without
+/// an identity is meaningless; only their annotated metadata fields default.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct MemoryHistory {
     /// Namespace the timeline is scoped to (db string form). Both endpoints of

--- a/crates/rb-types/src/lib.rs
+++ b/crates/rb-types/src/lib.rs
@@ -9,6 +9,7 @@ mod anchor;
 mod change;
 mod error;
 mod feedback_kind;
+mod history;
 mod job;
 mod link;
 mod link_type;
@@ -28,6 +29,7 @@ pub use anchor::{
 pub use change::{ChangeKind, MemoryChanged};
 pub use error::{Error, Result};
 pub use feedback_kind::FeedbackKind;
+pub use history::{HistoryEdge, HistoryEntry, MemoryHistory};
 pub use job::JobKind;
 pub use link::{MemoryLink, SIMILARITY_LINK_MAX_COSINE_DISTANCE};
 pub use link_type::LinkType;

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -462,6 +462,19 @@ pub enum Command {
         depth: u8,
     },
 
+    /// Show a memory's decision history: the supersede chain in both
+    /// directions (prior and newer versions) plus active contradicts/extends/
+    /// references links, with current/superseded/contested markers. Read-only
+    /// — issues zero writer ops.
+    History {
+        /// Memory id (UUID).
+        id: String,
+        /// Maximum supersede hops walked per direction (server-clamped to
+        /// 1-100; default: the server safety cap).
+        #[arg(long, value_parser = value_parser!(u32).range(1..=100))]
+        depth: Option<u32>,
+    },
+
     /// Apply a partial update to a memory (only provided fields change).
     /// Content cannot be updated — store a new memory so embeddings stay
     /// consistent.
@@ -1429,6 +1442,38 @@ mod tests {
         // --kind is required.
         let res = Cli::try_parse_from(["rusty-brain", "feedback", "an-id"]);
         assert!(res.is_err(), "--kind is required for feedback");
+    }
+
+    #[test]
+    fn parses_history_with_optional_depth() {
+        let id = "0c8e7f76-3a4f-4f7e-9d3a-111111111111";
+        let cli = Cli::parse_from(["rusty-brain", "history", id]);
+        match cli.command {
+            Command::History { id: got, depth } => {
+                assert_eq!(got, id);
+                assert_eq!(depth, None, "absent depth defers to the server cap");
+            }
+            other => panic!("expected History, got {other:?}"),
+        }
+        let cli = Cli::parse_from(["rusty-brain", "history", id, "--depth", "3"]);
+        assert!(matches!(
+            cli.command,
+            Command::History { depth: Some(3), .. }
+        ));
+        // Global --json applies to history.
+        let cli = Cli::parse_from(["rusty-brain", "--json", "history", id]);
+        assert!(cli.json);
+        assert!(matches!(cli.command, Command::History { .. }));
+    }
+
+    #[test]
+    fn history_rejects_out_of_range_depth_at_parse_time() {
+        for bad in ["0", "101"] {
+            let res = Cli::try_parse_from(["rusty-brain", "history", "some-id", "--depth", bad]);
+            assert!(res.is_err(), "--depth {bad} must be rejected at parse time");
+        }
+        // An id argument is required.
+        assert!(Cli::try_parse_from(["rusty-brain", "history"]).is_err());
     }
 
     #[test]

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -487,6 +487,131 @@ pub fn render_stats(
     out.trim_end().to_string()
 }
 
+/// Compact relative age for a timeline line, e.g. `just now` / `5m ago` /
+/// `3d ago` / `2w ago` / `4mo ago` / `1y ago` — the W3.3 age-marker
+/// convention (mirrors the rb-mcp projection). Negative deltas (clock skew)
+/// read as `just now`.
+fn relative_age(created_at: chrono::DateTime<chrono::Utc>) -> String {
+    let secs = (chrono::Utc::now() - created_at).num_seconds().max(0);
+    let (n, unit) = if secs < 60 {
+        return "just now".to_string();
+    } else if secs < 3600 {
+        (secs / 60, "m")
+    } else if secs < 86_400 {
+        (secs / 3600, "h")
+    } else if secs < 604_800 {
+        (secs / 86_400, "d")
+    } else if secs < 2_592_000 {
+        (secs / 604_800, "w")
+    } else if secs < 31_536_000 {
+        (secs / 2_592_000, "mo")
+    } else {
+        (secs / 31_536_000, "y")
+    };
+    format!("{n}{unit} ago")
+}
+
+/// The reader-facing verb for a history edge, from the chain member's side.
+fn edge_verb(link_type: rb_types::LinkType, outbound: bool) -> &'static str {
+    use rb_types::LinkType;
+    match (link_type, outbound) {
+        (LinkType::Contradicts, true) => "contradicts",
+        (LinkType::Contradicts, false) => "contradicted by",
+        (LinkType::Extends, true) => "extends",
+        (LinkType::Extends, false) => "extended by",
+        (LinkType::References, true) => "references",
+        (LinkType::References, false) => "referenced by",
+        // The store never emits these on the history edge surface; keep the
+        // mapping total so a future payload renders instead of panicking.
+        (LinkType::Implements, true) => "implements",
+        (LinkType::Implements, false) => "implemented by",
+        (LinkType::Supersedes, true) => "supersedes",
+        (LinkType::Supersedes, false) => "superseded by",
+    }
+}
+
+/// Render the `history` payload: the decision timeline for one memory.
+/// JSON: the raw `MemoryHistory`. Human: one line per chain version (oldest
+/// first) with age and `current`/`superseded`/`contested` markers (the W3.3
+/// projection vocabulary), plus each version's active links indented below it.
+pub fn render_history(history: &rb_types::MemoryHistory, json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(history).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render history JSON");
+            "{}".to_string()
+        });
+    }
+
+    let versions = history.chain.len();
+    let mut out = format!(
+        "Decision history in {} ({} version{})\n",
+        history.namespace,
+        versions,
+        if versions == 1 { "" } else { "s" }
+    );
+    for (i, entry) in history.chain.iter().enumerate() {
+        let marker = if entry.is_target { "->" } else { "  " };
+        let mut flags = String::new();
+        if entry.current {
+            flags.push_str(" [current]");
+        }
+        if entry.archived {
+            flags.push_str(" [superseded]");
+        }
+        if entry.contested {
+            flags.push_str(" [contested]");
+        }
+        let origin = match (&entry.origin_user, &entry.origin_source) {
+            (Some(user), Some(source)) => format!(", by {user} via {source}"),
+            (Some(user), None) => format!(", by {user}"),
+            (None, Some(source)) => format!(", via {source}"),
+            (None, None) => String::new(),
+        };
+        out.push_str(&format!(
+            "{marker} {}. {} (imp {}, conf {:.2}, {}{}){} {}\n",
+            i + 1,
+            entry.id,
+            entry.importance,
+            entry.confidence,
+            relative_age(entry.created_at),
+            origin,
+            flags,
+            entry.summary,
+        ));
+        for edge in history.edges.iter().filter(|e| e.local == entry.id) {
+            let contested = if edge.other_contested {
+                " [contested]"
+            } else {
+                ""
+            };
+            let reason = if edge.reason.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", edge.reason)
+            };
+            out.push_str(&format!(
+                "       {} {} (conf {:.2}){} {}{}\n",
+                edge_verb(edge.link_type, edge.outbound),
+                edge.other,
+                edge.other_confidence,
+                contested,
+                edge.other_summary,
+                reason,
+            ));
+        }
+    }
+    if !history.chain.iter().any(|e| e.current) {
+        out.push_str("(no current version: every chain member is archived)\n");
+    }
+    if history.truncated {
+        out.push_str(
+            "(truncated: the depth or edge bound was reached — raise --depth, or \
+             anchor `history` on an end-of-chain id to continue)\n",
+        );
+    }
+    out.trim_end().to_string()
+}
+
 /// Everything the extended `status` line-up needs (DOC-1), gathered by the
 /// caller: the ping reply, the stats payload, and a client-side stat of the
 /// DB file mode (`None` when the file could not be inspected).
@@ -1200,6 +1325,133 @@ mod tests {
         assert_eq!(parsed["stats"]["feedback"]["net"].as_i64(), Some(2));
         assert_eq!(parsed["provider_model"].as_str(), Some("deterministic"));
         assert_eq!(parsed["writer_alive"].as_bool(), Some(true));
+    }
+
+    fn sample_history() -> rb_types::MemoryHistory {
+        let old_id = rb_types::MemoryId::new();
+        let new_id = rb_types::MemoryId::new();
+        let rival_id = rb_types::MemoryId::new();
+        let now = chrono::Utc::now();
+        rb_types::MemoryHistory {
+            namespace: "project:rusty-brain".to_string(),
+            depth: 100,
+            chain: vec![
+                rb_types::HistoryEntry {
+                    id: old_id,
+                    summary: "we use rabbitmq".to_string(),
+                    importance: 7,
+                    confidence: 1.0,
+                    created_at: now - chrono::Duration::days(3),
+                    archived: true,
+                    contested: false,
+                    current: false,
+                    is_target: false,
+                    superseded_by: Some(new_id.clone()),
+                    origin_user: Some("alice".to_string()),
+                    origin_host: None,
+                    origin_agent: None,
+                    origin_source: Some("cli".to_string()),
+                },
+                rb_types::HistoryEntry {
+                    id: new_id.clone(),
+                    summary: "we use kafka".to_string(),
+                    importance: 8,
+                    confidence: 0.9,
+                    created_at: now,
+                    archived: false,
+                    contested: true,
+                    current: true,
+                    is_target: true,
+                    superseded_by: None,
+                    origin_user: None,
+                    origin_host: None,
+                    origin_agent: None,
+                    origin_source: None,
+                },
+            ],
+            edges: vec![rb_types::HistoryEdge {
+                link_type: rb_types::LinkType::Contradicts,
+                local: new_id,
+                other: rival_id,
+                outbound: false,
+                reason: "bench results disagree".to_string(),
+                other_summary: "kafka too slow for us".to_string(),
+                other_confidence: 0.6,
+                other_contested: true,
+                created_at: now,
+            }],
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn human_history_marks_current_superseded_contested_and_target() {
+        let history = sample_history();
+        let out = render_history(&history, false);
+        assert!(out.contains("project:rusty-brain"), "namespace: {out}");
+        assert!(out.contains("2 versions"), "chain length: {out}");
+        assert!(out.contains("[superseded]"), "archived marker: {out}");
+        assert!(out.contains("[current]"), "current-truth marker: {out}");
+        assert!(out.contains("[contested]"), "contested marker: {out}");
+        assert!(out.contains("->"), "target arrow: {out}");
+        assert!(out.contains("we use rabbitmq"), "old summary: {out}");
+        assert!(out.contains("we use kafka"), "new summary: {out}");
+        assert!(out.contains("3d ago"), "age marker: {out}");
+        assert!(out.contains("by alice via cli"), "provenance: {out}");
+        // The contradiction renders under its chain member with the far
+        // memory's summary and the edge reason (acceptance criterion).
+        assert!(out.contains("contradicted by"), "edge verb: {out}");
+        assert!(out.contains("kafka too slow for us"), "far summary: {out}");
+        assert!(out.contains("bench results disagree"), "edge reason: {out}");
+        assert!(!out.contains("truncated"), "no truncation note: {out}");
+    }
+
+    #[test]
+    fn human_history_orders_oldest_first_with_indices() {
+        let history = sample_history();
+        let out = render_history(&history, false);
+        let old_pos = out.find("we use rabbitmq").unwrap();
+        let new_pos = out.find("we use kafka").unwrap();
+        assert!(old_pos < new_pos, "oldest first: {out}");
+        assert!(out.contains(" 1. "), "indexed timeline: {out}");
+        assert!(out.contains(" 2. "), "indexed timeline: {out}");
+    }
+
+    #[test]
+    fn human_history_notes_truncation_and_a_fully_archived_chain() {
+        let mut history = sample_history();
+        history.truncated = true;
+        history.chain[1].archived = true;
+        history.chain[1].current = false;
+        let out = render_history(&history, false);
+        assert!(out.contains("truncated"), "truncation note: {out}");
+        assert!(
+            out.contains("no current version"),
+            "all-archived note: {out}"
+        );
+    }
+
+    #[test]
+    fn json_history_is_the_raw_payload() {
+        let history = sample_history();
+        let out = render_history(&history, true);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["namespace"].as_str(), Some("project:rusty-brain"));
+        assert_eq!(parsed["chain"].as_array().map(Vec::len), Some(2));
+        assert_eq!(parsed["chain"][1]["current"].as_bool(), Some(true));
+        assert_eq!(parsed["chain"][1]["is_target"].as_bool(), Some(true));
+        assert_eq!(parsed["chain"][0]["archived"].as_bool(), Some(true));
+        assert_eq!(
+            parsed["edges"][0]["link_type"].as_str(),
+            Some("Contradicts")
+        );
+        assert_eq!(
+            parsed["edges"][0]["other_summary"].as_str(),
+            Some("kafka too slow for us")
+        );
+        // The round trip back into the typed payload is lossless.
+        let back: rb_types::MemoryHistory = serde_json::from_str(&out).unwrap();
+        assert_eq!(back, history);
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -529,6 +529,11 @@ async fn run_client(
             let notes = client.graph(id, depth).await.context("graph failed")?;
             println!("{}", output::render_notes(&notes, json));
         }
+        Command::History { id, depth } => {
+            let id = parse_id(&id).context("invalid memory id")?;
+            let history = client.history(id, depth).await.context("history failed")?;
+            println!("{}", output::render_history(&history, json));
+        }
         Command::Update {
             id,
             summary,

--- a/docs/prds/2026-07-02-decision-history-timeline.md
+++ b/docs/prds/2026-07-02-decision-history-timeline.md
@@ -2,11 +2,29 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review. The supersede chain and
+Delivered 2026-07-11 (branch `claude/decision-history-timeline`, Vikunja
+#456). From the 2026-07-02 senior-PM product review. The supersede chain and
 `contradicts` links already exist but are not surfaced as a *story*. Surfacing
 the evolution of a decision turns memory from a flat store into an
 institutional decision journal - the strongest single differentiator vs
 flat-recall competitors.
+
+Delivery notes:
+
+- The chain walk is `memories.superseded_by` based (the atomic supersede's
+  artifact) — no `supersedes` link rows exist in storage, and the supersede
+  op records no per-hop *reason* anywhere (the oplog `details` carry only the
+  replacement id). HIST-1's "supersede `reason`" therefore has nothing to
+  derive from in v1 storage; chain hops carry no reason field. Link edges DO
+  carry their stored `reason`.
+- Server bounds: depth clamps to 100 hops per direction (an absent `--depth`
+  uses the cap, per HIST-3's "default unbounded but capped"); the edge list
+  caps at 200. Both report `truncated`.
+- "Active" edges follow the `contested` semantics exactly: both endpoints
+  non-archived AND in the request namespace (the `active_contradicts`
+  double-endpoint scoping), so edges on archived chain members do not render.
+- The MCP `history` tool ships full-toolset-gated (HIST-3): the default
+  `tools/list` token budget is unchanged.
 
 ## Owner Area
 
@@ -107,12 +125,12 @@ asserting the rendered timeline.
 
 ## Implementation Checklist
 
-- [ ] Add `History` subcommand + additive `History` request/response.
-- [ ] Implement derivation over existing supersede/link queries.
-- [ ] Add cycle handling + depth cap.
-- [ ] Human + JSON output with age/contested/superseded markers.
-- [ ] Optional MCP `history` tool behind `RB_MCP_FULL_TOOLSET`.
-- [ ] Zero-writer-ops + chain e2e tests.
+- [x] Add `History` subcommand + additive `History` request/response.
+- [x] Implement derivation over existing supersede/link queries.
+- [x] Add cycle handling + depth cap.
+- [x] Human + JSON output with age/contested/superseded markers.
+- [x] Optional MCP `history` tool behind `RB_MCP_FULL_TOOLSET`.
+- [x] Zero-writer-ops + chain e2e tests.
 
 ## Roadmap Fit
 

--- a/docs/prds/2026-07-02-decision-history-timeline.md
+++ b/docs/prds/2026-07-02-decision-history-timeline.md
@@ -19,7 +19,17 @@ Delivery notes:
   carry their stored `reason`.
 - Server bounds: depth clamps to 100 hops per direction (an absent `--depth`
   uses the cap, per HIST-3's "default unbounded but capped"); the edge list
-  caps at 200. Both report `truncated`.
+  and the TOTAL chain membership each cap at 200 (depth bounds hops, not
+  width — near-dup fan-in can point many predecessors at one id). All report
+  `truncated`; depth-truncation is exact (a boundary coinciding with a
+  dangling/cross-namespace pointer or a cycle revisit does not claim it).
+- Traversal is one bounded recursive CTE per direction (the `graph_neighbors`
+  shape): the directions are walked independently, so an ancestor entering a
+  supersede cycle is still found, and cycle handling lives in SQL
+  (`MIN(hop) GROUP BY id` + the hop bound).
+- Supersede-writer hygiene (rejecting `old == new` and re-supersede of an
+  archived row at the source) is follow-up Vikunja #501 — out of this PRD's
+  read-only scope; the timeline defends against such rows regardless.
 - "Active" edges follow the `contested` semantics exactly: both endpoints
   non-archived AND in the request namespace (the `active_contradicts`
   double-endpoint scoping), so edges on archived chain members do not render.


### PR DESCRIPTION
## Summary

Implements PRD `docs/prds/2026-07-02-decision-history-timeline.md` (Vikunja #456): a read-only timeline of a memory's evolution — the supersede chain in BOTH directions plus active `contradicts`/`extends`/`references` edges — derived entirely from existing rows. Zero schema change, zero new persistence, zero writer ops.

### Surfaces

- **CLI**: `rusty-brain history <id> [--depth N] [--json]` — indexed oldest-first timeline with age markers, `[current]`/`[superseded]`/`[contested]` flags, `origin_*` provenance, a `->` target arrow, and each version's active links indented beneath it; `--json` emits the raw typed payload.
- **Wire**: additive `Request::History { id, depth }` / `Response::History { history }` (no `CONTRACT_VERSION` bump — the depth-less frame is minimal via `skip_serializing_if`, and every payload field is serde-default per the `Stats` precedent). Recorded in `contract-snapshot.toml` as an `additive` decision.
- **Types**: `rb_types::{MemoryHistory, HistoryEntry, HistoryEdge}` (leaf-crate vocabulary, the `MemoryStats` shape).
- **Store**: `SqliteStore::memory_history` inherent-impl module (`store/history.rs`, the `stats.rs` precedent — never on the `Store` trait, so it can only run on the daemon's READ pool).
- **Daemon**: dispatch through `StoreHandle::memory_history` on the read pool; classified non-admin/namespace-scoped in the exhaustive `is_admin_op` match; server-side depth clamp `1..=100` per direction (absent depth = the cap, per HIST-3 "default unbounded but capped") and a 200-edge cap, both reported via `truncated`.
- **MCP**: `history` tool gated behind `RB_MCP_FULL_TOOLSET` (HIST-3) — NOT in the default advertised set, so the per-turn `tools/list` token budget is byte-for-byte unchanged (the budget guard still passes at its prior margin); the tool stays routable when called directly.

### Semantics guarantees

- **Zero writer ops (W1.8)**: proven twice — `memory_history_runs_on_the_read_pool_with_zero_writer_ops` (StoreHandle level) and `history_over_the_wire_walks_the_chain_and_issues_zero_writer_ops` (e2e over a real socket), both asserting `writer_ops_count()` is unchanged across the call.
- **Cycle defense**: `superseded_by` is user-influencable; a visited set plus the depth cap terminate the walk on any input (`history_terminates_on_a_supersede_cycle` builds a real A→B→A cycle).
- **Namespace purity**: every chain hop and BOTH endpoints of every edge are scoped to the request namespace (the `active_contradicts` double-endpoint rigor); a foreign target id is indistinguishable from a missing one (`NotFound`). Tested with a raw cross-namespace supersede pointer and a cross-namespace contradicts edge (`history_never_crosses_namespaces`, `history_surfaces_active_edges_with_far_endpoint_state`).
- **Bounded output**: per-direction depth bound (backward walk is a BFS supporting near-dup fan-in), edge cap, deterministic ordering (hop distance primary — `created_at` has one-second resolution and would shuffle fast chains).

### Known scope notes (PRD delivery notes updated in-repo)

- v1 storage records no per-hop supersede *reason* (no `supersedes` link rows exist; the oplog carries only the replacement id), so chain hops carry none. Link edges DO carry their stored `reason`.
- "Active" edges follow the established `contested` semantics exactly: both endpoints non-archived and in-namespace, so edges on archived (superseded) chain members do not render.

## Test plan

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace` — 1449 passed, 9 ignored (25 new tests: 10 store, 5 types, 5 proto, 2 daemon zero-writer/e2e + admin-classification update, 4 CLI output, 3 CLI parse, 3 MCP)
- `cargo deny check` — ok
- `cargo run -p rb-contract-guard -- check` — snapshot matches (32 wire items, additive log entry)
- Live end-to-end against a real daemon: built an A→B→C supersede chain + contradiction via the CLI; `history B` renders A→B→C oldest-first with `[current]`/`[superseded]`/`[contested]` markers, the far memory's summary and edge reason; `--depth 1` truncates with a note; invalid and missing ids exit non-zero with clean errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only decision history timeline for memories, showing superseded versions, current and archived status, contested markers, and related links.
  * Added the `rusty-brain history <id>` command with depth and JSON output options.
  * Added an optional MCP `history` tool in the full toolset.
* **Documentation**
  * Updated the quickstart, tool documentation, changelog, and feature status documentation.
* **Bug Fixes**
  * Added safeguards for depth, edge limits, namespace isolation, cycles, and missing memories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->