### PR TITLE
fix(scorecard): un-break real-session runs under claude 2.1.x

### DIFF
--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -67,19 +67,18 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          # Prints ONLY the HTTP status; the key and response body are never
-          # echoed. 200 = key valid; 401 = invalid/revoked or mangled paste.
+          # Validate the secret's shape BEFORE it is used anywhere, then print
+          # ONLY the HTTP status; the key and response body are never echoed.
+          # 200 = key valid; 401 = invalid/revoked or mangled paste.
+          case "$ANTHROPIC_API_KEY" in
+            *[[:space:]]*) echo "::error::secret contains whitespace (bad paste?)"; exit 1 ;;
+          esac
           status="$(curl -sS -o /dev/null -w '%{http_code}' \
             --max-time 30 \
             -H "x-api-key: ${ANTHROPIC_API_KEY}" \
             -H "anthropic-version: 2023-06-01" \
             https://api.anthropic.com/v1/models)"
           echo "anthropic /v1/models HTTP status: ${status}"
-          key_len="${#ANTHROPIC_API_KEY}"
-          echo "secret length: ${key_len} chars"
-          case "$ANTHROPIC_API_KEY" in
-            *[[:space:]]*) echo "::error::secret contains whitespace (bad paste?)"; exit 1 ;;
-          esac
           if [ "$status" != "200" ]; then
             echo "::error::ANTHROPIC_API_KEY did not authenticate (HTTP ${status}); fix the repository secret."
             exit 1
@@ -97,17 +96,19 @@ jobs:
           probe_home="$(mktemp -d)"
           printf '{"hasCompletedOnboarding": true}\n' > "${probe_home}/.claude.json"
           probe_proj="$(mktemp -d)"
-          # No `timeout` wrapper: macOS runners lack GNU timeout (the scorecard
-          # script falls back to gtimeout for the same reason); the job-level
-          # timeout bounds this step instead.
+          # macOS runners lack GNU timeout (the scorecard script falls back to
+          # gtimeout for the same reason); perl alarm gives a portable 180s
+          # bound so a hung CLI cannot eat the 300-minute job budget.
           (
             export HOME="$probe_home"
             cd "$probe_proj"
-            claude -p 'reply with exactly: ok' \
+            perl -e 'alarm 180; exec @ARGV' -- \
+              claude -p 'reply with exactly: ok' \
               --model haiku --max-budget-usd 0.50 \
               --output-format stream-json --verbose </dev/null || true
           ) | python3 -c '
           import sys, json
+          ok_result = False
           seen = 0
           for line in sys.stdin:
               try:
@@ -125,8 +126,13 @@ jobs:
                         "| turns:", r.get("num_turns"),
                         "| cost_usd:", r.get("total_cost_usd"))
                   print("result text:", str(r.get("result"))[:300])
+                  if not r.get("is_error"):
+                      ok_result = True
           if seen == 0:
               print("PROBE FAILURE: no parseable stream-json records at all", file=sys.stderr)
+              sys.exit(1)
+          if not ok_result:
+              print("PROBE FAILURE: no non-error result record (key/billing/model-access problem — the error text is printed above)", file=sys.stderr)
               sys.exit(1)
           '
 

--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -63,6 +63,28 @@ jobs:
             exit 1
           fi
 
+      - name: Preflight - verify the key authenticates (status code only)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Prints ONLY the HTTP status; the key and response body are never
+          # echoed. 200 = key valid; 401 = invalid/revoked or mangled paste.
+          status="$(curl -sS -o /dev/null -w '%{http_code}' \
+            --max-time 30 \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            https://api.anthropic.com/v1/models)"
+          echo "anthropic /v1/models HTTP status: ${status}"
+          key_len="${#ANTHROPIC_API_KEY}"
+          echo "secret length: ${key_len} chars"
+          case "$ANTHROPIC_API_KEY" in
+            *[[:space:]]*) echo "::error::secret contains whitespace (bad paste?)"; exit 1 ;;
+          esac
+          if [ "$status" != "200" ]; then
+            echo "::error::ANTHROPIC_API_KEY did not authenticate (HTTP ${status}); fix the repository secret."
+            exit 1
+          fi
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -85,6 +85,44 @@ jobs:
             exit 1
           fi
 
