### PR TITLE
feat: guided contradiction/dedup review (rusty-brain review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,26 @@ All notable changes to rusty-brain are documented here. The format is based on
 - **Safety posture (the forget precedent)**: apply requires an explicit
   policy (never auto-resolve without consent); on a TTY it previews the
   SAME plan the pass executes and asks with a default-NO prompt; `--yes`
-  is required for `--json`/piped automation. Every action is reversible —
-  merge stores a combined memory and supersedes both originals (the W3.1
-  update-as-supersede path), archive is a soft delete, demote/bump are
+  is required for `--json`/piped automation; `--dry-run` conflicts with
+  `--apply` at parse time and wins over every mutating flag at runtime.
+  Every action is reversible — merge is restricted to near-duplicate items
+  and runs as ONE writer transaction (re-validate the pair still qualifies
+  at the resolve-time threshold, insert the combined memory, copy the
+  originals' external graph edges, supersede both originals behind a
+  pointer guard, write the audit row — all-or-nothing, so concurrent
+  resolutions of the same pair cannot split the chain: the loser gets the
+  distinct `stale_plan` error); archive is a soft delete; demote/bump are
   bounded confidence nudges (`-0.15` / `+0.05`, the feedback magnitudes).
-  Partial failures follow the `ForgetOutcome` shape: completed items stay
-  committed, the failure is reported, the pass is re-runnable, and the bulk
+  Contradiction actions re-prove the pair is still an active contradiction
+  at resolve time. Partial failures follow the `ForgetOutcome` shape:
+  completed items stay committed, benign stale-plan collisions are skipped
+  (the pass continues), real failures stop re-runnably, and the bulk
   `review_sweep` oplog row is written unconditionally.
 - **Snooze persistence**: the additive `review_state` table (migration 010)
   keyed by the canonical item key (reason + sorted member ids), so a
   snoozed item stays hidden until its window elapses and acting on an item
-  clears its snooze. Every resolution records provenance + a
+  clears its snooze; `namespace rename` re-keys the rows in the same
+  transaction so snoozes survive a rename. Every resolution records provenance + a
   `review_resolve` oplog row (REV-4), so merges surface in the history
   timeline and review activity feeds stats.
 - **Wire surface**: additive `Review`/`Resolve` requests and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added — Guided contradiction/dedup review (PRD 2026-07-02)
+
+- **`rusty-brain review`**: one guided sweep over the trust backlog. The
+  queue surfaces, in priority order, active contradiction pairs (the
+  pairwise expression of `active_contradicts`, held in lockstep by a drift
+  test), near-duplicate pairs (reusing `near_duplicates()` — the one
+  similarity definition, conservative 0.95 default / 0.80 floor), and
+  low-confidence (< 0.4) plus stale never-recalled singles (the stats
+  predicate + a 30-day age bound). Bare `review` is a DRY-RUN listing;
+  `--interactive` walks the queue item by item (`keep` / `bump` / `merge` /
+  `archive` / `demote` / `snooze`); `--apply --policy auto-merge-dups |
+  demote-low-confidence` executes one bounded pass non-interactively.
+  `--since <seq>` scopes to recently-touched memories; `--limit` and
+  `--threshold` are server-clamped.
+- **Safety posture (the forget precedent)**: apply requires an explicit
+  policy (never auto-resolve without consent); on a TTY it previews the
+  SAME plan the pass executes and asks with a default-NO prompt; `--yes`
+  is required for `--json`/piped automation. Every action is reversible —
+  merge stores a combined memory and supersedes both originals (the W3.1
+  update-as-supersede path), archive is a soft delete, demote/bump are
+  bounded confidence nudges (`-0.15` / `+0.05`, the feedback magnitudes).
+  Partial failures follow the `ForgetOutcome` shape: completed items stay
+  committed, the failure is reported, the pass is re-runnable, and the bulk
+  `review_sweep` oplog row is written unconditionally.
+- **Snooze persistence**: the additive `review_state` table (migration 010)
+  keyed by the canonical item key (reason + sorted member ids), so a
+  snoozed item stays hidden until its window elapses and acting on an item
+  clears its snooze. Every resolution records provenance + a
+  `review_resolve` oplog row (REV-4), so merges surface in the history
+  timeline and review activity feeds stats.
+- **Wire surface**: additive `Review`/`Resolve` requests and
+  `ReviewPlanned`/`ReviewDone`/`Resolved` responses (serde-default
+  payloads, no `CONTRACT_VERSION` bump; an absent `dry_run` always
+  previews). Queue generation runs entirely on the read pool (zero writer
+  ops, pinned). Deliberately NOT an MCP tool (the forget precedent:
+  destructive surface; tools/list budget at 897/900).
+- **Stats**: new additive `low_confidence_live` gauge — with `contested`
+  and `never_recalled_live`, the review-queue trend.
+
 ### Added — HTTP/REST surface and agent-agnostic prompt-time recall (PRD 2026-07-02)
 
 - **Opt-in loopback HTTP listener** (`serve --http [bind]` / `[http]`

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -11,8 +11,8 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
-"crates/rb-proto/src/messages.rs::Request" = "af5a8ce05ce48088d2e862964f847e1a243095ed58c2cc53c41c1d920fefa870"
-"crates/rb-proto/src/messages.rs::Response" = "267061d0c21b7a996d9be0c70f7f753ec2c71859dcb055981a3b8ba80d98b341"
+"crates/rb-proto/src/messages.rs::Request" = "a355c43db067c79b6adce7e0823a6229b8c96add1698cb8388019637c5d32b8c"
+"crates/rb-proto/src/messages.rs::Response" = "9db3b5b9faf7163bcc85a93568856cb254ee85abb1fe2f947f5a47aaeb418d5e"
 "crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
@@ -41,9 +41,20 @@ contract_version = 2
 "crates/rb-types/src/retention.rs::ForgetPlan" = "6211f4307be6ddac772b354e4430b794994b2c34f98566a6b0405b6f32785984"
 "crates/rb-types/src/retention.rs::ForgetRule" = "c7054d9aa7e213a2f3ef3dd9af26f0d81b365174ee51a95187c110af34302abd"
 "crates/rb-types/src/retention.rs::RetentionPolicy" = "bff5adcdadc3efbcf99ba4c2cbeb725c16f968f79acd5df84020f6984179c48a"
+"crates/rb-types/src/review.rs::MemberConfidence" = "4b62c5e265ee2304c28c2b7ca61fac86ed423d18d52c8d53f65d86035c91ac65"
+"crates/rb-types/src/review.rs::PlannedResolution" = "16462e1f7e7e5dff6c06aba8b5faba932ea89315869d9decad0e53880d731ef3"
+"crates/rb-types/src/review.rs::ReviewAction" = "f376ccefa1bb9d25ec4c55b1f421bff880574c3ba7f8f83faa284a85b662abb3"
+"crates/rb-types/src/review.rs::ReviewItem" = "0e9850bce1622ac0f8a09e4f233b02d4c8354e3b5b005db67b0bdda5b8b2099b"
+"crates/rb-types/src/review.rs::ReviewMember" = "5473f402c9704d37747bb1031fcb7f28cd0371e62b7fb648d887b7812b0b6588"
+"crates/rb-types/src/review.rs::ReviewOutcome" = "2388dc58f480caf6b0df7a81d467a8b430062a3619090f464db4a681534cf456"
+"crates/rb-types/src/review.rs::ReviewPlan" = "c17af0851f1b651910f5650c350fd8bac8954bb1d265e646724b462359f411c4"
+"crates/rb-types/src/review.rs::ReviewPolicy" = "d16e28f9323ea9c32dbf5852536112459766583788b9f1a847c6a18bd8de5374"
+"crates/rb-types/src/review.rs::ReviewReason" = "37eb2d83f358bca5209cd609f6aa41404b4e1c572049c77100553b64aba4f306"
+"crates/rb-types/src/review.rs::ReviewResolution" = "86028eeb5d8bff0514cb84c606bb62b63b933d871b80fa5fc5330c430d679b39"
+"crates/rb-types/src/review.rs::ReviewTotals" = "24036939b87eb2632d012eee8db2df6ef41a93511c2bf5c0802e2096461df8f9"
 "crates/rb-types/src/stats.rs::FeedbackTotals" = "ab6a1ea796d5866a566a9372536caed43217046b16245604cf41225963bbcd23"
 "crates/rb-types/src/stats.rs::GrowthBucket" = "552aa8d7fcb065ccc8275263b55fb0b5e1aad3493bbffa4e1c695bcd14174de6"
-"crates/rb-types/src/stats.rs::MemoryStats" = "3d041a5431a380be4602f14a8f6ec9eb68bef017166c80d2663f337ddf9fc90e"
+"crates/rb-types/src/stats.rs::MemoryStats" = "ed42bc5a916a5f0ac3f939e516e89d7770cff334c8d06b033200bbcba1bc045d"
 "crates/rb-types/src/stats.rs::TopRecalled" = "8d416dd284f9995cd45563cfe7d9fa56db1ca81e211dce44e09b45e850db8dd6"
 
 [migrations]
@@ -56,6 +67,7 @@ contract_version = 2
 "007_base_importance.sql" = "be04183c1209fdb8adfdcbd66dc96ecf6125b79a45cd4a65f40388b6cca6586b"
 "008_memory_feedback.sql" = "64901f555624da4b738e437877d6b2b60579dbd5051f55ab476390015a67b70b"
 "009_memory_anchors.sql" = "d65aa99503a1573dfc55e65c60eb4045087e26680e2e6e426fdd6b9be1b3f6eb"
+"010_review_state.sql" = "a174de82d5ebbf75cd68e28369b1ef7ce549daa9874d5d497a5efde067b86d45"
 
 [[log]]
 contract_version = 2
@@ -91,3 +103,8 @@ note = "PR #60 retention/forget: Request::Forget + retention payloads (no bump, 
 contract_version = 2
 intent = "additive"
 note = "PR #61 decision history timeline: Request/Response::History + rb-types history payloads (no bump, additive per W5a.4)"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR: review sweep — Request::Review/Resolve + Response::ReviewPlanned/ReviewDone/Resolved, rb-types review payloads (ReviewPlan/Item/Member/Action/Policy/Outcome/Resolution/Totals), MemoryStats.low_confidence_live, migration 010_review_state (no bump, additive per W5a.4)"

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -11,7 +11,7 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::Handshake" = "0e5a28374c8f0a527ab97db51e530b91b6a6cbaa1f9a2cf328a1bcffb9246961"
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
-"crates/rb-proto/src/messages.rs::Request" = "a355c43db067c79b6adce7e0823a6229b8c96add1698cb8388019637c5d32b8c"
+"crates/rb-proto/src/messages.rs::Request" = "4ea3877bcfbbc0c0a3b824baefe860629eafb07f77d1ced5e64be1ac87420926"
 "crates/rb-proto/src/messages.rs::Response" = "9db3b5b9faf7163bcc85a93568856cb254ee85abb1fe2f947f5a47aaeb418d5e"
 "crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
@@ -108,3 +108,8 @@ note = "PR #61 decision history timeline: Request/Response::History + rb-types h
 contract_version = 2
 intent = "additive"
 note = "PR: review sweep — Request::Review/Resolve + Response::ReviewPlanned/ReviewDone/Resolved, rb-types review payloads (ReviewPlan/Item/Member/Action/Policy/Outcome/Resolution/Totals), MemoryStats.low_confidence_live, migration 010_review_state (no bump, additive per W5a.4)"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "PR #63 review fixes: Resolve.threshold (serde-default merge-revalidation bound) + stale_plan error kind (no bump, additive per W5a.4)"

--- a/crates/rb-daemon/Cargo.toml
+++ b/crates/rb-daemon/Cargo.toml
@@ -23,6 +23,8 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
+# HTTP body encoding (HTTP PRD) + review_resolve / review_sweep oplog detail
+# payloads (PRD 2026-07-02 review).
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/rb-daemon/src/error_map.rs
+++ b/crates/rb-daemon/src/error_map.rs
@@ -19,6 +19,9 @@ pub(crate) fn error_to_response(err: Error) -> Response {
         Error::DimensionMismatch { .. } => ("dimension_mismatch", err.to_string()),
         Error::InvalidArgument(_) => ("invalid_argument", err.to_string()),
         Error::PermissionDenied(_) => ("permission_denied", err.to_string()),
+        // Client-safe: "your plan is stale, re-run review" is caller
+        // guidance, and the distinct kind lets clients classify it.
+        Error::StalePlan(_) => ("stale_plan", err.to_string()),
 
         // Internal: log the real detail, send a generic message to the client.
         Error::Storage(_) => {

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -701,7 +701,10 @@ fn is_admin_op(req: &Request) -> bool {
         // like Delete) and dry-runs of either mode are read-only, so none of
         // those are admin.
         Request::Forget { mode, dry_run, .. } => *mode == rb_types::ForgetMode::Hard && !dry_run,
-        // Namespace-scoped by the handshake: not admin.
+        // Namespace-scoped by the handshake: not admin. Review/Resolve
+        // (PRD 2026-07-02) are deliberately non-admin: every review action is
+        // reversible (supersede/archive are soft, demote is an update) and
+        // namespace-scoped — the Forget APPLY precedent, not the hard purge.
         Request::Remember { .. }
         | Request::Recall { .. }
         | Request::Get { .. }
@@ -715,6 +718,8 @@ fn is_admin_op(req: &Request) -> bool {
         | Request::Subscribe { .. }
         | Request::Stats { .. }
         | Request::History { .. }
+        | Request::Review { .. }
+        | Request::Resolve { .. }
         | Request::Ping => false,
     }
 }
@@ -1013,6 +1018,292 @@ async fn suppress_hook_near_duplicates<P>(
     }
 }
 
+/// Apply ONE review resolution (PRD 2026-07-02 REV-2) through the existing
+/// atomic primitives. Fail-closed order: validate the action shape against
+/// the member ids, resolve every member through the namespace-scoped engine
+/// (`peek` — a maintenance read must not pollute the W3.7 access signal; a
+/// foreign or missing id is `NotFound` before any write), mutate, then record
+/// the `review_resolve` audit row (REV-4).
+///
+/// Merge is the W3.1 update-as-supersede composition: store the combined
+/// memory FIRST (through the engine, so it is embedded, linked, and stamped
+/// with the caller's provenance), then supersede each original through the
+/// existing atomic supersede — a failure between the steps leaves the new
+/// memory stored and the un-superseded original live, never a partial or
+/// corrupt state (the `Remember.supersedes` argument); the pair simply
+/// resurfaces on the next sweep.
+async fn apply_review_action<P>(
+    engine: &MemoryEngine<StoreHandle, P>,
+    job_store: &StoreHandle,
+    provenance: &rb_engine::Provenance,
+    namespace: &rb_types::Namespace,
+    reason: rb_types::ReviewReason,
+    ids: &[rb_types::MemoryId],
+    action: &rb_types::ReviewAction,
+) -> Result<rb_types::ReviewResolution>
+where
+    P: EmbeddingProvider,
+{
+    use rb_types::{MemberConfidence, ReviewAction};
+
+    action.validate(ids)?;
+    let key = rb_types::review_item_key(reason, ids);
+    let mut notes = Vec::with_capacity(ids.len());
+    for id in ids {
+        match engine.peek(id.clone()).await? {
+            Some(note) => notes.push(note),
+            None => return Err(Error::NotFound(id.clone())),
+        }
+    }
+
+    let mut resolution = rb_types::ReviewResolution {
+        key: key.clone(),
+        action: action.kind_str().to_string(),
+        ..Default::default()
+    };
+
+    match action {
+        ReviewAction::Keep { bump } => {
+            if *bump {
+                for note in &notes {
+                    let confidence = (note.confidence + rb_types::REVIEW_KEEP_BUMP).clamp(0.0, 1.0);
+                    engine
+                        .update(
+                            note.id.clone(),
+                            rb_types::MemoryUpdates {
+                                confidence: Some(confidence),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    resolution.confidence.push(MemberConfidence {
+                        id: note.id.clone(),
+                        confidence,
+                    });
+                }
+            }
+        }
+        ReviewAction::Merge => {
+            // Merging requires both originals ACTIVE: superseding an already
+            // archived row would overwrite its existing supersede identity.
+            for note in &notes {
+                if note.archived_at.is_some() {
+                    return Err(Error::InvalidArgument(format!(
+                        "cannot merge {}: it is already archived; re-run review \
+                         for a fresh queue",
+                        note.id
+                    )));
+                }
+            }
+            let (a, b) = (&notes[0], &notes[1]);
+            // Deterministic combine: identical contents collapse to one;
+            // otherwise both bodies are kept, first member first. Metadata
+            // keeps the strongest signal (max importance/confidence) and the
+            // union of keywords/tags/files/anchors.
+            let content = if a.content == b.content {
+                a.content.clone()
+            } else {
+                format!("{}\n\n---\n\n{}", a.content, b.content)
+            };
+            let mut keywords = a.keywords.clone();
+            for k in &b.keywords {
+                if !keywords.contains(k) {
+                    keywords.push(k.clone());
+                }
+            }
+            let mut tags = a.tags.clone();
+            for t in &b.tags {
+                if !tags.contains(t) {
+                    tags.push(t.clone());
+                }
+            }
+            let mut related_files = a.related_files.clone();
+            for f in &b.related_files {
+                if !related_files.contains(f) {
+                    related_files.push(f.clone());
+                }
+            }
+            let mut anchors = a.anchors.clone();
+            for an in &b.anchors {
+                if !anchors.contains(an) {
+                    anchors.push(an.clone());
+                }
+            }
+            let context = [&a.context, &b.context]
+                .into_iter()
+                .find(|c| !c.is_empty())
+                .cloned();
+            let memory_type = if b.importance > a.importance {
+                b.memory_type
+            } else {
+                a.memory_type
+            };
+            let new_id = engine
+                .remember(rb_engine::RememberInput {
+                    content,
+                    context,
+                    memory_type,
+                    importance: a.importance.max(b.importance),
+                    keywords,
+                    tags,
+                    related_files,
+                    confidence: Some(a.confidence.max(b.confidence)),
+                    provenance: provenance.clone(),
+                    anchors,
+                })
+                .await?;
+            job_store
+                .supersede(namespace.clone(), a.id.clone(), new_id.clone())
+                .await?;
+            job_store
+                .supersede(namespace.clone(), b.id.clone(), new_id.clone())
+                .await?;
+            resolution.merged_into = Some(new_id);
+        }
+        ReviewAction::Archive { id } => {
+            engine.delete(id.clone()).await?;
+        }
+        ReviewAction::Demote { id } => {
+            // `validate` proved membership; the note is in `notes`.
+            if let Some(note) = notes.iter().find(|n| &n.id == id) {
+                let confidence = (note.confidence - rb_types::REVIEW_DEMOTE_STEP).clamp(0.0, 1.0);
+                engine
+                    .update(
+                        id.clone(),
+                        rb_types::MemoryUpdates {
+                            confidence: Some(confidence),
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                resolution.confidence.push(MemberConfidence {
+                    id: id.clone(),
+                    confidence,
+                });
+            }
+        }
+        ReviewAction::Snooze { days } => {
+            let details = serde_json::json!({
+                "key": key,
+                "action": "snooze",
+                "days": days,
+            })
+            .to_string();
+            // The snooze op writes its own `review_resolve` oplog row inside
+            // the same transaction as the review_state upsert.
+            let until = job_store
+                .review_snooze(namespace.clone(), key.clone(), *days, details)
+                .await?;
+            resolution.snoozed_until = Some(until);
+            return Ok(resolution);
+        }
+    }
+
+    // REV-4: every non-snooze resolution stamps reviewed_at (clearing any
+    // snooze — the user acted) and appends one `review_resolve` oplog row.
+    // The per-memory mutations above already wrote their own oplog rows
+    // through the existing primitives.
+    let details = serde_json::json!({
+        "key": key,
+        "action": action.kind_str(),
+        "ids": ids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        "merged_into": resolution.merged_into.as_ref().map(std::string::ToString::to_string),
+    })
+    .to_string();
+    job_store
+        .record_review_resolution(namespace.clone(), key, details)
+        .await?;
+    Ok(resolution)
+}
+
+/// One bounded review apply pass (REV-3 `--apply --policy`): recompute the
+/// queue, derive the plan through the pure `ReviewPolicy::plan_action` (the
+/// SAME mapping a dry-run shows), and apply each planned action through
+/// [`apply_review_action`]. The `ForgetOutcome` failure shape (PR #60):
+/// every completed item's transactions are durable — a mid-batch failure is
+/// captured into `outcome.failure` instead of discarding the pass, and the
+/// bulk `review_sweep` oplog row is written unconditionally so a zero-change
+/// or partial pass is still an auditable run.
+async fn run_review_sweep<P>(
+    engine: &MemoryEngine<StoreHandle, P>,
+    job_store: &StoreHandle,
+    provenance: &rb_engine::Provenance,
+    namespace: &rb_types::Namespace,
+    policy: rb_types::ReviewPolicy,
+    params: rb_store::ReviewQueueParams,
+) -> Result<rb_types::ReviewOutcome>
+where
+    P: EmbeddingProvider,
+{
+    let plan = job_store.review_plan(namespace.clone(), params).await?;
+    let mut outcome = rb_types::ReviewOutcome {
+        policy: Some(policy),
+        total_items: plan.items.len() as u64,
+        ..Default::default()
+    };
+    let mut failure: Option<String> = None;
+    for item in &plan.items {
+        let Some(action) = policy.plan_action(item) else {
+            outcome.skipped += 1;
+            continue;
+        };
+        let ids: Vec<rb_types::MemoryId> = item.members.iter().map(|m| m.id.clone()).collect();
+        match apply_review_action(
+            engine,
+            job_store,
+            provenance,
+            namespace,
+            item.reason,
+            &ids,
+            &action,
+        )
+        .await
+        {
+            Ok(_) => match action {
+                rb_types::ReviewAction::Keep { .. } => outcome.kept += 1,
+                rb_types::ReviewAction::Merge => outcome.merged += 1,
+                rb_types::ReviewAction::Archive { .. } => outcome.archived += 1,
+                rb_types::ReviewAction::Demote { .. } => outcome.demoted += 1,
+                rb_types::ReviewAction::Snooze { .. } => outcome.snoozed += 1,
+            },
+            Err(e) => {
+                // The failed item's own steps rolled back or stand alone;
+                // earlier items are committed. Stop (re-runnable), report
+                // the partial pass.
+                failure = Some(format!("{} of {} failed: {e}", action.kind_str(), item.key));
+                break;
+            }
+        }
+    }
+    // The bulk row records the RUN unconditionally (the retention_sweep
+    // precedent): a zero-change or partial pass is still a durable, auditable
+    // run. A failure recording it never erases the completed batch.
+    let details = serde_json::json!({
+        "policy": policy.as_str(),
+        "merged": outcome.merged,
+        "archived": outcome.archived,
+        "demoted": outcome.demoted,
+        "kept": outcome.kept,
+        "snoozed": outcome.snoozed,
+        "skipped": outcome.skipped,
+        "total_items": outcome.total_items,
+        "failure": failure,
+    })
+    .to_string();
+    if let Err(e) = job_store
+        .record_review_sweep(namespace.clone(), details)
+        .await
+    {
+        let msg = format!("recording the sweep run: {e}");
+        failure = Some(match failure {
+            Some(prior) => format!("{prior}; {msg}"),
+            None => msg,
+        });
+    }
+    outcome.failure = failure;
+    Ok(outcome)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn dispatch<P>(
     engine: &MemoryEngine<StoreHandle, P>,
@@ -1309,6 +1600,88 @@ where
                 .await
             {
                 Ok(history) => Response::History { history },
+                Err(e) => error_to_response(e),
+            }
+        }
+        // Guided review (PRD 2026-07-02), namespace-scoped by the handshake.
+        // Dry-run generates the queue on the read pool (zero writer ops) and,
+        // when a policy is named, derives the per-item plan through the pure
+        // `ReviewPolicy::plan_action` — the SAME mapping the apply pass
+        // executes, so preview and mutation cannot diverge (REV-3). Execute
+        // requires an explicit policy (never auto-resolve without consent).
+        // The knobs are clamped server-side: a wire threshold can never drop
+        // below the conservative floor (false-positive merge risk).
+        Request::Review {
+            policy,
+            dry_run,
+            since,
+            limit,
+            threshold,
+        } => {
+            let params = rb_store::ReviewQueueParams {
+                threshold: match threshold {
+                    Some(t) if t.is_finite() => t.clamp(rb_types::REVIEW_MIN_THRESHOLD, 1.0),
+                    _ => rb_types::REVIEW_DEFAULT_THRESHOLD,
+                },
+                limit: limit
+                    .unwrap_or(rb_types::REVIEW_DEFAULT_LIMIT)
+                    .clamp(1, rb_types::REVIEW_MAX_LIMIT) as usize,
+                since,
+            };
+            if dry_run {
+                match job_store.review_plan(namespace.clone(), params).await {
+                    Ok(mut plan) => {
+                        if let Some(policy) = policy {
+                            plan.policy = Some(policy);
+                            plan.planned = plan
+                                .items
+                                .iter()
+                                .filter_map(|item| {
+                                    policy.plan_action(item).map(|action| {
+                                        rb_types::PlannedResolution {
+                                            key: item.key.clone(),
+                                            action,
+                                        }
+                                    })
+                                })
+                                .collect();
+                        }
+                        Response::ReviewPlanned { plan }
+                    }
+                    Err(e) => error_to_response(e),
+                }
+            } else {
+                let Some(policy) = policy else {
+                    return error_to_response(Error::InvalidArgument(
+                        "review execute requires an explicit policy (REV-3: never \
+                         auto-resolve without consent); name one or use the dry-run \
+                         preview"
+                            .to_string(),
+                    ));
+                };
+                match run_review_sweep(engine, job_store, provenance, namespace, policy, params)
+                    .await
+                {
+                    Ok(outcome) => Response::ReviewDone { outcome },
+                    Err(e) => error_to_response(e),
+                }
+            }
+        }
+        // One per-item resolution (REV-2 interactive mode). Validation is
+        // fail-closed at this boundary: the action shape against the member
+        // ids, then every member resolved through the namespace-scoped
+        // engine (a foreign or missing id is NotFound before any write).
+        Request::Resolve {
+            reason,
+            ids,
+            action,
+        } => {
+            match apply_review_action(
+                engine, job_store, provenance, namespace, reason, &ids, &action,
+            )
+            .await
+            {
+                Ok(resolution) => Response::Resolved { resolution },
                 Err(e) => error_to_response(e),
             }
         }

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1018,20 +1018,27 @@ async fn suppress_hook_near_duplicates<P>(
     }
 }
 
-/// Apply ONE review resolution (PRD 2026-07-02 REV-2) through the existing
-/// atomic primitives. Fail-closed order: validate the action shape against
-/// the member ids, resolve every member through the namespace-scoped engine
-/// (`peek` — a maintenance read must not pollute the W3.7 access signal; a
-/// foreign or missing id is `NotFound` before any write), mutate, then record
-/// the `review_resolve` audit row (REV-4).
+/// Apply ONE review resolution (PRD 2026-07-02 REV-2). Fail-closed order:
+/// validate the action shape against the item's REASON and member ids
+/// (merge is near-duplicate-only), re-validate the planned relationship at
+/// resolve time (the PR #63 TOCTOU fix — a contradiction item must still be
+/// an active contradiction pair; a near-dup merge re-proves similarity
+/// inside the writer transaction), resolve every member through the
+/// namespace-scoped engine (`peek` — a maintenance read must not pollute the
+/// W3.7 access signal; a foreign or missing id is `NotFound` before any
+/// write), mutate, then record the `review_resolve` audit row (REV-4).
 ///
-/// Merge is the W3.1 update-as-supersede composition: store the combined
-/// memory FIRST (through the engine, so it is embedded, linked, and stamped
-/// with the caller's provenance), then supersede each original through the
-/// existing atomic supersede — a failure between the steps leaves the new
-/// memory stored and the un-superseded original live, never a partial or
-/// corrupt state (the `Remember.supersedes` argument); the pair simply
-/// resurfaces on the next sweep.
+/// Merge is ONE writer transaction end to end (the PR #63 atomicity fix):
+/// the combined memory is COMPOSED through the engine (validated, enriched,
+/// embedded, provenance-stamped — `MemoryEngine::compose_note`, the same
+/// construction `remember` commits) and handed to
+/// `StoreHandle::review_merge`, whose single store transaction re-validates,
+/// inserts, copies the originals' external edges, supersedes both originals
+/// behind the pointer guard, and writes the audit row. Any failure rolls the
+/// WHOLE merge back — no orphaned combined memory, no split chain; a raced
+/// resolution loses with the distinct [`Error::StalePlan`], which the policy
+/// sweep treats as skip-and-continue.
+#[allow(clippy::too_many_arguments)] // the resolve context is irreducible here
 async fn apply_review_action<P>(
     engine: &MemoryEngine<StoreHandle, P>,
     job_store: &StoreHandle,
@@ -1040,14 +1047,35 @@ async fn apply_review_action<P>(
     reason: rb_types::ReviewReason,
     ids: &[rb_types::MemoryId],
     action: &rb_types::ReviewAction,
+    threshold: f32,
 ) -> Result<rb_types::ReviewResolution>
 where
     P: EmbeddingProvider,
 {
     use rb_types::{MemberConfidence, ReviewAction};
 
-    action.validate(ids)?;
+    action.validate(reason, ids)?;
     let key = rb_types::review_item_key(reason, ids);
+
+    // Resolve-time revalidation of the claimed relationship (PR #63 TOCTOU
+    // fix). Contradiction items are re-proved here for EVERY action; a
+    // near-dup MERGE is re-proved inside the atomic store transaction below
+    // (where the guard is race-free). Non-merge actions on other reasons are
+    // individually-targeted, reversible primitives.
+    if reason == rb_types::ReviewReason::Contradiction {
+        if let [a, b] = ids {
+            let still = job_store
+                .contradiction_pair_active(namespace.clone(), a.clone(), b.clone())
+                .await?;
+            if !still {
+                return Err(Error::StalePlan(format!(
+                    "{a} and {b} no longer form an active contradiction; re-run \
+                     review for a fresh queue"
+                )));
+            }
+        }
+    }
+
     let mut notes = Vec::with_capacity(ids.len());
     for id in ids {
         match engine.peek(id.clone()).await? {
@@ -1084,22 +1112,12 @@ where
             }
         }
         ReviewAction::Merge => {
-            // Merging requires both originals ACTIVE: superseding an already
-            // archived row would overwrite its existing supersede identity.
-            for note in &notes {
-                if note.archived_at.is_some() {
-                    return Err(Error::InvalidArgument(format!(
-                        "cannot merge {}: it is already archived; re-run review \
-                         for a fresh queue",
-                        note.id
-                    )));
-                }
-            }
             let (a, b) = (&notes[0], &notes[1]);
             // Deterministic combine: identical contents collapse to one;
             // otherwise both bodies are kept, first member first. Metadata
             // keeps the strongest signal (max importance/confidence) and the
-            // union of keywords/tags/files/anchors.
+            // union of keywords/tags/files/anchors; the graph edges are
+            // unioned inside the store transaction.
             let content = if a.content == b.content {
                 a.content.clone()
             } else {
@@ -1138,8 +1156,8 @@ where
             } else {
                 a.memory_type
             };
-            let new_id = engine
-                .remember(rb_engine::RememberInput {
+            let (note, embedding) = engine
+                .compose_note(rb_engine::RememberInput {
                     content,
                     context,
                     memory_type,
@@ -1152,13 +1170,28 @@ where
                     anchors,
                 })
                 .await?;
+            let new_id = note.id.clone();
+            let details = serde_json::json!({
+                "key": key,
+                "action": "merge",
+                "ids": ids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+                "merged_into": new_id.to_string(),
+            })
+            .to_string();
             job_store
-                .supersede(namespace.clone(), a.id.clone(), new_id.clone())
-                .await?;
-            job_store
-                .supersede(namespace.clone(), b.id.clone(), new_id.clone())
+                .review_merge(
+                    namespace.clone(),
+                    a.id.clone(),
+                    b.id.clone(),
+                    threshold,
+                    note,
+                    embedding,
+                    details,
+                )
                 .await?;
             resolution.merged_into = Some(new_id);
+            // The audit row was written INSIDE the merge transaction.
+            return Ok(resolution);
         }
         ReviewAction::Archive { id } => {
             engine.delete(id.clone()).await?;
@@ -1207,7 +1240,6 @@ where
         "key": key,
         "action": action.kind_str(),
         "ids": ids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
-        "merged_into": resolution.merged_into.as_ref().map(std::string::ToString::to_string),
     })
     .to_string();
     job_store
@@ -1216,26 +1248,29 @@ where
     Ok(resolution)
 }
 
-/// One bounded review apply pass (REV-3 `--apply --policy`): recompute the
-/// queue, derive the plan through the pure `ReviewPolicy::plan_action` (the
-/// SAME mapping a dry-run shows), and apply each planned action through
-/// [`apply_review_action`]. The `ForgetOutcome` failure shape (PR #60):
-/// every completed item's transactions are durable — a mid-batch failure is
-/// captured into `outcome.failure` instead of discarding the pass, and the
-/// bulk `review_sweep` oplog row is written unconditionally so a zero-change
-/// or partial pass is still an auditable run.
-async fn run_review_sweep<P>(
+/// Execute an already-generated review plan under `policy` (the apply half of
+/// `run_review_sweep`, split out so plan staleness is testable): derive each
+/// item's action through the pure `ReviewPolicy::plan_action` (the SAME
+/// mapping a dry-run shows) and apply it via [`apply_review_action`].
+///
+/// Failure semantics (PR #60 partial-outcome shape + the PR #63 refinement):
+/// a distinct [`Error::StalePlan`] — the item was resolved concurrently or
+/// its relationship dissolved between plan and apply — is a benign collision:
+/// counted as `skipped`, the pass continues. Any OTHER error stops the pass
+/// re-runnably; completed items stay committed. The bulk `review_sweep` oplog
+/// row is written unconditionally.
+async fn execute_review_plan<P>(
     engine: &MemoryEngine<StoreHandle, P>,
     job_store: &StoreHandle,
     provenance: &rb_engine::Provenance,
     namespace: &rb_types::Namespace,
     policy: rb_types::ReviewPolicy,
-    params: rb_store::ReviewQueueParams,
+    plan: &rb_types::ReviewPlan,
+    threshold: f32,
 ) -> Result<rb_types::ReviewOutcome>
 where
     P: EmbeddingProvider,
 {
-    let plan = job_store.review_plan(namespace.clone(), params).await?;
     let mut outcome = rb_types::ReviewOutcome {
         policy: Some(policy),
         total_items: plan.items.len() as u64,
@@ -1256,6 +1291,7 @@ where
             item.reason,
             &ids,
             &action,
+            threshold,
         )
         .await
         {
@@ -1266,6 +1302,13 @@ where
                 rb_types::ReviewAction::Demote { .. } => outcome.demoted += 1,
                 rb_types::ReviewAction::Snooze { .. } => outcome.snoozed += 1,
             },
+            Err(Error::StalePlan(reason)) => {
+                // Benign collision: someone resolved the item (or its
+                // relationship dissolved) between plan and apply. Skip it —
+                // the rest of the batch must still complete.
+                tracing::debug!(key = %item.key, %reason, "review item went stale; skipping");
+                outcome.skipped += 1;
+            }
             Err(e) => {
                 // The failed item's own steps rolled back or stand alone;
                 // earlier items are committed. Stop (re-runnable), report
@@ -1302,6 +1345,32 @@ where
     }
     outcome.failure = failure;
     Ok(outcome)
+}
+
+/// One bounded review apply pass (REV-3 `--apply --policy`): recompute the
+/// queue, then execute it via [`execute_review_plan`].
+async fn run_review_sweep<P>(
+    engine: &MemoryEngine<StoreHandle, P>,
+    job_store: &StoreHandle,
+    provenance: &rb_engine::Provenance,
+    namespace: &rb_types::Namespace,
+    policy: rb_types::ReviewPolicy,
+    params: rb_store::ReviewQueueParams,
+) -> Result<rb_types::ReviewOutcome>
+where
+    P: EmbeddingProvider,
+{
+    let plan = job_store.review_plan(namespace.clone(), params).await?;
+    execute_review_plan(
+        engine,
+        job_store,
+        provenance,
+        namespace,
+        policy,
+        &plan,
+        params.threshold,
+    )
+    .await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1668,16 +1737,24 @@ where
             }
         }
         // One per-item resolution (REV-2 interactive mode). Validation is
-        // fail-closed at this boundary: the action shape against the member
-        // ids, then every member resolved through the namespace-scoped
-        // engine (a foreign or missing id is NotFound before any write).
+        // fail-closed at this boundary: the action shape against the item
+        // reason and member ids, the resolve-time relationship revalidation
+        // (PR #63 TOCTOU fix), then every member resolved through the
+        // namespace-scoped engine (a foreign or missing id is NotFound
+        // before any write). The merge-revalidation threshold is clamped
+        // exactly like Review's.
         Request::Resolve {
             reason,
             ids,
             action,
+            threshold,
         } => {
+            let threshold = match threshold {
+                Some(t) if t.is_finite() => t.clamp(rb_types::REVIEW_MIN_THRESHOLD, 1.0),
+                _ => rb_types::REVIEW_DEFAULT_THRESHOLD,
+            };
             match apply_review_action(
-                engine, job_store, provenance, namespace, reason, &ids, &action,
+                engine, job_store, provenance, namespace, reason, &ids, &action, threshold,
             )
             .await
             {
@@ -2283,5 +2360,92 @@ mod tests {
         );
 
         store.shutdown().await;
+    }
+
+    /// PR #63 MEDIUM: a policy sweep must skip-and-continue past a BENIGN
+    /// stale-plan collision (an item resolved concurrently between plan and
+    /// apply) instead of aborting the whole batch; real errors still stop
+    /// the pass (proved by the mid-batch-failure e2e).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn review_sweep_skips_stale_items_and_completes_the_rest() {
+        use rb_embed::DeterministicProvider;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, 8, 2).unwrap();
+        let ns = Namespace::Project("sweep-stale".to_string());
+        let engine = rb_engine::MemoryEngine::new(
+            handle.clone(),
+            SharedEmbedder::new(DeterministicProvider::new(8)),
+            ns.clone(),
+        );
+        let provenance = rb_engine::Provenance {
+            origin_source: Some("cli".to_string()),
+            ..Default::default()
+        };
+
+        // Two independent dup pairs => two planned merges.
+        let mut ids = Vec::new();
+        for content in [
+            "first duplicated remark",
+            "first duplicated remark",
+            "second duplicated remark",
+            "second duplicated remark",
+        ] {
+            let id = engine
+                .remember(rb_engine::RememberInput {
+                    content: content.to_string(),
+                    context: None,
+                    memory_type: rb_types::MemoryType::Insight,
+                    importance: 5,
+                    keywords: vec![],
+                    tags: vec![],
+                    related_files: vec![],
+                    confidence: Some(1.0),
+                    provenance: provenance.clone(),
+                    anchors: vec![],
+                })
+                .await
+                .unwrap();
+            ids.push(id);
+        }
+
+        let params = rb_store::ReviewQueueParams {
+            threshold: rb_types::REVIEW_DEFAULT_THRESHOLD,
+            limit: 50,
+            since: None,
+        };
+        let plan = handle.review_plan(ns.clone(), params).await.unwrap();
+        let dup_items = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == rb_types::ReviewReason::NearDuplicate)
+            .count();
+        assert_eq!(dup_items, 2, "both pairs planned: {plan:?}");
+
+        // Concurrent-resolution simulation: archive one member of the FIRST
+        // planned pair after the plan was generated.
+        let stale_member = plan.items[0].members[0].id.clone();
+        engine.delete(stale_member).await.unwrap();
+
+        let outcome = execute_review_plan(
+            &engine,
+            &handle,
+            &provenance,
+            &ns,
+            rb_types::ReviewPolicy::AutoMergeDups,
+            &plan,
+            params.threshold,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outcome.failure, None,
+            "a benign collision must not fail the pass: {outcome:?}"
+        );
+        assert_eq!(outcome.merged, 1, "the live pair still merges");
+        assert_eq!(outcome.skipped, 1, "the stale item is counted as skipped");
+
+        handle.shutdown().await;
     }
 }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -193,6 +193,34 @@ enum WriteCommand {
         mode: rb_types::ForgetMode,
         reply: oneshot::Sender<Result<rb_types::ForgetOutcome>>,
     },
+    /// Persist one review snooze (REV-2): upsert `review_state` + the
+    /// `review_resolve` oplog row in one store transaction. Typed reply
+    /// carries the snooze expiry (the RenameNamespace/Scrub pattern). No
+    /// `MemoryChanged` event: a snooze changes no memory row.
+    ReviewSnooze {
+        namespace: Namespace,
+        key: String,
+        days: u32,
+        details: String,
+        reply: oneshot::Sender<Result<i64>>,
+    },
+    /// Stamp `reviewed_at` + append the `review_resolve` oplog row (REV-4)
+    /// for a non-snooze resolution. The mutation itself already ran through
+    /// the existing primitives (each publishing its own event).
+    ReviewResolutionRecord {
+        namespace: Namespace,
+        key: String,
+        details: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Append the bulk `review_sweep` oplog row (the `retention_sweep`
+    /// bulk-row precedent: written unconditionally, empty memory-id sentinel
+    /// so replay skips it).
+    ReviewSweepRecord {
+        namespace: Namespace,
+        details: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
     #[cfg(test)]
     PanicForTest {
         reply: oneshot::Sender<Result<()>>,
@@ -984,6 +1012,80 @@ impl StoreHandle {
         self.with_read(move |store| store.candidates_for_consolidation(limit))
             .await
     }
+
+    /// The review queue (PRD 2026-07-02 contradiction/dedup review): the
+    /// priority-ordered candidate set for `namespace`. Read-only, via the
+    /// bounded read pool — queue generation never reaches the writer (W1.8;
+    /// pinned by `review_plan_runs_on_the_read_pool_with_zero_writer_ops`).
+    pub async fn review_plan(
+        &self,
+        namespace: Namespace,
+        params: rb_store::ReviewQueueParams,
+    ) -> Result<rb_types::ReviewPlan> {
+        self.with_read(move |store| store.review_queue(&namespace, &params, chrono::Utc::now()))
+            .await
+    }
+
+    /// Persist one review snooze (REV-2) through the single writer: upsert
+    /// the item's `review_state` row and append the `review_resolve` oplog
+    /// row in one store transaction. Returns the snooze expiry (unix secs).
+    pub async fn review_snooze(
+        &self,
+        namespace: Namespace,
+        key: String,
+        days: u32,
+        details: String,
+    ) -> Result<i64> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(Error::Storage("writer thread unavailable".to_string()));
+        }
+        let (reply, rx) = oneshot::channel();
+        self.writer_tx
+            .send(WriteCommand::ReviewSnooze {
+                namespace,
+                key,
+                days,
+                details,
+                reply,
+            })
+            .await
+            .map_err(|_| Error::Storage("writer thread unavailable".to_string()))?;
+        rx.await
+            .map_err(|_| Error::Storage("writer dropped reply".to_string()))?
+    }
+
+    /// Record one non-snooze review resolution (REV-4 audit): stamp
+    /// `reviewed_at` (clearing any snooze) and append the `review_resolve`
+    /// oplog row — one store transaction through the single writer. The
+    /// mutation itself runs through the existing primitives beforehand.
+    pub async fn record_review_resolution(
+        &self,
+        namespace: Namespace,
+        key: String,
+        details: String,
+    ) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::ReviewResolutionRecord {
+            namespace,
+            key,
+            details,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
+
+    /// Append the bulk `review_sweep` oplog row (REV-4) — written
+    /// unconditionally after a policy apply pass, the `retention_sweep`
+    /// bulk-row precedent.
+    pub async fn record_review_sweep(&self, namespace: Namespace, details: String) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        let cmd = WriteCommand::ReviewSweepRecord {
+            namespace,
+            details,
+            reply,
+        };
+        self.send_write(cmd, rx).await
+    }
 }
 
 struct StoreOpReport {
@@ -1657,6 +1759,81 @@ fn writer_loop(
                     outcome
                 });
                 let _ = reply.send(result);
+                if !writer_usable {
+                    break;
+                }
+            }
+            WriteCommand::ReviewSnooze {
+                namespace,
+                key,
+                days,
+                details,
+                reply,
+            } => {
+                // Typed payload via the RenameNamespace/Scrub pattern. No
+                // MemoryChanged event: a snooze changes no memory row — the
+                // oplog row (empty-sentinel) is the durable record.
+                let mut payload = None;
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| {
+                        payload = Some(s.snooze_review_item(
+                            &namespace,
+                            &key,
+                            days,
+                            &details,
+                            chrono::Utc::now(),
+                        )?);
+                        Ok(())
+                    },
+                );
+                let writer_usable = report.writer_usable;
+                let result = report.result.and_then(|()| {
+                    payload.ok_or_else(|| {
+                        Error::Storage("review snooze completed without an expiry".to_string())
+                    })
+                });
+                let _ = reply.send(result);
+                if !writer_usable {
+                    break;
+                }
+            }
+            WriteCommand::ReviewResolutionRecord {
+                namespace,
+                key,
+                details,
+                reply,
+            } => {
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.record_review_resolution(&namespace, &key, &details, chrono::Utc::now()),
+                );
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if !writer_usable {
+                    break;
+                }
+            }
+            WriteCommand::ReviewSweepRecord {
+                namespace,
+                details,
+                reply,
+            } => {
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| s.record_review_sweep(&namespace, &details, chrono::Utc::now()),
+                );
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
                 if !writer_usable {
                     break;
                 }
@@ -3132,6 +3309,122 @@ mod tests {
                 Namespace::Project("retention".to_string())
             ]
         );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn review_plan_runs_on_the_read_pool_with_zero_writer_ops() {
+        // The review queue is a read-side aggregate (W1.8): generating it
+        // must enqueue NOTHING on the writer thread — the stats/history
+        // proof, extended to the review path.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("review-read-pool".to_string());
+
+        let a = note(&ns, "sqlite is the only database");
+        let b = note(&ns, "postgres is the only database");
+        let (aid, bid) = (a.id.clone(), b.id.clone());
+        handle.write(a, None).await.unwrap();
+        handle.write(b, None).await.unwrap();
+        handle
+            .add_link(rb_types::MemoryLink {
+                source_id: aid.clone(),
+                target_id: bid.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 1.0,
+                reason: "test".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let ops_before = handle.writer_ops_count();
+        let plan = handle
+            .review_plan(
+                ns.clone(),
+                rb_store::ReviewQueueParams {
+                    threshold: 0.95,
+                    limit: 50,
+                    since: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(plan.items.len(), 1, "the seeded pair surfaces");
+        assert_eq!(plan.items[0].reason, rb_types::ReviewReason::Contradiction);
+        assert_eq!(
+            handle.writer_ops_count(),
+            ops_before,
+            "review-plan generation must issue ZERO writer-thread ops"
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn review_snooze_and_records_go_through_the_writer_and_hide_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("review-snooze".to_string());
+
+        let a = note(&ns, "one side");
+        let b = note(&ns, "other side");
+        let (aid, bid) = (a.id.clone(), b.id.clone());
+        handle.write(a, None).await.unwrap();
+        handle.write(b, None).await.unwrap();
+        handle
+            .add_link(rb_types::MemoryLink {
+                source_id: aid.clone(),
+                target_id: bid.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 1.0,
+                reason: "test".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let params = rb_store::ReviewQueueParams {
+            threshold: 0.95,
+            limit: 50,
+            since: None,
+        };
+        let key = rb_types::review_item_key(
+            rb_types::ReviewReason::Contradiction,
+            &[aid.clone(), bid.clone()],
+        );
+
+        let ops_before = handle.writer_ops_count();
+        let until = handle
+            .review_snooze(ns.clone(), key.clone(), 7, "{}".to_string())
+            .await
+            .unwrap();
+        assert!(until > chrono::Utc::now().timestamp(), "future expiry");
+        assert!(
+            handle.writer_ops_count() > ops_before,
+            "snooze persistence is a writer op"
+        );
+
+        let plan = handle.review_plan(ns.clone(), params).await.unwrap();
+        assert!(
+            plan.items.is_empty(),
+            "snoozed item hidden: {:?}",
+            plan.items
+        );
+        assert_eq!(plan.totals.snoozed, 1);
+
+        // The audit records go through the writer without error.
+        handle
+            .record_review_resolution(ns.clone(), key, r#"{"action":"keep"}"#.to_string())
+            .await
+            .unwrap();
+        handle
+            .record_review_sweep(ns.clone(), r#"{"policy":"auto-merge-dups"}"#.to_string())
+            .await
+            .unwrap();
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -204,6 +204,23 @@ enum WriteCommand {
         details: String,
         reply: oneshot::Sender<Result<i64>>,
     },
+    /// Atomically merge a near-duplicate pair (PRD 2026-07-02 review; the
+    /// PR #63 atomicity fix): ONE store transaction re-validates the pair,
+    /// inserts the pre-composed combined memory, copies the originals'
+    /// external edges, supersedes both originals behind the pointer guard,
+    /// and writes the audit row. Single-writer serialization makes two
+    /// concurrent merges of the same pair impossible — the loser gets
+    /// `Error::StalePlan`.
+    ReviewMerge {
+        namespace: Namespace,
+        a: MemoryId,
+        b: MemoryId,
+        min_similarity: f32,
+        note: Box<MemoryNote>,
+        embedding: Option<Vec<f32>>,
+        details: String,
+        reply: oneshot::Sender<Result<()>>,
+    },
     /// Stamp `reviewed_at` + append the `review_resolve` oplog row (REV-4)
     /// for a non-snooze resolution. The mutation itself already ran through
     /// the existing primitives (each publishing its own event).
@@ -1026,6 +1043,56 @@ impl StoreHandle {
             .await
     }
 
+    /// Is there still an active contradiction between exactly `a` and `b` in
+    /// `namespace`? The resolve-time revalidation for contradiction items
+    /// (PR #63 TOCTOU fix). Read-only, via the bounded read pool.
+    pub async fn contradiction_pair_active(
+        &self,
+        namespace: Namespace,
+        a: MemoryId,
+        b: MemoryId,
+    ) -> Result<bool> {
+        self.with_read(move |store| store.contradiction_pair_active(&namespace, &a, &b))
+            .await
+    }
+
+    /// Atomically merge a near-duplicate pair through the single writer (PRD
+    /// 2026-07-02 review; the PR #63 atomicity fix): one all-or-nothing store
+    /// transaction — see [`rb_store::SqliteStore::review_merge`]. On success
+    /// the arm publishes `Created` for the combined memory and `Archived` for
+    /// both originals.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn review_merge(
+        &self,
+        namespace: Namespace,
+        a: MemoryId,
+        b: MemoryId,
+        min_similarity: f32,
+        note: MemoryNote,
+        embedding: Option<Vec<f32>>,
+        details: String,
+    ) -> Result<()> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(Error::Storage("writer thread unavailable".to_string()));
+        }
+        let (reply, rx) = oneshot::channel();
+        self.writer_tx
+            .send(WriteCommand::ReviewMerge {
+                namespace,
+                a,
+                b,
+                min_similarity,
+                note: Box::new(note),
+                embedding,
+                details,
+                reply,
+            })
+            .await
+            .map_err(|_| Error::Storage("writer thread unavailable".to_string()))?;
+        rx.await
+            .map_err(|_| Error::Storage("writer dropped reply".to_string()))?
+    }
+
     /// Persist one review snooze (REV-2) through the single writer: upsert
     /// the item's `review_state` row and append the `review_resolve` oplog
     /// row in one store transaction. Returns the snooze expiry (unix secs).
@@ -1797,6 +1864,62 @@ fn writer_loop(
                     })
                 });
                 let _ = reply.send(result);
+                if !writer_usable {
+                    break;
+                }
+            }
+            WriteCommand::ReviewMerge {
+                namespace,
+                a,
+                b,
+                min_similarity,
+                note,
+                embedding,
+                details,
+                reply,
+            } => {
+                let report = run_store_op(
+                    &mut store,
+                    &db_path,
+                    embedding_dim,
+                    embedding_model.as_deref(),
+                    |s| {
+                        s.review_merge(
+                            &namespace,
+                            &a,
+                            &b,
+                            min_similarity,
+                            &note,
+                            embedding.as_deref(),
+                            &details,
+                            chrono::Utc::now(),
+                        )
+                    },
+                );
+                let merged = report.result.is_ok();
+                let writer_usable = report.writer_usable;
+                let _ = reply.send(report.result);
+                if merged {
+                    // Subscribers observe the merge as one Created (the
+                    // combined memory) plus two Archived events, each stamped
+                    // with its own oplog seq (the retention-sweep rule).
+                    publish_change_stamped(
+                        &events,
+                        store.as_ref(),
+                        note.id.clone(),
+                        namespace.clone(),
+                        ChangeKind::Created,
+                    );
+                    for old in [a, b] {
+                        publish_change_stamped(
+                            &events,
+                            store.as_ref(),
+                            old,
+                            namespace.clone(),
+                            ChangeKind::Archived,
+                        );
+                    }
+                }
                 if !writer_usable {
                     break;
                 }

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -2241,6 +2241,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::Contradiction,
             vec![con_a.clone(), con_b.clone()],
             rb_types::ReviewAction::Keep { bump: true },
+            None,
         )
         .await
         .unwrap();
@@ -2262,6 +2263,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::LowConfidence,
             vec![low.clone()],
             rb_types::ReviewAction::Demote { id: low.clone() },
+            None,
         )
         .await
         .unwrap();
@@ -2279,6 +2281,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::Contradiction,
             vec![con_a.clone(), con_b.clone()],
             rb_types::ReviewAction::Archive { id: con_b.clone() },
+            None,
         )
         .await
         .unwrap();
@@ -2302,6 +2305,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::LowConfidence,
             vec![low.clone()],
             rb_types::ReviewAction::Snooze { days: 3 },
+            None,
         )
         .await
         .unwrap();
@@ -2324,6 +2328,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::NearDuplicate,
             vec![con_a.clone()],
             rb_types::ReviewAction::Merge,
+            None,
         )
         .await
         .unwrap_err();
@@ -2334,6 +2339,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewReason::Contradiction,
             vec![con_a.clone(), con_b.clone()],
             rb_types::ReviewAction::Archive { id: outsider },
+            None,
         )
         .await
         .unwrap_err();
@@ -2353,6 +2359,7 @@ async fn review_resolve_actions_apply_atomically_over_the_wire() {
             rb_types::ReviewAction::Archive {
                 id: foreign.clone(),
             },
+            None,
         )
         .await
         .unwrap_err();
@@ -2526,6 +2533,167 @@ async fn review_apply_reports_partial_outcome_on_mid_batch_failure() {
         .unwrap();
     assert_eq!(outcome.merged, 1, "re-run completes the remaining pair");
     assert_eq!(outcome.failure, None);
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_merges_of_the_same_pair_resolve_exactly_once() {
+    // PR #63 CRITICAL: two concurrent resolutions of the same pair (e.g. an
+    // interactive session racing a policy sweep) must never split the chain.
+    // The whole merge is ONE writer transaction, so the loser re-validates
+    // inside its own tx, finds the members claimed, and fails with the
+    // distinct stale-plan error while the winner's chain stays single.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-race".to_string());
+    let mut seeder = cli_client(&daemon.socket, &ns).await.unwrap();
+    let a = store_plain(&mut seeder, "the same fact twice", 1.0).await;
+    let b = store_plain(&mut seeder, "the same fact twice", 1.0).await;
+
+    let mut c1 = cli_client(&daemon.socket, &ns).await.unwrap();
+    let mut c2 = cli_client(&daemon.socket, &ns).await.unwrap();
+    let ids = vec![a.clone(), b.clone()];
+    let (r1, r2) = tokio::join!(
+        c1.resolve_review_item(
+            rb_types::ReviewReason::NearDuplicate,
+            ids.clone(),
+            rb_types::ReviewAction::Merge,
+            None,
+        ),
+        c2.resolve_review_item(
+            rb_types::ReviewReason::NearDuplicate,
+            ids.clone(),
+            rb_types::ReviewAction::Merge,
+            None,
+        ),
+    );
+    let (ok, err) = match (r1, r2) {
+        (Ok(ok), Err(err)) | (Err(err), Ok(ok)) => (ok, err),
+        (Ok(x), Ok(y)) => panic!("BOTH merges succeeded — split chain: {x:?} / {y:?}"),
+        (Err(x), Err(y)) => panic!("both merges failed: {x:?} / {y:?}"),
+    };
+    assert!(
+        matches!(err, Error::StalePlan(_)),
+        "the loser gets the distinct stale-plan error, got {err:?}"
+    );
+    let merged_id = ok.merged_into.expect("winner reports the combined id");
+
+    // Single, consistent chain: both originals point at the ONE combined
+    // memory; exactly one combined row is live.
+    let a_row = seeder.get(a).await.unwrap().unwrap();
+    let b_row = seeder.get(b).await.unwrap().unwrap();
+    assert_eq!(a_row.superseded_by, Some(merged_id.clone()));
+    assert_eq!(b_row.superseded_by, Some(merged_id.clone()));
+    assert!(a_row.archived_at.is_some() && b_row.archived_at.is_some());
+    let live: Vec<_> = seeder.list(None, 50).await.unwrap();
+    assert_eq!(
+        live.iter().map(|m| m.id.clone()).collect::<Vec<_>>(),
+        vec![merged_id],
+        "exactly one live memory: the winner's combined row"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resolve_revalidates_the_planned_relationship() {
+    // PR #63 HIGH (TOCTOU): a Resolve must prove the (reason, ids) claim at
+    // resolve time — the wire must not accept Merge for two arbitrary active
+    // ids, a broken contradiction, or a pair someone already resolved.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-stale".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+
+    // Merge of two DISTINCT (non-near-dup) actives: stale plan, no writes.
+    let x = store_plain(&mut client, "topic one entirely", 1.0).await;
+    let y = store_plain(&mut client, "a different topic altogether", 1.0).await;
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::NearDuplicate,
+            vec![x.clone(), y.clone()],
+            rb_types::ReviewAction::Merge,
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::StalePlan(_)), "{err:?}");
+    for id in [&x, &y] {
+        let m = client.get((*id).clone()).await.unwrap().unwrap();
+        assert!(m.archived_at.is_none() && m.superseded_by.is_none());
+    }
+
+    // Merge after a member was resolved (archived): stale plan.
+    let d1 = store_plain(&mut client, "duplicated remark", 1.0).await;
+    let d2 = store_plain(&mut client, "duplicated remark", 1.0).await;
+    client.delete(d2.clone()).await.unwrap();
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::NearDuplicate,
+            vec![d1.clone(), d2.clone()],
+            rb_types::ReviewAction::Merge,
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::StalePlan(_)), "{err:?}");
+
+    // A contradiction action after the pair stopped contradicting (one side
+    // archived): stale plan, nothing mutated.
+    let c1 = store_plain(&mut client, "always squash merge", 0.8).await;
+    let c2 = store_plain(&mut client, "never squash merge", 0.8).await;
+    client
+        .link(
+            c1.clone(),
+            c2.clone(),
+            rb_types::LinkType::Contradicts,
+            None,
+        )
+        .await
+        .unwrap();
+    client.delete(c2.clone()).await.unwrap();
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::Contradiction,
+            vec![c1.clone(), c2.clone()],
+            rb_types::ReviewAction::Keep { bump: true },
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::StalePlan(_)), "{err:?}");
+    let untouched = client.get(c1.clone()).await.unwrap().unwrap();
+    assert!(
+        (untouched.confidence - 0.8).abs() < 1e-6,
+        "the stale keep-bump must not nudge confidence"
+    );
+
+    // Merge on a Contradiction item is rejected outright (reason-restricted).
+    let e1 = store_plain(&mut client, "tabs are correct", 1.0).await;
+    let e2 = store_plain(&mut client, "spaces are correct", 1.0).await;
+    client
+        .link(
+            e1.clone(),
+            e2.clone(),
+            rb_types::LinkType::Contradicts,
+            None,
+        )
+        .await
+        .unwrap();
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::Contradiction,
+            vec![e1, e2],
+            rb_types::ReviewAction::Merge,
+            None,
+        )
+        .await
+        .unwrap_err();
+    match &err {
+        Error::InvalidArgument(msg) => {
+            assert!(msg.contains("near-duplicate"), "{msg}");
+        }
+        other => panic!("merge on a contradiction must be invalid, got {other:?}"),
+    }
 
     daemon.stop().await;
 }

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1,6 +1,6 @@
 //! End-to-end daemon tests over a real Unix socket with the offline
 //! DeterministicProvider (no network).
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -1998,4 +1998,534 @@ async fn retention_forget_flow_over_the_wire_respects_guards() {
         .await
         .expect("daemon shutdown")
         .expect("daemon task ok");
+}
+
+// ---------------------------------------------------------------------------
+// Guided review (PRD 2026-07-02 contradiction/dedup review)
+// ---------------------------------------------------------------------------
+
+/// Store one CLI-sourced memory with explicit confidence and NO tags/keywords
+/// (so the composite embedding is exactly the content — identical contents
+/// become cosine-1.0 near-dups under the DeterministicProvider, distinct
+/// contents stay far apart).
+async fn store_plain(client: &mut Client, text: &str, confidence: f32) -> rb_types::MemoryId {
+    client
+        .remember(
+            text.to_string(),
+            None,
+            MemoryType::Insight,
+            5,
+            vec![],
+            vec![],
+            vec![],
+            Some(confidence),
+        )
+        .await
+        .unwrap()
+}
+
+async fn cli_client(socket: &std::path::Path, ns: &Namespace) -> rb_types::Result<Client> {
+    Client::connect_with_identity(
+        socket,
+        ns.clone(),
+        Some(ClientIdentity {
+            source: Some("cli".to_string()),
+            ..Default::default()
+        }),
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn review_queue_surfaces_seeded_items_in_priority_order() {
+    // PRD acceptance 1: `review` surfaces a seeded contradiction and a
+    // near-dup pair in priority order; dry-run makes zero writes.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-queue".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+
+    // Tier 3 first so insertion order cannot fake priority order.
+    let low = store_plain(&mut client, "half remembered hunch about the cache", 0.2).await;
+    // Tier 2: identical contents => cosine-1.0 twins (write-time suppression
+    // is hook-gated, so both CLI writes stay live).
+    let dup_a = store_plain(&mut client, "release trains depart every Tuesday", 1.0).await;
+    let dup_b = store_plain(&mut client, "release trains depart every Tuesday", 1.0).await;
+    // Tier 1: an explicit contradiction.
+    let con_a = store_plain(
+        &mut client,
+        "the daemon owns exactly one writer thread",
+        1.0,
+    )
+    .await;
+    let con_b = store_plain(
+        &mut client,
+        "every connection writes straight to sqlite",
+        1.0,
+    )
+    .await;
+    client
+        .link(
+            con_a.clone(),
+            con_b.clone(),
+            rb_types::LinkType::Contradicts,
+            Some("seeded".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let plan = client.review_plan(None, None, None, None).await.unwrap();
+    let reasons: Vec<rb_types::ReviewReason> = plan.items.iter().map(|i| i.reason).collect();
+    assert_eq!(
+        reasons,
+        vec![
+            rb_types::ReviewReason::Contradiction,
+            rb_types::ReviewReason::NearDuplicate,
+            rb_types::ReviewReason::LowConfidence,
+        ],
+        "priority order: contradictions, dups, low-confidence — got {plan:?}"
+    );
+    let contra_ids: Vec<&rb_types::MemoryId> =
+        plan.items[0].members.iter().map(|m| &m.id).collect();
+    assert!(contra_ids.contains(&&con_a) && contra_ids.contains(&&con_b));
+    let dup_ids: Vec<&rb_types::MemoryId> = plan.items[1].members.iter().map(|m| &m.id).collect();
+    assert!(dup_ids.contains(&&dup_a) && dup_ids.contains(&&dup_b));
+    assert!(
+        plan.items[1].similarity.unwrap() >= 0.95,
+        "near-dup similarity rides the item"
+    );
+    assert_eq!(plan.items[2].members[0].id, low);
+    assert_eq!(
+        plan.items[2].members[0].origin_source.as_deref(),
+        Some("cli"),
+        "members carry provenance for the human decision"
+    );
+    assert!(plan.policy.is_none() && plan.planned.is_empty());
+
+    // With a policy, the dry-run plans EXACTLY the policy's actions (the
+    // shared-plan determinism the apply pass executes).
+    let planned = client
+        .review_plan(
+            Some(rb_types::ReviewPolicy::AutoMergeDups),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(planned.policy, Some(rb_types::ReviewPolicy::AutoMergeDups));
+    assert_eq!(planned.planned.len(), 1, "one dup pair to merge");
+    assert_eq!(planned.planned[0].action, rb_types::ReviewAction::Merge);
+    assert_eq!(planned.planned[0].key, planned.items[1].key);
+
+    // Dry-runs made zero writes: everything is still live and unchanged.
+    for id in [&low, &dup_a, &dup_b, &con_a, &con_b] {
+        let m = client.get((*id).clone()).await.unwrap().unwrap();
+        assert!(m.archived_at.is_none(), "{id} was mutated by a dry-run");
+    }
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn review_apply_auto_merge_dups_merges_pair_and_feeds_history() {
+    // PRD acceptance 2: `--apply --policy auto-merge-dups` merges a dup pair
+    // into one superseding memory (originals archived), recording provenance
+    // and feeding the history timeline.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-apply".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+
+    let dup_a = store_plain(&mut client, "retro notes live in the shared drive", 0.9).await;
+    let dup_b = store_plain(&mut client, "retro notes live in the shared drive", 0.6).await;
+    let con_a = store_plain(&mut client, "use tabs in this repository", 1.0).await;
+    let con_b = store_plain(&mut client, "use spaces in this repository", 1.0).await;
+    client
+        .link(
+            con_a.clone(),
+            con_b.clone(),
+            rb_types::LinkType::Contradicts,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let outcome = client
+        .review_apply(rb_types::ReviewPolicy::AutoMergeDups, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(outcome.policy, Some(rb_types::ReviewPolicy::AutoMergeDups));
+    assert_eq!(outcome.merged, 1, "one dup pair merged: {outcome:?}");
+    assert_eq!(
+        outcome.skipped, 1,
+        "the contradiction is out of policy scope"
+    );
+    assert_eq!(outcome.total_items, 2);
+    assert_eq!(outcome.failure, None);
+
+    // Both originals archived and superseded by ONE combined memory.
+    let a = client.get(dup_a.clone()).await.unwrap().unwrap();
+    let b = client.get(dup_b.clone()).await.unwrap().unwrap();
+    assert!(a.archived_at.is_some() && b.archived_at.is_some());
+    let merged_id = a.superseded_by.clone().expect("a points at the merge");
+    assert_eq!(b.superseded_by, Some(merged_id.clone()), "one survivor");
+    let merged = client.get(merged_id.clone()).await.unwrap().unwrap();
+    assert!(merged.archived_at.is_none(), "the combined memory is live");
+    assert!(
+        merged
+            .content
+            .contains("retro notes live in the shared drive"),
+        "combined content carries the originals"
+    );
+    assert!(
+        (merged.confidence - 0.9).abs() < 1e-6,
+        "merge keeps the strongest confidence, got {}",
+        merged.confidence
+    );
+    assert_eq!(
+        merged.origin_source.as_deref(),
+        Some("cli"),
+        "REV-4: the resolution records the standard provenance"
+    );
+
+    // The contradiction pair is untouched.
+    for id in [&con_a, &con_b] {
+        let m = client.get((*id).clone()).await.unwrap().unwrap();
+        assert!(m.archived_at.is_none());
+    }
+
+    // History (PRD 5 integration): the original's timeline walks forward to
+    // the merged memory.
+    let history = client.history(dup_a.clone(), None).await.unwrap();
+    let chain_ids: Vec<&rb_types::MemoryId> = history.chain.iter().map(|e| &e.id).collect();
+    assert!(
+        chain_ids.contains(&&merged_id),
+        "the merge shows up in the supersede chain: {history:?}"
+    );
+
+    // The queue converges: re-running review no longer surfaces the dup pair.
+    let plan = client.review_plan(None, None, None, None).await.unwrap();
+    assert!(
+        plan.items
+            .iter()
+            .all(|i| i.reason != rb_types::ReviewReason::NearDuplicate),
+        "merged pair must not resurface: {plan:?}"
+    );
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn review_resolve_actions_apply_atomically_over_the_wire() {
+    // PRD acceptance 3/4: interactive per-item actions apply atomically;
+    // snoozed items do not reappear.
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-resolve".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+
+    let con_a = store_plain(&mut client, "deploy on fridays is fine", 0.8).await;
+    let con_b = store_plain(&mut client, "never deploy on fridays", 0.8).await;
+    client
+        .link(
+            con_a.clone(),
+            con_b.clone(),
+            rb_types::LinkType::Contradicts,
+            None,
+        )
+        .await
+        .unwrap();
+    let low = store_plain(&mut client, "possibly the cache is per host", 0.2).await;
+
+    // keep --bump nudges every member up by the documented delta.
+    let resolution = client
+        .resolve_review_item(
+            rb_types::ReviewReason::Contradiction,
+            vec![con_a.clone(), con_b.clone()],
+            rb_types::ReviewAction::Keep { bump: true },
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolution.action, "keep");
+    assert_eq!(resolution.confidence.len(), 2);
+    for mc in &resolution.confidence {
+        assert!(
+            (mc.confidence - 0.85).abs() < 1e-6,
+            "0.8 + 0.05 bump, got {}",
+            mc.confidence
+        );
+    }
+    let bumped = client.get(con_a.clone()).await.unwrap().unwrap();
+    assert!((bumped.confidence - 0.85).abs() < 1e-6, "bump persisted");
+
+    // demote lowers the target's confidence by the documented step.
+    let resolution = client
+        .resolve_review_item(
+            rb_types::ReviewReason::LowConfidence,
+            vec![low.clone()],
+            rb_types::ReviewAction::Demote { id: low.clone() },
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolution.action, "demote");
+    let demoted = client.get(low.clone()).await.unwrap().unwrap();
+    assert!(
+        (demoted.confidence - 0.05).abs() < 1e-6,
+        "0.2 - 0.15 step, got {}",
+        demoted.confidence
+    );
+
+    // archive soft-deletes the chosen loser and leaves the winner live.
+    let resolution = client
+        .resolve_review_item(
+            rb_types::ReviewReason::Contradiction,
+            vec![con_a.clone(), con_b.clone()],
+            rb_types::ReviewAction::Archive { id: con_b.clone() },
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolution.action, "archive");
+    let loser = client.get(con_b.clone()).await.unwrap().unwrap();
+    assert!(loser.archived_at.is_some(), "loser archived");
+    let winner = client.get(con_a.clone()).await.unwrap().unwrap();
+    assert!(winner.archived_at.is_none(), "winner untouched");
+
+    // snooze hides the remaining low-confidence item from the queue.
+    let before = client.review_plan(None, None, None, None).await.unwrap();
+    assert!(
+        before
+            .items
+            .iter()
+            .any(|i| i.reason == rb_types::ReviewReason::LowConfidence),
+        "low-confidence item present before snooze: {before:?}"
+    );
+    let resolution = client
+        .resolve_review_item(
+            rb_types::ReviewReason::LowConfidence,
+            vec![low.clone()],
+            rb_types::ReviewAction::Snooze { days: 3 },
+        )
+        .await
+        .unwrap();
+    assert_eq!(resolution.action, "snooze");
+    let until = resolution.snoozed_until.expect("expiry returned");
+    assert!(until > chrono::Utc::now().timestamp());
+    let after = client.review_plan(None, None, None, None).await.unwrap();
+    assert!(
+        after
+            .items
+            .iter()
+            .all(|i| i.reason != rb_types::ReviewReason::LowConfidence),
+        "snoozed item must not reappear: {after:?}"
+    );
+    assert_eq!(after.totals.snoozed, 1);
+
+    // Fail-closed validation: malformed resolutions never mutate.
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::NearDuplicate,
+            vec![con_a.clone()],
+            rb_types::ReviewAction::Merge,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+    let outsider = store_plain(&mut client, "an unrelated bystander", 1.0).await;
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::Contradiction,
+            vec![con_a.clone(), con_b.clone()],
+            rb_types::ReviewAction::Archive { id: outsider },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::InvalidArgument(_)), "{err:?}");
+
+    // Namespace isolation: a foreign-namespace member fails closed (NotFound
+    // at the daemon, surfaced as a wire error the client maps to
+    // Error::Storage — the update/delete isolation convention) and nothing
+    // is written.
+    let other = Namespace::Project("review-resolve-other".to_string());
+    let mut foreign_client = cli_client(&daemon.socket, &other).await.unwrap();
+    let foreign = store_plain(&mut foreign_client, "foreign namespace memory", 1.0).await;
+    let err = client
+        .resolve_review_item(
+            rb_types::ReviewReason::LowConfidence,
+            vec![foreign.clone()],
+            rb_types::ReviewAction::Archive {
+                id: foreign.clone(),
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(&err, Error::Storage(msg) if msg.contains("not found")),
+        "foreign-namespace resolve must fail closed, got {err:?}"
+    );
+    let untouched = foreign_client.get(foreign).await.unwrap().unwrap();
+    assert!(untouched.archived_at.is_none());
+
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn review_execute_requires_policy_and_absent_dry_run_previews() {
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("review-gate".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+    store_plain(&mut client, "just one memory", 0.2).await;
+
+    // Raw frame path (an old or hand-rolled client): executing without a
+    // policy is refused — REV-3 requires an explicit policy filter.
+    let stream = tokio::net::UnixStream::connect(&daemon.socket)
+        .await
+        .unwrap();
+    let mut framed = rb_proto::bounded_framed(stream);
+    rb_proto::write_frame(
+        &mut framed,
+        &rb_proto::Handshake {
+            contract_version: rb_proto::CONTRACT_VERSION,
+            namespace: ns.clone(),
+            identity: None,
+        },
+    )
+    .await
+    .unwrap();
+    let ack: rb_proto::HandshakeAck = rb_proto::read_frame(&mut framed).await.unwrap();
+    assert!(ack.ok);
+
+    let raw: serde_json::Value = serde_json::json!({"op": "Review", "dry_run": false});
+    rb_proto::write_frame(&mut framed, &raw).await.unwrap();
+    let resp: rb_proto::Response = rb_proto::read_frame(&mut framed).await.unwrap();
+    match resp {
+        rb_proto::Response::Error { kind, message } => {
+            assert_eq!(kind, "invalid_argument", "{message}");
+            assert!(message.contains("policy"), "{message}");
+        }
+        other => panic!("execute without a policy must be refused, got {other:?}"),
+    }
+
+    // A frame with NO dry_run key at all must PREVIEW (the serde default),
+    // never execute.
+    let raw: serde_json::Value = serde_json::json!({"op": "Review"});
+    rb_proto::write_frame(&mut framed, &raw).await.unwrap();
+    let resp: rb_proto::Response = rb_proto::read_frame(&mut framed).await.unwrap();
+    match resp {
+        rb_proto::Response::ReviewPlanned { plan } => {
+            assert_eq!(plan.totals.low_confidence, 1);
+        }
+        other => panic!("an absent dry_run must preview, got {other:?}"),
+    }
+
+    daemon.stop().await;
+}
+
+/// Delegates to the DeterministicProvider until the test ARMS a bounded
+/// document-embed budget; once the budget is spent every further document
+/// embed fails — injecting a mid-batch failure between two planned merges.
+struct ArmableFailingProvider {
+    inner: DeterministicProvider,
+    budget: std::sync::Arc<std::sync::atomic::AtomicI64>,
+}
+
+#[async_trait::async_trait]
+impl rb_embed::EmbeddingProvider for ArmableFailingProvider {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn dim(&self) -> usize {
+        DIM
+    }
+
+    async fn embed(
+        &self,
+        texts: &[String],
+        kind: rb_embed::EmbedKind,
+    ) -> rb_types::Result<Vec<Vec<f32>>> {
+        if kind == rb_embed::EmbedKind::Document
+            && self
+                .budget
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
+                <= 0
+        {
+            return Err(Error::Embedding(
+                "document embed outage (injected)".to_string(),
+            ));
+        }
+        self.inner.embed(texts, kind).await
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn review_apply_reports_partial_outcome_on_mid_batch_failure() {
+    // The ForgetOutcome shape (PR #60): completed per-item work is never
+    // disowned by a mid-batch failure — the first merge stays committed, the
+    // failure is reported, and the pass is re-runnable.
+    let budget = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(i64::MAX));
+    let embedder = SharedEmbedder::new(ArmableFailingProvider {
+        inner: DeterministicProvider::new(DIM),
+        budget: std::sync::Arc::clone(&budget),
+    });
+    let daemon = RunningDaemon::start_with_embedder(2, embedder).await;
+    let ns = Namespace::Project("review-partial".to_string());
+    let mut client = cli_client(&daemon.socket, &ns).await.unwrap();
+
+    // Two independent dup pairs => two planned merges, in deterministic
+    // (oldest-anchor-first) order.
+    let a1 = store_plain(&mut client, "standups happen at nine thirty", 1.0).await;
+    let a2 = store_plain(&mut client, "standups happen at nine thirty", 1.0).await;
+    let b1 = store_plain(&mut client, "the staging box lives in the closet", 1.0).await;
+    let b2 = store_plain(&mut client, "the staging box lives in the closet", 1.0).await;
+
+    // Arm the outage: exactly ONE more document embed may succeed (the first
+    // merge's combined memory); the second merge's embed fails.
+    budget.store(1, std::sync::atomic::Ordering::SeqCst);
+
+    let outcome = client
+        .review_apply(rb_types::ReviewPolicy::AutoMergeDups, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(outcome.merged, 1, "the first merge committed: {outcome:?}");
+    let failure = outcome
+        .failure
+        .expect("the second merge's failure is reported");
+    assert!(failure.contains("injected"), "{failure}");
+
+    // Exactly ONE pair merged (which one is timing-dependent: seeds written
+    // within the same unix second tie on created_at, so the anchor order
+    // falls to the random-id tiebreak), and the other pair is fully intact.
+    let mut merged_pairs = 0;
+    for (x, y) in [(&a1, &a2), (&b1, &b2)] {
+        let first = client.get((*x).clone()).await.unwrap().unwrap();
+        let second = client.get((*y).clone()).await.unwrap().unwrap();
+        if first.superseded_by.is_some() {
+            merged_pairs += 1;
+            assert!(
+                first.archived_at.is_some() && second.archived_at.is_some(),
+                "a merged pair archives both originals"
+            );
+            assert_eq!(
+                second.superseded_by, first.superseded_by,
+                "both originals point at the one combined memory"
+            );
+        } else {
+            assert!(
+                first.archived_at.is_none()
+                    && second.archived_at.is_none()
+                    && second.superseded_by.is_none(),
+                "the failed merge left its pair untouched"
+            );
+        }
+    }
+    assert_eq!(merged_pairs, 1, "completed merge stays committed");
+
+    // Disarm: the pass is re-runnable and converges.
+    budget.store(i64::MAX, std::sync::atomic::Ordering::SeqCst);
+    let outcome = client
+        .review_apply(rb_types::ReviewPolicy::AutoMergeDups, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(outcome.merged, 1, "re-run completes the remaining pair");
+    assert_eq!(outcome.failure, None);
+
+    daemon.stop().await;
 }

--- a/crates/rb-engine/src/engine.rs
+++ b/crates/rb-engine/src/engine.rs
@@ -194,6 +194,32 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
 
     /// Store a new memory: heuristic-enrich, embed the content, then write.
     pub async fn remember(&self, input: RememberInput) -> rb_types::Result<MemoryId> {
+        let (note, embedding) = self.compose_note(input).await?;
+        let id = note.id.clone();
+        // Keep a copy of the embedding for candidate search before the note moves.
+        let embedding_for_links = embedding.clone();
+        self.backend.write(note, embedding).await?;
+
+        // Best-effort link generation: never fails the remember.
+        if let Some(emb) = embedding_for_links {
+            if let Err(e) = self.generate_links(&id, emb).await {
+                tracing::warn!(error = %e, memory_id = %id, "link generation failed; continuing");
+            }
+        }
+        Ok(id)
+    }
+
+    /// Compose a fully-stamped memory (validation, enrichment, summary /
+    /// keyword derivation, provenance, embedding-model stamps, and the
+    /// composite-document embedding) WITHOUT writing it. `remember` is
+    /// compose + write + link generation; the review merge composes here and
+    /// hands the note to the store's single atomic merge transaction
+    /// (PRD 2026-07-02 review) — the two paths cannot drift on how a memory
+    /// is built.
+    pub async fn compose_note(
+        &self,
+        input: RememberInput,
+    ) -> rb_types::Result<(MemoryNote, Option<Vec<f32>>)> {
         rb_types::validate_importance(input.importance)?;
         // Fail-closed confidence range check on an EXPLICIT caller prior
         // (mirrors the storage CHECK, but surfaces as a clean validation error
@@ -296,19 +322,7 @@ impl<B: MemoryBackend, P: EmbeddingProvider> MemoryEngine<B, P> {
         let input = crate::embed_input::embedding_input(&note);
         let mut embeddings = self.embedder.embed(&[input], EmbedKind::Document).await?;
         let embedding = embeddings.pop();
-
-        let id = note.id.clone();
-        // Keep a copy of the embedding for candidate search before the note moves.
-        let embedding_for_links = embedding.clone();
-        self.backend.write(note, embedding).await?;
-
-        // Best-effort link generation: never fails the remember.
-        if let Some(emb) = embedding_for_links {
-            if let Err(e) = self.generate_links(&id, emb).await {
-                tracing::warn!(error = %e, memory_id = %id, "link generation failed; continuing");
-            }
-        }
-        Ok(id)
+        Ok((note, embedding))
     }
 
     /// Vector-search for candidates similar to the just-written memory, fetch

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -647,6 +647,15 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
         // the model fetched it deliberately, so keep the full JSON as text
         // (the `get` convention).
         Response::History { history } => ToolContent::json(json!({ "history": history }), false),
+        // Review is DELIBERATELY not an MCP tool (the forget precedent): a
+        // destructive surface stays off the model-facing toolset (and the
+        // tools/list budget sits at 897/900). Projected anyway so the
+        // mapping stays total.
+        Response::ReviewPlanned { plan } => ToolContent::json(json!({ "plan": plan }), false),
+        Response::ReviewDone { outcome } => ToolContent::json(json!({ "outcome": outcome }), false),
+        Response::Resolved { resolution } => {
+            ToolContent::json(json!({ "resolution": resolution }), false)
+        }
         Response::Error { kind, message } => ToolContent::json(
             json!({ "error": { "kind": kind, "message": message } }),
             true,

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -328,6 +328,16 @@ mod tests {
                 Request::Forget { .. } => Response::ForgetPlanned {
                     plan: rb_types::ForgetPlan::default(),
                 },
+                // No MCP tool maps to the review ops either (the forget
+                // precedent: destructive surface, and the tools/list budget
+                // sits at 897/900); the arms exist only to keep this fake
+                // total over `Request`.
+                Request::Review { .. } => Response::ReviewPlanned {
+                    plan: rb_types::ReviewPlan::default(),
+                },
+                Request::Resolve { .. } => Response::Resolved {
+                    resolution: rb_types::ReviewResolution::default(),
+                },
                 // The `history` tool maps here (full-toolset-gated); echo the
                 // requested id so dispatch tests can assert the payload.
                 Request::History { ref id, .. } => Response::History {

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -722,6 +722,82 @@ where
         }
     }
 
+    /// Dry-run review (PRD 2026-07-02 contradiction/dedup review): the
+    /// priority-ordered queue for this connection's namespace plus, when
+    /// `policy` is named, the per-item plan one apply pass would execute.
+    /// Read-only server-side: the queue path issues zero writer ops (W1.8).
+    pub async fn review_plan(
+        &mut self,
+        policy: Option<rb_types::ReviewPolicy>,
+        since: Option<u64>,
+        limit: Option<u32>,
+        threshold: Option<f32>,
+    ) -> Result<rb_types::ReviewPlan> {
+        let resp = self
+            .request(Request::Review {
+                policy,
+                dry_run: true,
+                since,
+                limit,
+                threshold,
+            })
+            .await?;
+        match resp {
+            Resp::ReviewPlanned { plan } => Ok(plan),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Execute one bounded review apply pass under `policy` (REV-3): the
+    /// daemon recomputes the queue, derives the SAME plan a dry-run shows
+    /// (`ReviewPolicy::plan_action` is the single mapping), and applies it
+    /// through the existing atomic primitives. Partial failures ride
+    /// `ReviewOutcome::failure`; completed items stay committed.
+    pub async fn review_apply(
+        &mut self,
+        policy: rb_types::ReviewPolicy,
+        since: Option<u64>,
+        limit: Option<u32>,
+        threshold: Option<f32>,
+    ) -> Result<rb_types::ReviewOutcome> {
+        let resp = self
+            .request(Request::Review {
+                policy: Some(policy),
+                dry_run: false,
+                since,
+                limit,
+                threshold,
+            })
+            .await?;
+        match resp {
+            Resp::ReviewDone { outcome } => Ok(outcome),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
+    /// Apply one per-item review resolution (REV-2 interactive mode). The
+    /// item is identified by `reason` + member `ids`; the daemon recomputes
+    /// the canonical key, validates the action fail-closed, and applies it
+    /// atomically through the existing primitives.
+    pub async fn resolve_review_item(
+        &mut self,
+        reason: rb_types::ReviewReason,
+        ids: Vec<MemoryId>,
+        action: rb_types::ReviewAction,
+    ) -> Result<rb_types::ReviewResolution> {
+        let resp = self
+            .request(Request::Resolve {
+                reason,
+                ids,
+                action,
+            })
+            .await?;
+        match resp {
+            Resp::Resolved { resolution } => Ok(resolution),
+            other => Err(Self::unexpected(other)),
+        }
+    }
+
     /// One-time namespace rename (W0.3 carryover): re-scope every memory from
     /// `old` to `new` in one daemon writer transaction. Refused with
     /// `Error::InvalidArgument` when `new` already has rows unless `merge` is
@@ -1171,6 +1247,51 @@ mod wrapper_tests {
                         truncated: false,
                     },
                 },
+                // Canned payloads keyed on dry_run/policy/since/limit so the
+                // typed-wrapper test can prove every knob rides the wire.
+                Request::Review {
+                    policy,
+                    dry_run,
+                    since,
+                    limit,
+                    ..
+                } => {
+                    if dry_run {
+                        Response::ReviewPlanned {
+                            plan: rb_types::ReviewPlan {
+                                policy,
+                                totals: rb_types::ReviewTotals {
+                                    contradictions: 1,
+                                    near_duplicates: since.unwrap_or(0),
+                                    low_confidence: u64::from(limit.unwrap_or(0)),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
+                        }
+                    } else {
+                        Response::ReviewDone {
+                            outcome: rb_types::ReviewOutcome {
+                                policy,
+                                merged: 1,
+                                ..Default::default()
+                            },
+                        }
+                    }
+                }
+                // Echo the canonical key + action so the wrapper test can
+                // prove reason/ids/action ride the wire.
+                Request::Resolve {
+                    reason,
+                    ids,
+                    action,
+                } => Response::Resolved {
+                    resolution: rb_types::ReviewResolution {
+                        key: rb_types::review_item_key(reason, &ids),
+                        action: action.kind_str().to_string(),
+                        ..Default::default()
+                    },
+                },
             };
             write_frame(&mut framed, &resp).await.unwrap();
         }
@@ -1210,6 +1331,59 @@ mod wrapper_tests {
             .await
             .unwrap();
         assert_eq!((outcome.archived, outcome.purged), (0, 1));
+
+        drop(client);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn review_wrappers_carry_policy_dry_run_and_resolution_over_the_wire() {
+        let (_dir, sock) = socket_path();
+        let listener = UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(serve(listener, MemoryId::new()));
+
+        let mut client = connect(&sock).await;
+
+        // Plan: dry_run=true rode the wire (the fake keys the totals on it)
+        // and the knobs echo back through the canned payload.
+        let plan = client
+            .review_plan(
+                Some(rb_types::ReviewPolicy::AutoMergeDups),
+                Some(7),
+                Some(3),
+                Some(0.97),
+            )
+            .await
+            .unwrap();
+        assert_eq!(plan.policy, Some(rb_types::ReviewPolicy::AutoMergeDups));
+        assert_eq!(plan.totals.contradictions, 1, "dry_run rode the wire");
+        assert_eq!(plan.totals.near_duplicates, 7, "since rode the wire");
+        assert_eq!(plan.totals.low_confidence, 3, "limit rode the wire");
+
+        // Apply: dry_run=false rides the wire and the outcome comes back typed.
+        let outcome = client
+            .review_apply(rb_types::ReviewPolicy::AutoMergeDups, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(outcome.policy, Some(rb_types::ReviewPolicy::AutoMergeDups));
+        assert_eq!(outcome.merged, 1, "apply keyed the canned outcome");
+
+        // Per-item resolve: reason/ids/action ride the wire.
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let resolution = client
+            .resolve_review_item(
+                rb_types::ReviewReason::NearDuplicate,
+                vec![a.clone(), b.clone()],
+                rb_types::ReviewAction::Snooze { days: 9 },
+            )
+            .await
+            .unwrap();
+        assert_eq!(resolution.action, "snooze");
+        assert_eq!(
+            resolution.key,
+            rb_types::review_item_key(rb_types::ReviewReason::NearDuplicate, &[a, b])
+        );
 
         drop(client);
         server.await.unwrap();

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -784,12 +784,14 @@ where
         reason: rb_types::ReviewReason,
         ids: Vec<MemoryId>,
         action: rb_types::ReviewAction,
+        threshold: Option<f32>,
     ) -> Result<rb_types::ReviewResolution> {
         let resp = self
             .request(Request::Resolve {
                 reason,
                 ids,
                 action,
+                threshold,
             })
             .await?;
         match resp {
@@ -1285,6 +1287,7 @@ mod wrapper_tests {
                     reason,
                     ids,
                     action,
+                    ..
                 } => Response::Resolved {
                     resolution: rb_types::ReviewResolution {
                         key: rb_types::review_item_key(reason, &ids),
@@ -1376,6 +1379,7 @@ mod wrapper_tests {
                 rb_types::ReviewReason::NearDuplicate,
                 vec![a.clone(), b.clone()],
                 rb_types::ReviewAction::Snooze { days: 9 },
+                None,
             )
             .await
             .unwrap();

--- a/crates/rb-proto/src/error.rs
+++ b/crates/rb-proto/src/error.rs
@@ -34,6 +34,7 @@ fn error_kind(err: &Error) -> &'static str {
         Error::Enrichment(_) => "enrichment",
         Error::InvalidArgument(_) => "invalid_argument",
         Error::PermissionDenied(_) => "permission_denied",
+        Error::StalePlan(_) => "stale_plan",
     }
 }
 
@@ -67,6 +68,7 @@ pub fn response_error_to_error(kind: &str, message: &str) -> Error {
         "enrichment" => Error::Enrichment(unprefixed(message, "enrichment error: ")),
         "invalid_argument" => Error::InvalidArgument(unprefixed(message, "invalid argument: ")),
         "permission_denied" => Error::PermissionDenied(unprefixed(message, "permission denied: ")),
+        "stale_plan" => Error::StalePlan(unprefixed(message, "stale review plan: ")),
         // not_found / dimension_mismatch / anything unrecognized: preserve the
         // message under Storage rather than fabricate structured fields.
         _ => Error::Storage(message.to_string()),
@@ -93,6 +95,26 @@ mod tests {
         match resp {
             Response::Error { kind, message } => response_error_to_error(&kind, &message),
             other => panic!("expected Response::Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stale_plan_round_trips_verbatim() {
+        // The stale-plan error is caller GUIDANCE (re-run review), so it must
+        // travel verbatim and reconstruct to the same variant — policy sweeps
+        // and interactive loops classify on it.
+        let err = Error::StalePlan("members were already resolved".to_string());
+        let resp = error_to_response(&err);
+        match &resp {
+            Response::Error { kind, message } => {
+                assert_eq!(kind, "stale_plan");
+                assert!(message.contains("already resolved"), "{message}");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        match round_trip(err) {
+            Error::StalePlan(msg) => assert_eq!(msg, "members were already resolved"),
+            other => panic!("expected StalePlan back, got {other:?}"),
         }
     }
 

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -282,10 +282,52 @@ pub enum Request {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         depth: Option<u32>,
     },
+    /// Review-queue generation / policy sweep (PRD 2026-07-02
+    /// contradiction/dedup review). Namespace-scoped by the handshake.
+    /// `dry_run: true` (the serde default — an absent flag must PREVIEW,
+    /// never execute) returns the priority-ordered queue plus, when `policy`
+    /// is named, the per-item plan; `dry_run: false` requires a `policy` and
+    /// executes one bounded apply pass. Every action is reversible
+    /// (supersede/archive are soft, demote is an update), so apply is NOT
+    /// admin-gated — the `Forget` apply precedent. `since`/`limit`/
+    /// `threshold` are optional knobs, server-clamped. Additive variant per
+    /// the `Forget` precedent: an old daemon fails to decode it and closes
+    /// the connection (no CONTRACT_VERSION bump).
+    Review {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        policy: Option<rb_types::ReviewPolicy>,
+        #[serde(default = "default_review_dry_run")]
+        dry_run: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        since: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        threshold: Option<f32>,
+    },
+    /// Apply ONE review resolution (REV-2 interactive mode): keep / merge /
+    /// archive / demote / snooze on the item identified by `reason` + member
+    /// `ids` (the daemon recomputes the canonical key server-side — the key
+    /// never travels as free text). Namespace-scoped like `Update`/`Link`
+    /// (NOT an admin op): the daemon verifies every id lives in the
+    /// connection's namespace, validates the action shape fail-closed
+    /// (`ReviewAction::validate`), and orchestrates the existing atomic
+    /// supersede/archive/confidence primitives. Additive variant per the
+    /// `Review` precedent (no CONTRACT_VERSION bump).
+    Resolve {
+        reason: rb_types::ReviewReason,
+        ids: Vec<MemoryId>,
+        action: rb_types::ReviewAction,
+    },
 }
 
 /// An absent `dry_run` on the wire must PREVIEW, never execute.
 fn default_forget_dry_run() -> bool {
+    true
+}
+
+/// An absent review `dry_run` must PREVIEW, never execute (the Forget rule).
+fn default_review_dry_run() -> bool {
     true
 }
 
@@ -429,6 +471,26 @@ pub enum Response {
     /// never see it because they never send the request.
     History {
         history: rb_types::MemoryHistory,
+    },
+    /// Reply to a dry-run `Request::Review`: the priority-ordered queue plus
+    /// the per-item plan when a policy was named — computed by the same
+    /// queue generator the apply pass executes. Every payload field is
+    /// `#[serde(default)]` so the shape stays additive. Additive variant;
+    /// old clients never see it because they never send the request.
+    ReviewPlanned {
+        plan: rb_types::ReviewPlan,
+    },
+    /// Reply to an executed `Request::Review`: what the bounded policy pass
+    /// did (the `ForgetDone` shape, including the partial-failure slot).
+    /// Additive variant; old clients never see it.
+    ReviewDone {
+        outcome: rb_types::ReviewOutcome,
+    },
+    /// Reply to a `Request::Resolve`: what the single resolution did (the
+    /// merged-into id, post-nudge confidences, or the snooze expiry).
+    /// Additive variant; old clients never see it.
+    Resolved {
+        resolution: rb_types::ReviewResolution,
     },
     Error {
         kind: String,
@@ -1698,5 +1760,153 @@ mod tests {
             json,
             r#"{"result":"JobRan","scanned":1,"changed":0,"skipped":1}"#
         );
+    }
+
+    #[test]
+    fn review_request_defaults_to_dry_run_and_minimal_frame_is_bare() {
+        // SAFETY DEFAULT (the Forget precedent): an absent `dry_run` on the
+        // wire must PREVIEW, never execute a policy.
+        let back: Request = serde_json::from_str(r#"{"op":"Review"}"#).unwrap();
+        match back {
+            Request::Review {
+                policy,
+                dry_run,
+                since,
+                limit,
+                threshold,
+            } => {
+                assert!(dry_run, "absent dry_run must decode to a preview");
+                assert!(policy.is_none());
+                assert!(since.is_none() && limit.is_none() && threshold.is_none());
+            }
+            other => panic!("expected Review, got {other:?}"),
+        }
+        // The default-shaped request keeps every optional key off the frame.
+        let json = serde_json::to_string(&Request::Review {
+            policy: None,
+            dry_run: true,
+            since: None,
+            limit: None,
+            threshold: None,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"op":"Review","dry_run":true}"#);
+    }
+
+    #[test]
+    fn review_request_round_trips_with_every_field() {
+        let req = Request::Review {
+            policy: Some(rb_types::ReviewPolicy::AutoMergeDups),
+            dry_run: false,
+            since: Some(42),
+            limit: Some(10),
+            threshold: Some(0.97),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["op"], "Review");
+        assert_eq!(value["policy"], "auto_merge_dups");
+        let back: Request = serde_json::from_str(&json).unwrap();
+        match back {
+            Request::Review {
+                policy,
+                dry_run,
+                since,
+                limit,
+                threshold,
+            } => {
+                assert_eq!(policy, Some(rb_types::ReviewPolicy::AutoMergeDups));
+                assert!(!dry_run);
+                assert_eq!(since, Some(42));
+                assert_eq!(limit, Some(10));
+                assert_eq!(threshold, Some(0.97));
+            }
+            other => panic!("expected Review, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_request_round_trips_reason_ids_and_action() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let req = Request::Resolve {
+            reason: rb_types::ReviewReason::NearDuplicate,
+            ids: vec![a.clone(), b.clone()],
+            action: rb_types::ReviewAction::Archive { id: b.clone() },
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["op"], "Resolve");
+        assert_eq!(value["action"]["action"], "archive");
+        let back: Request = serde_json::from_str(&json).unwrap();
+        match back {
+            Request::Resolve {
+                reason,
+                ids,
+                action,
+            } => {
+                assert_eq!(reason, rb_types::ReviewReason::NearDuplicate);
+                assert_eq!(ids, vec![a, b.clone()]);
+                assert_eq!(action, rb_types::ReviewAction::Archive { id: b });
+            }
+            other => panic!("expected Resolve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn review_responses_round_trip_and_payloads_are_additive() {
+        let resp = Response::ReviewPlanned {
+            plan: rb_types::ReviewPlan {
+                totals: rb_types::ReviewTotals {
+                    contradictions: 2,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["result"], "ReviewPlanned");
+        match serde_json::from_str::<Response>(&json).unwrap() {
+            Response::ReviewPlanned { plan } => assert_eq!(plan.totals.contradictions, 2),
+            other => panic!("expected ReviewPlanned, got {other:?}"),
+        }
+
+        // Additive payloads: empty-object payloads decode to defaults (the
+        // Stats/History precedent).
+        match serde_json::from_str::<Response>(r#"{"result":"ReviewPlanned","plan":{}}"#).unwrap() {
+            Response::ReviewPlanned { plan } => assert_eq!(plan, rb_types::ReviewPlan::default()),
+            other => panic!("expected ReviewPlanned, got {other:?}"),
+        }
+        match serde_json::from_str::<Response>(r#"{"result":"ReviewDone","outcome":{}}"#).unwrap() {
+            Response::ReviewDone { outcome } => {
+                assert_eq!(outcome, rb_types::ReviewOutcome::default());
+            }
+            other => panic!("expected ReviewDone, got {other:?}"),
+        }
+        match serde_json::from_str::<Response>(r#"{"result":"Resolved","resolution":{}}"#).unwrap()
+        {
+            Response::Resolved { resolution } => {
+                assert_eq!(resolution, rb_types::ReviewResolution::default());
+            }
+            other => panic!("expected Resolved, got {other:?}"),
+        }
+
+        let done = Response::ReviewDone {
+            outcome: rb_types::ReviewOutcome {
+                policy: Some(rb_types::ReviewPolicy::DemoteLowConfidence),
+                demoted: 3,
+                failure: Some("injected".to_string()),
+                ..Default::default()
+            },
+        };
+        let back: Response = serde_json::from_str(&serde_json::to_string(&done).unwrap()).unwrap();
+        match back {
+            Response::ReviewDone { outcome } => {
+                assert_eq!(outcome.demoted, 3);
+                assert_eq!(outcome.failure.as_deref(), Some("injected"));
+            }
+            other => panic!("expected ReviewDone, got {other:?}"),
+        }
     }
 }

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -318,6 +318,15 @@ pub enum Request {
         reason: rb_types::ReviewReason,
         ids: Vec<MemoryId>,
         action: rb_types::ReviewAction,
+        /// Near-dup similarity bound for the resolve-time MERGE revalidation
+        /// (the plan->resolve TOCTOU fix): the daemon re-checks that the pair
+        /// still qualifies as near-duplicates at this threshold inside the
+        /// atomic merge transaction. `None` uses the conservative default;
+        /// server-clamped like `Review.threshold`. Additive +
+        /// `#[serde(default, skip_serializing_if)]` — an old frame decodes to
+        /// the default and a `None` stays off the wire.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        threshold: Option<f32>,
     },
 }
 
@@ -1833,6 +1842,7 @@ mod tests {
             reason: rb_types::ReviewReason::NearDuplicate,
             ids: vec![a.clone(), b.clone()],
             action: rb_types::ReviewAction::Archive { id: b.clone() },
+            threshold: Some(0.9),
         };
         let json = serde_json::to_string(&req).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1844,11 +1854,22 @@ mod tests {
                 reason,
                 ids,
                 action,
+                threshold,
             } => {
                 assert_eq!(reason, rb_types::ReviewReason::NearDuplicate);
                 assert_eq!(ids, vec![a, b.clone()]);
                 assert_eq!(action, rb_types::ReviewAction::Archive { id: b });
+                assert_eq!(threshold, Some(0.9));
             }
+            other => panic!("expected Resolve, got {other:?}"),
+        }
+        // Additive: a frame WITHOUT the threshold key decodes to None (the
+        // server then revalidates a merge at the conservative default).
+        let mut value = value;
+        value.as_object_mut().unwrap().remove("threshold");
+        let back: Request = serde_json::from_value(value).unwrap();
+        match back {
+            Request::Resolve { threshold, .. } => assert_eq!(threshold, None),
             other => panic!("expected Resolve, got {other:?}"),
         }
     }

--- a/crates/rb-store/migrations/010_review_state.sql
+++ b/crates/rb-store/migrations/010_review_state.sql
@@ -1,0 +1,17 @@
+-- Review-sweep snooze/reviewed-at persistence (PRD 2026-07-02
+-- contradiction/dedup review, REV-2 `snooze`). Additive side table, bounded:
+-- at most one row per reviewed item, keyed by the canonical item key
+-- (reason-prefixed, lexicographically-sorted member ids — see
+-- rb_types::review_item_key), so the same pair discovered from either scan
+-- anchor maps to one row. Deliberately NO FK to memories: an item key spans
+-- up to two memories, and a row whose memories were purged simply stops
+-- matching the queue's exclusion probe (harmless, bounded residue).
+CREATE TABLE review_state (
+  item_key     TEXT PRIMARY KEY,
+  namespace    TEXT NOT NULL,
+  reviewed_at  INTEGER NOT NULL,  -- unix seconds of the last resolution
+  snooze_until INTEGER            -- unix seconds; NULL = reviewed, not hidden
+);
+
+-- The queue's snooze-exclusion probe and the snoozed gauge scan by namespace.
+CREATE INDEX idx_review_state_ns ON review_state(namespace, snooze_until);

--- a/crates/rb-store/src/lib.rs
+++ b/crates/rb-store/src/lib.rs
@@ -12,5 +12,6 @@ mod store;
 pub use migrations::run_migrations;
 pub use store::{
     read_meta_embedding_model, AccessBump, ConsolidationCandidate, LinkRow, NamespaceRenameOutcome,
-    OplogReplayPage, RecalRow, RetentionSweepEffects, ScrubOutcome, SqliteStore, Store,
+    OplogReplayPage, RecalRow, RetentionSweepEffects, ReviewQueueParams, ScrubOutcome, SqliteStore,
+    Store,
 };

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -9,6 +9,7 @@ mod oplog;
 mod reembed;
 mod rename;
 mod retention;
+mod review;
 mod scrub;
 mod stats;
 
@@ -199,5 +200,6 @@ pub use link_decay::LinkRow;
 pub use oplog::OplogReplayPage;
 pub use rename::NamespaceRenameOutcome;
 pub use retention::RetentionSweepEffects;
+pub use review::ReviewQueueParams;
 pub use scrub::ScrubOutcome;
 pub use stats::read_meta_embedding_model;

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -311,6 +311,156 @@ impl SqliteStore {
         }
         Ok(out)
     }
+
+    /// The insert transaction body (memories row + oplog + anchors + vector +
+    /// links), shared by [`Store::insert_memory`] (which wraps it in its own
+    /// `immediate_tx`) and the atomic review merge (which runs it INSIDE the
+    /// merge's single transaction — PRD 2026-07-02 review, atomicity fix).
+    /// MUST be called inside an open transaction.
+    pub(crate) fn insert_memory_tx_body(
+        &self,
+        note: &MemoryNote,
+        embedding: Option<&[f32]>,
+    ) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO memories (
+                        memory_id, namespace, created_at, updated_at, content, summary,
+                        keywords, tags, context, memory_type, importance, confidence,
+                        related_files, access_count, last_accessed_at, archived_at,
+                        superseded_by, embedding_model, embedding_input_version,
+                        origin_user, origin_host, origin_agent, origin_source, session_id,
+                        base_importance
+                     ) VALUES (
+                        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                        ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
+                     )",
+                rusqlite::params![
+                    note.id.to_string(),
+                    note.namespace.as_db_string(),
+                    ts(note.created_at),
+                    ts(note.updated_at),
+                    note.content,
+                    note.summary,
+                    json_array(&note.keywords)?,
+                    json_array(&note.tags)?,
+                    note.context,
+                    note.memory_type.as_str(),
+                    note.importance as i64,
+                    note.confidence as f64,
+                    json_array(&note.related_files)?,
+                    note.access_count as i64,
+                    opt_ts(note.last_accessed_at),
+                    opt_ts(note.archived_at),
+                    note.superseded_by.as_ref().map(|id| id.to_string()),
+                    note.embedding_model,
+                    note.embedding_input_version,
+                    note.origin_user,
+                    note.origin_host,
+                    note.origin_agent,
+                    note.origin_source,
+                    note.session_id,
+                    // W1.9: the author-set importance prior. Stamped once at
+                    // insert; the recalibration job never writes it, so the
+                    // bounded-delta formula stays anchored to author intent.
+                    note.importance as i64,
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        append_oplog(&self.conn, &self.site_id, "insert", &note.id, "")?;
+
+        // Typed code anchors (PRD 2026-07-02): kind-split value columns
+        // (`path` for file anchors, `ref` for commit/symbol — the 009
+        // CHECK pins the split). Values are stored NORMALIZED
+        // (rb_types::normalize_anchor_value) so the anchor-filter SQL can
+        // compare by plain equality. Exact duplicates (post-normalization,
+        // incl. the line range) collapse to ONE row here — repeated CLI
+        // flags / `--batch` fan-out must not accumulate copies, and a
+        // UNIQUE constraint cannot do it (SQLite treats the NULL
+        // path/ref/line columns as pairwise distinct). First-seen order
+        // is preserved.
+        let mut seen_anchors = std::collections::HashSet::new();
+        for anchor in &note.anchors {
+            let value = rb_types::normalize_anchor_value(anchor.kind, &anchor.value);
+            if !seen_anchors.insert((
+                rb_types::anchor_kind_str(anchor.kind),
+                value.clone(),
+                anchor.start_line,
+                anchor.end_line,
+            )) {
+                continue;
+            }
+            let is_file = anchor.kind == rb_types::AnchorKind::File;
+            self.conn
+                .execute(
+                    "INSERT INTO memory_anchors
+                            (memory_id, namespace, kind, path, start_line, end_line, ref)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    rusqlite::params![
+                        note.id.to_string(),
+                        note.namespace.as_db_string(),
+                        rb_types::anchor_kind_str(anchor.kind),
+                        is_file.then_some(value.as_str()),
+                        anchor.start_line.map(i64::from),
+                        anchor.end_line.map(i64::from),
+                        (!is_file).then_some(value.as_str()),
+                    ],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+
+        if let Some(emb) = embedding {
+            // The namespace partition key MUST mirror memories.namespace
+            // (vector_search scopes KNN on it). Any path that mutates a
+            // memory's namespace MUST re-key its memory_vectors row in the
+            // same transaction or vectors strand under the old partition
+            // key — `rename_namespace` (the only such path today) does the
+            // DELETE+INSERT re-key for exactly this reason.
+            self.conn
+                .execute(
+                    "INSERT INTO memory_vectors (memory_id, namespace, embedding)
+                         VALUES (?1, ?2, ?3)",
+                    rusqlite::params![
+                        note.id.to_string(),
+                        note.namespace.as_db_string(),
+                        embedding_bytes(emb)
+                    ],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+
+        for link in &note.links {
+            self.conn
+                    .execute(
+                        "INSERT INTO memory_links
+                            (source_id, target_id, link_type, strength, base_strength, reason, created_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        rusqlite::params![
+                            link.source_id.to_string(),
+                            link.target_id.to_string(),
+                            link.link_type.as_str(),
+                            link.strength as f64,
+                            // Baseline equals the created strength; decay never
+                            // mutates it, so the pass stays idempotent.
+                            link.strength as f64,
+                            link.reason,
+                            ts(link.created_at),
+                        ],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            // One `link` oplog row per edge, same shape as `add_link`'s:
+            // a replay consumer could not reconstruct edges from the bare
+            // `insert` row alone.
+            let details = serde_json::json!({
+                "type": link.link_type.as_str(),
+                "target": link.target_id.to_string(),
+            })
+            .to_string();
+            append_oplog(&self.conn, &self.site_id, "link", &link.source_id, &details)?;
+        }
+        Ok(())
+    }
 }
 /// One active memory's recalibration inputs: the spine fields the importance
 /// job reads to recompute `importance`. `last_accessed_at` is the raw stored
@@ -836,146 +986,7 @@ impl Store for SqliteStore {
         // writer mid-transaction; the busy_timeout above makes a contended BEGIN
         // wait rather than fail immediately. Atomicity is unchanged: all writes
         // commit together, and any error rolls the whole transaction back.
-        immediate_tx(&self.conn, || {
-            self.conn
-                .execute(
-                    "INSERT INTO memories (
-                        memory_id, namespace, created_at, updated_at, content, summary,
-                        keywords, tags, context, memory_type, importance, confidence,
-                        related_files, access_count, last_accessed_at, archived_at,
-                        superseded_by, embedding_model, embedding_input_version,
-                        origin_user, origin_host, origin_agent, origin_source, session_id,
-                        base_importance
-                     ) VALUES (
-                        ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                        ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
-                     )",
-                    rusqlite::params![
-                        note.id.to_string(),
-                        note.namespace.as_db_string(),
-                        ts(note.created_at),
-                        ts(note.updated_at),
-                        note.content,
-                        note.summary,
-                        json_array(&note.keywords)?,
-                        json_array(&note.tags)?,
-                        note.context,
-                        note.memory_type.as_str(),
-                        note.importance as i64,
-                        note.confidence as f64,
-                        json_array(&note.related_files)?,
-                        note.access_count as i64,
-                        opt_ts(note.last_accessed_at),
-                        opt_ts(note.archived_at),
-                        note.superseded_by.as_ref().map(|id| id.to_string()),
-                        note.embedding_model,
-                        note.embedding_input_version,
-                        note.origin_user,
-                        note.origin_host,
-                        note.origin_agent,
-                        note.origin_source,
-                        note.session_id,
-                        // W1.9: the author-set importance prior. Stamped once at
-                        // insert; the recalibration job never writes it, so the
-                        // bounded-delta formula stays anchored to author intent.
-                        note.importance as i64,
-                    ],
-                )
-                .map_err(|e| Error::Storage(e.to_string()))?;
-
-            append_oplog(&self.conn, &self.site_id, "insert", &note.id, "")?;
-
-            // Typed code anchors (PRD 2026-07-02): kind-split value columns
-            // (`path` for file anchors, `ref` for commit/symbol — the 009
-            // CHECK pins the split). Values are stored NORMALIZED
-            // (rb_types::normalize_anchor_value) so the anchor-filter SQL can
-            // compare by plain equality. Exact duplicates (post-normalization,
-            // incl. the line range) collapse to ONE row here — repeated CLI
-            // flags / `--batch` fan-out must not accumulate copies, and a
-            // UNIQUE constraint cannot do it (SQLite treats the NULL
-            // path/ref/line columns as pairwise distinct). First-seen order
-            // is preserved.
-            let mut seen_anchors = std::collections::HashSet::new();
-            for anchor in &note.anchors {
-                let value = rb_types::normalize_anchor_value(anchor.kind, &anchor.value);
-                if !seen_anchors.insert((
-                    rb_types::anchor_kind_str(anchor.kind),
-                    value.clone(),
-                    anchor.start_line,
-                    anchor.end_line,
-                )) {
-                    continue;
-                }
-                let is_file = anchor.kind == rb_types::AnchorKind::File;
-                self.conn
-                    .execute(
-                        "INSERT INTO memory_anchors
-                            (memory_id, namespace, kind, path, start_line, end_line, ref)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                        rusqlite::params![
-                            note.id.to_string(),
-                            note.namespace.as_db_string(),
-                            rb_types::anchor_kind_str(anchor.kind),
-                            is_file.then_some(value.as_str()),
-                            anchor.start_line.map(i64::from),
-                            anchor.end_line.map(i64::from),
-                            (!is_file).then_some(value.as_str()),
-                        ],
-                    )
-                    .map_err(|e| Error::Storage(e.to_string()))?;
-            }
-
-            if let Some(emb) = embedding {
-                // The namespace partition key MUST mirror memories.namespace
-                // (vector_search scopes KNN on it). Any path that mutates a
-                // memory's namespace MUST re-key its memory_vectors row in the
-                // same transaction or vectors strand under the old partition
-                // key — `rename_namespace` (the only such path today) does the
-                // DELETE+INSERT re-key for exactly this reason.
-                self.conn
-                    .execute(
-                        "INSERT INTO memory_vectors (memory_id, namespace, embedding)
-                         VALUES (?1, ?2, ?3)",
-                        rusqlite::params![
-                            note.id.to_string(),
-                            note.namespace.as_db_string(),
-                            embedding_bytes(emb)
-                        ],
-                    )
-                    .map_err(|e| Error::Storage(e.to_string()))?;
-            }
-
-            for link in &note.links {
-                self.conn
-                    .execute(
-                        "INSERT INTO memory_links
-                            (source_id, target_id, link_type, strength, base_strength, reason, created_at)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                        rusqlite::params![
-                            link.source_id.to_string(),
-                            link.target_id.to_string(),
-                            link.link_type.as_str(),
-                            link.strength as f64,
-                            // Baseline equals the created strength; decay never
-                            // mutates it, so the pass stays idempotent.
-                            link.strength as f64,
-                            link.reason,
-                            ts(link.created_at),
-                        ],
-                    )
-                    .map_err(|e| Error::Storage(e.to_string()))?;
-                // One `link` oplog row per edge, same shape as `add_link`'s:
-                // a replay consumer could not reconstruct edges from the bare
-                // `insert` row alone.
-                let details = serde_json::json!({
-                    "type": link.link_type.as_str(),
-                    "target": link.target_id.to_string(),
-                })
-                .to_string();
-                append_oplog(&self.conn, &self.site_id, "link", &link.source_id, &details)?;
-            }
-            Ok(())
-        })
+        immediate_tx(&self.conn, || self.insert_memory_tx_body(note, embedding))
     }
 
     fn get_memory(&self, id: &MemoryId) -> Result<Option<MemoryNote>> {

--- a/crates/rb-store/src/store/rename.rs
+++ b/crates/rb-store/src/store/rename.rs
@@ -26,6 +26,11 @@ impl SqliteStore {
     /// - `memory_anchors` — namespace mirrors memories.namespace (the 009
     ///   migration's scoping column for anchor-filter lookups), so it is
     ///   re-keyed with a plain UPDATE in the same transaction.
+    /// - `review_state` — namespace scopes the review queue's
+    ///   snooze-exclusion probe (migration 010), so it is re-keyed with a
+    ///   plain UPDATE in the same transaction (a stranded row would let a
+    ///   snoozed item resurface immediately after the rename). Item keys are
+    ///   memory-id based and namespace-free, so no key rewrite is needed.
     /// - `memory_oplog` — ONE `namespace_rename` row recording old, new and
     ///   the row counts; historical oplog rows keep their original namespace
     ///   (the log is history, not state).
@@ -120,6 +125,16 @@ impl SqliteStore {
             self.conn
                 .execute(
                     "UPDATE memory_anchors SET namespace = ?1 WHERE namespace = ?2",
+                    rusqlite::params![new_str, old_str],
+                )
+                .map_err(storage_err)?;
+
+            // Re-key the review snooze/reviewed-at rows (migration 010): the
+            // queue's snooze-exclusion probe scopes by namespace, so a
+            // stranded row would silently un-hide every snoozed item.
+            self.conn
+                .execute(
+                    "UPDATE review_state SET namespace = ?1 WHERE namespace = ?2",
                     rusqlite::params![new_str, old_str],
                 )
                 .map_err(storage_err)?;
@@ -336,6 +351,62 @@ mod namespace_rename_tests {
         assert_eq!(v["moved"], 3);
         assert_eq!(v["vectors"], 2);
         assert_eq!(v["merged_into"], 0);
+    }
+
+    #[test]
+    fn rename_rekeys_review_state_namespace_and_snoozes_survive() {
+        // review_state.namespace scopes the review queue's snooze-exclusion
+        // probe; a rename must re-key it in the same transaction or every
+        // snooze silently evaporates (the item resurfaces immediately under
+        // the new namespace).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let old = Namespace::Project("review-old".into());
+        let new = Namespace::Project("review-new".into());
+
+        let mut low = MemoryNote::new(old.clone(), "shaky note".into(), MemoryType::Insight, 5);
+        low.confidence = 0.2;
+        let low_id = low.id.clone();
+        store.insert_memory(&low, None).unwrap();
+        let key = rb_types::review_item_key(
+            rb_types::ReviewReason::LowConfidence,
+            std::slice::from_ref(&low_id),
+        );
+        store
+            .snooze_review_item(&old, &key, 7, "{}", chrono::Utc::now())
+            .unwrap();
+
+        store.rename_namespace(&old, &new, false).unwrap();
+
+        let stranded: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM review_state WHERE namespace = ?1",
+                rusqlite::params![old.as_db_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stranded, 0,
+            "no review row may stay under the old namespace"
+        );
+
+        let plan = store
+            .review_queue(
+                &new,
+                &crate::ReviewQueueParams {
+                    threshold: 0.95,
+                    limit: 50,
+                    since: None,
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert!(
+            plan.items.is_empty(),
+            "the snooze must keep hiding the item after the rename: {:?}",
+            plan.items
+        );
+        assert_eq!(plan.totals.snoozed, 1, "the snooze follows the namespace");
     }
 
     #[test]

--- a/crates/rb-store/src/store/review.rs
+++ b/crates/rb-store/src/store/review.rs
@@ -485,6 +485,254 @@ impl SqliteStore {
         self.append_review_oplog(ns, "review_sweep", details, now)
     }
 
+    /// Atomically merge a near-duplicate pair (PRD 2026-07-02 review;
+    /// CRITICAL fix from the PR #63 review): ONE writer transaction that
+    /// re-validates, inserts the combined memory, copies the originals'
+    /// external graph edges, supersedes both originals with a GUARDED
+    /// pointer update, and writes the `review_resolve` audit row —
+    /// all-or-nothing. Combined with single-writer serialization, two
+    /// concurrent resolutions of the same pair cannot interleave: the loser
+    /// re-validates inside its own transaction, finds the members already
+    /// resolved, and fails with the distinct [`Error::StalePlan`] while the
+    /// winner's chain stays single and consistent.
+    ///
+    /// Re-validation (TOCTOU fix): both members must be live (active, not
+    /// superseded, in `ns`) AND still qualify as near-duplicates — their
+    /// stored vectors' cosine similarity must be `>= min_similarity`, the
+    /// same unit `near_duplicates()` reports (pinned by the
+    /// `review_merge_similarity_agrees_with_near_duplicates` drift test). A
+    /// missing vector cannot be re-validated and is a stale plan.
+    ///
+    /// Link union (HIGH fix): every external edge of either original (both
+    /// directions) is COPIED onto the combined memory — copies, not moves,
+    /// so the archived originals keep their history; duplicates collapse via
+    /// the `(source, target, type)` primary key; the intra-pair edge is
+    /// dropped (it would become a self-link) and `supersedes`-type rows are
+    /// never copied (that edge type belongs to the supersede machinery).
+    ///
+    /// Failure semantics: any error rolls back the WHOLE transaction — no
+    /// orphaned combined memory, no half-superseded pair, no audit row for
+    /// work that did not happen (the item-6 rollback contract).
+    #[allow(clippy::too_many_arguments)]
+    pub fn review_merge(
+        &self,
+        ns: &Namespace,
+        a: &MemoryId,
+        b: &MemoryId,
+        min_similarity: f32,
+        note: &MemoryNote,
+        embedding: Option<&[f32]>,
+        details: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        if a == b || note.id == *a || note.id == *b {
+            return Err(Error::InvalidArgument(
+                "merge needs two distinct originals and a fresh combined id".to_string(),
+            ));
+        }
+        if note.namespace != *ns {
+            return Err(Error::InvalidArgument(format!(
+                "combined memory namespace {} does not match the merge namespace {}",
+                note.namespace.as_db_string(),
+                ns.as_db_string()
+            )));
+        }
+        let key = review_item_key(ReviewReason::NearDuplicate, &[a.clone(), b.clone()]);
+        immediate_tx(&self.conn, || {
+            // 1. Both members live in `ns`, active, and unresolved.
+            for id in [a, b] {
+                let row: Option<(String, Option<i64>, Option<String>)> = match self.conn.query_row(
+                    "SELECT namespace, archived_at, superseded_by
+                     FROM memories WHERE memory_id = ?1",
+                    rusqlite::params![id.to_string()],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                ) {
+                    Ok(row) => Some(row),
+                    Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                    Err(e) => return Err(storage_err(e)),
+                };
+                let Some((row_ns, archived_at, superseded_by)) = row else {
+                    return Err(Error::NotFound(id.clone()));
+                };
+                if row_ns != ns.as_db_string() {
+                    return Err(Error::NotFound(id.clone()));
+                }
+                if archived_at.is_some() || superseded_by.is_some() {
+                    return Err(Error::StalePlan(format!(
+                        "{id} was already resolved (archived or superseded), likely by a \
+                         concurrent review; re-run review for a fresh queue"
+                    )));
+                }
+            }
+
+            // 2. The pair still qualifies as near-duplicates AT RESOLVE TIME.
+            let similarity = self.stored_pair_similarity(a, b)?.ok_or_else(|| {
+                Error::StalePlan(format!(
+                    "the pair {a} / {b} can no longer be compared (a stored vector is \
+                     missing); re-run review for a fresh queue"
+                ))
+            })?;
+            if similarity < min_similarity {
+                return Err(Error::StalePlan(format!(
+                    "similarity {similarity:.3} of {a} / {b} is below the {min_similarity} \
+                     threshold; the pair no longer qualifies as near-duplicates"
+                )));
+            }
+
+            // 3. The combined memory (row + oplog + anchors + vector + links),
+            //    via the SAME body `insert_memory` commits.
+            rb_types::validate_importance(note.importance)?;
+            rb_types::validate_confidence(note.confidence)?;
+            for anchor in &note.anchors {
+                anchor.validate()?;
+            }
+            self.insert_memory_tx_body(note, embedding)?;
+
+            // 4. Copy the originals' external edges onto the combined memory
+            //    (both directions; OR IGNORE dedupes on the (source, target,
+            //    type) primary key).
+            let new_str = note.id.to_string();
+            let a_str = a.to_string();
+            let b_str = b.to_string();
+            self.conn
+                .execute(
+                    "INSERT OR IGNORE INTO memory_links
+                        (source_id, target_id, link_type, strength, base_strength, reason, created_at)
+                     SELECT ?1, l.target_id, l.link_type, l.strength, l.base_strength, l.reason, l.created_at
+                     FROM memory_links l
+                     WHERE l.source_id IN (?2, ?3)
+                       AND l.target_id NOT IN (?1, ?2, ?3)
+                       AND l.link_type != 'supersedes'",
+                    rusqlite::params![new_str, a_str, b_str],
+                )
+                .map_err(storage_err)?;
+            self.conn
+                .execute(
+                    "INSERT OR IGNORE INTO memory_links
+                        (source_id, target_id, link_type, strength, base_strength, reason, created_at)
+                     SELECT l.source_id, ?1, l.link_type, l.strength, l.base_strength, l.reason, l.created_at
+                     FROM memory_links l
+                     WHERE l.target_id IN (?2, ?3)
+                       AND l.source_id NOT IN (?1, ?2, ?3)
+                       AND l.link_type != 'supersedes'",
+                    rusqlite::params![new_str, a_str, b_str],
+                )
+                .map_err(storage_err)?;
+
+            // 5. Guarded supersede of each original (the minimal pointer
+            //    guard from the review; full source hardening is #501): the
+            //    pointer is taken only if still unset on an active row, so a
+            //    raced resolution fails HERE and rolls everything back.
+            for old in [a, b] {
+                self.supersede_unclaimed_in_tx(old, &note.id, now, &key)?;
+            }
+
+            // 6. The audit trail (REV-4), inside the same transaction.
+            self.upsert_review_state(ns, &key, now.timestamp(), None)?;
+            self.append_review_oplog(ns, "review_resolve", details, now)
+        })
+    }
+
+    /// Is there STILL an active contradiction between exactly `a` and `b` in
+    /// `ns`? The pair-scoped expression of the queue's contradiction listing
+    /// (both endpoints active AND in `ns`, either edge direction) — the
+    /// resolve-time revalidation for contradiction items (PR #63 TOCTOU fix),
+    /// pinned by `contradiction_pair_active_matches_the_queue_semantics`.
+    pub fn contradiction_pair_active(
+        &self,
+        ns: &Namespace,
+        a: &MemoryId,
+        b: &MemoryId,
+    ) -> Result<bool> {
+        let found: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_links l
+                   JOIN memories x ON x.memory_id = l.source_id
+                   JOIN memories y ON y.memory_id = l.target_id
+                 WHERE l.link_type = 'contradicts'
+                   AND x.archived_at IS NULL AND y.archived_at IS NULL
+                   AND x.namespace = ?1 AND y.namespace = ?1
+                   AND ((l.source_id = ?2 AND l.target_id = ?3)
+                     OR (l.source_id = ?3 AND l.target_id = ?2))",
+                rusqlite::params![ns.as_db_string(), a.to_string(), b.to_string()],
+                |r| r.get(0),
+            )
+            .map_err(storage_err)?;
+        Ok(found > 0)
+    }
+
+    /// Cosine similarity of two STORED vectors, in the exact unit
+    /// [`SqliteStore::near_duplicates`] reports (`1 - cosine_distance`,
+    /// clamped to `[0, 1]`). `None` when either vector is missing or
+    /// degenerate (zero norm) — the caller treats that as un-comparable.
+    fn stored_pair_similarity(&self, a: &MemoryId, b: &MemoryId) -> Result<Option<f32>> {
+        let load = |id: &MemoryId| -> Result<Option<Vec<f32>>> {
+            match self.conn.query_row(
+                "SELECT embedding FROM memory_vectors WHERE memory_id = ?1",
+                rusqlite::params![id.to_string()],
+                |r| r.get::<_, Vec<u8>>(0),
+            ) {
+                Ok(blob) => Ok(Some(super::internal::decode_embedding_bytes(&blob)?)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(storage_err(e)),
+            }
+        };
+        let (Some(va), Some(vb)) = (load(a)?, load(b)?) else {
+            return Ok(None);
+        };
+        if va.len() != vb.len() {
+            return Ok(None);
+        }
+        let dot: f32 = va.iter().zip(&vb).map(|(x, y)| x * y).sum();
+        let na: f32 = va.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let nb: f32 = vb.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if na == 0.0 || nb == 0.0 {
+            return Ok(None);
+        }
+        // vec0's cosine DISTANCE is 1 - cos; near_duplicates converts back
+        // with distance_to_similarity (clamp to [0, 1]) — mirror that clamp.
+        Ok(Some((dot / (na * nb)).clamp(0.0, 1.0)))
+    }
+
+    /// The supersede transaction body with the pointer GUARD: pointer,
+    /// archive, vector prune, and one `supersede` oplog row — but only when
+    /// the pointer is still unclaimed on an active row. MUST run inside an
+    /// open transaction; a guard miss is [`Error::StalePlan`] so the whole
+    /// merge rolls back (never a split chain).
+    fn supersede_unclaimed_in_tx(
+        &self,
+        old: &MemoryId,
+        new: &MemoryId,
+        now: chrono::DateTime<chrono::Utc>,
+        key: &str,
+    ) -> Result<()> {
+        let now_ts = now.timestamp();
+        let affected = self
+            .conn
+            .execute(
+                "UPDATE memories
+                 SET superseded_by = ?1, archived_at = ?2, updated_at = ?2
+                 WHERE memory_id = ?3 AND superseded_by IS NULL AND archived_at IS NULL",
+                rusqlite::params![new.to_string(), now_ts, old.to_string()],
+            )
+            .map_err(storage_err)?;
+        if affected == 0 {
+            return Err(Error::StalePlan(format!(
+                "{old} was claimed by a concurrent resolution of {key}; re-run review \
+                 for a fresh queue"
+            )));
+        }
+        self.conn
+            .execute(
+                "DELETE FROM memory_vectors WHERE memory_id = ?1",
+                rusqlite::params![old.to_string()],
+            )
+            .map_err(storage_err)?;
+        let details = serde_json::json!({ "new": new.to_string() }).to_string();
+        super::internal::append_oplog(&self.conn, &self.site_id, "supersede", old, &details)
+    }
+
     fn upsert_review_state(
         &self,
         ns: &Namespace,
@@ -1138,6 +1386,436 @@ mod review_tests {
         );
         assert_eq!(namespace, ns().as_db_string());
         assert!(details.contains("auto-merge-dups"));
+    }
+
+    /// DRIFT/agreement: the pair-scoped revalidation predicate must match the
+    /// queue's contradiction listing (and therefore `active_contradicts`).
+    #[test]
+    fn contradiction_pair_active_matches_the_queue_semantics() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let other = Namespace::Project("elsewhere".into());
+
+        let a = insert(&store, &ns(), "a", |_| {});
+        let b = insert(&store, &ns(), "b", |_| {});
+        contradict(&store, &a, &b);
+        assert!(store.contradiction_pair_active(&ns(), &a, &b).unwrap());
+        // Direction-independent (the canonical-pair rule).
+        assert!(store.contradiction_pair_active(&ns(), &b, &a).unwrap());
+
+        // No edge between the pair: not a contradiction item, even though
+        // both are active.
+        let c = insert(&store, &ns(), "c", |_| {});
+        assert!(!store.contradiction_pair_active(&ns(), &a, &c).unwrap());
+
+        // An archived endpoint breaks the pair (the active_contradicts rule).
+        store.archive_memory(&b).unwrap();
+        assert!(!store.contradiction_pair_active(&ns(), &a, &b).unwrap());
+
+        // Cross-namespace edges never count in `ns`.
+        let foreign = insert(&store, &other, "foreign", |_| {});
+        contradict(&store, &a, &foreign);
+        assert!(!store
+            .contradiction_pair_active(&ns(), &a, &foreign)
+            .unwrap());
+    }
+
+    // --- atomic merge (review finding: single-writer, single-transaction) -----
+
+    fn combined_note(namespace: &Namespace, content: &str) -> MemoryNote {
+        let mut m = MemoryNote::new(namespace.clone(), content.into(), MemoryType::Insight, 6);
+        m.summary = content.to_string();
+        m
+    }
+
+    fn v_unit() -> [f32; 8] {
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    }
+
+    fn merge_key(a: &MemoryId, b: &MemoryId) -> String {
+        review_item_key(ReviewReason::NearDuplicate, &[a.clone(), b.clone()])
+    }
+
+    #[test]
+    fn review_merge_supersedes_both_into_the_combined_memory() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert_vec(&store, &ns(), "twin a", v_unit());
+        let b = insert_vec(&store, &ns(), "twin b", v_unit());
+        let note = combined_note(&ns(), "combined twin");
+        let now = chrono::Utc::now();
+
+        store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                r#"{"action":"merge"}"#,
+                now,
+            )
+            .unwrap();
+
+        let merged = store.get_memory(&note.id).unwrap().expect("combined row");
+        assert!(merged.archived_at.is_none(), "the combined memory is live");
+        for old in [&a, &b] {
+            let m = store.get_memory(old).unwrap().unwrap();
+            assert!(m.archived_at.is_some(), "{old} archived");
+            assert_eq!(
+                m.superseded_by,
+                Some(note.id.clone()),
+                "{old} points at the merge"
+            );
+        }
+        // The combined memory owns a live vector; the originals' are pruned.
+        let vectors: i64 = store
+            .conn
+            .query_row("SELECT COUNT(*) FROM memory_vectors", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(vectors, 1, "one live vector: the combined memory's");
+        // One review_resolve audit row + two supersede rows + the insert.
+        for (op, want) in [("insert", 3i64), ("supersede", 2), ("review_resolve", 1)] {
+            let got: i64 = store
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memory_oplog WHERE op = ?1",
+                    rusqlite::params![op],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(got, want, "{op} oplog rows");
+        }
+        // reviewed_at stamped for the pair's canonical key.
+        let reviewed: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM review_state WHERE item_key = ?1 AND snooze_until IS NULL",
+                rusqlite::params![merge_key(&a, &b)],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(reviewed, 1);
+    }
+
+    #[test]
+    fn review_merge_is_all_or_nothing_when_a_supersede_pointer_is_taken() {
+        // Review finding (CRITICAL): the guarded pointer UPDATE
+        // (`WHERE superseded_by IS NULL AND archived_at IS NULL`) must fail
+        // the WHOLE transaction — never a split chain, never an orphaned
+        // combined memory (this is also the item-6 rollback proof: the
+        // combined insert happens BEFORE the failing guard and must vanish).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert_vec(&store, &ns(), "twin a", v_unit());
+        let b = insert_vec(&store, &ns(), "twin b", v_unit());
+        let other = insert_vec(
+            &store,
+            &ns(),
+            "unrelated",
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        // Simulate a concurrent winner: b's pointer is already taken while b
+        // is still active (the exact interleaving the unguarded UPDATE let
+        // through).
+        store
+            .conn
+            .execute(
+                "UPDATE memories SET superseded_by = ?1 WHERE memory_id = ?2",
+                rusqlite::params![other.to_string(), b.to_string()],
+            )
+            .unwrap();
+
+        let note = combined_note(&ns(), "combined twin");
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::StalePlan(_)),
+            "distinct error: {err:?}"
+        );
+
+        // ALL-OR-NOTHING: no combined row, `a` fully untouched, no audit row.
+        assert!(
+            store.get_memory(&note.id).unwrap().is_none(),
+            "insert rolled back"
+        );
+        let a_row = store.get_memory(&a).unwrap().unwrap();
+        assert!(a_row.archived_at.is_none() && a_row.superseded_by.is_none());
+        let audits: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_oplog WHERE op IN ('review_resolve','supersede')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(audits, 0, "no partial audit trail survives the rollback");
+    }
+
+    #[test]
+    fn review_merge_rejects_already_resolved_members_with_stale_plan() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert_vec(&store, &ns(), "twin a", v_unit());
+        let b = insert_vec(&store, &ns(), "twin b", v_unit());
+        store.archive_memory(&b).unwrap();
+
+        let note = combined_note(&ns(), "combined twin");
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "{err:?}");
+        assert!(store.get_memory(&note.id).unwrap().is_none());
+
+        // Missing or foreign-namespace members are NotFound (fail closed).
+        let ghost = MemoryId::new();
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &ghost,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound(_)), "{err:?}");
+        let other_ns = Namespace::Project("elsewhere".into());
+        let foreign = insert_vec(&store, &other_ns, "foreign twin", v_unit());
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &foreign,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound(_)), "{err:?}");
+    }
+
+    #[test]
+    fn review_merge_revalidates_similarity_at_resolve_time() {
+        // Review finding (TOCTOU): the wire would otherwise accept Merge for
+        // ANY two active ids — the pair must still qualify as near-duplicates
+        // AT RESOLVE TIME, through the same similarity unit near_duplicates()
+        // reports.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert_vec(&store, &ns(), "one thing", v_unit());
+        let b = insert_vec(
+            &store,
+            &ns(),
+            "another thing entirely",
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        let note = combined_note(&ns(), "bogus merge");
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::StalePlan(_)),
+            "orthogonal pair: {err:?}"
+        );
+        assert!(store.get_memory(&note.id).unwrap().is_none());
+
+        // A member with no stored vector cannot be revalidated: stale plan.
+        let no_vec = insert(&store, &ns(), "vectorless", |_| {});
+        let err = store
+            .review_merge(
+                &ns(),
+                &a,
+                &no_vec,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::StalePlan(_)),
+            "missing vector: {err:?}"
+        );
+    }
+
+    /// DRIFT TEST: the merge revalidation and `near_duplicates()` must share
+    /// one similarity unit — a pair near_duplicates() admits at threshold t
+    /// must pass revalidation at the same t.
+    #[test]
+    fn review_merge_similarity_agrees_with_near_duplicates() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        // Similar but not identical: cosine ~0.894.
+        let a = insert_vec(&store, &ns(), "close one", v_unit());
+        let b = insert_vec(
+            &store,
+            &ns(),
+            "close two",
+            [1.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        let dups = store.near_duplicates(&ns(), &a, 0.85, 10).unwrap();
+        let (dup_id, sim) = dups.first().expect("the 0.89 pair is admitted at 0.85");
+        assert_eq!(dup_id, &b);
+
+        // Revalidation at exactly the reported similarity must ADMIT the pair
+        // (>= semantics, same unit)...
+        let note = combined_note(&ns(), "combined close");
+        store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                *sim,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        // ...which also proves the two paths agree on the number itself: a
+        // stricter bound just above it must REJECT (checked on fresh twins in
+        // review_merge_revalidates_similarity_at_resolve_time).
+    }
+
+    #[test]
+    fn review_merge_carries_union_of_external_links() {
+        // Review finding (HIGH): the originals' graph edges must survive the
+        // merge — copied (not moved) onto the combined memory, deduped, with
+        // the intra-pair edge and supersede-machinery edges dropped (a merged
+        // memory must not link to itself or fake a chain).
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert_vec(&store, &ns(), "twin a", v_unit());
+        let b = insert_vec(&store, &ns(), "twin b", v_unit());
+        let x = insert(&store, &ns(), "outside x", |_| {});
+        let z = insert(&store, &ns(), "outside z", |_| {});
+
+        let link = |src: &MemoryId, dst: &MemoryId, lt: rb_types::LinkType| {
+            store
+                .add_link(&rb_types::MemoryLink {
+                    source_id: src.clone(),
+                    target_id: dst.clone(),
+                    link_type: lt,
+                    strength: 1.0,
+                    reason: "seeded".to_string(),
+                    created_at: chrono::Utc::now(),
+                })
+                .unwrap();
+        };
+        // Outgoing from a; incoming to b; the SAME edge from both members
+        // (dedupe); the intra-pair edge (dropped); a supersedes row (never
+        // copied — that edge type belongs to the supersede machinery).
+        link(&a, &x, rb_types::LinkType::Extends);
+        link(&z, &b, rb_types::LinkType::References);
+        link(&a, &z, rb_types::LinkType::References);
+        link(&b, &z, rb_types::LinkType::References);
+        link(&a, &b, rb_types::LinkType::Contradicts);
+        link(&b, &x, rb_types::LinkType::Supersedes);
+
+        let note = combined_note(&ns(), "combined twin");
+        store
+            .review_merge(
+                &ns(),
+                &a,
+                &b,
+                0.95,
+                &note,
+                Some(&v_unit()),
+                "{}",
+                chrono::Utc::now(),
+            )
+            .unwrap();
+
+        let count = |sql: &str, p1: &str, p2: &str| -> i64 {
+            store
+                .conn
+                .query_row(sql, rusqlite::params![p1, p2], |r| r.get(0))
+                .unwrap()
+        };
+        let new_str = note.id.to_string();
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+                &new_str,
+                &x.to_string()
+            ),
+            1,
+            "outgoing extends edge copied"
+        );
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+                &z.to_string(),
+                &new_str
+            ),
+            1,
+            "incoming references edge copied"
+        );
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+                &new_str,
+                &z.to_string()
+            ),
+            1,
+            "the duplicate a->z / b->z edge collapses to ONE copy"
+        );
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND target_id = ?1 AND ?2 = ?2",
+                &new_str,
+                &new_str
+            ),
+            0,
+            "the intra-pair edge must not become a self-link"
+        );
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND link_type = 'supersedes' AND ?2 = ?2",
+                &new_str,
+                &new_str
+            ),
+            0,
+            "supersede-machinery edges are never copied"
+        );
+        // Copies, not moves: the archived originals keep their history.
+        assert_eq!(
+            count(
+                "SELECT COUNT(*) FROM memory_links WHERE source_id = ?1 AND target_id = ?2",
+                &a.to_string(),
+                &x.to_string()
+            ),
+            1,
+            "the original's edge stays for the audit trail"
+        );
     }
 
     // --- since ------------------------------------------------------------------

--- a/crates/rb-store/src/store/review.rs
+++ b/crates/rb-store/src/store/review.rs
@@ -1,0 +1,1187 @@
+//! Review-queue generation and snooze persistence (PRD 2026-07-02
+//! contradiction/dedup review).
+//!
+//! Read side: [`SqliteStore::review_queue`] surfaces, in priority order,
+//! active contradiction pairs, near-duplicate pairs (via the ONE similarity
+//! definition, [`SqliteStore::near_duplicates`]), and low-confidence /
+//! stale-never-recalled singles. Write side: small helpers that persist
+//! snoozes in the additive `review_state` table (migration 010) and append
+//! the `review_resolve` / `review_sweep` oplog rows (REV-4 audit).
+
+use super::internal::{immediate_tx, parse_id};
+use super::*;
+use crate::error::storage_err;
+use rb_types::{
+    review_item_key, ReviewItem, ReviewMember, ReviewPlan, ReviewReason, ReviewTotals,
+    REVIEW_LOW_CONFIDENCE_BOUND, REVIEW_MAX_LIMIT, REVIEW_MAX_SNOOZE_DAYS, REVIEW_MIN_THRESHOLD,
+    REVIEW_STALE_DAYS,
+};
+use std::collections::HashSet;
+
+/// Bound on the near-dup anchor scan per sweep (the consolidation
+/// `batch_limit` idea): each anchor costs one vec0 KNN probe, so the scan is
+/// O(budget) probes no matter how large the namespace. Anchors outside the
+/// window are picked up by later sweeps (deterministic oldest-first order).
+const NEAR_DUP_SCAN_BUDGET: usize = 200;
+/// Max near-duplicates fetched per anchor (the write-time suppression bound).
+const NEAR_DUP_PER_ANCHOR: usize = 8;
+
+/// Parameters for one review-queue generation pass (REV-1/REV-3).
+#[derive(Debug, Clone, Copy)]
+pub struct ReviewQueueParams {
+    /// Raw cosine-similarity bound for the near-dup tier (the
+    /// `near_duplicates()` unit). Validated to
+    /// `REVIEW_MIN_THRESHOLD..=1.0` fail-closed.
+    pub threshold: f32,
+    /// Max queue items emitted (1..=`REVIEW_MAX_LIMIT`); totals still report
+    /// the full per-tier counts.
+    pub limit: usize,
+    /// When set, only items with a member touched by an oplog row with
+    /// `seq > since` qualify (REV-3 `--since`).
+    pub since: Option<u64>,
+}
+
+/// The snooze-exclusion probe, resolved INSIDE each bounded tier query (the
+/// PR #58 contested-filter lesson: post-filtering a fetch window silently
+/// under-fills the limit). `{key}` is the SQL expression computing the
+/// canonical item key for the row.
+fn not_snoozed_sql(key_expr: &str, ns_param: usize, now_param: usize) -> String {
+    format!(
+        "({key_expr}) NOT IN (SELECT item_key FROM review_state
+             WHERE namespace = ?{ns_param}
+               AND snooze_until IS NOT NULL AND snooze_until > ?{now_param})"
+    )
+}
+
+/// The `--since` probe: the memory aliased `{alias}` was touched by an oplog
+/// row after the cursor.
+fn touched_since_sql(alias: &str, since_param: usize) -> String {
+    format!(
+        "EXISTS (SELECT 1 FROM memory_oplog o WHERE o.memory_id = {alias}.memory_id
+             AND o.seq > ?{since_param})"
+    )
+}
+
+impl SqliteStore {
+    /// Generate the review queue for `ns` (REV-1), priority-ordered:
+    /// contradiction pairs, near-duplicate pairs, then low-confidence and
+    /// stale-never-recalled singles. Read-only — this IS the dry-run, and the
+    /// daemon's apply pass derives its actions from this same queue plus the
+    /// pure `ReviewPolicy::plan_action`, so preview and mutation cannot
+    /// diverge structurally.
+    ///
+    /// Sources of truth, deliberately not re-invented:
+    /// - contradictions: the pair SQL below is the pairwise expression of
+    ///   `active_contradicts` (both endpoints active AND in `ns`), pinned by
+    ///   the `contradiction_items_agree_with_active_contradicts` drift test;
+    /// - near-duplicates: [`SqliteStore::near_duplicates`] — the ONE
+    ///   similarity definition (write-time suppression and the consolidation
+    ///   job use the same function);
+    /// - stale: the stats `never_recalled_live` predicate
+    ///   (`access_count = 0`) plus the [`REVIEW_STALE_DAYS`] age bound.
+    ///
+    /// Snoozed items (unexpired `review_state.snooze_until`) are excluded
+    /// inside each bounded query; `totals` count the actionable (unsnoozed)
+    /// sets, with `totals.snoozed` reporting what is currently hidden.
+    pub fn review_queue(
+        &self,
+        ns: &Namespace,
+        params: &ReviewQueueParams,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ReviewPlan> {
+        if !params.threshold.is_finite()
+            || params.threshold < REVIEW_MIN_THRESHOLD
+            || params.threshold > 1.0
+        {
+            return Err(Error::InvalidArgument(format!(
+                "review threshold {} is out of range {REVIEW_MIN_THRESHOLD}..=1.0",
+                params.threshold
+            )));
+        }
+        if params.limit == 0 || params.limit > REVIEW_MAX_LIMIT as usize {
+            return Err(Error::InvalidArgument(format!(
+                "review limit {} is out of range 1..={REVIEW_MAX_LIMIT}",
+                params.limit
+            )));
+        }
+        let ns_str = ns.as_db_string();
+        let now_ts = now.timestamp();
+        let mut totals = ReviewTotals::default();
+        let mut items: Vec<ReviewItem> = Vec::new();
+        let mut truncated = false;
+
+        // Currently-hidden items (unexpired snoozes): the gauge plus the
+        // Rust-side probe for near-dup pairs (whose keys are computed here,
+        // not in SQL).
+        let snoozed_keys: HashSet<String> = {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT item_key FROM review_state
+                     WHERE namespace = ?1 AND snooze_until IS NOT NULL AND snooze_until > ?2",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![ns_str, now_ts], |r| r.get::<_, String>(0))
+                .map_err(storage_err)?;
+            let mut out = HashSet::new();
+            for r in rows {
+                out.insert(r.map_err(storage_err)?);
+            }
+            out
+        };
+        totals.snoozed = snoozed_keys.len() as u64;
+
+        // --- tier 1: active contradiction pairs -----------------------------
+        // Canonical pair form (lo < hi, TEXT/BINARY order — the same order
+        // `review_item_key` produces) collapses a<->b and b<->a edges into one
+        // row. Both endpoints must be ACTIVE and IN `ns`: the pairwise
+        // expression of `active_contradicts` (see the drift test).
+        let since_frag = match params.since {
+            // ?3 below is the since cursor in both pair-side probes.
+            Some(_) => format!(
+                " AND ({} OR {})",
+                touched_since_sql("a", 3),
+                touched_since_sql("b", 3)
+            ),
+            None => String::new(),
+        };
+        let pairs_cte = format!(
+            "SELECT DISTINCT
+                CASE WHEN l.source_id < l.target_id THEN l.source_id ELSE l.target_id END AS lo,
+                CASE WHEN l.source_id < l.target_id THEN l.target_id ELSE l.source_id END AS hi
+             FROM memory_links l
+               JOIN memories a ON a.memory_id = l.source_id
+               JOIN memories b ON b.memory_id = l.target_id
+             WHERE l.link_type = 'contradicts'
+               AND a.archived_at IS NULL AND b.archived_at IS NULL
+               AND a.namespace = ?1 AND b.namespace = ?1{since_frag}"
+        );
+        let not_snoozed = not_snoozed_sql("'contradiction:' || p.lo || ':' || p.hi", 1, 2);
+        let mut pair_params: Vec<Box<dyn rusqlite::ToSql>> =
+            vec![Box::new(ns_str.clone()), Box::new(now_ts)];
+        if let Some(since) = params.since {
+            pair_params.push(Box::new(i64::try_from(since).unwrap_or(i64::MAX)));
+        }
+        let refs: Vec<&dyn rusqlite::ToSql> = pair_params.iter().map(|b| b.as_ref()).collect();
+        let count: i64 = self
+            .conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM ({pairs_cte}) p WHERE {not_snoozed}"),
+                refs.as_slice(),
+                |r| r.get(0),
+            )
+            .map_err(storage_err)?;
+        totals.contradictions = u64::try_from(count).unwrap_or(0);
+        {
+            let remaining = params.limit.saturating_sub(items.len());
+            let mut stmt = self
+                .conn
+                .prepare(&format!(
+                    "SELECT p.lo, p.hi FROM ({pairs_cte}) p WHERE {not_snoozed}
+                     ORDER BY p.lo, p.hi LIMIT {remaining}"
+                ))
+                .map_err(storage_err)?;
+            let mut rows = stmt.query(refs.as_slice()).map_err(storage_err)?;
+            while let Some(row) = rows.next().map_err(storage_err)? {
+                let lo: String = row.get(0).map_err(storage_err)?;
+                let hi: String = row.get(1).map_err(storage_err)?;
+                let lo = parse_id(&lo)?;
+                let hi = parse_id(&hi)?;
+                items.push(ReviewItem {
+                    key: review_item_key(ReviewReason::Contradiction, &[lo.clone(), hi.clone()]),
+                    reason: ReviewReason::Contradiction,
+                    members: vec![
+                        self.review_member(&lo, now_ts)?,
+                        self.review_member(&hi, now_ts)?,
+                    ],
+                    similarity: None,
+                });
+            }
+        }
+        truncated |= totals.contradictions > items.len() as u64;
+
+        // --- tier 2: near-duplicate pairs ------------------------------------
+        // Bounded anchor scan (deterministic oldest-first, the consolidation
+        // order); each anchor probes `near_duplicates` — the ONE similarity
+        // definition. A member joins at most one pair per sweep so a single
+        // apply pass can never plan two mutations over the same memory;
+        // remaining cluster members re-pair on later sweeps (convergent, the
+        // consolidation argument).
+        let tier1_len = items.len();
+        let anchor_since = match params.since {
+            Some(_) => format!(" AND {}", touched_since_sql("m", 2)),
+            None => String::new(),
+        };
+        let anchors_sql = format!(
+            "SELECT m.memory_id FROM memories m
+             WHERE m.namespace = ?1 AND m.archived_at IS NULL{anchor_since}
+             ORDER BY m.created_at ASC, m.memory_id ASC LIMIT {NEAR_DUP_SCAN_BUDGET}"
+        );
+        let mut anchor_params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(ns_str.clone())];
+        if let Some(since) = params.since {
+            anchor_params.push(Box::new(i64::try_from(since).unwrap_or(i64::MAX)));
+        }
+        let anchor_refs: Vec<&dyn rusqlite::ToSql> =
+            anchor_params.iter().map(|b| b.as_ref()).collect();
+        let anchors: Vec<MemoryId> = {
+            let mut stmt = self.conn.prepare(&anchors_sql).map_err(storage_err)?;
+            let rows = stmt
+                .query_map(anchor_refs.as_slice(), |r| r.get::<_, String>(0))
+                .map_err(storage_err)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(parse_id(&r.map_err(storage_err)?)?);
+            }
+            out
+        };
+        let mut consumed: HashSet<String> = HashSet::new();
+        for anchor in &anchors {
+            if consumed.contains(&anchor.to_string()) {
+                continue;
+            }
+            let dups = self.near_duplicates(ns, anchor, params.threshold, NEAR_DUP_PER_ANCHOR)?;
+            for (dup, similarity) in dups {
+                if consumed.contains(&dup.to_string()) {
+                    continue;
+                }
+                let key =
+                    review_item_key(ReviewReason::NearDuplicate, &[anchor.clone(), dup.clone()]);
+                if snoozed_keys.contains(&key) {
+                    // A snoozed pair neither surfaces nor consumes its
+                    // members — the anchor may still pair with another twin.
+                    continue;
+                }
+                totals.near_duplicates += 1;
+                consumed.insert(anchor.to_string());
+                consumed.insert(dup.to_string());
+                if items.len() < params.limit {
+                    items.push(ReviewItem {
+                        key,
+                        reason: ReviewReason::NearDuplicate,
+                        members: vec![
+                            self.review_member(anchor, now_ts)?,
+                            self.review_member(&dup, now_ts)?,
+                        ],
+                        similarity: Some(similarity),
+                    });
+                }
+                break; // one pair per anchor per sweep
+            }
+        }
+        truncated |= totals.near_duplicates > (items.len() - tier1_len) as u64;
+
+        // --- tier 3: low-confidence, then stale never-recalled ----------------
+        let single_since = match params.since {
+            Some(_) => format!(" AND {}", touched_since_sql("m", 4)),
+            None => String::new(),
+        };
+        let mut single_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(ns_str.clone()),
+            Box::new(now_ts),
+            Box::new(f64::from(REVIEW_LOW_CONFIDENCE_BOUND)),
+        ];
+        if let Some(since) = params.since {
+            single_params.push(Box::new(i64::try_from(since).unwrap_or(i64::MAX)));
+        }
+        let single_refs: Vec<&dyn rusqlite::ToSql> =
+            single_params.iter().map(|b| b.as_ref()).collect();
+
+        let low_where = format!(
+            "m.namespace = ?1 AND m.archived_at IS NULL AND m.confidence < ?3{single_since}
+             AND {}",
+            not_snoozed_sql("'low_confidence:' || m.memory_id", 1, 2)
+        );
+        let (low_count, low_ids) = self.single_tier(
+            &low_where,
+            "m.confidence ASC, m.created_at ASC, m.memory_id ASC",
+            single_refs.as_slice(),
+            params.limit.saturating_sub(items.len()),
+        )?;
+        totals.low_confidence = low_count;
+        for id in &low_ids {
+            items.push(ReviewItem {
+                key: review_item_key(ReviewReason::LowConfidence, std::slice::from_ref(id)),
+                reason: ReviewReason::LowConfidence,
+                members: vec![self.review_member(id, now_ts)?],
+                similarity: None,
+            });
+        }
+        truncated |= low_count > low_ids.len() as u64;
+
+        // Stale: the stats never-recalled predicate (`access_count = 0`) plus
+        // the age bound; low-confidence rows are excluded so a memory is
+        // listed once, under its higher tier.
+        let stale_cutoff = now_ts - i64::from(REVIEW_STALE_DAYS) * 86_400;
+        let mut stale_params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(ns_str.clone()),
+            Box::new(now_ts),
+            Box::new(f64::from(REVIEW_LOW_CONFIDENCE_BOUND)),
+        ];
+        if let Some(since) = params.since {
+            stale_params.push(Box::new(i64::try_from(since).unwrap_or(i64::MAX)));
+        }
+        stale_params.push(Box::new(stale_cutoff));
+        let stale_cutoff_param = stale_params.len();
+        let stale_refs: Vec<&dyn rusqlite::ToSql> =
+            stale_params.iter().map(|b| b.as_ref()).collect();
+        let stale_where = format!(
+            "m.namespace = ?1 AND m.archived_at IS NULL AND m.access_count = 0
+             AND m.created_at < ?{stale_cutoff_param} AND m.confidence >= ?3{single_since}
+             AND {}",
+            not_snoozed_sql("'stale_never_recalled:' || m.memory_id", 1, 2)
+        );
+        let (stale_count, stale_ids) = self.single_tier(
+            &stale_where,
+            "m.created_at ASC, m.memory_id ASC",
+            stale_refs.as_slice(),
+            params.limit.saturating_sub(items.len()),
+        )?;
+        totals.stale_never_recalled = stale_count;
+        for id in &stale_ids {
+            items.push(ReviewItem {
+                key: review_item_key(ReviewReason::StaleNeverRecalled, std::slice::from_ref(id)),
+                reason: ReviewReason::StaleNeverRecalled,
+                members: vec![self.review_member(id, now_ts)?],
+                similarity: None,
+            });
+        }
+        truncated |= stale_count > stale_ids.len() as u64;
+
+        Ok(ReviewPlan {
+            items,
+            totals,
+            policy: None,
+            planned: Vec::new(),
+            truncated,
+        })
+    }
+
+    /// Count + bounded fetch for one tier-3 predicate — count and rows share
+    /// the WHERE so the gauge can never disagree with the listing.
+    fn single_tier(
+        &self,
+        where_sql: &str,
+        order_sql: &str,
+        refs: &[&dyn rusqlite::ToSql],
+        limit: usize,
+    ) -> Result<(u64, Vec<MemoryId>)> {
+        let count: i64 = self
+            .conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM memories m WHERE {where_sql}"),
+                refs,
+                |r| r.get(0),
+            )
+            .map_err(storage_err)?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!(
+                "SELECT m.memory_id FROM memories m WHERE {where_sql}
+                 ORDER BY {order_sql} LIMIT {limit}"
+            ))
+            .map_err(storage_err)?;
+        let rows = stmt
+            .query_map(refs, |r| r.get::<_, String>(0))
+            .map_err(storage_err)?;
+        let mut ids = Vec::new();
+        for r in rows {
+            ids.push(parse_id(&r.map_err(storage_err)?)?);
+        }
+        Ok((u64::try_from(count).unwrap_or(0), ids))
+    }
+
+    /// Load the display fields one review member needs (REV-1: summary,
+    /// importance, confidence, age, provenance). Counts, ids and the STORED
+    /// summary only — renderers redact before display.
+    fn review_member(&self, id: &MemoryId, now_ts: i64) -> Result<ReviewMember> {
+        self.conn
+            .query_row(
+                "SELECT summary, importance, confidence, created_at, last_accessed_at,
+                        origin_source, origin_user
+                 FROM memories WHERE memory_id = ?1",
+                rusqlite::params![id.to_string()],
+                |r| {
+                    Ok(ReviewMember {
+                        id: id.clone(),
+                        summary: r.get(0)?,
+                        importance: u8::try_from(r.get::<_, i64>(1)?).unwrap_or(u8::MAX),
+                        confidence: r.get::<_, f64>(2)? as f32,
+                        created_at: r.get(3)?,
+                        age_days: u32::try_from((now_ts - r.get::<_, i64>(3)?) / 86_400)
+                            .unwrap_or(0),
+                        last_accessed_at: r.get(4)?,
+                        origin_source: r.get(5)?,
+                        origin_user: r.get(6)?,
+                    })
+                },
+            )
+            .map_err(storage_err)
+    }
+
+    /// Persist a snooze (REV-2): upsert the item's `review_state` row with
+    /// `reviewed_at = now` and `snooze_until = now + days`, and append one
+    /// `review_resolve` oplog row (REV-4) — one transaction. Returns the
+    /// snooze expiry (unix seconds).
+    pub fn snooze_review_item(
+        &self,
+        ns: &Namespace,
+        key: &str,
+        days: u32,
+        details: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<i64> {
+        if key.trim().is_empty() {
+            return Err(Error::InvalidArgument(
+                "review item key must not be empty".to_string(),
+            ));
+        }
+        if days == 0 || days > REVIEW_MAX_SNOOZE_DAYS {
+            return Err(Error::InvalidArgument(format!(
+                "snooze days {days} is out of range 1..={REVIEW_MAX_SNOOZE_DAYS}"
+            )));
+        }
+        let until = now.timestamp() + i64::from(days) * 86_400;
+        immediate_tx(&self.conn, || {
+            self.upsert_review_state(ns, key, now.timestamp(), Some(until))?;
+            self.append_review_oplog(ns, "review_resolve", details, now)
+        })?;
+        Ok(until)
+    }
+
+    /// Record a non-snooze resolution (REV-4): stamp `reviewed_at` (clearing
+    /// any snooze — the user acted on the item) and append one
+    /// `review_resolve` oplog row — one transaction. The mutation itself
+    /// (supersede/archive/update) runs through the existing primitives, each
+    /// with its own oplog row.
+    pub fn record_review_resolution(
+        &self,
+        ns: &Namespace,
+        key: &str,
+        details: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        if key.trim().is_empty() {
+            return Err(Error::InvalidArgument(
+                "review item key must not be empty".to_string(),
+            ));
+        }
+        immediate_tx(&self.conn, || {
+            self.upsert_review_state(ns, key, now.timestamp(), None)?;
+            self.append_review_oplog(ns, "review_resolve", details, now)
+        })
+    }
+
+    /// Append the bulk `review_sweep` oplog row (namespace-stamped, empty
+    /// memory-id sentinel so replay skips it — the `retention_sweep`
+    /// precedent). Written unconditionally after a policy apply pass, so a
+    /// zero-change or partial pass is still a durable, auditable run.
+    pub fn record_review_sweep(
+        &self,
+        ns: &Namespace,
+        details: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        self.append_review_oplog(ns, "review_sweep", details, now)
+    }
+
+    fn upsert_review_state(
+        &self,
+        ns: &Namespace,
+        key: &str,
+        reviewed_at: i64,
+        snooze_until: Option<i64>,
+    ) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO review_state (item_key, namespace, reviewed_at, snooze_until)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(item_key) DO UPDATE SET
+                   namespace = excluded.namespace,
+                   reviewed_at = excluded.reviewed_at,
+                   snooze_until = excluded.snooze_until",
+                rusqlite::params![key, ns.as_db_string(), reviewed_at, snooze_until],
+            )
+            .map_err(storage_err)?;
+        Ok(())
+    }
+
+    fn append_review_oplog(
+        &self,
+        ns: &Namespace,
+        op: &str,
+        details: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO memory_oplog (site_id, op, memory_id, namespace, at, details)
+                 VALUES (?1, ?2, '', ?3, ?4, ?5)",
+                rusqlite::params![
+                    self.site_id,
+                    op,
+                    ns.as_db_string(),
+                    now.timestamp(),
+                    details
+                ],
+            )
+            .map_err(storage_err)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod review_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::super::*;
+    use rb_types::{
+        review_item_key, MemoryId, MemoryNote, MemoryType, Namespace, ReviewReason,
+        REVIEW_DEFAULT_SNOOZE_DAYS,
+    };
+
+    fn ns() -> Namespace {
+        Namespace::Project("review".into())
+    }
+
+    fn params() -> ReviewQueueParams {
+        ReviewQueueParams {
+            threshold: 0.95,
+            limit: 50,
+            since: None,
+        }
+    }
+
+    fn insert(
+        store: &SqliteStore,
+        namespace: &Namespace,
+        content: &str,
+        f: impl FnOnce(&mut MemoryNote),
+    ) -> MemoryId {
+        let mut m = MemoryNote::new(namespace.clone(), content.into(), MemoryType::Insight, 5);
+        m.summary = content.to_string();
+        f(&mut m);
+        let id = m.id.clone();
+        store.insert_memory(&m, None).unwrap();
+        id
+    }
+
+    fn insert_vec(
+        store: &SqliteStore,
+        namespace: &Namespace,
+        content: &str,
+        v: [f32; 8],
+    ) -> MemoryId {
+        let mut m = MemoryNote::new(namespace.clone(), content.into(), MemoryType::Insight, 5);
+        m.summary = content.to_string();
+        let id = m.id.clone();
+        store.insert_memory(&m, Some(&v)).unwrap();
+        id
+    }
+
+    fn contradict(store: &SqliteStore, a: &MemoryId, b: &MemoryId) {
+        store
+            .add_link(&rb_types::MemoryLink {
+                source_id: a.clone(),
+                target_id: b.clone(),
+                link_type: rb_types::LinkType::Contradicts,
+                strength: 1.0,
+                reason: "test contradiction".to_string(),
+                created_at: chrono::Utc::now(),
+            })
+            .unwrap();
+    }
+
+    fn queue(store: &SqliteStore, p: &ReviewQueueParams) -> rb_types::ReviewPlan {
+        store.review_queue(&ns(), p, chrono::Utc::now()).unwrap()
+    }
+
+    // --- contradictions (priority 1) -----------------------------------------
+
+    /// DRIFT TEST: the queue's contradiction items must resolve contested
+    /// state through the same semantics as `active_contradicts` (the source
+    /// of truth `contested` filtering also agrees with). Change the pair SQL
+    /// without this invariant and this test fails.
+    #[test]
+    fn contradiction_items_agree_with_active_contradicts() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let other = Namespace::Project("elsewhere".into());
+
+        // An active in-namespace pair: BOTH endpoints contested.
+        let a = insert(&store, &ns(), "a", |_| {});
+        let b = insert(&store, &ns(), "b", |_| {});
+        contradict(&store, &a, &b);
+
+        // A pair whose far endpoint is archived: NOT contested.
+        let c = insert(&store, &ns(), "c", |_| {});
+        let dead = insert(&store, &ns(), "dead", |_| {});
+        contradict(&store, &c, &dead);
+        store.archive_memory(&dead).unwrap();
+
+        // A cross-namespace edge: NEVER contested in `ns`.
+        let d = insert(&store, &ns(), "d", |_| {});
+        let foreign = insert(&store, &other, "foreign", |_| {});
+        contradict(&store, &d, &foreign);
+
+        let all = vec![a.clone(), b.clone(), c.clone(), dead.clone(), d.clone()];
+        let truth = store.active_contradicts(&ns(), &all).unwrap();
+
+        let plan = queue(&store, &params());
+        let mut member_ids: Vec<MemoryId> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::Contradiction)
+            .flat_map(|i| i.members.iter().map(|m| m.id.clone()))
+            .collect();
+        member_ids.sort_by_key(std::string::ToString::to_string);
+        let mut expected: Vec<MemoryId> = truth.into_iter().collect();
+        expected.sort_by_key(std::string::ToString::to_string);
+        assert_eq!(
+            member_ids, expected,
+            "contradiction items must contain exactly the active_contradicts set"
+        );
+        assert_eq!(plan.totals.contradictions, 1, "one actionable pair");
+    }
+
+    #[test]
+    fn a_contradiction_pair_is_one_item_with_a_canonical_key() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert(&store, &ns(), "a", |_| {});
+        let b = insert(&store, &ns(), "b", |_| {});
+        // Both directions on the same pair must still yield ONE item.
+        contradict(&store, &a, &b);
+        contradict(&store, &b, &a);
+
+        let plan = queue(&store, &params());
+        let items: Vec<_> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::Contradiction)
+            .collect();
+        assert_eq!(items.len(), 1, "one pair, one item: {items:?}");
+        assert_eq!(
+            items[0].key,
+            review_item_key(ReviewReason::Contradiction, &[a.clone(), b.clone()])
+        );
+        assert_eq!(items[0].members.len(), 2);
+        // Members carry what the human decision needs.
+        assert!(!items[0].members[0].summary.is_empty());
+    }
+
+    // --- near-duplicates (priority 2) -----------------------------------------
+
+    #[test]
+    fn near_dup_items_come_from_near_duplicates_with_similarity() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let v = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let a = insert_vec(&store, &ns(), "twin one", v);
+        let b = insert_vec(&store, &ns(), "twin two", v);
+        // Orthogonal: similarity ~0, never a dup at any sane threshold.
+        let c = insert_vec(
+            &store,
+            &ns(),
+            "different",
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+
+        let plan = queue(&store, &params());
+        let dups: Vec<_> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::NearDuplicate)
+            .collect();
+        assert_eq!(dups.len(), 1, "exactly the twin pair: {dups:?}");
+        let item = dups[0];
+        assert_eq!(
+            item.key,
+            review_item_key(ReviewReason::NearDuplicate, &[a.clone(), b.clone()])
+        );
+        assert!(
+            item.similarity.unwrap() >= 0.95,
+            "similarity is the raw near_duplicates() unit: {:?}",
+            item.similarity
+        );
+        let ids: Vec<&MemoryId> = item.members.iter().map(|m| &m.id).collect();
+        assert!(!ids.contains(&&c), "the orthogonal memory is not a dup");
+    }
+
+    #[test]
+    fn near_dup_members_join_at_most_one_pair_per_sweep() {
+        // Three near-identical memories: ONE pair this sweep (the remaining
+        // member re-pairs on a later sweep once the pair is resolved) — a
+        // member appearing in two merge plans could double-supersede.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let v = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        insert_vec(&store, &ns(), "one", v);
+        insert_vec(&store, &ns(), "two", v);
+        insert_vec(&store, &ns(), "three", v);
+
+        let plan = queue(&store, &params());
+        let dups: Vec<_> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::NearDuplicate)
+            .collect();
+        assert_eq!(dups.len(), 1, "one pair per member per sweep: {dups:?}");
+        let mut seen = std::collections::HashSet::new();
+        for m in dups.iter().flat_map(|i| i.members.iter()) {
+            assert!(
+                seen.insert(m.id.to_string()),
+                "member repeated across items"
+            );
+        }
+    }
+
+    #[test]
+    fn near_dup_threshold_is_honored() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        // Two similar-but-not-identical vectors: cosine similarity ~0.894.
+        insert_vec(
+            &store,
+            &ns(),
+            "close one",
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        insert_vec(
+            &store,
+            &ns(),
+            "close two",
+            [1.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        let strict = queue(&store, &params());
+        assert!(
+            !strict
+                .items
+                .iter()
+                .any(|i| i.reason == ReviewReason::NearDuplicate),
+            "0.894 similarity is below the 0.95 threshold"
+        );
+        let loose = store
+            .review_queue(
+                &ns(),
+                &ReviewQueueParams {
+                    threshold: 0.85,
+                    ..params()
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert!(
+            loose
+                .items
+                .iter()
+                .any(|i| i.reason == ReviewReason::NearDuplicate),
+            "a looser threshold admits the pair"
+        );
+    }
+
+    // --- tier 3: low confidence + stale never-recalled -------------------------
+
+    #[test]
+    fn low_confidence_and_stale_items_fill_tier_three() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let low = insert(&store, &ns(), "low confidence", |m| m.confidence = 0.2);
+        let _confident = insert(&store, &ns(), "confident", |m| m.confidence = 0.9);
+        let stale = insert(&store, &ns(), "stale never recalled", |m| {
+            m.confidence = 0.9;
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(90);
+        });
+        // Old but recalled: not stale.
+        let recalled = insert(&store, &ns(), "old but recalled", |m| {
+            m.confidence = 0.9;
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(90);
+        });
+        store.record_access(&recalled).unwrap();
+        // Low confidence AND stale: listed once, as low-confidence (the
+        // higher tier), never twice.
+        let both = insert(&store, &ns(), "low and stale", |m| {
+            m.confidence = 0.1;
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(90);
+        });
+        // Archived low-confidence: never listed.
+        let dead = insert(&store, &ns(), "archived low", |m| m.confidence = 0.1);
+        store.archive_memory(&dead).unwrap();
+
+        let plan = queue(&store, &params());
+        let low_items: Vec<&MemoryId> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::LowConfidence)
+            .map(|i| &i.members[0].id)
+            .collect();
+        let stale_items: Vec<&MemoryId> = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::StaleNeverRecalled)
+            .map(|i| &i.members[0].id)
+            .collect();
+        assert!(low_items.contains(&&low));
+        assert!(low_items.contains(&&both));
+        assert!(!low_items.contains(&&dead), "archived rows never enter");
+        assert_eq!(
+            stale_items,
+            vec![&stale],
+            "never-recalled + old, not {stale_items:?}"
+        );
+        assert_eq!(plan.totals.low_confidence, 2);
+        assert_eq!(plan.totals.stale_never_recalled, 1);
+        // Priority order within tier 3: low-confidence before stale.
+        let reasons: Vec<ReviewReason> = plan.items.iter().map(|i| i.reason).collect();
+        let low_pos = reasons
+            .iter()
+            .position(|r| *r == ReviewReason::LowConfidence)
+            .unwrap();
+        let stale_pos = reasons
+            .iter()
+            .position(|r| *r == ReviewReason::StaleNeverRecalled)
+            .unwrap();
+        assert!(low_pos < stale_pos);
+    }
+
+    /// DRIFT TEST: the stale tier's "never recalled" predicate must agree
+    /// with the stats surface (`never_recalled_live`: active rows with
+    /// `access_count = 0`) — REV-1 sources tier 3 "from the stats surface".
+    #[test]
+    fn stale_never_recalled_agrees_with_the_stats_predicate() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        for i in 0..3 {
+            insert(&store, &ns(), &format!("old {i}"), |m| {
+                m.created_at = chrono::Utc::now() - chrono::Duration::days(90);
+            });
+        }
+        let recalled = insert(&store, &ns(), "old recalled", |m| {
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(90);
+        });
+        store.record_access(&recalled).unwrap();
+
+        let stats = store.namespace_stats(&ns(), 30, "", "", 5, None).unwrap();
+        let plan = queue(&store, &params());
+        let stale_count = plan
+            .items
+            .iter()
+            .filter(|i| i.reason == ReviewReason::StaleNeverRecalled)
+            .count() as u64;
+        // Every memory here is older than the stale horizon, so the stale
+        // tier must equal the stats gauge exactly.
+        assert_eq!(stale_count, stats.never_recalled_live);
+        assert_eq!(plan.totals.stale_never_recalled, stats.never_recalled_live);
+    }
+
+    // --- ordering, bounds, isolation -------------------------------------------
+
+    #[test]
+    fn queue_is_priority_ordered_and_bounded_with_truncation_flag() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        // Tier 3 first so insertion order cannot fake priority order.
+        insert(&store, &ns(), "low", |m| m.confidence = 0.2);
+        let v = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        insert_vec(&store, &ns(), "twin one", v);
+        insert_vec(&store, &ns(), "twin two", v);
+        let a = insert(&store, &ns(), "contra a", |_| {});
+        let b = insert(&store, &ns(), "contra b", |_| {});
+        contradict(&store, &a, &b);
+
+        let plan = queue(&store, &params());
+        let reasons: Vec<ReviewReason> = plan.items.iter().map(|i| i.reason).collect();
+        assert_eq!(
+            reasons,
+            vec![
+                ReviewReason::Contradiction,
+                ReviewReason::NearDuplicate,
+                ReviewReason::LowConfidence,
+            ]
+        );
+        assert!(!plan.truncated);
+
+        // A limit of 1 keeps only the highest-priority item and flags the cut.
+        let bounded = store
+            .review_queue(
+                &ns(),
+                &ReviewQueueParams {
+                    limit: 1,
+                    ..params()
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert_eq!(bounded.items.len(), 1);
+        assert_eq!(bounded.items[0].reason, ReviewReason::Contradiction);
+        assert!(bounded.truncated);
+        // Totals still report the full picture.
+        assert_eq!(bounded.totals.contradictions, 1);
+        assert_eq!(bounded.totals.low_confidence, 1);
+    }
+
+    #[test]
+    fn queue_is_namespace_isolated() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let other = Namespace::Project("elsewhere".into());
+        let a = insert(&store, &other, "foreign a", |m| m.confidence = 0.1);
+        let b = insert(&store, &other, "foreign b", |_| {});
+        contradict(&store, &a, &b);
+        let v = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        insert_vec(&store, &other, "foreign twin 1", v);
+        insert_vec(&store, &other, "foreign twin 2", v);
+
+        let plan = queue(&store, &params());
+        assert!(
+            plan.items.is_empty(),
+            "foreign items leaked: {:?}",
+            plan.items
+        );
+        assert_eq!(plan.totals, rb_types::ReviewTotals::default());
+    }
+
+    #[test]
+    fn queue_rejects_out_of_range_params_fail_closed() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        for bad in [
+            ReviewQueueParams {
+                threshold: 0.5,
+                ..params()
+            },
+            ReviewQueueParams {
+                threshold: 1.5,
+                ..params()
+            },
+            ReviewQueueParams {
+                threshold: f32::NAN,
+                ..params()
+            },
+            ReviewQueueParams {
+                limit: 0,
+                ..params()
+            },
+            ReviewQueueParams {
+                limit: (rb_types::REVIEW_MAX_LIMIT + 1) as usize,
+                ..params()
+            },
+        ] {
+            let err = store
+                .review_queue(&ns(), &bad, chrono::Utc::now())
+                .unwrap_err();
+            assert!(matches!(err, Error::InvalidArgument(_)), "{bad:?}: {err:?}");
+        }
+    }
+
+    // --- snooze -----------------------------------------------------------------
+
+    #[test]
+    fn snoozed_item_stays_hidden_until_the_window_elapses() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert(&store, &ns(), "a", |_| {});
+        let b = insert(&store, &ns(), "b", |_| {});
+        contradict(&store, &a, &b);
+        let key = review_item_key(ReviewReason::Contradiction, &[a, b]);
+
+        let now = chrono::Utc::now();
+        let until = store
+            .snooze_review_item(&ns(), &key, REVIEW_DEFAULT_SNOOZE_DAYS, "{}", now)
+            .unwrap();
+        assert_eq!(
+            until,
+            now.timestamp() + i64::from(REVIEW_DEFAULT_SNOOZE_DAYS) * 86_400
+        );
+
+        let hidden = store.review_queue(&ns(), &params(), now).unwrap();
+        assert!(
+            hidden.items.is_empty(),
+            "snoozed item resurfaced early: {:?}",
+            hidden.items
+        );
+        assert_eq!(hidden.totals.snoozed, 1);
+        assert_eq!(hidden.totals.contradictions, 0, "snoozed = not actionable");
+
+        // One second past the window it reappears (REV acceptance).
+        let later = now
+            + chrono::Duration::days(i64::from(REVIEW_DEFAULT_SNOOZE_DAYS))
+            + chrono::Duration::seconds(1);
+        let back = store.review_queue(&ns(), &params(), later).unwrap();
+        assert_eq!(back.items.len(), 1, "expired snooze must resurface");
+        assert_eq!(back.totals.snoozed, 0, "expired snoozes don't count");
+    }
+
+    #[test]
+    fn snooze_exclusion_fills_the_limit_beyond_snoozed_rows() {
+        // The PR #58 lesson: exclusion must be resolved INSIDE the bounded
+        // query — a snoozed row must not consume the limit budget.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let first = insert(&store, &ns(), "low one", |m| {
+            m.confidence = 0.1;
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(2);
+        });
+        let second = insert(&store, &ns(), "low two", |m| {
+            m.confidence = 0.2;
+            m.created_at = chrono::Utc::now() - chrono::Duration::days(1);
+        });
+        let key = review_item_key(ReviewReason::LowConfidence, std::slice::from_ref(&first));
+        store
+            .snooze_review_item(&ns(), &key, 7, "{}", chrono::Utc::now())
+            .unwrap();
+
+        let plan = store
+            .review_queue(
+                &ns(),
+                &ReviewQueueParams {
+                    limit: 1,
+                    ..params()
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert_eq!(plan.items.len(), 1);
+        assert_eq!(
+            plan.items[0].members[0].id, second,
+            "the unsnoozed row must fill the bounded window"
+        );
+    }
+
+    #[test]
+    fn snooze_upserts_and_appends_a_review_resolve_oplog_row() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let key = "contradiction:x:y";
+        let now = chrono::Utc::now();
+        store
+            .snooze_review_item(&ns(), key, 7, r#"{"action":"snooze"}"#, now)
+            .unwrap();
+        // Snoozing again REPLACES the row (one row per item, bounded).
+        store
+            .snooze_review_item(&ns(), key, 14, r#"{"action":"snooze"}"#, now)
+            .unwrap();
+        let (count, until): (i64, i64) = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*), MAX(snooze_until) FROM review_state WHERE item_key = ?1",
+                rusqlite::params![key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "upsert, not append");
+        assert_eq!(until, now.timestamp() + 14 * 86_400);
+
+        let ops: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_oplog WHERE op = 'review_resolve' AND namespace = ?1",
+                rusqlite::params![ns().as_db_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ops, 2, "every snooze is oplog-recorded (REV-4)");
+    }
+
+    #[test]
+    fn record_review_resolution_marks_reviewed_at_and_appends_oplog() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let key = "near_duplicate:x:y";
+        let now = chrono::Utc::now();
+        store
+            .record_review_resolution(&ns(), key, r#"{"action":"keep"}"#, now)
+            .unwrap();
+        let (reviewed_at, snooze_until): (i64, Option<i64>) = store
+            .conn
+            .query_row(
+                "SELECT reviewed_at, snooze_until FROM review_state WHERE item_key = ?1",
+                rusqlite::params![key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(reviewed_at, now.timestamp());
+        assert_eq!(snooze_until, None, "a non-snooze resolution never hides");
+        let details: String = store
+            .conn
+            .query_row(
+                "SELECT details FROM memory_oplog WHERE op = 'review_resolve'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(details.contains("keep"), "{details}");
+        // A later snooze on the same key must not lose the row (upsert).
+        store.snooze_review_item(&ns(), key, 7, "{}", now).unwrap();
+        // And a later plain resolution CLEARS the snooze (the user acted on it).
+        store
+            .record_review_resolution(&ns(), key, r#"{"action":"demote"}"#, now)
+            .unwrap();
+        let snooze_until: Option<i64> = store
+            .conn
+            .query_row(
+                "SELECT snooze_until FROM review_state WHERE item_key = ?1",
+                rusqlite::params![key],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(snooze_until, None, "acting on an item clears its snooze");
+    }
+
+    #[test]
+    fn record_review_sweep_appends_a_namespace_stamped_bulk_row() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        store
+            .record_review_sweep(
+                &ns(),
+                r#"{"policy":"auto-merge-dups","merged":2}"#,
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        let (op, memory_id, namespace, details): (String, String, String, String) = store
+            .conn
+            .query_row(
+                "SELECT op, memory_id, namespace, details FROM memory_oplog",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(op, "review_sweep");
+        assert_eq!(
+            memory_id, "",
+            "bulk rows use the empty sentinel (replay skips)"
+        );
+        assert_eq!(namespace, ns().as_db_string());
+        assert!(details.contains("auto-merge-dups"));
+    }
+
+    // --- since ------------------------------------------------------------------
+
+    #[test]
+    fn since_limits_the_queue_to_recently_touched_memories() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = insert(&store, &ns(), "old low", |m| m.confidence = 0.1);
+        let cutoff = store.latest_oplog_seq_for(&a).unwrap().unwrap();
+        let b = insert(&store, &ns(), "new low", |m| m.confidence = 0.2);
+
+        let plan = store
+            .review_queue(
+                &ns(),
+                &ReviewQueueParams {
+                    since: Some(cutoff),
+                    ..params()
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        let ids: Vec<&MemoryId> = plan.items.iter().map(|i| &i.members[0].id).collect();
+        assert_eq!(ids, vec![&b], "only the memory touched after the cursor");
+
+        // A pair qualifies when EITHER side was touched after the cursor.
+        let c = insert(&store, &ns(), "contra c", |_| {});
+        let cutoff2 = store.latest_oplog_seq_for(&c).unwrap().unwrap();
+        contradict(&store, &a, &c);
+        let plan = store
+            .review_queue(
+                &ns(),
+                &ReviewQueueParams {
+                    since: Some(cutoff2),
+                    ..params()
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert!(
+            plan.items
+                .iter()
+                .any(|i| i.reason == ReviewReason::Contradiction),
+            "the link touched a side after the cursor: {:?}",
+            plan.items
+        );
+    }
+}

--- a/crates/rb-store/src/store/stats.rs
+++ b/crates/rb-store/src/store/stats.rs
@@ -162,6 +162,18 @@ impl SqliteStore {
             rusqlite::params![ns_str],
         )?;
 
+        // Review-queue tier-3 trend (PRD 2026-07-02 REV-4): live rows below
+        // the review bound (exclusive). Shares the constant with the review
+        // queue's low-confidence tier; the
+        // `low_confidence_gauge_agrees_with_the_review_queue_tier` drift test
+        // pins the agreement.
+        let low_confidence_live = count_query(
+            &self.conn,
+            "SELECT COUNT(*) FROM memories
+             WHERE namespace = ?1 AND archived_at IS NULL AND confidence < ?2",
+            rusqlite::params![ns_str, f64::from(rb_types::REVIEW_LOW_CONFIDENCE_BOUND)],
+        )?;
+
         let created_per_day = {
             let mut stmt = self
                 .conn
@@ -231,6 +243,7 @@ impl SqliteStore {
             top_recalled,
             never_recalled_live,
             contested,
+            low_confidence_live,
             created_per_day,
             reembed_pending,
             // RET-4 visibility: apply-mode eligible count under the daemon's
@@ -528,5 +541,52 @@ mod tests {
         let _ = crate::read_meta_embedding_model(&path).unwrap();
         let after = std::fs::metadata(&path).unwrap().modified().unwrap();
         assert_eq!(before, after, "a read-only open must not touch the file");
+    }
+
+    /// DRIFT TEST: the stats `low_confidence_live` gauge (the review-queue
+    /// tier-3 trend, PRD 2026-07-02 REV-4) must count exactly what the
+    /// review queue's low-confidence tier reports.
+    #[test]
+    fn low_confidence_gauge_agrees_with_the_review_queue_tier() {
+        let store = SqliteStore::open_in_memory(DIM).unwrap();
+        let ns = Namespace::Project("stats-low-conf".to_string());
+
+        let mut low = MemoryNote::new(ns.clone(), "shaky".into(), MemoryType::Insight, 5);
+        low.confidence = 0.2;
+        store.insert_memory(&low, None).unwrap();
+        let mut edge = MemoryNote::new(
+            ns.clone(),
+            "exactly at bound".into(),
+            MemoryType::Insight,
+            5,
+        );
+        edge.confidence = 0.4; // the bound is EXCLUSIVE (< 0.4)
+        store.insert_memory(&edge, None).unwrap();
+        let mut dead = MemoryNote::new(ns.clone(), "archived shaky".into(), MemoryType::Insight, 5);
+        dead.confidence = 0.1;
+        let dead_id = dead.id.clone();
+        store.insert_memory(&dead, None).unwrap();
+        store.archive_memory(&dead_id).unwrap();
+
+        let stats = store
+            .namespace_stats(&ns, 30, MODEL, INPUT_VERSION, 10, None)
+            .unwrap();
+        assert_eq!(stats.low_confidence_live, 1, "one live row below the bound");
+
+        let plan = store
+            .review_queue(
+                &ns,
+                &crate::ReviewQueueParams {
+                    threshold: 0.95,
+                    limit: 50,
+                    since: None,
+                },
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        assert_eq!(
+            stats.low_confidence_live, plan.totals.low_confidence,
+            "the stats gauge and the review tier share one predicate"
+        );
     }
 }

--- a/crates/rb-types/src/error.rs
+++ b/crates/rb-types/src/error.rs
@@ -27,6 +27,14 @@ pub enum Error {
     Enrichment(String),
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
+    /// A review resolution raced a concurrent change (PRD 2026-07-02): the
+    /// item's members were already resolved (archived/superseded) or the
+    /// planned relationship no longer holds at resolve time. Client-safe
+    /// guidance — re-run `review` for a fresh queue. Distinct variant so a
+    /// policy sweep can skip-and-continue past a benign collision while real
+    /// errors still stop the pass.
+    #[error("stale review plan: {0}")]
+    StalePlan(String),
     /// An authenticated peer is not authorized for the requested operation
     /// (W2.6: admin ops are gated on the daemon-verified peer identity, not on
     /// anything the client declares). Client-safe: the message is guidance.

--- a/crates/rb-types/src/lib.rs
+++ b/crates/rb-types/src/lib.rs
@@ -19,6 +19,7 @@ mod memory_type;
 mod namespace;
 mod query;
 mod retention;
+mod review;
 mod stats;
 mod validate;
 
@@ -44,6 +45,13 @@ pub use query::{
 pub use retention::{
     ForgetCandidate, ForgetMode, ForgetOutcome, ForgetPlan, ForgetRule, RetentionPolicy,
     DEFAULT_BATCH_LIMIT, DEFAULT_IMPORTANCE_FLOOR, MAX_BATCH_LIMIT,
+};
+pub use review::{
+    review_item_key, MemberConfidence, PlannedResolution, ReviewAction, ReviewItem, ReviewMember,
+    ReviewOutcome, ReviewPlan, ReviewPolicy, ReviewReason, ReviewResolution, ReviewTotals,
+    REVIEW_DEFAULT_LIMIT, REVIEW_DEFAULT_SNOOZE_DAYS, REVIEW_DEFAULT_THRESHOLD, REVIEW_DEMOTE_STEP,
+    REVIEW_KEEP_BUMP, REVIEW_LOW_CONFIDENCE_BOUND, REVIEW_MAX_LIMIT, REVIEW_MAX_SNOOZE_DAYS,
+    REVIEW_MIN_THRESHOLD, REVIEW_STALE_DAYS,
 };
 pub use stats::{FeedbackTotals, GrowthBucket, MemoryStats, TopRecalled};
 pub use validate::{validate_confidence, validate_importance};

--- a/crates/rb-types/src/review.rs
+++ b/crates/rb-types/src/review.rs
@@ -221,10 +221,13 @@ impl ReviewAction {
         }
     }
 
-    /// Fail-closed shape validation against the item's member ids — shared by
-    /// the daemon boundary (never trust a wire-supplied resolution) and the
-    /// CLI (reject before the round trip).
-    pub fn validate(&self, member_ids: &[MemoryId]) -> Result<()> {
+    /// Fail-closed shape validation against the item's reason and member ids
+    /// — shared by the daemon boundary (never trust a wire-supplied
+    /// resolution) and the CLI (reject before the round trip). Merge is
+    /// restricted to near-duplicate items: merging a contradiction would
+    /// collapse both sides of a dispute into one memory with no marker of
+    /// the conflict.
+    pub fn validate(&self, reason: ReviewReason, member_ids: &[MemoryId]) -> Result<()> {
         if member_ids.is_empty() || member_ids.len() > 2 {
             return Err(Error::InvalidArgument(format!(
                 "a review item has 1 or 2 members, got {}",
@@ -234,6 +237,13 @@ impl ReviewAction {
         match self {
             ReviewAction::Keep { .. } => Ok(()),
             ReviewAction::Merge => {
+                if reason != ReviewReason::NearDuplicate {
+                    return Err(Error::InvalidArgument(
+                        "merge applies to near-duplicate items only; resolve a \
+                         contradiction with keep, archive, demote, or snooze"
+                            .to_string(),
+                    ));
+                }
                 if member_ids.len() != 2 || member_ids[0] == member_ids[1] {
                     return Err(Error::InvalidArgument(
                         "merge needs exactly two distinct members".to_string(),
@@ -544,21 +554,27 @@ mod tests {
         let a = MemoryId::new();
         let b = MemoryId::new();
         let pair = [a.clone(), b.clone()];
-        ReviewAction::Keep { bump: true }.validate(&pair).unwrap();
-        ReviewAction::Merge.validate(&pair).unwrap();
-        ReviewAction::Archive { id: b.clone() }
-            .validate(&pair)
+        for reason in [ReviewReason::Contradiction, ReviewReason::NearDuplicate] {
+            ReviewAction::Keep { bump: true }
+                .validate(reason, &pair)
+                .unwrap();
+            ReviewAction::Archive { id: b.clone() }
+                .validate(reason, &pair)
+                .unwrap();
+            ReviewAction::Demote { id: a.clone() }
+                .validate(reason, &pair)
+                .unwrap();
+            ReviewAction::Snooze {
+                days: REVIEW_DEFAULT_SNOOZE_DAYS,
+            }
+            .validate(reason, &pair)
             .unwrap();
-        ReviewAction::Demote { id: a.clone() }
-            .validate(&pair)
-            .unwrap();
-        ReviewAction::Snooze {
-            days: REVIEW_DEFAULT_SNOOZE_DAYS,
         }
-        .validate(&pair)
-        .unwrap();
+        ReviewAction::Merge
+            .validate(ReviewReason::NearDuplicate, &pair)
+            .unwrap();
         ReviewAction::Keep { bump: false }
-            .validate(std::slice::from_ref(&a))
+            .validate(ReviewReason::LowConfidence, std::slice::from_ref(&a))
             .unwrap();
     }
 
@@ -566,13 +582,44 @@ mod tests {
     fn merge_requires_exactly_two_distinct_members() {
         let a = MemoryId::new();
         let err = ReviewAction::Merge
-            .validate(std::slice::from_ref(&a))
+            .validate(ReviewReason::NearDuplicate, std::slice::from_ref(&a))
             .unwrap_err();
         assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
         let err = ReviewAction::Merge
-            .validate(&[a.clone(), a.clone()])
+            .validate(ReviewReason::NearDuplicate, &[a.clone(), a.clone()])
             .unwrap_err();
         assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+    }
+
+    #[test]
+    fn merge_is_restricted_to_near_duplicate_items() {
+        // Review finding: merging a CONTRADICTION collapses two sides of a
+        // dispute into one memory with no marker of the conflict — the
+        // resolution for contradictions is keep/archive/demote/snooze. The
+        // restriction lives in validate (the daemon boundary) so no wire
+        // caller can bypass it.
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let pair = [a, b];
+        for reason in [
+            ReviewReason::Contradiction,
+            ReviewReason::LowConfidence,
+            ReviewReason::StaleNeverRecalled,
+        ] {
+            let err = ReviewAction::Merge.validate(reason, &pair).unwrap_err();
+            assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("near-duplicate"),
+                "the error names the restriction: {msg}"
+            );
+            if reason == ReviewReason::Contradiction {
+                assert!(
+                    msg.contains("keep") && msg.contains("archive"),
+                    "contradictions get redirected to the right actions: {msg}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -588,7 +635,9 @@ mod tests {
                 id: outsider.clone(),
             },
         ] {
-            let err = action.validate(&[a.clone(), b.clone()]).unwrap_err();
+            let err = action
+                .validate(ReviewReason::Contradiction, &[a.clone(), b.clone()])
+                .unwrap_err();
             assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
         }
     }
@@ -598,7 +647,7 @@ mod tests {
         let a = MemoryId::new();
         for bad in [0u32, REVIEW_MAX_SNOOZE_DAYS + 1] {
             let err = ReviewAction::Snooze { days: bad }
-                .validate(std::slice::from_ref(&a))
+                .validate(ReviewReason::LowConfidence, std::slice::from_ref(&a))
                 .unwrap_err();
             assert!(
                 matches!(err, crate::Error::InvalidArgument(_)),
@@ -611,11 +660,11 @@ mod tests {
     fn empty_or_oversized_member_lists_fail_closed() {
         let ids: Vec<MemoryId> = (0..3).map(|_| MemoryId::new()).collect();
         let err = ReviewAction::Keep { bump: false }
-            .validate(&[])
+            .validate(ReviewReason::Contradiction, &[])
             .unwrap_err();
         assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
         let err = ReviewAction::Keep { bump: false }
-            .validate(&ids)
+            .validate(ReviewReason::Contradiction, &ids)
             .unwrap_err();
         assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
     }

--- a/crates/rb-types/src/review.rs
+++ b/crates/rb-types/src/review.rs
@@ -1,0 +1,739 @@
+//! Guided-review vocabulary (PRD 2026-07-02 contradiction/dedup review).
+//!
+//! Lives in `rb-types` (the leaf crate) so `rb-store` (the queue generator
+//! and snooze persistence), `rb-proto` (the wire `Request::Review` /
+//! `Request::Resolve`), `rb-daemon` (the resolution orchestrator) and the CLI
+//! (rendering + the interactive loop) share one definition — the
+//! `RetentionPolicy`/`ForgetPlan` precedent. Every wire field is
+//! `#[serde(default)]` so the shapes stay additive (no CONTRACT_VERSION bump).
+
+use crate::error::{Error, Result};
+use crate::memory_id::MemoryId;
+use serde::{Deserialize, Serialize};
+
+/// PRD REV-1 tier 3: live memories with confidence strictly below this bound
+/// enter the review queue.
+pub const REVIEW_LOW_CONFIDENCE_BOUND: f32 = 0.4;
+/// Default near-duplicate similarity threshold — the consolidation job's
+/// documented conservative 0.95 (raw cosine similarity, the
+/// `near_duplicates()` unit). One knob, one definition.
+pub const REVIEW_DEFAULT_THRESHOLD: f32 = 0.95;
+/// Floor for a caller-supplied threshold: the server clamps below this so a
+/// wild client cannot turn the whole corpus into "duplicates" (PRD risk:
+/// destructive auto-merge on false positives).
+pub const REVIEW_MIN_THRESHOLD: f32 = 0.80;
+/// Tier 3 staleness horizon: a live memory never recalled and older than
+/// this many days is a stale candidate (mirrors the stats
+/// `never_recalled_live` predicate plus an age bound).
+pub const REVIEW_STALE_DAYS: u32 = 30;
+/// `keep --bump` confidence delta — deliberately the `FeedbackKind::Helpful`
+/// magnitude, clamped to `0.0..=1.0` on apply.
+pub const REVIEW_KEEP_BUMP: f32 = 0.05;
+/// `demote` confidence delta — deliberately the `FeedbackKind::Stale`
+/// magnitude (a review demotion means "outdated", not "wrong"), clamped to
+/// `0.0..=1.0` on apply.
+pub const REVIEW_DEMOTE_STEP: f32 = 0.15;
+/// Default snooze window (REV-2): a snoozed item stays hidden this long.
+pub const REVIEW_DEFAULT_SNOOZE_DAYS: u32 = 7;
+/// Hard ceiling for a snooze window so a typo cannot hide an item forever.
+pub const REVIEW_MAX_SNOOZE_DAYS: u32 = 365;
+/// Default bound on queue items per sweep (the `batch_limit` precedent).
+pub const REVIEW_DEFAULT_LIMIT: u32 = 50;
+/// Hard ceiling for the per-sweep item bound.
+pub const REVIEW_MAX_LIMIT: u32 = 500;
+
+/// Why an item is in the review queue (REV-1, in priority order).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewReason {
+    /// An active `contradicts` pair (`contested` memories) — priority 1.
+    #[default]
+    Contradiction,
+    /// A near-duplicate pair from `near_duplicates()` — priority 2.
+    NearDuplicate,
+    /// A live memory with confidence below
+    /// [`REVIEW_LOW_CONFIDENCE_BOUND`] — priority 3.
+    LowConfidence,
+    /// A live memory never recalled and older than
+    /// [`REVIEW_STALE_DAYS`] — priority 3 (after low-confidence).
+    StaleNeverRecalled,
+}
+
+impl ReviewReason {
+    /// Stable string form — the key prefix and the oplog/JSON vocabulary.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReviewReason::Contradiction => "contradiction",
+            ReviewReason::NearDuplicate => "near_duplicate",
+            ReviewReason::LowConfidence => "low_confidence",
+            ReviewReason::StaleNeverRecalled => "stale_never_recalled",
+        }
+    }
+}
+
+/// Canonical, order-independent key for a review item: the reason prefix plus
+/// the member ids sorted lexicographically. This is the `review_state`
+/// primary key (snooze persistence), so the same pair discovered from either
+/// anchor maps to one row, and a snoozed dup pair can never hide a later
+/// contradiction over the same ids.
+pub fn review_item_key(reason: ReviewReason, ids: &[MemoryId]) -> String {
+    let mut sorted: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+    sorted.sort();
+    format!("{}:{}", reason.as_str(), sorted.join(":"))
+}
+
+/// One side of a review item — everything the human decision needs (REV-1:
+/// summary, importance, confidence, age, provenance). Counts, ids, and the
+/// stored summary only; renderers redact the summary before display.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct ReviewMember {
+    #[serde(default)]
+    pub id: MemoryId,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub importance: u8,
+    #[serde(default)]
+    pub confidence: f32,
+    /// Unix seconds.
+    #[serde(default)]
+    pub created_at: i64,
+    /// Whole days since creation at plan time (display convenience).
+    #[serde(default)]
+    pub age_days: u32,
+    /// Unix seconds of the last recall access, if any.
+    #[serde(default)]
+    pub last_accessed_at: Option<i64>,
+    #[serde(default)]
+    pub origin_source: Option<String>,
+    #[serde(default)]
+    pub origin_user: Option<String>,
+}
+
+/// One queue entry: a contradiction pair, a near-dup pair, or a single
+/// low-confidence/stale memory.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct ReviewItem {
+    /// [`review_item_key`] of this item — the snooze identity.
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub reason: ReviewReason,
+    /// Two members for pairs, one for tier-3 singles.
+    #[serde(default)]
+    pub members: Vec<ReviewMember>,
+    /// Raw cosine similarity (near-duplicate items only).
+    #[serde(default)]
+    pub similarity: Option<f32>,
+}
+
+/// A documented non-interactive policy (REV-3 `--policy`).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewPolicy {
+    /// Merge every near-duplicate pair into one combined superseding memory.
+    AutoMergeDups,
+    /// Demote (lower confidence) every low-confidence item.
+    DemoteLowConfidence,
+}
+
+impl ReviewPolicy {
+    /// Documented (kebab-case) name, as the CLI help spells it.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReviewPolicy::AutoMergeDups => "auto-merge-dups",
+            ReviewPolicy::DemoteLowConfidence => "demote-low-confidence",
+        }
+    }
+
+    /// Parse a policy name (kebab or snake case). Fails closed listing the
+    /// documented policies — a typo must never select a different sweep.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.trim().replace('_', "-").as_str() {
+            "auto-merge-dups" => Ok(ReviewPolicy::AutoMergeDups),
+            "demote-low-confidence" => Ok(ReviewPolicy::DemoteLowConfidence),
+            other => Err(Error::InvalidArgument(format!(
+                "unknown review policy '{other}': expected auto-merge-dups or \
+                 demote-low-confidence"
+            ))),
+        }
+    }
+
+    /// The action this policy takes on `item`, or `None` when the item is out
+    /// of the policy's scope. Pure — dry-run and apply both derive their plan
+    /// from this one function, so they cannot diverge (REV-3 determinism).
+    pub fn plan_action(&self, item: &ReviewItem) -> Option<ReviewAction> {
+        match (self, item.reason) {
+            (ReviewPolicy::AutoMergeDups, ReviewReason::NearDuplicate)
+                if item.members.len() == 2 =>
+            {
+                Some(ReviewAction::Merge)
+            }
+            (ReviewPolicy::DemoteLowConfidence, ReviewReason::LowConfidence) => item
+                .members
+                .first()
+                .map(|m| ReviewAction::Demote { id: m.id.clone() }),
+            _ => None,
+        }
+    }
+}
+
+fn default_snooze_days() -> u32 {
+    REVIEW_DEFAULT_SNOOZE_DAYS
+}
+
+/// A per-item resolution (REV-2). Serde-tagged on `action`; the safety
+/// defaults keep an under-specified frame harmless (`keep` without `bump` is
+/// a no-op; `snooze` without `days` uses the documented default).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ReviewAction {
+    /// No-op; with `bump`, nudge every member's confidence up by
+    /// [`REVIEW_KEEP_BUMP`].
+    Keep {
+        #[serde(default)]
+        bump: bool,
+    },
+    /// Store a combined memory and supersede both originals (the W3.1
+    /// update-as-supersede path). Pair items only.
+    Merge,
+    /// Soft-delete (archive) the loser — must be a member of the item.
+    Archive { id: MemoryId },
+    /// Lower the member's confidence by [`REVIEW_DEMOTE_STEP`] (the W2.2 knob).
+    Demote { id: MemoryId },
+    /// Record `reviewed_at`/`snooze_until` so the item does not reappear
+    /// until the window elapses.
+    Snooze {
+        #[serde(default = "default_snooze_days")]
+        days: u32,
+    },
+}
+
+impl ReviewAction {
+    /// Stable action name for oplog details and outcome rendering.
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            ReviewAction::Keep { .. } => "keep",
+            ReviewAction::Merge => "merge",
+            ReviewAction::Archive { .. } => "archive",
+            ReviewAction::Demote { .. } => "demote",
+            ReviewAction::Snooze { .. } => "snooze",
+        }
+    }
+
+    /// Fail-closed shape validation against the item's member ids — shared by
+    /// the daemon boundary (never trust a wire-supplied resolution) and the
+    /// CLI (reject before the round trip).
+    pub fn validate(&self, member_ids: &[MemoryId]) -> Result<()> {
+        if member_ids.is_empty() || member_ids.len() > 2 {
+            return Err(Error::InvalidArgument(format!(
+                "a review item has 1 or 2 members, got {}",
+                member_ids.len()
+            )));
+        }
+        match self {
+            ReviewAction::Keep { .. } => Ok(()),
+            ReviewAction::Merge => {
+                if member_ids.len() != 2 || member_ids[0] == member_ids[1] {
+                    return Err(Error::InvalidArgument(
+                        "merge needs exactly two distinct members".to_string(),
+                    ));
+                }
+                Ok(())
+            }
+            ReviewAction::Archive { id } | ReviewAction::Demote { id } => {
+                if !member_ids.contains(id) {
+                    return Err(Error::InvalidArgument(format!(
+                        "{} target {id} is not a member of this review item",
+                        self.kind_str()
+                    )));
+                }
+                Ok(())
+            }
+            ReviewAction::Snooze { days } => {
+                if *days == 0 || *days > REVIEW_MAX_SNOOZE_DAYS {
+                    return Err(Error::InvalidArgument(format!(
+                        "snooze days {days} is out of range 1..={REVIEW_MAX_SNOOZE_DAYS}"
+                    )));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Full-namespace category counts for the queue (the review-queue trend).
+/// `near_duplicates` counts pairs FOUND within the bounded scan (a full
+/// pairwise count would be O(n) KNN probes); the other tiers are exact.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReviewTotals {
+    #[serde(default)]
+    pub contradictions: u64,
+    #[serde(default)]
+    pub near_duplicates: u64,
+    #[serde(default)]
+    pub low_confidence: u64,
+    #[serde(default)]
+    pub stale_never_recalled: u64,
+    /// Items currently hidden by an unexpired snooze.
+    #[serde(default)]
+    pub snoozed: u64,
+}
+
+/// What a policy would do to one queue item (dry-run) — and exactly what the
+/// apply pass executes (shared-plan determinism, REV-3).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PlannedResolution {
+    #[serde(default)]
+    pub key: String,
+    pub action: ReviewAction,
+}
+
+/// The review queue / dry-run plan (REV-1): priority-ordered items plus, when
+/// a policy was named, the per-item actions one apply pass would take.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct ReviewPlan {
+    #[serde(default)]
+    pub items: Vec<ReviewItem>,
+    #[serde(default)]
+    pub totals: ReviewTotals,
+    #[serde(default)]
+    pub policy: Option<ReviewPolicy>,
+    /// Empty without a policy. Always derived via
+    /// [`ReviewPolicy::plan_action`] over `items`.
+    #[serde(default)]
+    pub planned: Vec<PlannedResolution>,
+    /// True when the item bound truncated the queue (re-run hint).
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+/// What one policy apply pass did (the `ForgetOutcome` shape: completed
+/// per-item work is never disowned by a mid-batch failure).
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReviewOutcome {
+    #[serde(default)]
+    pub policy: Option<ReviewPolicy>,
+    #[serde(default)]
+    pub merged: u64,
+    #[serde(default)]
+    pub archived: u64,
+    #[serde(default)]
+    pub demoted: u64,
+    #[serde(default)]
+    pub kept: u64,
+    #[serde(default)]
+    pub snoozed: u64,
+    /// Queue items the policy did not cover.
+    #[serde(default)]
+    pub skipped: u64,
+    /// Queue size when the pass started.
+    #[serde(default)]
+    pub total_items: u64,
+    /// Present when the pass stopped early: the error that aborted it AFTER
+    /// the counts above had already durably committed (each item's mutations
+    /// are their own transactions — a later failure never rolls back
+    /// completed work). The pass is re-runnable once the cause is fixed.
+    #[serde(default)]
+    pub failure: Option<String>,
+}
+
+/// Confidence of one member after a keep-bump/demote resolution.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct MemberConfidence {
+    #[serde(default)]
+    pub id: MemoryId,
+    #[serde(default)]
+    pub confidence: f32,
+}
+
+/// The daemon's reply to one per-item resolution (REV-2 interactive mode).
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct ReviewResolution {
+    #[serde(default)]
+    pub key: String,
+    /// [`ReviewAction::kind_str`] of the applied action.
+    #[serde(default)]
+    pub action: String,
+    /// The combined memory's id (merge only).
+    #[serde(default)]
+    pub merged_into: Option<MemoryId>,
+    /// Post-nudge confidences (keep-bump / demote only).
+    #[serde(default)]
+    pub confidence: Vec<MemberConfidence>,
+    /// Unix seconds the snooze expires (snooze only).
+    #[serde(default)]
+    pub snoozed_until: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use crate::MemoryId;
+
+    fn member(id: &MemoryId) -> ReviewMember {
+        ReviewMember {
+            id: id.clone(),
+            summary: "a summary".to_string(),
+            importance: 5,
+            confidence: 0.9,
+            created_at: 1_700_000_000,
+            age_days: 10,
+            last_accessed_at: None,
+            origin_source: Some("cli".to_string()),
+            origin_user: None,
+        }
+    }
+
+    fn pair_item(reason: ReviewReason, a: &MemoryId, b: &MemoryId) -> ReviewItem {
+        ReviewItem {
+            key: review_item_key(reason, &[a.clone(), b.clone()]),
+            reason,
+            members: vec![member(a), member(b)],
+            similarity: Some(0.97),
+        }
+    }
+
+    // --- canonical item keys -------------------------------------------------
+
+    #[test]
+    fn item_key_is_order_independent_and_reason_prefixed() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let forward = review_item_key(ReviewReason::Contradiction, &[a.clone(), b.clone()]);
+        let reverse = review_item_key(ReviewReason::Contradiction, &[b.clone(), a.clone()]);
+        assert_eq!(
+            forward, reverse,
+            "the snooze key must not depend on which side was the scan anchor"
+        );
+        assert!(
+            forward.starts_with("contradiction:"),
+            "key carries the reason so a snoozed dup pair does not hide a \
+             later contradiction over the same ids: {forward}"
+        );
+        assert!(forward.contains(&a.to_string()) && forward.contains(&b.to_string()));
+    }
+
+    #[test]
+    fn item_keys_differ_across_reasons_for_the_same_ids() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let contra = review_item_key(ReviewReason::Contradiction, &[a.clone(), b.clone()]);
+        let dup = review_item_key(ReviewReason::NearDuplicate, &[a, b]);
+        assert_ne!(contra, dup);
+    }
+
+    #[test]
+    fn single_member_key_is_reason_plus_id() {
+        let a = MemoryId::new();
+        let key = review_item_key(ReviewReason::LowConfidence, std::slice::from_ref(&a));
+        assert_eq!(key, format!("low_confidence:{a}"));
+    }
+
+    // --- reason serde --------------------------------------------------------
+
+    #[test]
+    fn reason_serde_is_snake_case_and_round_trips() {
+        for (reason, s) in [
+            (ReviewReason::Contradiction, "\"contradiction\""),
+            (ReviewReason::NearDuplicate, "\"near_duplicate\""),
+            (ReviewReason::LowConfidence, "\"low_confidence\""),
+            (ReviewReason::StaleNeverRecalled, "\"stale_never_recalled\""),
+        ] {
+            assert_eq!(serde_json::to_string(&reason).unwrap(), s);
+            let back: ReviewReason = serde_json::from_str(s).unwrap();
+            assert_eq!(back, reason);
+        }
+    }
+
+    // --- policy parsing / planning -------------------------------------------
+
+    #[test]
+    fn policy_parses_documented_names_in_kebab_and_snake_case() {
+        for s in ["auto-merge-dups", "auto_merge_dups"] {
+            assert_eq!(
+                ReviewPolicy::parse(s).unwrap(),
+                ReviewPolicy::AutoMergeDups,
+                "{s}"
+            );
+        }
+        for s in ["demote-low-confidence", "demote_low_confidence"] {
+            assert_eq!(
+                ReviewPolicy::parse(s).unwrap(),
+                ReviewPolicy::DemoteLowConfidence,
+                "{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_parse_rejects_garbage_with_the_documented_names() {
+        let err = ReviewPolicy::parse("delete-everything").unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidArgument(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("auto-merge-dups") && msg.contains("demote-low-confidence"),
+            "the error must list the documented policies: {msg}"
+        );
+    }
+
+    #[test]
+    fn policy_as_str_round_trips_through_parse() {
+        for p in [
+            ReviewPolicy::AutoMergeDups,
+            ReviewPolicy::DemoteLowConfidence,
+        ] {
+            assert_eq!(ReviewPolicy::parse(p.as_str()).unwrap(), p);
+        }
+    }
+
+    #[test]
+    fn auto_merge_dups_plans_merge_only_for_near_dup_pairs() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let dup = pair_item(ReviewReason::NearDuplicate, &a, &b);
+        assert_eq!(
+            ReviewPolicy::AutoMergeDups.plan_action(&dup),
+            Some(ReviewAction::Merge)
+        );
+        // A contradiction is a human decision, never auto-merged.
+        let contra = pair_item(ReviewReason::Contradiction, &a, &b);
+        assert_eq!(ReviewPolicy::AutoMergeDups.plan_action(&contra), None);
+        // Single-member items cannot merge.
+        let low = ReviewItem {
+            key: review_item_key(ReviewReason::LowConfidence, std::slice::from_ref(&a)),
+            reason: ReviewReason::LowConfidence,
+            members: vec![member(&a)],
+            similarity: None,
+        };
+        assert_eq!(ReviewPolicy::AutoMergeDups.plan_action(&low), None);
+    }
+
+    #[test]
+    fn demote_low_confidence_plans_demote_only_for_low_confidence_items() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let low = ReviewItem {
+            key: review_item_key(ReviewReason::LowConfidence, std::slice::from_ref(&a)),
+            reason: ReviewReason::LowConfidence,
+            members: vec![member(&a)],
+            similarity: None,
+        };
+        assert_eq!(
+            ReviewPolicy::DemoteLowConfidence.plan_action(&low),
+            Some(ReviewAction::Demote { id: a.clone() })
+        );
+        // Stale-never-recalled has UNKNOWN confidence (possibly high): the
+        // low-confidence policy must not touch it.
+        let stale = ReviewItem {
+            key: review_item_key(ReviewReason::StaleNeverRecalled, std::slice::from_ref(&a)),
+            reason: ReviewReason::StaleNeverRecalled,
+            members: vec![member(&a)],
+            similarity: None,
+        };
+        assert_eq!(ReviewPolicy::DemoteLowConfidence.plan_action(&stale), None);
+        let dup = pair_item(ReviewReason::NearDuplicate, &a, &b);
+        assert_eq!(ReviewPolicy::DemoteLowConfidence.plan_action(&dup), None);
+    }
+
+    // --- action validation ----------------------------------------------------
+
+    #[test]
+    fn action_validate_accepts_well_formed_actions() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let pair = [a.clone(), b.clone()];
+        ReviewAction::Keep { bump: true }.validate(&pair).unwrap();
+        ReviewAction::Merge.validate(&pair).unwrap();
+        ReviewAction::Archive { id: b.clone() }
+            .validate(&pair)
+            .unwrap();
+        ReviewAction::Demote { id: a.clone() }
+            .validate(&pair)
+            .unwrap();
+        ReviewAction::Snooze {
+            days: REVIEW_DEFAULT_SNOOZE_DAYS,
+        }
+        .validate(&pair)
+        .unwrap();
+        ReviewAction::Keep { bump: false }
+            .validate(std::slice::from_ref(&a))
+            .unwrap();
+    }
+
+    #[test]
+    fn merge_requires_exactly_two_distinct_members() {
+        let a = MemoryId::new();
+        let err = ReviewAction::Merge
+            .validate(std::slice::from_ref(&a))
+            .unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+        let err = ReviewAction::Merge
+            .validate(&[a.clone(), a.clone()])
+            .unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+    }
+
+    #[test]
+    fn archive_and_demote_targets_must_be_members() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let outsider = MemoryId::new();
+        for action in [
+            ReviewAction::Archive {
+                id: outsider.clone(),
+            },
+            ReviewAction::Demote {
+                id: outsider.clone(),
+            },
+        ] {
+            let err = action.validate(&[a.clone(), b.clone()]).unwrap_err();
+            assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+        }
+    }
+
+    #[test]
+    fn snooze_days_are_bounded() {
+        let a = MemoryId::new();
+        for bad in [0u32, REVIEW_MAX_SNOOZE_DAYS + 1] {
+            let err = ReviewAction::Snooze { days: bad }
+                .validate(std::slice::from_ref(&a))
+                .unwrap_err();
+            assert!(
+                matches!(err, crate::Error::InvalidArgument(_)),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_or_oversized_member_lists_fail_closed() {
+        let ids: Vec<MemoryId> = (0..3).map(|_| MemoryId::new()).collect();
+        let err = ReviewAction::Keep { bump: false }
+            .validate(&[])
+            .unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+        let err = ReviewAction::Keep { bump: false }
+            .validate(&ids)
+            .unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidArgument(_)), "{err}");
+    }
+
+    // --- wire shapes ----------------------------------------------------------
+
+    #[test]
+    fn action_serde_is_tagged_snake_case() {
+        let id = MemoryId::new();
+        let json = serde_json::to_string(&ReviewAction::Archive { id: id.clone() }).unwrap();
+        assert!(json.contains("\"action\":\"archive\""), "{json}");
+        let back: ReviewAction = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ReviewAction::Archive { id });
+        // An absent `bump` decodes to false (never a surprise write).
+        let keep: ReviewAction = serde_json::from_str(r#"{"action":"keep"}"#).unwrap();
+        assert_eq!(keep, ReviewAction::Keep { bump: false });
+        // An absent snooze window decodes to the documented default.
+        let snooze: ReviewAction = serde_json::from_str(r#"{"action":"snooze"}"#).unwrap();
+        assert_eq!(
+            snooze,
+            ReviewAction::Snooze {
+                days: REVIEW_DEFAULT_SNOOZE_DAYS
+            }
+        );
+    }
+
+    #[test]
+    fn plan_outcome_resolution_round_trip_and_decode_from_empty_objects() {
+        let a = MemoryId::new();
+        let b = MemoryId::new();
+        let plan = ReviewPlan {
+            items: vec![pair_item(ReviewReason::NearDuplicate, &a, &b)],
+            totals: ReviewTotals {
+                contradictions: 1,
+                near_duplicates: 2,
+                low_confidence: 3,
+                stale_never_recalled: 4,
+                snoozed: 5,
+            },
+            policy: Some(ReviewPolicy::AutoMergeDups),
+            planned: vec![PlannedResolution {
+                key: review_item_key(ReviewReason::NearDuplicate, &[a.clone(), b.clone()]),
+                action: ReviewAction::Merge,
+            }],
+            truncated: true,
+        };
+        let back: ReviewPlan =
+            serde_json::from_str(&serde_json::to_string(&plan).unwrap()).unwrap();
+        assert_eq!(back, plan);
+
+        let outcome = ReviewOutcome {
+            policy: Some(ReviewPolicy::DemoteLowConfidence),
+            merged: 1,
+            archived: 2,
+            demoted: 3,
+            kept: 4,
+            snoozed: 5,
+            skipped: 6,
+            total_items: 21,
+            failure: Some("injected".to_string()),
+        };
+        let back: ReviewOutcome =
+            serde_json::from_str(&serde_json::to_string(&outcome).unwrap()).unwrap();
+        assert_eq!(back, outcome);
+
+        let resolution = ReviewResolution {
+            key: "near_duplicate:a:b".to_string(),
+            action: "merge".to_string(),
+            merged_into: Some(MemoryId::new()),
+            confidence: vec![MemberConfidence {
+                id: a.clone(),
+                confidence: 0.75,
+            }],
+            snoozed_until: Some(1_800_000_000),
+        };
+        let back: ReviewResolution =
+            serde_json::from_str(&serde_json::to_string(&resolution).unwrap()).unwrap();
+        assert_eq!(back, resolution);
+
+        // Additive wire shapes: every field serde(default) so a peer that
+        // omits fields still decodes (the ForgetPlan precedent).
+        let plan: ReviewPlan = serde_json::from_str("{}").unwrap();
+        assert!(plan.items.is_empty());
+        assert!(plan.policy.is_none());
+        assert!(!plan.truncated);
+        let outcome: ReviewOutcome = serde_json::from_str("{}").unwrap();
+        assert_eq!(outcome.failure, None);
+        assert_eq!(outcome.merged, 0);
+        let resolution: ReviewResolution = serde_json::from_str("{}").unwrap();
+        assert!(resolution.merged_into.is_none());
+        let totals: ReviewTotals = serde_json::from_str("{}").unwrap();
+        assert_eq!(totals.snoozed, 0);
+        let member: ReviewMember = serde_json::from_str("{}").unwrap();
+        assert_eq!(member.confidence, 0.0);
+        let item: ReviewItem = serde_json::from_str("{}").unwrap();
+        assert!(item.members.is_empty());
+        assert_eq!(item.reason, ReviewReason::Contradiction);
+    }
+
+    #[test]
+    // Deliberate constant pins: the test exists to make changing a documented
+    // PRD value a conscious, reviewed act (the `contract_version_is_two`
+    // precedent).
+    #[allow(clippy::assertions_on_constants)]
+    fn documented_constants_hold_their_prd_values() {
+        // PRD REV-1: the low-confidence bound is < 0.4.
+        assert!((REVIEW_LOW_CONFIDENCE_BOUND - 0.4).abs() < f32::EPSILON);
+        // The near-dup default matches the consolidation job's documented 0.95.
+        assert!((REVIEW_DEFAULT_THRESHOLD - 0.95).abs() < f32::EPSILON);
+        // A caller-supplied threshold can only be MORE conservative than the
+        // floor, never loose enough to call everything a dup.
+        assert!(REVIEW_MIN_THRESHOLD >= 0.8);
+        // The bounded knobs are sane.
+        assert!(REVIEW_KEEP_BUMP > 0.0 && REVIEW_DEMOTE_STEP > 0.0);
+        assert!(REVIEW_DEFAULT_SNOOZE_DAYS >= 1);
+        assert!(
+            REVIEW_DEFAULT_LIMIT >= 1
+                && u64::from(REVIEW_DEFAULT_LIMIT) <= u64::from(REVIEW_MAX_LIMIT)
+        );
+    }
+}

--- a/crates/rb-types/src/stats.rs
+++ b/crates/rb-types/src/stats.rs
@@ -61,6 +61,14 @@ pub struct MemoryStats {
     /// endpoints are active and in this namespace (the `contested` read flag).
     #[serde(default)]
     pub contested: u64,
+    /// Live memories with confidence below the review bound
+    /// (`REVIEW_LOW_CONFIDENCE_BOUND`, exclusive) — with `contested` and
+    /// `never_recalled_live`, the review-queue trend (PRD 2026-07-02 REV-4;
+    /// the near-dup tier is deliberately not counted here: it would cost one
+    /// KNN probe per live memory on every stats call). Additive
+    /// `#[serde(default)]` field, the `retention_eligible` precedent.
+    #[serde(default)]
+    pub low_confidence_live: u64,
     /// Corpus growth: memories created per UTC day inside the window, oldest
     /// first. Days with no writes are omitted.
     #[serde(default)]
@@ -152,6 +160,7 @@ mod tests {
             }],
             never_recalled_live: 4,
             contested: 1,
+            low_confidence_live: 2,
             created_per_day: vec![GrowthBucket {
                 day: "2026-07-10".to_string(),
                 count: 2,

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -656,7 +656,9 @@ pub enum Command {
     /// confidence).
     Review {
         /// Preview only (the default posture even without this flag).
-        #[arg(long, conflicts_with = "interactive")]
+        /// Conflicts with --apply and --interactive: an invocation that says
+        /// "preview" must never be able to mutate (PR #63 Copilot finding).
+        #[arg(long, conflicts_with_all = ["interactive", "apply"])]
         dry_run: bool,
         /// Execute one bounded pass under --policy (required with this flag).
         #[arg(long, requires = "policy", conflicts_with = "interactive")]
@@ -1049,6 +1051,20 @@ mod tests {
         ] {
             assert!(Cli::try_parse_from(args).is_err(), "{args:?}");
         }
+        // Copilot finding (PR #63): --dry-run --apply must be a PARSE error —
+        // an invocation that says "preview" must never be able to mutate.
+        assert!(
+            Cli::try_parse_from([
+                "rusty-brain",
+                "review",
+                "--dry-run",
+                "--apply",
+                "--policy",
+                "auto-merge-dups"
+            ])
+            .is_err(),
+            "--dry-run conflicts with --apply"
+        );
     }
 
     #[test]

--- a/crates/rusty-brain/src/cli.rs
+++ b/crates/rusty-brain/src/cli.rs
@@ -47,6 +47,27 @@ fn parse_confidence(s: &str) -> Result<f32, String> {
     Ok(v)
 }
 
+/// Parse a review `--policy` name (kebab or snake case) into the documented
+/// [`rb_types::ReviewPolicy`]; a typo fails at parse time listing the options.
+fn parse_review_policy(s: &str) -> Result<rb_types::ReviewPolicy, String> {
+    rb_types::ReviewPolicy::parse(s).map_err(|e| e.to_string())
+}
+
+/// Clap range check for review `--threshold`: finite raw cosine similarity in
+/// the conservative `0.80..=1.0` band (the server clamps too — this just
+/// fails fast locally with a clear message).
+fn parse_review_threshold(s: &str) -> Result<f32, String> {
+    let v: f32 = s.parse().map_err(|e| format!("not a number: {e}"))?;
+    if !v.is_finite() || !(rb_types::REVIEW_MIN_THRESHOLD..=1.0).contains(&v) {
+        return Err(format!(
+            "threshold must be within {}..=1.0 (raw cosine similarity; lower \
+             values mis-flag distinct memories as duplicates)",
+            rb_types::REVIEW_MIN_THRESHOLD
+        ));
+    }
+    Ok(v)
+}
+
 /// Parse a `--since`/`--until` bound: an RFC 3339 timestamp
 /// (`2026-07-10T12:00:00Z`), a date (`2026-07-01`, midnight UTC), or a
 /// now-relative age (`7d`, `36h`, `45m`, `10s`).
@@ -625,6 +646,51 @@ pub enum Command {
         yes: bool,
     },
 
+    /// Guided review of contradictions, near-duplicates, and low-confidence
+    /// memories (PRD 2026-07-02). With no flags this is a DRY-RUN listing of
+    /// the priority-ordered queue and writes NOTHING; add --policy to preview
+    /// what that policy would do. --interactive walks the queue item by item
+    /// (keep / bump / merge / archive / demote / snooze). --apply --policy
+    /// executes one bounded pass non-interactively; every action is
+    /// reversible (merge/archive supersede or soft-archive, demote lowers
+    /// confidence).
+    Review {
+        /// Preview only (the default posture even without this flag).
+        #[arg(long, conflicts_with = "interactive")]
+        dry_run: bool,
+        /// Execute one bounded pass under --policy (required with this flag).
+        #[arg(long, requires = "policy", conflicts_with = "interactive")]
+        apply: bool,
+        /// Documented policy: auto-merge-dups (merge every near-dup pair
+        /// into one combined superseding memory) or demote-low-confidence
+        /// (lower every low-confidence item's confidence one step).
+        #[arg(long, value_parser = parse_review_policy, conflicts_with = "interactive")]
+        policy: Option<rb_types::ReviewPolicy>,
+        /// Walk the queue item by item on this terminal.
+        #[arg(long, short = 'i')]
+        interactive: bool,
+        /// Only review memories touched after this oplog sequence number
+        /// (REV-3 recent-changes scope).
+        #[arg(long)]
+        since: Option<u64>,
+        /// Max queue items per sweep (server-clamped).
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Near-duplicate similarity threshold (raw cosine similarity,
+        /// 0.80..=1.0; default 0.95 — the conservative consolidation bound).
+        #[arg(long, value_parser = parse_review_threshold)]
+        threshold: Option<f32>,
+        /// Snooze window in days for interactive snoozes.
+        #[arg(long, default_value_t = rb_types::REVIEW_DEFAULT_SNOOZE_DAYS,
+              value_parser = clap::value_parser!(u32).range(1..=rb_types::REVIEW_MAX_SNOOZE_DAYS as i64))]
+        snooze_days: u32,
+        /// Skip the interactive confirmation --apply otherwise requires (the
+        /// import-confirmation precedent). Without it, a non-interactive
+        /// invocation (--json or piped stdin) refuses instead of sweeping.
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
     /// Retroactively redact secrets from every stored memory (W2.4). Rewrites
     /// content/summary/context in place and marks affected rows for
     /// re-embedding; follow with `rusty-brain reembed` until changed=0. Admin
@@ -890,6 +956,118 @@ mod tests {
         );
         assert!(Cli::try_parse_from(["rusty-brain", "forget", "--nonsense"]).is_err());
         assert!(Cli::try_parse_from(["rusty-brain", "forget", "extra-positional"]).is_err());
+    }
+
+    #[test]
+    fn review_defaults_to_dry_run_posture_and_flags_compose() {
+        // Bare `review` is a DRY-RUN listing (the forget safety posture).
+        let cli = Cli::parse_from(["rusty-brain", "review"]);
+        match cli.command {
+            Command::Review {
+                dry_run,
+                apply,
+                policy,
+                interactive,
+                since,
+                limit,
+                threshold,
+                snooze_days,
+                yes,
+            } => {
+                assert!(!dry_run && !apply && !interactive && !yes);
+                assert!(policy.is_none() && since.is_none() && limit.is_none());
+                assert!(threshold.is_none());
+                assert_eq!(snooze_days, rb_types::REVIEW_DEFAULT_SNOOZE_DAYS);
+            }
+            other => panic!("expected Review, got {other:?}"),
+        }
+        for args in [
+            ["rusty-brain", "review", "--dry-run"].as_slice(),
+            ["rusty-brain", "review", "--interactive"].as_slice(),
+            ["rusty-brain", "review", "-i"].as_slice(),
+            [
+                "rusty-brain",
+                "review",
+                "--apply",
+                "--policy",
+                "auto-merge-dups",
+            ]
+            .as_slice(),
+            [
+                "rusty-brain",
+                "review",
+                "--policy",
+                "demote_low_confidence",
+                "--dry-run",
+            ]
+            .as_slice(),
+            [
+                "rusty-brain",
+                "review",
+                "--since",
+                "42",
+                "--limit",
+                "10",
+                "--threshold",
+                "0.97",
+            ]
+            .as_slice(),
+            [
+                "rusty-brain",
+                "review",
+                "--apply",
+                "--policy",
+                "auto-merge-dups",
+                "-y",
+            ]
+            .as_slice(),
+        ] {
+            assert!(Cli::try_parse_from(args).is_ok(), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn review_apply_requires_a_policy_and_interactive_conflicts() {
+        // REV-3: --apply without an explicit policy must fail at parse time.
+        assert!(
+            Cli::try_parse_from(["rusty-brain", "review", "--apply"]).is_err(),
+            "--apply requires --policy"
+        );
+        // Interactive and scripted modes are mutually exclusive.
+        for args in [
+            [
+                "rusty-brain",
+                "review",
+                "-i",
+                "--apply",
+                "--policy",
+                "auto-merge-dups",
+            ]
+            .as_slice(),
+            ["rusty-brain", "review", "-i", "--policy", "auto-merge-dups"].as_slice(),
+            ["rusty-brain", "review", "-i", "--dry-run"].as_slice(),
+        ] {
+            assert!(Cli::try_parse_from(args).is_err(), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn review_rejects_garbage_without_panicking() {
+        // Garbage argv is a clean parse error, never a panic (the forget
+        // precedent).
+        for args in [
+            ["rusty-brain", "review", "--policy", "delete-everything"].as_slice(),
+            ["rusty-brain", "review", "--threshold", "banana"].as_slice(),
+            ["rusty-brain", "review", "--threshold", "0.2"].as_slice(),
+            ["rusty-brain", "review", "--threshold", "NaN"].as_slice(),
+            ["rusty-brain", "review", "--since", "-3"].as_slice(),
+            ["rusty-brain", "review", "--snooze-days", "0"].as_slice(),
+            ["rusty-brain", "review", "--snooze-days", "9999"].as_slice(),
+            ["rusty-brain", "review", "--nonsense"].as_slice(),
+            ["rusty-brain", "review", "extra-positional"].as_slice(),
+        ] {
+            assert!(Cli::try_parse_from(args).is_err(), "{args:?}");
+        }
     }
 
     #[test]

--- a/crates/rusty-brain/src/output.rs
+++ b/crates/rusty-brain/src/output.rs
@@ -455,6 +455,9 @@ pub fn render_stats(
         }
     }
     out.push_str(&format!("contested: {}\n", stats.contested));
+    // Review-queue trend (PRD 2026-07-02 REV-4), alongside `contested` and
+    // `never recalled` above.
+    out.push_str(&format!("low confidence: {}\n", stats.low_confidence_live));
     out.push_str(&format!("re-embed backlog: {}\n", stats.reembed_pending));
     // RET-4 visibility: only rendered when a [retention] policy exists /
     // a sweep ever ran — "0 eligible" and "no policy" must not look alike.
@@ -828,6 +831,167 @@ pub fn render_forget_outcome(outcome: &rb_types::ForgetOutcome, json: bool) -> S
     out
 }
 
+/// One review-queue member line (REV-1: both sides render summary,
+/// importance, confidence, age, provenance). The stored summary passes
+/// through the shared redactor — a review listing must never leak a secret.
+fn review_member_line(index: usize, m: &rb_types::ReviewMember) -> String {
+    let last = match m.last_accessed_at {
+        Some(ts) => format!("last-recalled {}", format_ts(ts)),
+        None => "never recalled".to_string(),
+    };
+    let source = m.origin_source.as_deref().unwrap_or("unknown");
+    format!(
+        "  {}) {} imp {} conf {:.2} age {}d {} [{}] {}",
+        index + 1,
+        m.id,
+        m.importance,
+        m.confidence,
+        m.age_days,
+        last,
+        source,
+        redact(&m.summary)
+    )
+}
+
+/// Human rendering of one review item (shared by the plan listing and the
+/// interactive loop).
+pub fn render_review_item(item: &rb_types::ReviewItem, position: usize, total: usize) -> String {
+    let reason = match item.reason {
+        rb_types::ReviewReason::Contradiction => "contradiction".to_string(),
+        rb_types::ReviewReason::NearDuplicate => match item.similarity {
+            Some(sim) => format!("near-duplicate (similarity {sim:.2})"),
+            None => "near-duplicate".to_string(),
+        },
+        rb_types::ReviewReason::LowConfidence => "low confidence".to_string(),
+        rb_types::ReviewReason::StaleNeverRecalled => "stale, never recalled".to_string(),
+    };
+    let mut out = format!("[{position}/{total}] {reason}\n");
+    for (i, m) in item.members.iter().enumerate() {
+        out.push_str(&review_member_line(i, m));
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+/// A [`rb_types::ReviewPlan`] with every member summary redacted (W2.4): the
+/// one shape BOTH render branches emit, so JSON and human output cannot
+/// disagree on redaction (the PR #60 forget-plan lesson).
+fn redacted_review_plan(plan: &rb_types::ReviewPlan) -> rb_types::ReviewPlan {
+    let mut plan = plan.clone();
+    for item in &mut plan.items {
+        for m in &mut item.members {
+            m.summary = redact(&m.summary);
+        }
+    }
+    plan
+}
+
+/// Render the review queue / dry-run plan (PRD 2026-07-02 REV-1). JSON: the
+/// redacted `ReviewPlan`. Human: the totals header, one block per item, and
+/// the policy's planned action per item when a policy was named.
+pub fn render_review_plan(plan: &rb_types::ReviewPlan, json: bool) -> String {
+    let plan = redacted_review_plan(plan);
+    if json {
+        return serde_json::to_string_pretty(&plan).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render review plan JSON");
+            "{}".to_string()
+        });
+    }
+    let t = &plan.totals;
+    if plan.items.is_empty() {
+        let mut out = "review: nothing needs review.".to_string();
+        if t.snoozed > 0 {
+            out.push_str(&format!(" ({} item(s) snoozed)", t.snoozed));
+        }
+        return out;
+    }
+    let mut out = format!(
+        "review queue: {} item(s) (contradictions {}, near-dups {}, low-confidence {}, \
+         stale {}; snoozed {})\n",
+        plan.items.len(),
+        t.contradictions,
+        t.near_duplicates,
+        t.low_confidence,
+        t.stale_never_recalled,
+        t.snoozed
+    );
+    let total = plan.items.len();
+    for (i, item) in plan.items.iter().enumerate() {
+        out.push_str(&render_review_item(item, i + 1, total));
+        out.push('\n');
+        if let Some(policy) = plan.policy {
+            match plan.planned.iter().find(|p| p.key == item.key) {
+                Some(p) => out.push_str(&format!(
+                    "  -> {} would {}\n",
+                    policy.as_str(),
+                    p.action.kind_str()
+                )),
+                None => out.push_str(&format!("  -> {} skips this item\n", policy.as_str())),
+            }
+        }
+    }
+    if plan.truncated {
+        out.push_str("note: the queue was truncated by the item limit; re-run to continue\n");
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a review apply outcome (REV-3). JSON: the raw `ReviewOutcome`.
+pub fn render_review_outcome(outcome: &rb_types::ReviewOutcome, json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(outcome).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render review outcome JSON");
+            "{}".to_string()
+        });
+    }
+    let policy = outcome
+        .policy
+        .map(|p| p.as_str())
+        .unwrap_or("no-policy")
+        .to_string();
+    let mut out = format!(
+        "review ({policy}): merged={} archived={} demoted={} kept={} snoozed={} \
+         skipped={} of {} item(s)",
+        outcome.merged,
+        outcome.archived,
+        outcome.demoted,
+        outcome.kept,
+        outcome.snoozed,
+        outcome.skipped,
+        outcome.total_items
+    );
+    if let Some(failure) = &outcome.failure {
+        // A partial pass is loud: the counts above DID commit durably, and
+        // the pass is re-runnable once the cause is fixed.
+        out.push_str(&format!(
+            "\nFAILED partway (completed work kept): {failure}"
+        ));
+    }
+    out
+}
+
+/// Render one per-item resolution ack (REV-2 interactive mode). JSON: the raw
+/// `ReviewResolution` (ids, action, and post-nudge numbers — no content).
+pub fn render_review_resolution(res: &rb_types::ReviewResolution, json: bool) -> String {
+    if json {
+        return serde_json::to_string_pretty(res).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to render review resolution JSON");
+            "{}".to_string()
+        });
+    }
+    let mut out = format!("applied {}", res.action);
+    if let Some(id) = &res.merged_into {
+        out.push_str(&format!(": merged into {id}"));
+    }
+    for mc in &res.confidence {
+        out.push_str(&format!("; {} confidence -> {:.2}", mc.id, mc.confidence));
+    }
+    if let Some(until) = res.snoozed_until {
+        out.push_str(&format!(": snoozed until {}", format_ts(until)));
+    }
+    out
+}
+
 /// Unix seconds to a short UTC date for the human reason lines.
 fn format_ts(ts: i64) -> String {
     chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
@@ -1137,6 +1301,7 @@ mod tests {
             }],
             never_recalled_live: 12,
             contested: 1,
+            low_confidence_live: 2,
             created_per_day: vec![rb_types::GrowthBucket {
                 day: "2026-07-10".to_string(),
                 count: 2,
@@ -1145,6 +1310,156 @@ mod tests {
             retention_eligible: Some(4),
             last_forget_at: Some(1_700_000_000),
         }
+    }
+
+    fn review_pair_plan() -> rb_types::ReviewPlan {
+        let a = rb_types::ReviewMember {
+            id: rb_types::MemoryId::new(),
+            summary: "left side with key sk-abc123def456ghi789jkl012mno".to_string(),
+            importance: 5,
+            confidence: 0.9,
+            created_at: 1_700_000_000,
+            age_days: 12,
+            last_accessed_at: None,
+            origin_source: Some("cli".to_string()),
+            origin_user: None,
+        };
+        let b = rb_types::ReviewMember {
+            id: rb_types::MemoryId::new(),
+            summary: "right side".to_string(),
+            importance: 7,
+            confidence: 0.4,
+            created_at: 1_700_000_000,
+            age_days: 3,
+            last_accessed_at: Some(1_710_000_000),
+            origin_source: Some("hook".to_string()),
+            origin_user: None,
+        };
+        let key = rb_types::review_item_key(
+            rb_types::ReviewReason::NearDuplicate,
+            &[a.id.clone(), b.id.clone()],
+        );
+        rb_types::ReviewPlan {
+            items: vec![rb_types::ReviewItem {
+                key: key.clone(),
+                reason: rb_types::ReviewReason::NearDuplicate,
+                members: vec![a, b],
+                similarity: Some(0.97),
+            }],
+            totals: rb_types::ReviewTotals {
+                contradictions: 0,
+                near_duplicates: 1,
+                low_confidence: 2,
+                stale_never_recalled: 3,
+                snoozed: 4,
+            },
+            policy: Some(rb_types::ReviewPolicy::AutoMergeDups),
+            planned: vec![rb_types::PlannedResolution {
+                key,
+                action: rb_types::ReviewAction::Merge,
+            }],
+            truncated: true,
+        }
+    }
+
+    #[test]
+    fn review_plan_renders_both_sides_with_redacted_summaries() {
+        let plan = review_pair_plan();
+        let out = render_review_plan(&plan, false);
+        // Both sides render what the human decision needs (REV-1).
+        assert!(out.contains("near-duplicate"), "{out}");
+        assert!(out.contains("similarity 0.97"), "{out}");
+        assert!(out.contains("imp 5"), "{out}");
+        assert!(out.contains("conf 0.90"), "{out}");
+        assert!(out.contains("age 12d"), "{out}");
+        assert!(out.contains("[cli]"), "{out}");
+        // The queue trend totals are visible.
+        assert!(out.contains("low-confidence 2"), "{out}");
+        assert!(out.contains("snoozed 4"), "{out}");
+        // The policy's planned action is announced per item.
+        assert!(out.contains("auto-merge-dups"), "{out}");
+        assert!(out.contains("merge"), "{out}");
+        // Truncation is a visible re-run hint.
+        assert!(out.contains("truncated"), "{out}");
+        // W2.4: stored summaries pass through the shared redactor.
+        assert!(!out.contains("sk-abc123def456ghi789jkl012mno"), "{out}");
+        assert!(out.contains("REDACTED"), "{out}");
+
+        let empty = rb_types::ReviewPlan::default();
+        let out = render_review_plan(&empty, false);
+        assert!(out.contains("nothing needs review"), "{out}");
+    }
+
+    #[test]
+    fn review_plan_json_redacts_summaries_like_sibling_renderers() {
+        // W2.4 consistency (the PR #60 forget-plan fix): the JSON branch
+        // must never leak a secret the human branch redacts.
+        let plan = review_pair_plan();
+        let json_out = render_review_plan(&plan, true);
+        assert!(
+            !json_out.contains("sk-abc123def456ghi789jkl012mno"),
+            "JSON review listing must redact summaries: {json_out}"
+        );
+        assert!(json_out.contains("REDACTED"), "{json_out}");
+        let parsed: rb_types::ReviewPlan = serde_json::from_str(&json_out).unwrap();
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.totals, plan.totals);
+        assert_eq!(parsed.planned.len(), 1);
+    }
+
+    #[test]
+    fn review_outcome_failure_is_rendered_in_both_modes() {
+        let outcome = rb_types::ReviewOutcome {
+            policy: Some(rb_types::ReviewPolicy::AutoMergeDups),
+            merged: 2,
+            skipped: 1,
+            total_items: 4,
+            failure: Some("merge of near_duplicate:a:b failed: injected".to_string()),
+            ..Default::default()
+        };
+        let human = render_review_outcome(&outcome, false);
+        assert!(human.contains("merged=2"), "{human}");
+        assert!(human.contains("skipped=1"), "{human}");
+        assert!(human.contains("FAILED partway"), "{human}");
+        assert!(human.contains("injected"), "{human}");
+
+        let parsed: rb_types::ReviewOutcome =
+            serde_json::from_str(&render_review_outcome(&outcome, true)).unwrap();
+        assert_eq!(parsed, outcome);
+    }
+
+    #[test]
+    fn review_resolution_renders_the_effect() {
+        let merged = rb_types::MemoryId::new();
+        let res = rb_types::ReviewResolution {
+            key: "near_duplicate:a:b".to_string(),
+            action: "merge".to_string(),
+            merged_into: Some(merged.clone()),
+            ..Default::default()
+        };
+        let out = render_review_resolution(&res, false);
+        assert!(out.contains("merge"), "{out}");
+        assert!(out.contains(&merged.to_string()), "{out}");
+
+        let snoozed = rb_types::ReviewResolution {
+            key: "low_confidence:x".to_string(),
+            action: "snooze".to_string(),
+            snoozed_until: Some(1_800_000_000),
+            ..Default::default()
+        };
+        let out = render_review_resolution(&snoozed, false);
+        assert!(out.contains("snoozed until"), "{out}");
+
+        let parsed: rb_types::ReviewResolution =
+            serde_json::from_str(&render_review_resolution(&res, true)).unwrap();
+        assert_eq!(parsed, res);
+    }
+
+    #[test]
+    fn human_stats_reports_the_low_confidence_gauge() {
+        // The review-queue trend (PRD 2026-07-02 REV-4) is visible in stats.
+        let out = render_stats(&sample_stats(), "deterministic", true, false);
+        assert!(out.contains("low confidence: 2"), "{out}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -801,7 +801,7 @@ async fn run_client(
             }
         }
         Command::Review {
-            dry_run: _,
+            dry_run,
             apply,
             policy,
             interactive,
@@ -813,6 +813,7 @@ async fn run_client(
         } => {
             use std::io::IsTerminal as _;
             match review_gate(
+                dry_run,
                 interactive,
                 apply,
                 yes,
@@ -987,7 +988,7 @@ async fn review_interactive(
                 // EOF (e.g. Ctrl-D): stop cleanly, nothing half-applied.
                 break 'items;
             }
-            match parse_review_choice(&line, item.members.len()) {
+            match parse_review_choice(&line, item.members.len(), item.reason) {
                 Ok(ReviewChoice::Quit) => break 'items,
                 Ok(ReviewChoice::Skip) => continue 'items,
                 Ok(choice) => match choice_to_action(choice, item, snooze_days) {
@@ -1001,7 +1002,10 @@ async fn review_interactive(
             }
         };
         let ids: Vec<rb_types::MemoryId> = item.members.iter().map(|m| m.id.clone()).collect();
-        match client.resolve_review_item(item.reason, ids, action).await {
+        match client
+            .resolve_review_item(item.reason, ids, action, threshold)
+            .await
+        {
             Ok(resolution) => {
                 resolved += 1;
                 println!("{}", output::render_review_resolution(&resolution, false));
@@ -1036,14 +1040,20 @@ enum ReviewGate {
 
 /// Decide how a `review` invocation may proceed. Mirrors `hard_execute_gate`:
 /// a batch mutation must never ride an unattended pipeline by accident, and
-/// the per-item loop needs a human at a terminal.
+/// the per-item loop needs a human at a terminal. An EXPLICIT `--dry-run`
+/// wins over everything (belt-and-suspenders under the clap conflict — a
+/// preview invocation must never mutate; PR #63 Copilot finding).
 fn review_gate(
+    dry_run: bool,
     interactive: bool,
     apply: bool,
     yes: bool,
     json: bool,
     stdin_is_tty: bool,
 ) -> ReviewGate {
+    if dry_run {
+        return ReviewGate::DryRun;
+    }
     if interactive {
         if json {
             return ReviewGate::Refuse(
@@ -1117,10 +1127,16 @@ enum ReviewChoice {
     Quit,
 }
 
-/// Parse one interactive answer against an item with `member_count` members.
-/// Garbage is a clear `Err` message, never a panic and never a silent
-/// mutation; an empty answer skips (the safe default).
-fn parse_review_choice(input: &str, member_count: usize) -> Result<ReviewChoice, String> {
+/// Parse one interactive answer against an item with `member_count` members
+/// and `reason`. Garbage is a clear `Err` message, never a panic and never a
+/// silent mutation; an empty answer skips (the safe default). Merge is
+/// near-duplicate-only (mirroring the daemon's `ReviewAction::validate`
+/// restriction) so the user gets the redirect locally, without a round trip.
+fn parse_review_choice(
+    input: &str,
+    member_count: usize,
+    reason: rb_types::ReviewReason,
+) -> Result<ReviewChoice, String> {
     const HELP: &str = "expected k(eep), b(ump), m(erge), a(rchive) [1|2], d(emote) [1|2], \
                         s(nooze), x/enter to skip, or q(uit)";
     let normalized = input.trim().to_ascii_lowercase();
@@ -1148,6 +1164,13 @@ fn parse_review_choice(input: &str, member_count: usize) -> Result<ReviewChoice,
         ("k" | "keep", None) => Ok(ReviewChoice::Keep),
         ("b" | "bump", None) => Ok(ReviewChoice::KeepBump),
         ("m" | "merge", None) => {
+            if reason != rb_types::ReviewReason::NearDuplicate {
+                return Err(
+                    "merge applies to near-duplicate items only; resolve this one with \
+                     keep, archive, demote, or snooze"
+                        .to_string(),
+                );
+            }
             if member_count == 2 {
                 Ok(ReviewChoice::Merge)
             } else {
@@ -1261,44 +1284,56 @@ mod tests {
     fn review_gate_matrix_mirrors_the_hard_execute_gate() {
         // Interactive mode needs a real terminal and human-readable output.
         assert!(matches!(
-            review_gate(true, false, false, false, true),
+            review_gate(false, true, false, false, false, true),
             ReviewGate::Interactive
         ));
         assert!(matches!(
-            review_gate(true, false, false, true, true),
+            review_gate(false, true, false, false, true, true),
             ReviewGate::Refuse(_)
         ));
         assert!(matches!(
-            review_gate(true, false, false, false, false),
+            review_gate(false, true, false, false, false, false),
             ReviewGate::Refuse(_)
         ));
 
         // Apply: --yes proceeds anywhere; without it, --json and piped stdin
         // refuse loudly, and only a TTY gets the default-NO prompt.
         assert!(matches!(
-            review_gate(false, true, true, true, false),
+            review_gate(false, false, true, true, true, false),
             ReviewGate::ApplyProceed
         ));
         assert!(matches!(
-            review_gate(false, true, false, false, true),
+            review_gate(false, false, true, false, false, true),
             ReviewGate::ApplyPrompt
         ));
-        match review_gate(false, true, false, true, true) {
+        match review_gate(false, false, true, false, true, true) {
             ReviewGate::Refuse(msg) => assert!(msg.contains("--yes"), "{msg}"),
             other => panic!("json apply without --yes must refuse, got {other:?}"),
         }
-        match review_gate(false, true, false, false, false) {
+        match review_gate(false, false, true, false, false, false) {
             ReviewGate::Refuse(msg) => assert!(msg.contains("--yes"), "{msg}"),
             other => panic!("piped apply without --yes must refuse, got {other:?}"),
         }
 
         // Neither flag: the dry-run listing, everywhere.
         assert!(matches!(
-            review_gate(false, false, false, true, false),
+            review_gate(false, false, false, false, true, false),
             ReviewGate::DryRun
         ));
         assert!(matches!(
-            review_gate(false, false, false, false, true),
+            review_gate(false, false, false, false, false, true),
+            ReviewGate::DryRun
+        ));
+
+        // Copilot finding (PR #63), belt-and-suspenders under the clap
+        // conflict: an EXPLICIT --dry-run wins over every mutating flag —
+        // even a hostile flag combination can only preview.
+        assert!(matches!(
+            review_gate(true, false, true, true, false, true),
+            ReviewGate::DryRun
+        ));
+        assert!(matches!(
+            review_gate(true, true, false, false, false, true),
             ReviewGate::DryRun
         ));
     }
@@ -1327,11 +1362,29 @@ mod tests {
             ("quit", C::Quit),
             ("  K  ", C::Keep),
         ] {
-            assert_eq!(parse_review_choice(input, 2), Ok(expected), "{input:?}");
+            assert_eq!(
+                parse_review_choice(input, 2, rb_types::ReviewReason::NearDuplicate),
+                Ok(expected),
+                "{input:?}"
+            );
         }
         // Single-member items: the side index is implicit.
-        assert_eq!(parse_review_choice("a", 1), Ok(C::Archive(0)));
-        assert_eq!(parse_review_choice("d", 1), Ok(C::Demote(0)));
+        let low = rb_types::ReviewReason::LowConfidence;
+        assert_eq!(parse_review_choice("a", 1, low), Ok(C::Archive(0)));
+        assert_eq!(parse_review_choice("d", 1, low), Ok(C::Demote(0)));
+    }
+
+    #[test]
+    fn parse_review_choice_restricts_merge_to_near_duplicates() {
+        // PR #63 review: the interactive loop must mirror the daemon's
+        // reason restriction — merging a contradiction pair gets a clear
+        // redirect instead of a round trip to a daemon rejection.
+        let err = parse_review_choice("m", 2, rb_types::ReviewReason::Contradiction).unwrap_err();
+        assert!(err.contains("near-duplicate"), "{err}");
+        assert!(
+            err.contains("keep") && err.contains("archive"),
+            "the error redirects to the valid actions: {err}"
+        );
     }
 
     #[test]
@@ -1349,7 +1402,7 @@ mod tests {
             ("merge now", 2),              // trailing garbage
             ("a 99999999999999999999", 2), // overflow
         ] {
-            let got = parse_review_choice(input, members);
+            let got = parse_review_choice(input, members, rb_types::ReviewReason::NearDuplicate);
             assert!(got.is_err(), "{input:?} must be rejected, got {got:?}");
         }
     }

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -800,6 +800,82 @@ async fn run_client(
                 }
             }
         }
+        Command::Review {
+            dry_run: _,
+            apply,
+            policy,
+            interactive,
+            since,
+            limit,
+            threshold,
+            snooze_days,
+            yes,
+        } => {
+            use std::io::IsTerminal as _;
+            match review_gate(
+                interactive,
+                apply,
+                yes,
+                json,
+                std::io::stdin().is_terminal(),
+            ) {
+                ReviewGate::Refuse(msg) => anyhow::bail!(msg),
+                ReviewGate::DryRun => {
+                    let plan = client
+                        .review_plan(policy, since, limit, threshold)
+                        .await
+                        .context("review dry-run failed")?;
+                    let has_items = !plan.items.is_empty();
+                    println!("{}", output::render_review_plan(&plan, json));
+                    if has_items && !json {
+                        // stderr so `--json` stdout stays machine-parseable.
+                        eprintln!(
+                            "dry-run only — nothing was changed; run `rusty-brain review \
+                             --interactive` to walk the queue or `--apply --policy <name>` \
+                             to execute"
+                        );
+                    }
+                }
+                gate @ (ReviewGate::ApplyProceed | ReviewGate::ApplyPrompt) => {
+                    // clap enforces `--apply requires --policy`; fail closed
+                    // anyway rather than sweep policy-less.
+                    let Some(policy) = policy else {
+                        anyhow::bail!("review --apply requires --policy");
+                    };
+                    if matches!(gate, ReviewGate::ApplyPrompt) {
+                        // The preview shown is the SAME queue + policy plan
+                        // the apply pass derives (shared plan, REV-3).
+                        let plan = client
+                            .review_plan(Some(policy), since, limit, threshold)
+                            .await
+                            .context("review preview failed")?;
+                        if plan.planned.is_empty() {
+                            println!("{}", output::render_review_plan(&plan, false));
+                            println!("review ({}): nothing to do", policy.as_str());
+                            return Ok(());
+                        }
+                        eprintln!("{}", output::render_review_plan(&plan, false));
+                        if !confirm_review_apply(plan.planned.len(), plan.items.len())? {
+                            println!("Aborted");
+                            return Ok(());
+                        }
+                    }
+                    let outcome = client
+                        .review_apply(policy, since, limit, threshold)
+                        .await
+                        .context("review apply failed")?;
+                    println!("{}", output::render_review_outcome(&outcome, json));
+                    if let Some(failure) = &outcome.failure {
+                        // The counts above committed durably; exit non-zero
+                        // so automation notices the pass did not complete.
+                        anyhow::bail!("review pass incomplete: {failure}");
+                    }
+                }
+                ReviewGate::Interactive => {
+                    review_interactive(&mut client, since, limit, threshold, snooze_days).await?;
+                }
+            }
+        }
         Command::Scrub => {
             let (scanned, redacted, reembed_pending) =
                 client.scrub().await.context("scrub failed")?;
@@ -875,6 +951,239 @@ async fn run_import_items(
     Ok(())
 }
 
+/// The interactive review loop (REV-2): fetch the queue once, then walk it
+/// item by item — render both sides, read one decision, apply it through the
+/// per-item `Resolve` op (each resolution is atomic daemon-side). Decisions
+/// are parsed by the pure [`parse_review_choice`]; this function is only the
+/// I/O shell around it.
+async fn review_interactive(
+    client: &mut rb_proto::Client,
+    since: Option<u64>,
+    limit: Option<u32>,
+    threshold: Option<f32>,
+    snooze_days: u32,
+) -> anyhow::Result<()> {
+    use std::io::Write as _;
+    let plan = client
+        .review_plan(None, since, limit, threshold)
+        .await
+        .context("review queue fetch failed")?;
+    if plan.items.is_empty() {
+        println!("{}", output::render_review_plan(&plan, false));
+        return Ok(());
+    }
+    let total = plan.items.len();
+    let mut resolved = 0usize;
+    'items: for (i, item) in plan.items.iter().enumerate() {
+        println!("{}", output::render_review_item(item, i + 1, total));
+        let action = loop {
+            eprint!("[k]eep [b]ump [m]erge [a]rchive [d]emote [s]nooze [x]skip [q]uit > ");
+            std::io::stderr().flush().context("flushing prompt")?;
+            let mut line = String::new();
+            let read = std::io::stdin()
+                .read_line(&mut line)
+                .context("reading answer")?;
+            if read == 0 {
+                // EOF (e.g. Ctrl-D): stop cleanly, nothing half-applied.
+                break 'items;
+            }
+            match parse_review_choice(&line, item.members.len()) {
+                Ok(ReviewChoice::Quit) => break 'items,
+                Ok(ReviewChoice::Skip) => continue 'items,
+                Ok(choice) => match choice_to_action(choice, item, snooze_days) {
+                    Some(action) => break action,
+                    None => continue 'items,
+                },
+                Err(msg) => {
+                    eprintln!("{msg}");
+                    continue;
+                }
+            }
+        };
+        let ids: Vec<rb_types::MemoryId> = item.members.iter().map(|m| m.id.clone()).collect();
+        match client.resolve_review_item(item.reason, ids, action).await {
+            Ok(resolution) => {
+                resolved += 1;
+                println!("{}", output::render_review_resolution(&resolution, false));
+            }
+            Err(e) => {
+                // One failed resolution never aborts the session; the item
+                // stays in the queue for the next sweep.
+                eprintln!("resolution failed (item left in the queue): {e}");
+            }
+        }
+    }
+    println!("review: {resolved} of {total} item(s) resolved");
+    Ok(())
+}
+
+/// Outcome of the review-mode gate (PRD 2026-07-02; the `hard_execute_gate`
+/// matrix pattern). Pure so every cell is testable.
+#[derive(Debug)]
+enum ReviewGate {
+    /// Default posture: list the queue (or the policy plan), write nothing.
+    DryRun,
+    /// Walk the queue item by item on a real terminal.
+    Interactive,
+    /// `--apply --yes`: execute without prompting (automation).
+    ApplyProceed,
+    /// `--apply` on an interactive TTY without `--yes`: show the plan and
+    /// ask (default NO).
+    ApplyPrompt,
+    /// Machine context without `--yes`, or interactive without a terminal.
+    Refuse(String),
+}
+
+/// Decide how a `review` invocation may proceed. Mirrors `hard_execute_gate`:
+/// a batch mutation must never ride an unattended pipeline by accident, and
+/// the per-item loop needs a human at a terminal.
+fn review_gate(
+    interactive: bool,
+    apply: bool,
+    yes: bool,
+    json: bool,
+    stdin_is_tty: bool,
+) -> ReviewGate {
+    if interactive {
+        if json {
+            return ReviewGate::Refuse(
+                "refusing interactive review: --json is machine output; drop --json or use \
+                 --apply --policy"
+                    .to_string(),
+            );
+        }
+        if !stdin_is_tty {
+            return ReviewGate::Refuse(
+                "refusing interactive review: stdin is not a terminal; use --apply --policy \
+                 for scripted runs"
+                    .to_string(),
+            );
+        }
+        return ReviewGate::Interactive;
+    }
+    if apply {
+        if yes {
+            return ReviewGate::ApplyProceed;
+        }
+        if json {
+            return ReviewGate::Refuse(
+                "refusing review apply: --json is non-interactive; pass --yes to confirm \
+                 the sweep"
+                    .to_string(),
+            );
+        }
+        if !stdin_is_tty {
+            return ReviewGate::Refuse(
+                "refusing review apply: stdin is non-interactive; pass --yes to confirm \
+                 the sweep"
+                    .to_string(),
+            );
+        }
+        return ReviewGate::ApplyPrompt;
+    }
+    ReviewGate::DryRun
+}
+
+/// Interactive confirmation for a review apply pass (the `confirm_import`
+/// precedent): default is NO.
+fn confirm_review_apply(actions: usize, total: usize) -> anyhow::Result<bool> {
+    use std::io::Write as _;
+    eprint!("Apply {actions} planned action(s) across {total} queue item(s)? [y/N] ");
+    std::io::stderr().flush().context("flushing prompt")?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("reading confirmation")?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+/// One parsed interactive decision. Pure data so the grammar is testable
+/// without a terminal (the `hard_execute_gate` pattern: decisions pure, I/O
+/// at the edge).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReviewChoice {
+    Keep,
+    KeepBump,
+    Merge,
+    /// Archive the 0-based member index.
+    Archive(usize),
+    /// Demote the 0-based member index.
+    Demote(usize),
+    Snooze,
+    Skip,
+    Quit,
+}
+
+/// Parse one interactive answer against an item with `member_count` members.
+/// Garbage is a clear `Err` message, never a panic and never a silent
+/// mutation; an empty answer skips (the safe default).
+fn parse_review_choice(input: &str, member_count: usize) -> Result<ReviewChoice, String> {
+    const HELP: &str = "expected k(eep), b(ump), m(erge), a(rchive) [1|2], d(emote) [1|2], \
+                        s(nooze), x/enter to skip, or q(uit)";
+    let normalized = input.trim().to_ascii_lowercase();
+    let mut parts = normalized.split_whitespace();
+    let verb = parts.next().unwrap_or("");
+    let arg = parts.next();
+    if parts.next().is_some() {
+        return Err(format!("too many words in {input:?}: {HELP}"));
+    }
+
+    let side = |arg: Option<&str>| -> Result<usize, String> {
+        match (member_count, arg) {
+            (1, None) => Ok(0),
+            (_, Some(n)) => match n.parse::<usize>() {
+                Ok(i) if (1..=member_count).contains(&i) => Ok(i - 1),
+                _ => Err(format!("side must be 1..={member_count}, got {n:?}")),
+            },
+            (_, None) => Err(format!("pick a side: 1..={member_count}")),
+        }
+    };
+
+    match (verb, arg) {
+        ("" | "x" | "skip", None) => Ok(ReviewChoice::Skip),
+        ("q" | "quit", None) => Ok(ReviewChoice::Quit),
+        ("k" | "keep", None) => Ok(ReviewChoice::Keep),
+        ("b" | "bump", None) => Ok(ReviewChoice::KeepBump),
+        ("m" | "merge", None) => {
+            if member_count == 2 {
+                Ok(ReviewChoice::Merge)
+            } else {
+                Err("merge needs a two-sided item".to_string())
+            }
+        }
+        ("a" | "archive", arg) => side(arg).map(ReviewChoice::Archive),
+        ("d" | "demote", arg) => side(arg).map(ReviewChoice::Demote),
+        ("s" | "snooze", None) => Ok(ReviewChoice::Snooze),
+        _ => Err(format!("unrecognized answer {input:?}: {HELP}")),
+    }
+}
+
+/// Map a non-skip choice onto the wire action for `item`.
+fn choice_to_action(
+    choice: ReviewChoice,
+    item: &rb_types::ReviewItem,
+    snooze_days: u32,
+) -> Option<rb_types::ReviewAction> {
+    match choice {
+        ReviewChoice::Keep => Some(rb_types::ReviewAction::Keep { bump: false }),
+        ReviewChoice::KeepBump => Some(rb_types::ReviewAction::Keep { bump: true }),
+        ReviewChoice::Merge => Some(rb_types::ReviewAction::Merge),
+        ReviewChoice::Archive(i) => item
+            .members
+            .get(i)
+            .map(|m| rb_types::ReviewAction::Archive { id: m.id.clone() }),
+        ReviewChoice::Demote(i) => item
+            .members
+            .get(i)
+            .map(|m| rb_types::ReviewAction::Demote { id: m.id.clone() }),
+        ReviewChoice::Snooze => Some(rb_types::ReviewAction::Snooze { days: snooze_days }),
+        ReviewChoice::Skip | ReviewChoice::Quit => None,
+    }
+}
+
 /// Outcome of the hard-forget confirmation gate (PR #60 review).
 #[derive(Debug)]
 enum HardGate {
@@ -947,6 +1256,103 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn review_gate_matrix_mirrors_the_hard_execute_gate() {
+        // Interactive mode needs a real terminal and human-readable output.
+        assert!(matches!(
+            review_gate(true, false, false, false, true),
+            ReviewGate::Interactive
+        ));
+        assert!(matches!(
+            review_gate(true, false, false, true, true),
+            ReviewGate::Refuse(_)
+        ));
+        assert!(matches!(
+            review_gate(true, false, false, false, false),
+            ReviewGate::Refuse(_)
+        ));
+
+        // Apply: --yes proceeds anywhere; without it, --json and piped stdin
+        // refuse loudly, and only a TTY gets the default-NO prompt.
+        assert!(matches!(
+            review_gate(false, true, true, true, false),
+            ReviewGate::ApplyProceed
+        ));
+        assert!(matches!(
+            review_gate(false, true, false, false, true),
+            ReviewGate::ApplyPrompt
+        ));
+        match review_gate(false, true, false, true, true) {
+            ReviewGate::Refuse(msg) => assert!(msg.contains("--yes"), "{msg}"),
+            other => panic!("json apply without --yes must refuse, got {other:?}"),
+        }
+        match review_gate(false, true, false, false, false) {
+            ReviewGate::Refuse(msg) => assert!(msg.contains("--yes"), "{msg}"),
+            other => panic!("piped apply without --yes must refuse, got {other:?}"),
+        }
+
+        // Neither flag: the dry-run listing, everywhere.
+        assert!(matches!(
+            review_gate(false, false, false, true, false),
+            ReviewGate::DryRun
+        ));
+        assert!(matches!(
+            review_gate(false, false, false, false, true),
+            ReviewGate::DryRun
+        ));
+    }
+
+    #[test]
+    fn parse_review_choice_covers_the_action_set() {
+        use ReviewChoice as C;
+        // Pair items: every action, both long and short spellings.
+        for (input, expected) in [
+            ("k", C::Keep),
+            ("keep", C::Keep),
+            ("b", C::KeepBump),
+            ("bump", C::KeepBump),
+            ("m", C::Merge),
+            ("merge", C::Merge),
+            ("a 1", C::Archive(0)),
+            ("archive 2", C::Archive(1)),
+            ("d 2", C::Demote(1)),
+            ("demote 1", C::Demote(0)),
+            ("s", C::Snooze),
+            ("snooze", C::Snooze),
+            ("", C::Skip),
+            ("x", C::Skip),
+            ("skip", C::Skip),
+            ("q", C::Quit),
+            ("quit", C::Quit),
+            ("  K  ", C::Keep),
+        ] {
+            assert_eq!(parse_review_choice(input, 2), Ok(expected), "{input:?}");
+        }
+        // Single-member items: the side index is implicit.
+        assert_eq!(parse_review_choice("a", 1), Ok(C::Archive(0)));
+        assert_eq!(parse_review_choice("d", 1), Ok(C::Demote(0)));
+    }
+
+    #[test]
+    fn parse_review_choice_rejects_garbage_without_panicking() {
+        // Garbage never panics and never silently maps to a mutation.
+        for (input, members) in [
+            ("m", 1),                      // merge needs a pair
+            ("a", 2),                      // pair archive needs a side
+            ("d", 2),                      // pair demote needs a side
+            ("a 3", 2),                    // out of range
+            ("a 0", 2),                    // 1-based
+            ("a banana", 2),               // not a number
+            ("archive 1 2", 2),            // trailing garbage
+            ("yolo", 2),                   // unknown verb
+            ("merge now", 2),              // trailing garbage
+            ("a 99999999999999999999", 2), // overflow
+        ] {
+            let got = parse_review_choice(input, members);
+            assert!(got.is_err(), "{input:?} must be rejected, got {got:?}");
+        }
+    }
 
     #[test]
     fn hard_forget_gate_requires_confirmation_or_explicit_yes() {

--- a/crates/rusty-brain/tests/end_to_end.rs
+++ b/crates/rusty-brain/tests/end_to_end.rs
@@ -816,3 +816,138 @@ fn doctor_fails_with_guidance_on_model_mismatch_against_db_meta() {
         "guidance names the opt-in: {stdout}"
     );
 }
+
+#[test]
+fn review_flow_lists_gates_and_applies_through_the_binary() {
+    // PRD 2026-07-02 (contradiction/dedup review) through the real binary:
+    // seed a contradiction and a near-dup pair, list the queue (dry-run,
+    // zero writes), verify the piped --apply refusal without --yes, then
+    // apply auto-merge-dups with --yes and assert the merge + history.
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("runtime").join("rb.sock");
+    let db = dir.path().join("rb.db");
+    let exe = cargo_bin("rusty-brain");
+    let ns = "review-e2e";
+
+    let _reap = spawn_daemon(&exe, &socket, &db, dir.path());
+    assert!(
+        wait_for_socket(&socket, Duration::from_secs(10)),
+        "daemon socket never appeared at {}",
+        socket.display()
+    );
+
+    let remember_json = |text: &str| -> String {
+        let out = cli(&exe, &socket, &db, dir.path(), ns)
+            .args(["--json", "remember", text])
+            .output()
+            .expect("run remember");
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value =
+            serde_json::from_slice(&out.stdout).expect("remember --json output");
+        v["id"].as_str().expect("id").to_string()
+    };
+
+    // Identical contents => cosine-1.0 near-dups under the deterministic
+    // provider (CLI-sourced writes are never suppressed at write time).
+    let dup_a = remember_json("standup notes are kept in the team channel");
+    let dup_b = remember_json("standup notes are kept in the team channel");
+    let con_a = remember_json("releases are cut from main every Monday");
+    let con_b = remember_json("releases are cut from release branches only");
+    let link = cli(&exe, &socket, &db, dir.path(), ns)
+        .args(["link", &con_a, &con_b, "--type", "contradicts"])
+        .output()
+        .expect("run link");
+    assert!(
+        link.status.success(),
+        "{}",
+        String::from_utf8_lossy(&link.stderr)
+    );
+
+    // Bare review: a dry-run listing, in priority order, with zero writes.
+    let listing = cli(&exe, &socket, &db, dir.path(), ns)
+        .args(["review"])
+        .output()
+        .expect("run review");
+    assert!(
+        listing.status.success(),
+        "{}",
+        String::from_utf8_lossy(&listing.stderr)
+    );
+    let text = String::from_utf8_lossy(&listing.stdout);
+    assert!(text.contains("contradiction"), "{text}");
+    assert!(text.contains("near-duplicate"), "{text}");
+    let contra_pos = text.find("contradiction").unwrap();
+    let dup_pos = text.find("near-duplicate").unwrap();
+    assert!(
+        contra_pos < dup_pos,
+        "priority order in the listing: {text}"
+    );
+    assert!(
+        String::from_utf8_lossy(&listing.stderr).contains("dry-run only"),
+        "the safety posture is announced"
+    );
+
+    // Piped --apply without --yes refuses loudly (never ride a pipeline by
+    // accident) and writes nothing.
+    let refused = cli(&exe, &socket, &db, dir.path(), ns)
+        .args(["review", "--apply", "--policy", "auto-merge-dups"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run review --apply");
+    assert!(
+        !refused.status.success(),
+        "piped apply without --yes must refuse"
+    );
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("--yes"),
+        "{}",
+        String::from_utf8_lossy(&refused.stderr)
+    );
+
+    // --apply --policy auto-merge-dups --yes merges the dup pair.
+    let applied = cli(&exe, &socket, &db, dir.path(), ns)
+        .args([
+            "--json",
+            "review",
+            "--apply",
+            "--policy",
+            "auto-merge-dups",
+            "--yes",
+        ])
+        .output()
+        .expect("run review apply");
+    assert!(
+        applied.status.success(),
+        "{}",
+        String::from_utf8_lossy(&applied.stderr)
+    );
+    let outcome: serde_json::Value = serde_json::from_slice(&applied.stdout).expect("outcome json");
+    assert_eq!(outcome["merged"], 1, "{outcome}");
+    assert_eq!(outcome["skipped"], 1, "{outcome}");
+
+    // The originals are archived into one superseding memory; history shows it.
+    let history = cli(&exe, &socket, &db, dir.path(), ns)
+        .args(["--json", "history", &dup_a])
+        .output()
+        .expect("run history");
+    assert!(
+        history.status.success(),
+        "{}",
+        String::from_utf8_lossy(&history.stderr)
+    );
+    let h: serde_json::Value = serde_json::from_slice(&history.stdout).expect("history json");
+    let chain = h["chain"].as_array().expect("chain");
+    assert!(chain.len() >= 2, "supersede chain reaches the merge: {h}");
+    let dup_b_in_queue = {
+        let listing = cli(&exe, &socket, &db, dir.path(), ns)
+            .args(["review"])
+            .output()
+            .expect("run review again");
+        String::from_utf8_lossy(&listing.stdout).contains(&dup_b)
+    };
+    assert!(!dup_b_in_queue, "the merged pair does not resurface");
+}

--- a/docs/prds/2026-07-02-contradiction-dedup-review.md
+++ b/docs/prds/2026-07-02-contradiction-dedup-review.md
@@ -2,10 +2,22 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review. `contested` flags and
-write-time near-dup suppression exist, but resolution is left to manual
-commands. This surfaces the W2.2 trust machinery to the user instead of
-leaving it latent.
+Delivered 2026-07-11 (branch `claude/review-sweep`, Vikunja #461). From the
+2026-07-02 senior-PM product review. `contested` flags and write-time
+near-dup suppression exist, but resolution is left to manual commands. This
+surfaces the W2.2 trust machinery to the user instead of leaving it latent.
+
+Delivery notes: near-dup detection reuses `near_duplicates()` (the one
+similarity definition; conservative 0.95 default, floor 0.80); contradiction
+pairs are the pairwise expression of `active_contradicts`, pinned by a drift
+test; snooze persists in the additive `review_state` table (migration 010);
+`--apply` follows the forget UX (dry-run default, TTY default-NO
+confirmation, `--yes` for automation, `ForgetOutcome`-shaped partial
+reporting); no MCP surface (the forget precedent: destructive surface,
+tools/list budget at 897/900); stats gains the `low_confidence_live` gauge
+(with `contested`/`never_recalled_live`, the review-queue trend — the
+near-dup tier is deliberately uncounted: one KNN probe per live memory per
+stats call).
 
 ## Owner Area
 
@@ -124,12 +136,12 @@ Plus an e2e seeding a contradiction + dup cluster and asserting the
 
 ## Implementation Checklist
 
-- [ ] Add `Review` subcommand with queue generator.
-- [ ] Implement interactive + `--apply --policy` + `--dry-run` modes.
-- [ ] Wire actions to existing supersede/link/confidence primitives.
-- [ ] Add snooze/reviewed_at tracking (additive, minimal).
-- [ ] Record provenance + oplog for every resolution.
-- [ ] E2E for contradiction + dup resolution.
+- [x] Add `Review` subcommand with queue generator.
+- [x] Implement interactive + `--apply --policy` + `--dry-run` modes.
+- [x] Wire actions to existing supersede/link/confidence primitives.
+- [x] Add snooze/reviewed_at tracking (additive, minimal).
+- [x] Record provenance + oplog for every resolution.
+- [x] E2E for contradiction + dup resolution.
 
 ## Roadmap Fit
 


### PR DESCRIPTION
## Summary

Implements Vikunja #461 / PRD `docs/prds/2026-07-02-contradiction-dedup-review.md`: a guided sweep surfacing contradictions, near-duplicates, and low-confidence/stale memories, with per-item keep/merge/archive/demote/snooze, in interactive, `--dry-run`, and `--apply --policy` modes.

### Queue (REV-1)
- Priority order: active **contradiction pairs** → **near-dup pairs** → **low-confidence (< 0.4)** → **stale never-recalled** singles.
- Contradictions are the pairwise expression of `active_contradicts`, held in lockstep by the `contradiction_items_agree_with_active_contradicts` drift test; the stale tier agrees with the stats `never_recalled_live` predicate (second drift test).
- Near-dup detection **reuses `near_duplicates()`** — the one similarity definition shared with write-time suppression and the consolidation job (conservative 0.95 default, 0.80 floor, server-clamped). Bounded anchor scan; one pair per member per sweep (convergent across sweeps, the consolidation argument).
- Snoozes persist in the additive `review_state` table (migration 010), keyed by the canonical item key (reason + sorted ids), excluded **inside** each bounded query (the PR #58 limit-fill lesson). `--since <seq>` scopes to oplog-touched memories.

### Actions (REV-2) — all through existing atomic primitives
- `merge`: combined memory (union metadata, max importance/confidence) stored through the engine, then both originals superseded (W3.1 update-as-supersede composition; a failure between steps never corrupts).
- `archive` = soft delete; `demote`/`bump` = bounded confidence nudges (−0.15 / +0.05, the feedback magnitudes); `snooze` = `review_state` upsert + expiry.
- Every resolution records provenance (`origin_source = "cli"` via the connection identity) and a `review_resolve` oplog row (REV-4); merges surface in the history timeline via the supersede chain.

### Safety (REV-3, the PR #60 forget posture)
- Bare `review` is a dry-run listing; an absent wire `dry_run` always previews.
- Execute requires an explicit policy (`auto-merge-dups` | `demote-low-confidence`); dry-run and apply derive their plan from the same pure `ReviewPolicy::plan_action`.
- `--apply` gate matrix mirrors `hard_execute_gate`: `--yes` proceeds, `--json`/piped stdin refuse loudly, a TTY gets a default-NO prompt previewing the same plan.
- Partial outcomes follow the `ForgetOutcome` shape: completed items stay committed, first failure stops re-runnably, bulk `review_sweep` oplog row written unconditionally; CLI exits non-zero on a partial pass.
- Review listings redact stored summaries in both human and JSON branches (W2.4).

### Wire surface
Additive `Request::Review`/`Request::Resolve` + `Response::ReviewPlanned`/`ReviewDone`/`Resolved` (serde-default payloads, **no CONTRACT_VERSION bump**), recorded in `contract-snapshot.toml` (additive intent). Review ops are non-admin (reversible, namespace-scoped — the Forget-apply precedent). **No MCP surface** (the forget precedent: destructive surface; tools/list budget at 897/900); the MCP response projection stays total.

### Stats integration
Additive `MemoryStats.low_confidence_live` gauge — with `contested` and `never_recalled_live`, the review-queue trend (near-dup tier deliberately uncounted: one KNN probe per live row per stats call), pinned to the review tier's predicate by a drift test.

## Test plan

- `cargo test --workspace` — 1624 tests green, including:
  - drift/agreement: `contradiction_items_agree_with_active_contradicts` (mutation-checked), `stale_never_recalled_agrees_with_the_stats_predicate`, `low_confidence_gauge_agrees_with_the_review_queue_tier`
  - store: snooze persistence/expiry/upsert, limit-fill past snoozed rows, priority order + truncation, namespace isolation, `--since`, fail-closed params
  - zero-writer proof: `review_plan_runs_on_the_read_pool_with_zero_writer_ops` (StoreHandle + wire e2e pair)
  - wire e2e: priority-order queue, auto-merge-dups apply (originals archived → one superseding memory → history chain), per-item resolve actions incl. fail-closed validation and namespace isolation, policy-required/absent-dry-run-previews raw frames, **partial outcome on injected mid-batch embed failure** (`review_apply_reports_partial_outcome_on_mid_batch_failure`, run 6x post-deflake)
  - CLI: parse matrix incl. garbage (no panics), `review_gate` matrix, interactive-choice grammar incl. garbage, renderer redaction in both output modes
  - binary e2e: seed → list → piped-apply refusal → `--apply --yes` merge → history through the real daemon
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo deny check`, `rb-contract-guard check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided `review` workflow for contradictions, near-duplicates, and low-confidence memories.
  * Added dry-run previews, policy-based batch actions, interactive resolution, and safe apply controls.
  * Added actions including merge, keep, archive, demote, snooze, and confidence updates.
  * Added review history, reversible audit tracking, snooze persistence, and partial-outcome reporting.
  * Added low-confidence memory statistics and enhanced review output in human-readable and JSON formats.

* **Documentation**
  * Updated review workflow documentation and delivery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->