+      - name: Preflight - bare claude session probe (prints result record, no secrets)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # One minimal -p session outside the scorecard harness: isolates
+          # key/billing/model-access errors from harness (hooks/daemon) errors.
+          # Only the stream-json system/result records are printed; they carry
+          # no key material.
+          npm install -g @anthropic-ai/claude-code
+          probe_home="$(mktemp -d)"
+          printf '{"hasCompletedOnboarding": true}\n' > "${probe_home}/.claude.json"
+          probe_proj="$(mktemp -d)"
+          set +e
+          (
+            export HOME="$probe_home"
+            cd "$probe_proj"
+            timeout 120 claude -p 'reply with exactly: ok' \
+              --model haiku --max-budget-usd 0.50 \
+              --output-format stream-json --verbose </dev/null
+          ) | python3 -c '
+          import sys, json
+          for line in sys.stdin:
+              try:
+                  r = json.loads(line)
+              except ValueError:
+                  continue
+              t = r.get("type")
+              if t == "system" and r.get("subtype") == "init":
+                  print("apiKeySource:", r.get("apiKeySource"), "| model:", r.get("model"))
+              if t == "result":
+                  print("result subtype:", r.get("subtype"),
+                        "| is_error:", r.get("is_error"),
+                        "| turns:", r.get("num_turns"),
+                        "| cost_usd:", r.get("total_cost_usd"))
+                  print("result text:", str(r.get("result"))[:300])
+          '
+          set -e
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false

--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -97,15 +97,18 @@ jobs:
           probe_home="$(mktemp -d)"
           printf '{"hasCompletedOnboarding": true}\n' > "${probe_home}/.claude.json"
           probe_proj="$(mktemp -d)"
-          set +e
+          # No `timeout` wrapper: macOS runners lack GNU timeout (the scorecard
+          # script falls back to gtimeout for the same reason); the job-level
+          # timeout bounds this step instead.
           (
             export HOME="$probe_home"
             cd "$probe_proj"
-            timeout 120 claude -p 'reply with exactly: ok' \
+            claude -p 'reply with exactly: ok' \
               --model haiku --max-budget-usd 0.50 \
-              --output-format stream-json --verbose </dev/null
+              --output-format stream-json --verbose </dev/null || true
           ) | python3 -c '
           import sys, json
+          seen = 0
           for line in sys.stdin:
               try:
                   r = json.loads(line)
@@ -113,15 +116,19 @@ jobs:
                   continue
               t = r.get("type")
               if t == "system" and r.get("subtype") == "init":
+                  seen += 1
                   print("apiKeySource:", r.get("apiKeySource"), "| model:", r.get("model"))
               if t == "result":
+                  seen += 1
                   print("result subtype:", r.get("subtype"),
                         "| is_error:", r.get("is_error"),
                         "| turns:", r.get("num_turns"),
                         "| cost_usd:", r.get("total_cost_usd"))
                   print("result text:", str(r.get("result"))[:300])
+          if seen == 0:
+              print("PROBE FAILURE: no parseable stream-json records at all", file=sys.stderr)
+              sys.exit(1)
           '
-          set -e
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -926,7 +926,27 @@ fi
 cleanup() { rm -rf "$WORKROOT" 2>/dev/null || true; }
 trap cleanup EXIT
 
-seed_home() { mkdir -p "$1"; printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"; }
+seed_home() { # home [proj]
+  # claude >= 2.1.x ignores project settings (hooks, permissions.allow, MCP)
+  # in a workspace with no recorded trust decision, and `-p` mode cannot show
+  # the trust dialog — so a generated project must be pre-trusted in the
+  # home's .claude.json (keyed by the project's REAL path; macOS tmpdirs
+  # resolve /var -> /private/var).
+  mkdir -p "$1"
+  if [ -n "${2:-}" ]; then
+    mkdir -p "$2"
+    python3 - "$1/.claude.json" "$2" <<'PY'
+import json, os, sys
+path, proj = sys.argv[1], os.path.realpath(sys.argv[2])
+json.dump(
+    {"hasCompletedOnboarding": True,
+     "projects": {proj: {"hasTrustDialogAccepted": True}}},
+    open(path, "w"), indent=2)
+PY
+  else
+    printf '{"hasCompletedOnboarding": true}\n' > "$1/.claude.json"
+  fi
+}
 
 run_session() { # home proj prompt log [extra args...]
   local home="$1" proj="$2" prompt="$3" log="$4"; shift 4
@@ -1142,7 +1162,7 @@ run_scenario() { # row
     # shared work home/project here is only set up for the non-reach dimensions.
     local wh="$mb/hw" wp="$mb/wp"
     if [ "$dim" != "reach" ]; then
-      seed_home "$wh"; mkdir -p "$wp"
+      seed_home "$wh" "$wp"
       install_rusty_brain "$wh" "$wp"; rm -f "$wp/CLAUDE.md"; rm -rf "$wp/.claude/skills"
     fi
     local sockdir; sockdir="$(mktemp -d /tmp/rbsc.XXXXXX)"; local sock="$sockdir/s"
@@ -1191,7 +1211,7 @@ run_scenario() { # row
         local ha pa hb pb
         IFS=$'\t' read -r ha pa hb pb < <(reach_identity_paths "$mb")
         : "$pa" # tab-split placeholder; A needs no project dir
-        seed_home "$ha"; seed_home "$hb"; mkdir -p "$pb"
+        seed_home "$ha"; seed_home "$hb" "$pb"
         install_rusty_brain "$hb" "$pb"; rm -f "$pb/CLAUDE.md"; rm -rf "$pb/.claude/skills"
         plant_explicit "$ha" "$facts"
         score_session "$dim" "$id" "memory-on" "$run" "$pb" "$hb" "$work" "$expect" "$forbid" "$stale"
@@ -1202,7 +1222,7 @@ run_scenario() { # row
           plant_corpus_distractors "$wh" "$id" "$corpus"
         elif [ "$plant_mode" = "auto-capture" ]; then
           local ph="$mb/hp" pp="$mb/pp" plog="$mb/plant.jsonl"
-          seed_home "$ph"; mkdir -p "$pp"
+          seed_home "$ph" "$pp"
           install_rusty_brain_hooks_only "$ph" "$pp"; rm -f "$pp/CLAUDE.md"; rm -rf "$pp/.claude/skills"
           # Auto-capture plant: a real Claude Code session whose SessionEnd hook
           # (no MCP) is the only path that writes memory for this dimension.
@@ -1225,15 +1245,15 @@ run_scenario() { # row
     # target is the ONLY difference: steelman holds target + distractors (diligent
     # human), realistic holds distractors only (target omitted — the common
     # "nobody wrote it down" reality).
-    local rb="$base/realistic"; seed_home "$rb/h"; mkdir -p "$rb/p"
+    local rb="$base/realistic"; seed_home "$rb/h" "$rb/p"
     write_claude_md "$rb/p/CLAUDE.md" "$realistic" "$distractors"
     score_session "$dim" "$id" "realistic-baseline" "$run" "$rb/p" "$rb/h" "$work" "$expect" "$forbid" "$stale"
 
-    local sb="$base/steelman"; seed_home "$sb/h"; mkdir -p "$sb/p"
+    local sb="$base/steelman"; seed_home "$sb/h" "$sb/p"
     write_claude_md "$sb/p/CLAUDE.md" "$steelman" "$distractors"
     score_session "$dim" "$id" "steelman-baseline" "$run" "$sb/p" "$sb/h" "$work" "$expect" "$forbid" "$stale"
 
-    local ob="$base/off"; seed_home "$ob/h"; mkdir -p "$ob/p"
+    local ob="$base/off"; seed_home "$ob/h" "$ob/p"
     score_session "$dim" "$id" "memory-off" "$run" "$ob/p" "$ob/h" "$work" "$expect" "$forbid" "$stale"
 
     run=$((run + 1))

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -185,9 +185,15 @@ extract_usage() {
 write_claude_md() { # file body distractors
   local file="$1" body="$2" distractors="$3"
   [ -n "$body" ] || [ -n "$distractors" ] || return 0
+  # Explicit if-blocks, not trailing `[ -n ... ] && ...` guards: a false guard
+  # as the last command makes the group (and under `set -e`, the whole script)
+  # fail silently whenever a scenario has no distractors.
   {
-    [ -n "$body" ] && printf '# Project conventions\n\n%s\n' "$body"
-    [ -n "$distractors" ] && { printf '\n## Other recorded decisions\n\n'; printf '%s\n' "$distractors"; }
+    if [ -n "$body" ]; then printf '# Project conventions\n\n%s\n' "$body"; fi
+    if [ -n "$distractors" ]; then
+      printf '\n## Other recorded decisions\n\n'
+      printf '%s\n' "$distractors"
+    fi
   } > "$file"
 }
 


### PR DESCRIPTION
## Summary

The memory-scorecard pipeline has been broken for every real-session run since late June (all paid runs were deferred at the 2026-06-23 closeout, so nothing exercised it). Two independent bugs, both reproduced and fixed:

1. **claude >= 2.1.x workspace-trust gate.** The unpinned `npm install -g @anthropic-ai/claude-code` now installs a version that ignores project settings (hooks, `permissions.allow`, MCP servers) in workspaces with no recorded trust decision, and `-p` mode cannot show the trust dialog. Every scorecard session errored instantly (the `turns=99` sentinel at zero cost), identically for any API key. `seed_home` now takes the paired project path and records `projects[<realpath>].hasTrustDialogAccepted: true` in the seeded `.claude.json` (realpath'd: macOS tmpdirs resolve `/var` -> `/private/var`).

2. **`set -e` latent kill in `write_claude_md`.** The trailing `[ -n "$distractors" ] && ...` guard was the function's final statement; for any scenario without distractors (all of Class C) the guard's false status became the function's return value and `set -e` silently aborted the whole run after the first arm. Shipped 2026-06-23 with the Class A distractor corpus; explicit if-blocks now. Swept the script for other members of the bug class (none live: the remaining trailing guards are mid-function).

Also adds two cheap self-diagnosing preflight steps to the workflow, which made this diagnosis possible and keep the nightly actionable:
- key sanity: curl `/v1/models` printing only the HTTP status + a whitespace check (secret never echoed; ~0s),
- a bare `claude -p` probe session outside the harness (~$0.01) that separates key/billing/model failures from harness failures, failing loudly if no stream-json records parse.

## Evidence

- Diagnosis chain: key preflight 200 -> bare probe session succeeds -> harness-shaped local repro reproduced the exact "workspace has not been trusted" refusal; after fix 1, sessions ran and billed but the run still died silently after one arm; `bash -x` pinned fix 2's guard as the killer.
- Local full-flow run (fake key, error-path sessions): 52/52 rows, aggregate + safety gate + correct DIRECTIONAL verdict, exit 0.
- CI smoke (`runs=1`, real sessions): https://github.com/brianluby/rusty-brain/actions/runs/29202607660 — success; all 4 dimensions pass (non-gating), capture fidelity 3/3, ADR-3 block populated.

## Test plan

- [x] `scripts/memory-scorecard.sh --self-test` green (unchanged math/judge paths)
- [x] `bash -n` clean; `seed_home` unit-verified (trust record with realpath'd key; no-project form unchanged)
- [x] Local 52-row flow run completes and aggregates (exit 0)
- [x] Real-session CI smoke green end-to-end (run 29202607660)
- [ ] N>=5 measured run (dispatched after merge — the Vikunja #381/#382/#383 deliverable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated validation by confirming API credentials are valid before running checks.
  * Added an end-to-end command-line session probe to detect setup or connectivity issues earlier.
  * Improved test environment setup for project trust and onboarding scenarios.
  * Fixed baseline preparation reliability under strict shell error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->