### PR TITLE
fix(store): harden supersede at the source (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed — Supersede hardened at the source (#501)
+
+- **`Store::supersede` now guards every half of the mutation** (generalizing
+  the PR #63 review-merge pointer guard into ONE shared primitive that the
+  review merge also delegates to): self-supersede (`old == new`) is rejected
+  as `invalid_argument`; an old row that is already archived or superseded is
+  rejected with the distinct `stale_plan` error via a guarded UPDATE
+  (`WHERE superseded_by IS NULL AND archived_at IS NULL` + rows-affected
+  check) — a `superseded_by` lineage pointer is now **set-once** and can never
+  be silently rewritten; and the `new` target must itself be current truth
+  (present, active, not superseded — `not_found` / `stale_plan` otherwise),
+  which is the write-side cycle defense (an A→B then B→A cycle is refused at
+  the second write). The history timeline's read-side cycle defense remains as
+  belt-and-suspenders for direct-DB corruption. No wire shape changes: only
+  existing error kinds on existing ops.
+- **Caller compatibility**: the consolidation job now skips-and-continues past
+  a lost supersede race (`stale_plan` from a concurrent resolution) instead of
+  aborting the pass, counting it `skipped`; the `remember --supersedes` fold
+  and hook near-dup suppression were already best-effort and now log the
+  refusal instead of silently mutating resolved rows. Previously a re-supersede
+  of an archived row silently planted a lineage pointer on a retired row —
+  that is now a refusal, because a plan formed against a retired row is stale
+  by definition and recording it would fabricate a decision-evolution step.
+
 ### Added — Codex `apply_patch` file-edit capture (follow-up 2026-06-02)
 
 - **Codex `apply_patch` capture is live**: openai/codex#16732 shipped in Codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,25 @@ All notable changes to rusty-brain are documented here. The format is based on
   existing error kinds on existing ops.
 - **Caller compatibility**: the consolidation job now skips-and-continues past
   a lost supersede race (`stale_plan` from a concurrent resolution) instead of
-  aborting the pass, counting it `skipped`; the `remember --supersedes` fold
-  and hook near-dup suppression were already best-effort and now log the
-  refusal instead of silently mutating resolved rows. Previously a re-supersede
-  of an archived row silently planted a lineage pointer on a retired row —
-  that is now a refusal, because a plan formed against a retired row is stale
-  by definition and recording it would fabricate a decision-evolution step.
+  aborting the pass, counting it `skipped`; a resolved/purged SURVIVOR is
+  discriminated from a member-side race loss — the whole cluster is abandoned
+  (warn-logged as `consolidation_stale_survivor`) and its unmerged members
+  stay eligible to re-cluster around a fresh survivor. The
+  `remember --supersedes` fold and hook near-dup suppression were already
+  best-effort and now log the refusal instead of silently mutating resolved
+  rows. Previously a re-supersede of an archived row silently planted a
+  lineage pointer on a retired row — that is now a refusal, because a plan
+  formed against a retired row is stale by definition and recording it would
+  fabricate a decision-evolution step.
+- **All three guards live in the ONE shared primitive**
+  (`SqliteStore::supersede_guarded_in_tx`), each reported as a distinct
+  variant, so acyclicity is structural rather than a caller invariant; the
+  general path and the review merge only map variants to their own errors
+  (exhaustively — a future guard forces every caller to reconsider).
+- **`Error::StalePlan` Display generalized** from `stale review plan:` to
+  the subsystem-neutral `stale plan:` (it now renders in daemon logs for
+  non-review supersede paths); the wire KIND string `stale_plan` is
+  unchanged and rb-proto's message round-trip strip moved in lockstep.
 
 ### Added — Codex `apply_patch` file-edit capture (follow-up 2026-06-02)
 

--- a/crates/rb-daemon/src/jobs/consolidation.rs
+++ b/crates/rb-daemon/src/jobs/consolidation.rs
@@ -5,6 +5,9 @@
 use crate::jobs::ConsolidationConfig;
 use crate::jobs::JobSummary;
 use crate::StoreHandle;
+// `StoreHandle::get` (the survivor re-read on a guard miss) is a
+// `MemoryBackend` trait method.
+use rb_engine::MemoryBackend as _;
 use rb_types::{MemoryId, Result};
 use std::collections::HashSet;
 
@@ -55,8 +58,13 @@ pub fn pick_survivor(candidates: &[MemoryMeta]) -> Option<MemoryId> {
 /// near-duplicates that also appear in this pass's candidate window, pick a
 /// deterministic survivor, and supersede every OTHER member into the survivor,
 /// marking each consumed so it is never revisited. `scanned` counts candidates
-/// examined; `changed` counts supersede writes; `skipped` counts candidates with
-/// no duplicate.
+/// examined; `changed` counts supersede writes; `skipped` counts candidates
+/// with no duplicate PLUS members not merged because a concurrent writer got
+/// there first (#501): a member-side race loss skips just that member
+/// (debug-logged), while a resolved/purged SURVIVOR abandons the whole
+/// cluster (warn-logged with `event = "consolidation_stale_survivor"`) and
+/// leaves its unmerged members eligible to re-cluster around a fresh
+/// survivor on a later anchor or pass.
 ///
 /// Idempotency: a superseded/archived member is excluded from the candidate scan
 /// AND from `near_duplicates` (both filter `archived_at IS NULL`), so a second
@@ -135,58 +143,127 @@ pub async fn run(store: &StoreHandle, config: &ConsolidationConfig) -> Result<Jo
         };
 
         // Supersede every member that is not the survivor into the survivor.
+        let mut survivor_stale = false;
         for member in &cluster {
             if member.id == survivor_id {
                 continue;
             }
-            if supersede_member(store, &cand.namespace, &member.id, &survivor_id).await? {
-                summary.changed += 1;
-            } else {
-                summary.skipped += 1;
+            match supersede_member(store, &cand.namespace, &member.id, &survivor_id).await? {
+                MemberOutcome::Changed => {
+                    summary.changed += 1;
+                    consumed.insert(member.id.to_string());
+                }
+                // The member was resolved by a concurrent writer: skip it and
+                // keep absorbing the rest — the survivor is still valid.
+                MemberOutcome::LostRace => {
+                    summary.skipped += 1;
+                    consumed.insert(member.id.to_string());
+                }
+                // The GROUP's target is dead (resolved or purged mid-pass):
+                // abandon the cluster. Unmerged members (and the anchor) stay
+                // UN-consumed so a later anchor in this pass — or the next
+                // scheduled pass — re-clusters them around a fresh survivor
+                // (the job's normal convergence). Distinct warn-level,
+                // structured observability (#501 follow-up): a dead survivor
+                // is rarer and more surprising than a member race.
+                MemberOutcome::StaleSurvivor => {
+                    summary.skipped += 1;
+                    survivor_stale = true;
+                    tracing::warn!(
+                        event = "consolidation_stale_survivor",
+                        survivor = %survivor_id,
+                        member = %member.id,
+                        namespace = %cand.namespace.as_db_string(),
+                        cluster_size = cluster.len(),
+                        "cluster survivor was resolved mid-pass; abandoning the cluster \
+                         so its members re-cluster around a fresh survivor"
+                    );
+                    break;
+                }
             }
-            consumed.insert(member.id.to_string());
         }
-        // The survivor (and the anchor, if it survived) is consumed so it is not
-        // re-clustered as a fresh anchor later in the same pass.
+        // The survivor is always consumed: either it absorbed the cluster, or
+        // it is a dead target that must not anchor a later cluster this pass.
         consumed.insert(survivor_id.to_string());
-        consumed.insert(cand.id.to_string());
+        if !survivor_stale {
+            // The anchor is consumed so it is not re-clustered as a fresh
+            // anchor later in the same pass. On a stale survivor it stays
+            // eligible instead (it may still be active and re-cluster).
+            consumed.insert(cand.id.to_string());
+        }
     }
 
     Ok(summary)
 }
 
+/// How one member's guarded supersede ended (#501): the job discriminates a
+/// benign member-side race loss from a dead GROUP target so `run` can skip
+/// one member vs abandon the whole cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemberOutcome {
+    /// The member was superseded into the survivor.
+    Changed,
+    /// The member itself was resolved by a concurrent writer; the survivor
+    /// is still a valid target for the remaining members.
+    LostRace,
+    /// The SURVIVOR is no longer a valid target (resolved or purged
+    /// mid-pass): every remaining supersede into it would also fail.
+    StaleSurvivor,
+}
+
 /// Supersede one cluster member into the survivor, tolerating the read/write
 /// race (#501 caller compatibility): the candidate window and near-dup lookup
-/// are reads, so a live daemon can resolve a member (remember --supersedes, a
-/// review merge, another writer) before this job's write lands. The store's
-/// supersede guard turns that into [`rb_types::Error::StalePlan`]; a bounded
-/// maintenance pass must skip past the benign collision (the review
-/// policy-sweep discipline) instead of aborting — the winner's pointer stays
-/// exactly as the winner wrote it. Every OTHER error (including a vanished
-/// member: `NotFound`) still fails the pass.
+/// are reads, so a live daemon can resolve a member OR the survivor (remember
+/// --supersedes, a review merge, another writer) before this job's write
+/// lands. The store's supersede guard turns both into a refusal; this helper
+/// discriminates them for `run`:
 ///
-/// Returns `Ok(true)` when the member was superseded, `Ok(false)` on a
-/// benign lost race.
+/// - [`MemberOutcome::LostRace`] — `StalePlan` where the survivor is still
+///   current: only this member was claimed; skip it and continue (the review
+///   policy-sweep discipline). The winner's pointer stays exactly as written.
+/// - [`MemberOutcome::StaleSurvivor`] — `StalePlan` where the survivor itself
+///   is archived/superseded, or `NotFound` naming the survivor (purged):
+///   the group's target is dead and the cluster must be abandoned.
+///
+/// Every other error (including a vanished MEMBER: `NotFound` naming it)
+/// still fails the pass.
 async fn supersede_member(
     store: &StoreHandle,
     namespace: &rb_types::Namespace,
     member: &MemoryId,
     survivor: &MemoryId,
-) -> Result<bool> {
+) -> Result<MemberOutcome> {
     match store
         .supersede(namespace.clone(), member.clone(), survivor.clone())
         .await
     {
-        Ok(()) => Ok(true),
+        Ok(()) => Ok(MemberOutcome::Changed),
         Err(rb_types::Error::StalePlan(reason)) => {
-            tracing::debug!(
-                member = %member,
-                survivor = %survivor,
-                %reason,
-                "consolidation lost a supersede race; skipping the member"
-            );
-            Ok(false)
+            // Disambiguate WHICH side went stale by re-reading the survivor:
+            // still current => the member lost a benign race; otherwise the
+            // group's target is dead. (`get` through the read pool; the tiny
+            // read only happens on the rare guard-miss path.)
+            let survivor_current = store
+                .get(namespace.clone(), survivor.clone())
+                .await?
+                .is_some_and(|s| s.archived_at.is_none() && s.superseded_by.is_none());
+            if survivor_current {
+                tracing::debug!(
+                    member = %member,
+                    survivor = %survivor,
+                    %reason,
+                    "consolidation lost a member supersede race; skipping the member"
+                );
+                Ok(MemberOutcome::LostRace)
+            } else {
+                Ok(MemberOutcome::StaleSurvivor)
+            }
         }
+        // A missing SURVIVOR surfaces as NotFound carrying ITS id (the
+        // daemon namespace pre-check and the store both name the offending
+        // side): a purged target is the same dead-end group state, not a
+        // pass-fatal error.
+        Err(rb_types::Error::NotFound(id)) if id == *survivor => Ok(MemberOutcome::StaleSurvivor),
         Err(e) => Err(e),
     }
 }
@@ -316,10 +393,13 @@ mod tests {
             .await
             .unwrap();
 
-        let changed = supersede_member(&handle, &ns, &member_id, &survivor_id)
+        let outcome = supersede_member(&handle, &ns, &member_id, &survivor_id)
             .await
             .unwrap();
-        assert!(changed, "an unresolved member is superseded");
+        assert!(
+            matches!(outcome, MemberOutcome::Changed),
+            "an unresolved member is superseded"
+        );
         let got = handle
             .get(ns.clone(), member_id.clone())
             .await
@@ -362,11 +442,15 @@ mod tests {
             .await
             .unwrap();
 
-        // The job's write loses the race: skipped (Ok(false)), never an Err.
-        let changed = supersede_member(&handle, &ns, &member_id, &survivor_id)
+        // The job's write loses the race: a benign member-side skip
+        // (the survivor is still a valid target), never an Err.
+        let outcome = supersede_member(&handle, &ns, &member_id, &survivor_id)
             .await
             .unwrap();
-        assert!(!changed, "a lost race is a benign skip, not a change");
+        assert!(
+            matches!(outcome, MemberOutcome::LostRace),
+            "a lost member race is a benign skip, not a change"
+        );
         let got = handle
             .get(ns.clone(), member_id.clone())
             .await
@@ -383,6 +467,70 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, rb_types::Error::NotFound(_)), "got {err:?}");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn supersede_member_reports_a_stale_survivor_distinctly() {
+        // #501 review follow-up (Copilot): a StalePlan caused by the
+        // SURVIVOR — the group's target was itself resolved mid-pass — is
+        // NOT a benign member skip: every remaining supersede into it would
+        // also fail, and lineage would aim at a dead end. The job must
+        // discriminate it (abandon the cluster; members re-cluster around a
+        // fresh survivor on a later anchor or pass) instead of burning one
+        // guarded write per member on a target known to be dead.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("tolerant".to_string());
+
+        let member = vnote(&ns, "member", 3);
+        let survivor = vnote(&ns, "survivor", 9);
+        let replacement = vnote(&ns, "replacement truth", 9);
+        let (member_id, survivor_id, replacement_id) = (
+            member.id.clone(),
+            survivor.id.clone(),
+            replacement.id.clone(),
+        );
+        for (n, v) in [
+            (member, vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            (survivor, vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            (replacement, vec![0.0f32, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        ] {
+            handle.write(n, Some(v)).await.unwrap();
+        }
+
+        // The "concurrent" resolution takes out the SURVIVOR itself.
+        handle
+            .supersede(ns.clone(), survivor_id.clone(), replacement_id.clone())
+            .await
+            .unwrap();
+
+        let outcome = supersede_member(&handle, &ns, &member_id, &survivor_id)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, MemberOutcome::StaleSurvivor),
+            "a resolved survivor must be reported distinctly, got {outcome:?}"
+        );
+        // The member is untouched: it stays eligible for re-clustering.
+        let got = handle
+            .get(ns.clone(), member_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(got.superseded_by.is_none() && got.archived_at.is_none());
+
+        // A PURGED survivor (NotFound on the new side) is the same dead-end
+        // group state, not a pass-fatal error.
+        let outcome = supersede_member(&handle, &ns, &member_id, &rb_types::MemoryId::new())
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, MemberOutcome::StaleSurvivor),
+            "a vanished survivor is a stale group target, got {outcome:?}"
+        );
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/src/jobs/consolidation.rs
+++ b/crates/rb-daemon/src/jobs/consolidation.rs
@@ -139,14 +139,11 @@ pub async fn run(store: &StoreHandle, config: &ConsolidationConfig) -> Result<Jo
             if member.id == survivor_id {
                 continue;
             }
-            store
-                .supersede(
-                    cand.namespace.clone(),
-                    member.id.clone(),
-                    survivor_id.clone(),
-                )
-                .await?;
-            summary.changed += 1;
+            if supersede_member(store, &cand.namespace, &member.id, &survivor_id).await? {
+                summary.changed += 1;
+            } else {
+                summary.skipped += 1;
+            }
             consumed.insert(member.id.to_string());
         }
         // The survivor (and the anchor, if it survived) is consumed so it is not
@@ -156,6 +153,42 @@ pub async fn run(store: &StoreHandle, config: &ConsolidationConfig) -> Result<Jo
     }
 
     Ok(summary)
+}
+
+/// Supersede one cluster member into the survivor, tolerating the read/write
+/// race (#501 caller compatibility): the candidate window and near-dup lookup
+/// are reads, so a live daemon can resolve a member (remember --supersedes, a
+/// review merge, another writer) before this job's write lands. The store's
+/// supersede guard turns that into [`rb_types::Error::StalePlan`]; a bounded
+/// maintenance pass must skip past the benign collision (the review
+/// policy-sweep discipline) instead of aborting — the winner's pointer stays
+/// exactly as the winner wrote it. Every OTHER error (including a vanished
+/// member: `NotFound`) still fails the pass.
+///
+/// Returns `Ok(true)` when the member was superseded, `Ok(false)` on a
+/// benign lost race.
+async fn supersede_member(
+    store: &StoreHandle,
+    namespace: &rb_types::Namespace,
+    member: &MemoryId,
+    survivor: &MemoryId,
+) -> Result<bool> {
+    match store
+        .supersede(namespace.clone(), member.clone(), survivor.clone())
+        .await
+    {
+        Ok(()) => Ok(true),
+        Err(rb_types::Error::StalePlan(reason)) => {
+            tracing::debug!(
+                member = %member,
+                survivor = %survivor,
+                %reason,
+                "consolidation lost a supersede race; skipping the member"
+            );
+            Ok(false)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]
@@ -256,6 +289,102 @@ mod tests {
             similarity_threshold: threshold,
             batch_limit,
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn supersede_member_reports_changed_on_the_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("tolerant".to_string());
+
+        let member = vnote(&ns, "member", 3);
+        let survivor = vnote(&ns, "survivor", 9);
+        let (member_id, survivor_id) = (member.id.clone(), survivor.id.clone());
+        handle
+            .write(
+                member,
+                Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            )
+            .await
+            .unwrap();
+        handle
+            .write(
+                survivor,
+                Some(vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            )
+            .await
+            .unwrap();
+
+        let changed = supersede_member(&handle, &ns, &member_id, &survivor_id)
+            .await
+            .unwrap();
+        assert!(changed, "an unresolved member is superseded");
+        let got = handle
+            .get(ns.clone(), member_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.superseded_by.as_ref(), Some(&survivor_id));
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn supersede_member_skips_a_concurrently_resolved_member() {
+        // #501 caller-compatibility: the job reads its candidate window, then
+        // writes one supersede per member — a live daemon can resolve a
+        // member in between (remember --supersedes, a review merge, another
+        // job). The store guard turns that race into StalePlan; the job must
+        // treat it as skip-and-continue (the review policy-sweep discipline),
+        // NOT abort the pass, and must never rewrite the winner's pointer.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("tolerant".to_string());
+
+        let member = vnote(&ns, "member", 3);
+        let winner = vnote(&ns, "concurrent winner", 5);
+        let survivor = vnote(&ns, "survivor", 9);
+        let (member_id, winner_id, survivor_id) =
+            (member.id.clone(), winner.id.clone(), survivor.id.clone());
+        for (n, v) in [
+            (member, vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            (winner, vec![0.0f32, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            (survivor, vec![1.0f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        ] {
+            handle.write(n, Some(v)).await.unwrap();
+        }
+
+        // The "concurrent" resolution lands first: member -> winner.
+        handle
+            .supersede(ns.clone(), member_id.clone(), winner_id.clone())
+            .await
+            .unwrap();
+
+        // The job's write loses the race: skipped (Ok(false)), never an Err.
+        let changed = supersede_member(&handle, &ns, &member_id, &survivor_id)
+            .await
+            .unwrap();
+        assert!(!changed, "a lost race is a benign skip, not a change");
+        let got = handle
+            .get(ns.clone(), member_id.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            got.superseded_by.as_ref(),
+            Some(&winner_id),
+            "the winner's pointer must never be rewritten"
+        );
+
+        // A real failure still propagates: a vanished member is NOT benign.
+        let err = supersede_member(&handle, &ns, &rb_types::MemoryId::new(), &survivor_id)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, rb_types::Error::NotFound(_)), "got {err:?}");
+
+        handle.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1437,8 +1437,12 @@ where
                     // archive the prior memory through the existing atomic
                     // supersede (separate writer tx). Best-effort — a supersede
                     // failure leaves the new memory stored and `old` un-archived,
-                    // never a partial state. `old == id` is impossible (the id is
-                    // freshly minted) but guarded for clarity.
+                    // never a partial state. That includes the #501 guard misses
+                    // (StalePlan: `old` was already resolved by an earlier fold or
+                    // another writer) — the established lineage pointer is kept
+                    // and only this warn records the refusal. `old == id` is
+                    // impossible (the id is freshly minted) but guarded for
+                    // clarity.
                     if let Some(old) = supersedes {
                         if old != id {
                             if let Err(e) = job_store

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -1659,7 +1659,11 @@ fn writer_loop(
                         // the caller's namespace before mutating, so the primitive can
                         // never merge across namespaces and the Archived event below is
                         // provably published under `old`'s real namespace. Fail closed
-                        // (NotFound) on a missing or cross-namespace target.
+                        // (NotFound) on a missing or cross-namespace target. The
+                        // archived/superseded state guards live in the store itself
+                        // (#501, `Store::supersede`): self-supersede is
+                        // InvalidArgument; a resolved old row or a non-current new
+                        // target is StalePlan — no event is published on any refusal.
                         match (s.get_memory(&old), s.get_memory(&new)) {
                             (Ok(Some(o)), Ok(Some(n)))
                                 if o.namespace == namespace && n.namespace == namespace =>
@@ -2744,6 +2748,68 @@ mod tests {
             "no cross-namespace pointer"
         );
         assert!(got_old.archived_at.is_none(), "old untouched: not archived");
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn store_handle_supersede_rejects_self_and_resolved_rows() {
+        // #501 daemon pins: the store-level guards surface unchanged through
+        // the single writer — self-supersede is a validation error, and both
+        // an already-resolved OLD row and a non-current NEW target are the
+        // distinct StalePlan (wire kind `stale_plan`), never a silent mutate.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rb.db");
+        let handle = StoreHandle::start(db, DIM, 2).unwrap();
+        let ns = Namespace::Project("guards".to_string());
+
+        let a = note(&ns, "first truth");
+        let b = note(&ns, "second truth");
+        let c = note(&ns, "third truth");
+        let (a_id, b_id, c_id) = (a.id.clone(), b.id.clone(), c.id.clone());
+        handle.write(a, Some(vec![0.1f32; DIM])).await.unwrap();
+        handle.write(b, Some(vec![0.2f32; DIM])).await.unwrap();
+        handle.write(c, Some(vec![0.3f32; DIM])).await.unwrap();
+
+        // Self-supersede: refused as a validation error.
+        let err = handle
+            .supersede(ns.clone(), a_id.clone(), a_id.clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "got {err:?}");
+
+        // A -> B succeeds; re-superseding A (already resolved) is StalePlan
+        // and the original pointer survives.
+        handle
+            .supersede(ns.clone(), a_id.clone(), b_id.clone())
+            .await
+            .unwrap();
+        let err = handle
+            .supersede(ns.clone(), a_id.clone(), c_id.clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+        let got_a = handle.get(ns.clone(), a_id.clone()).await.unwrap().unwrap();
+        assert_eq!(
+            got_a.superseded_by.as_ref(),
+            Some(&b_id),
+            "lineage never rewritten"
+        );
+
+        // B -> A (the two-hop cycle): refused because A is no longer current.
+        let err = handle
+            .supersede(ns.clone(), b_id.clone(), a_id.clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+        let got_b = handle.get(ns.clone(), b_id.clone()).await.unwrap().unwrap();
+        assert!(got_b.superseded_by.is_none() && got_b.archived_at.is_none());
+
+        // The writer survives every refusal (guard misses are clean errors).
+        handle
+            .supersede(ns.clone(), b_id.clone(), c_id.clone())
+            .await
+            .unwrap();
 
         handle.shutdown().await;
     }

--- a/crates/rb-daemon/src/store_handle.rs
+++ b/crates/rb-daemon/src/store_handle.rs
@@ -1659,20 +1659,27 @@ fn writer_loop(
                         // the caller's namespace before mutating, so the primitive can
                         // never merge across namespaces and the Archived event below is
                         // provably published under `old`'s real namespace. Fail closed
-                        // (NotFound) on a missing or cross-namespace target. The
+                        // (NotFound) on a missing or cross-namespace target, NAMING the
+                        // offending id (a foreign row is indistinguishable from a
+                        // missing one on purpose): the consolidation job discriminates
+                        // a purged survivor by the id inside NotFound (#501). The
                         // archived/superseded state guards live in the store itself
                         // (#501, `Store::supersede`): self-supersede is
                         // InvalidArgument; a resolved old row or a non-current new
                         // target is StalePlan — no event is published on any refusal.
-                        match (s.get_memory(&old), s.get_memory(&new)) {
-                            (Ok(Some(o)), Ok(Some(n)))
-                                if o.namespace == namespace && n.namespace == namespace =>
-                            {
-                                s.supersede(&old, &new)
-                            }
-                            (Err(e), _) | (_, Err(e)) => Err(e),
-                            _ => Err(Error::NotFound(old.clone())),
+                        let old_in_ns = s
+                            .get_memory(&old)?
+                            .is_some_and(|m| m.namespace == namespace);
+                        if !old_in_ns {
+                            return Err(Error::NotFound(old.clone()));
                         }
+                        let new_in_ns = s
+                            .get_memory(&new)?
+                            .is_some_and(|m| m.namespace == namespace);
+                        if !new_in_ns {
+                            return Err(Error::NotFound(new.clone()));
+                        }
+                        s.supersede(&old, &new)
                     },
                 );
                 let changed = report.result.is_ok();

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -1574,6 +1574,78 @@ async fn remember_superseding_archives_old_and_keeps_new() {
     daemon.stop().await;
 }
 
+// #501 caller compatibility: the supersede fold after `remember` is
+// best-effort — when the old row was ALREADY resolved (here: superseded by an
+// earlier fold whose id a fail-open hook lost), the store guard refuses the
+// re-supersede, the daemon logs it, and the NEW memory is still stored. The
+// established lineage pointer is never rewritten.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remember_superseding_an_already_resolved_row_keeps_new_and_lineage() {
+    let daemon = RunningDaemon::start(2).await;
+    let ns = Namespace::Project("supersede-stale-wire".to_string());
+    let mut client = Client::connect(&daemon.socket, ns.clone()).await.unwrap();
+
+    let old = client
+        .remember(
+            "first draft of the session summary".to_string(),
+            None,
+            MemoryType::Insight,
+            5,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
+    let first = client
+        .remember_superseding(
+            "second draft of the session summary".to_string(),
+            None,
+            MemoryType::Insight,
+            5,
+            vec![],
+            vec![],
+            vec![],
+            None,
+            old.clone(),
+        )
+        .await
+        .unwrap();
+
+    // A stale client re-supersedes the SAME old id: the remember must still
+    // succeed (best-effort fold), and old must still point at `first`.
+    let second = client
+        .remember_superseding(
+            "third draft written against a stale view".to_string(),
+            None,
+            MemoryType::Insight,
+            5,
+            vec![],
+            vec![],
+            vec![],
+            None,
+            old.clone(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(second, first);
+
+    let old_row = client.get(old.clone()).await.unwrap().unwrap();
+    assert_eq!(
+        old_row.superseded_by,
+        Some(first.clone()),
+        "the established lineage pointer is never rewritten"
+    );
+    let second_row = client.get(second.clone()).await.unwrap().unwrap();
+    assert!(
+        second_row.archived_at.is_none(),
+        "the new memory is stored live despite the refused fold"
+    );
+
+    daemon.stop().await;
+}
+
 // W3.1 write-time near-dup suppression: two hook captures with identical
 // content embed to the same vector under the DeterministicProvider, so storing
 // the second (a cosine-1.0 near-dup) absorbs the first via supersede — automatic

--- a/crates/rb-proto/src/error.rs
+++ b/crates/rb-proto/src/error.rs
@@ -68,7 +68,12 @@ pub fn response_error_to_error(kind: &str, message: &str) -> Error {
         "enrichment" => Error::Enrichment(unprefixed(message, "enrichment error: ")),
         "invalid_argument" => Error::InvalidArgument(unprefixed(message, "invalid argument: ")),
         "permission_denied" => Error::PermissionDenied(unprefixed(message, "permission denied: ")),
-        "stale_plan" => Error::StalePlan(unprefixed(message, "stale review plan: ")),
+        // The prefix matches `Error::StalePlan`'s Display exactly (#501: it
+        // was generalized from "stale review plan: " when the guarded
+        // supersede became a second producer; the wire KIND is unchanged).
+        // An old peer's "stale review plan: " message strips nothing here --
+        // the documented no-op degradation, cosmetic only.
+        "stale_plan" => Error::StalePlan(unprefixed(message, "stale plan: ")),
         // not_found / dimension_mismatch / anything unrecognized: preserve the
         // message under Storage rather than fabricate structured fields.
         _ => Error::Storage(message.to_string()),

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -1470,50 +1470,24 @@ impl Store for SqliteStore {
     }
 
     fn supersede(&self, old: &MemoryId, new: &MemoryId) -> Result<()> {
-        // Guard 1 (#501): a self-supersede is statically invalid — a memory
-        // can never be its own replacement — and would seed a pointer cycle.
-        // Refused before any SQL runs.
-        if old == new {
-            return Err(Error::InvalidArgument(format!(
-                "a memory cannot supersede itself: {old}"
-            )));
-        }
+        // Every guard lives in the shared primitive (#501,
+        // `supersede_guarded_in_tx` — the one choke point that makes the
+        // pointer graph structurally acyclic); this wrapper only owns the
+        // transaction and the general-path error mapping:
+        // - self-supersede is a static caller bug (InvalidArgument);
+        // - a missing row on either side is a precise NotFound;
+        // - an already-resolved old row or a non-current new target means the
+        //   caller's plan was formed against a stale view (StalePlan): the
+        //   established lineage must never be rewritten, and pointing lineage
+        //   at a dead end would fabricate a decision-evolution step on the
+        //   W2.2 audit surface.
         let now = chrono::Utc::now().timestamp();
         immediate_tx(&self.conn, || {
-            // Guard 3 (#501): `new` must be CURRENT TRUTH — present, active,
-            // and not itself superseded — or the lineage pointer would aim at
-            // a dead end. This is the write-side cycle defense: pointers are
-            // set-once (guard 2) and old != new (guard 1), so the last edge
-            // of any would-be cycle necessarily targets a row that is already
-            // superseded and is refused HERE. It also upgrades the
-            // missing-`new` FK failure to a precise NotFound; the FK stays as
-            // belt-and-suspenders.
-            let new_row: Option<(bool, bool)> = match self.conn.query_row(
-                "SELECT archived_at IS NOT NULL, superseded_by IS NOT NULL
-                 FROM memories WHERE memory_id = ?1",
-                rusqlite::params![new.to_string()],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            ) {
-                Ok(v) => Some(v),
-                Err(rusqlite::Error::QueryReturnedNoRows) => None,
-                Err(e) => return Err(Error::Storage(e.to_string())),
-            };
-            match new_row {
-                None => return Err(Error::NotFound(new.clone())),
-                Some((false, false)) => {}
-                Some(_) => {
-                    return Err(Error::StalePlan(format!(
-                        "{new} is no longer current truth (archived or superseded); \
-                         a supersede must point at an active replacement"
-                    )))
-                }
-            }
-            // Guard 2 (#501): the pointer is taken only while still unclaimed
-            // on an active row — the shared guarded body (also the PR #63
-            // review-merge guard) enforces it with a rows-affected check, so
-            // lineage can never be silently rewritten.
             match self.supersede_guarded_in_tx(old, new, now)? {
                 SupersedeGuard::Applied => Ok(()),
+                SupersedeGuard::SelfSupersede => Err(Error::InvalidArgument(format!(
+                    "a memory cannot supersede itself: {old}"
+                ))),
                 SupersedeGuard::MissingOld => Err(Error::NotFound(old.clone())),
                 SupersedeGuard::OldResolved {
                     archived,
@@ -1521,6 +1495,14 @@ impl Store for SqliteStore {
                 } => Err(Error::StalePlan(format!(
                     "{old} was already resolved (archived: {archived}, superseded: \
                      {superseded}); re-plan against the current row"
+                ))),
+                SupersedeGuard::MissingNew => Err(Error::NotFound(new.clone())),
+                SupersedeGuard::NewNotCurrent {
+                    archived,
+                    superseded,
+                } => Err(Error::StalePlan(format!(
+                    "{new} is no longer current truth (archived: {archived}, superseded: \
+                     {superseded}); a supersede must point at an active replacement"
                 ))),
             }
         })
@@ -1826,37 +1808,77 @@ impl Store for SqliteStore {
     }
 }
 
-/// Outcome of the guarded supersede pointer-take (#501). The SQL guard is
+/// Outcome of the guarded supersede pointer-take (#501). The guards are
 /// shared by every supersede path; each caller owns the error mapping (the
 /// review-merge path wants its keyed StalePlan message, the general path
-/// disambiguates NotFound), so the guard reports data, not errors.
+/// disambiguates NotFound), so the guard reports data, not errors. One
+/// distinct variant per guard: callers match exhaustively, so adding a guard
+/// forces every caller to reconsider its mapping.
 pub(crate) enum SupersedeGuard {
     /// Pointer taken, old row archived, vector pruned, oplog row appended.
     Applied,
+    /// `old == new`: statically invalid, nothing was written.
+    SelfSupersede,
     /// The old row does not exist.
     MissingOld,
     /// The old row was already resolved (archived and/or superseded): the
     /// guarded UPDATE refused and nothing was written.
     OldResolved { archived: bool, superseded: bool },
+    /// The new target does not exist.
+    MissingNew,
+    /// The new target is not current truth (archived and/or superseded):
+    /// refused before the pointer UPDATE, nothing was written.
+    NewNotCurrent { archived: bool, superseded: bool },
 }
 
 impl SqliteStore {
     /// The guarded supersede transaction body (#501, generalizing the PR #63
-    /// review-merge guard): point `old` at `new`, archive it, and stamp
-    /// `updated_at` in ONE guarded statement
-    /// (`WHERE superseded_by IS NULL AND archived_at IS NULL`), then prune the
-    /// vector (W1.7) and append the `supersede` oplog row. The rows-affected
-    /// check makes the pointer set-once by construction — a row that is
-    /// already archived or superseded is never touched, so lineage can never
-    /// be silently rewritten. MUST run inside an open transaction; callers
-    /// map a non-`Applied` outcome to their own error so the whole
-    /// transaction rolls back.
+    /// review-merge guard) — the ONE choke point that structurally enforces
+    /// acyclicity, with no reliance on caller invariants:
+    ///
+    /// 1. `old != new` (a self-loop is never a replacement);
+    /// 2. `new` is CURRENT TRUTH — present, active, not itself superseded —
+    ///    so the last edge of any would-be cycle, which necessarily targets
+    ///    an already-superseded row, is refused here;
+    /// 3. the pointer UPDATE (pointer + archive + `updated_at` in ONE
+    ///    statement, `WHERE superseded_by IS NULL AND archived_at IS NULL`)
+    ///    with a rows-affected check makes `superseded_by` set-once, so
+    ///    lineage can never be silently rewritten.
+    ///
+    /// On `Applied` the vector is pruned (W1.7) and the `supersede` oplog row
+    /// appended in the same transaction. MUST run inside an open transaction;
+    /// callers map every non-`Applied` outcome to their own error so the
+    /// whole transaction rolls back. The `superseded_by` FK stays as
+    /// belt-and-suspenders behind the explicit `new`-side check.
     pub(crate) fn supersede_guarded_in_tx(
         &self,
         old: &MemoryId,
         new: &MemoryId,
         now_ts: i64,
     ) -> Result<SupersedeGuard> {
+        if old == new {
+            return Ok(SupersedeGuard::SelfSupersede);
+        }
+        let new_row: Option<(bool, bool)> = match self.conn.query_row(
+            "SELECT archived_at IS NOT NULL, superseded_by IS NOT NULL
+             FROM memories WHERE memory_id = ?1",
+            rusqlite::params![new.to_string()],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        ) {
+            Ok(v) => Some(v),
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(e) => return Err(Error::Storage(e.to_string())),
+        };
+        match new_row {
+            None => return Ok(SupersedeGuard::MissingNew),
+            Some((false, false)) => {}
+            Some((archived, superseded)) => {
+                return Ok(SupersedeGuard::NewNotCurrent {
+                    archived,
+                    superseded,
+                })
+            }
+        }
         let affected = self
             .conn
             .execute(
@@ -4245,6 +4267,90 @@ mod access_tests {
             "no lineage pointer is invented on a retired row"
         );
         assert!(got.archived_at.is_some(), "still archived");
+    }
+
+    #[test]
+    fn supersede_guarded_in_tx_owns_every_guard_including_new_side() {
+        // #501 review follow-up (HIGH): the acyclicity induction must be
+        // STRUCTURAL in the one shared primitive, not an undocumented caller
+        // invariant -- an in-tx call passing a non-fresh `new` (which the
+        // review-merge path never does today) must be refused by the
+        // primitive itself, with a distinct variant per guard so each caller
+        // can own its error mapping.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let now = chrono::Utc::now().timestamp();
+
+        // Guard 1 lives in the primitive: self-supersede.
+        let a = node(&store, "self");
+        assert!(matches!(
+            store.supersede_guarded_in_tx(&a.id, &a.id, now).unwrap(),
+            SupersedeGuard::SelfSupersede
+        ));
+
+        // Guard 3 lives in the primitive: missing new target.
+        assert!(matches!(
+            store
+                .supersede_guarded_in_tx(&a.id, &MemoryId::new(), now)
+                .unwrap(),
+            SupersedeGuard::MissingNew
+        ));
+
+        // Guard 3: an archived (non-current) new target.
+        let live = node(&store, "live old");
+        let dead = node(&store, "archived new");
+        store.archive_memory(&dead.id).unwrap();
+        assert!(matches!(
+            store
+                .supersede_guarded_in_tx(&live.id, &dead.id, now)
+                .unwrap(),
+            SupersedeGuard::NewNotCurrent {
+                archived: true,
+                superseded: false
+            }
+        ));
+        let got_live = store.get_memory(&live.id).unwrap().unwrap();
+        assert!(
+            got_live.superseded_by.is_none() && got_live.archived_at.is_none(),
+            "a refused new-side guard writes nothing"
+        );
+
+        // Guard 3: a superseded new target -- the cycle-closing edge.
+        let x = node(&store, "x");
+        let y = node(&store, "y");
+        store.supersede(&x.id, &y.id).unwrap();
+        assert!(matches!(
+            store.supersede_guarded_in_tx(&y.id, &x.id, now).unwrap(),
+            SupersedeGuard::NewNotCurrent {
+                archived: true,
+                superseded: true
+            }
+        ));
+        let got_y = store.get_memory(&y.id).unwrap().unwrap();
+        assert!(got_y.superseded_by.is_none() && got_y.archived_at.is_none());
+
+        // Guard 2 arms are unchanged: missing old / already-resolved old.
+        assert!(matches!(
+            store
+                .supersede_guarded_in_tx(&MemoryId::new(), &a.id, now)
+                .unwrap(),
+            SupersedeGuard::MissingOld
+        ));
+        assert!(matches!(
+            store.supersede_guarded_in_tx(&x.id, &a.id, now).unwrap(),
+            SupersedeGuard::OldResolved {
+                archived: true,
+                superseded: true
+            }
+        ));
+
+        // The happy path through the bare primitive still applies.
+        let b = node(&store, "fresh new");
+        assert!(matches!(
+            store.supersede_guarded_in_tx(&a.id, &b.id, now).unwrap(),
+            SupersedeGuard::Applied
+        ));
+        let got_a = store.get_memory(&a.id).unwrap().unwrap();
+        assert_eq!(got_a.superseded_by.as_ref(), Some(&b.id));
     }
 
     #[test]

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -1470,43 +1470,59 @@ impl Store for SqliteStore {
     }
 
     fn supersede(&self, old: &MemoryId, new: &MemoryId) -> Result<()> {
+        // Guard 1 (#501): a self-supersede is statically invalid — a memory
+        // can never be its own replacement — and would seed a pointer cycle.
+        // Refused before any SQL runs.
+        if old == new {
+            return Err(Error::InvalidArgument(format!(
+                "a memory cannot supersede itself: {old}"
+            )));
+        }
         let now = chrono::Utc::now().timestamp();
         immediate_tx(&self.conn, || {
-            // Point old -> new. FK on superseded_by makes a missing `new` fail here,
-            // rolling back the whole transaction (old stays unarchived).
-            let affected = self
-                .conn
-                .execute(
-                    "UPDATE memories SET superseded_by = ?1, updated_at = ?2 WHERE memory_id = ?3",
-                    rusqlite::params![new.to_string(), now, old.to_string()],
-                )
-                .map_err(|e| Error::Storage(e.to_string()))?;
-            // Fail fast on a missing `old`: 0 rows updated means a caller bug, not a
-            // silent success. Returning the error rolls the whole transaction back.
-            if affected == 0 {
-                return Err(Error::NotFound(old.clone()));
+            // Guard 3 (#501): `new` must be CURRENT TRUTH — present, active,
+            // and not itself superseded — or the lineage pointer would aim at
+            // a dead end. This is the write-side cycle defense: pointers are
+            // set-once (guard 2) and old != new (guard 1), so the last edge
+            // of any would-be cycle necessarily targets a row that is already
+            // superseded and is refused HERE. It also upgrades the
+            // missing-`new` FK failure to a precise NotFound; the FK stays as
+            // belt-and-suspenders.
+            let new_row: Option<(bool, bool)> = match self.conn.query_row(
+                "SELECT archived_at IS NOT NULL, superseded_by IS NOT NULL
+                 FROM memories WHERE memory_id = ?1",
+                rusqlite::params![new.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            ) {
+                Ok(v) => Some(v),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(Error::Storage(e.to_string())),
+            };
+            match new_row {
+                None => return Err(Error::NotFound(new.clone())),
+                Some((false, false)) => {}
+                Some(_) => {
+                    return Err(Error::StalePlan(format!(
+                        "{new} is no longer current truth (archived or superseded); \
+                         a supersede must point at an active replacement"
+                    )))
+                }
             }
-            // Archive old (idempotent: only if currently active).
-            self.conn
-                .execute(
-                    "UPDATE memories SET archived_at = ?1, updated_at = ?1
-                     WHERE memory_id = ?2 AND archived_at IS NULL",
-                    rusqlite::params![now, old.to_string()],
-                )
-                .map_err(|e| Error::Storage(e.to_string()))?;
-            // Vector hygiene (W1.7): the superseded (now archived) memory's
-            // vector leaves the KNN index in the same transaction. Idempotent:
-            // a vectorless or already-cleaned row deletes nothing.
-            self.conn
-                .execute(
-                    "DELETE FROM memory_vectors WHERE memory_id = ?1",
-                    rusqlite::params![old.to_string()],
-                )
-                .map_err(|e| Error::Storage(e.to_string()))?;
-            // One `supersede` oplog row covers the whole compound mutation
-            // (pointer + archive); the replacement id rides in `details`.
-            let details = serde_json::json!({ "new": new.to_string() }).to_string();
-            append_oplog(&self.conn, &self.site_id, "supersede", old, &details)
+            // Guard 2 (#501): the pointer is taken only while still unclaimed
+            // on an active row — the shared guarded body (also the PR #63
+            // review-merge guard) enforces it with a rows-affected check, so
+            // lineage can never be silently rewritten.
+            match self.supersede_guarded_in_tx(old, new, now)? {
+                SupersedeGuard::Applied => Ok(()),
+                SupersedeGuard::MissingOld => Err(Error::NotFound(old.clone())),
+                SupersedeGuard::OldResolved {
+                    archived,
+                    superseded,
+                } => Err(Error::StalePlan(format!(
+                    "{old} was already resolved (archived: {archived}, superseded: \
+                     {superseded}); re-plan against the current row"
+                ))),
+            }
         })
     }
 
@@ -1807,6 +1823,84 @@ impl Store for SqliteStore {
             }
             Ok(())
         })
+    }
+}
+
+/// Outcome of the guarded supersede pointer-take (#501). The SQL guard is
+/// shared by every supersede path; each caller owns the error mapping (the
+/// review-merge path wants its keyed StalePlan message, the general path
+/// disambiguates NotFound), so the guard reports data, not errors.
+pub(crate) enum SupersedeGuard {
+    /// Pointer taken, old row archived, vector pruned, oplog row appended.
+    Applied,
+    /// The old row does not exist.
+    MissingOld,
+    /// The old row was already resolved (archived and/or superseded): the
+    /// guarded UPDATE refused and nothing was written.
+    OldResolved { archived: bool, superseded: bool },
+}
+
+impl SqliteStore {
+    /// The guarded supersede transaction body (#501, generalizing the PR #63
+    /// review-merge guard): point `old` at `new`, archive it, and stamp
+    /// `updated_at` in ONE guarded statement
+    /// (`WHERE superseded_by IS NULL AND archived_at IS NULL`), then prune the
+    /// vector (W1.7) and append the `supersede` oplog row. The rows-affected
+    /// check makes the pointer set-once by construction — a row that is
+    /// already archived or superseded is never touched, so lineage can never
+    /// be silently rewritten. MUST run inside an open transaction; callers
+    /// map a non-`Applied` outcome to their own error so the whole
+    /// transaction rolls back.
+    pub(crate) fn supersede_guarded_in_tx(
+        &self,
+        old: &MemoryId,
+        new: &MemoryId,
+        now_ts: i64,
+    ) -> Result<SupersedeGuard> {
+        let affected = self
+            .conn
+            .execute(
+                "UPDATE memories
+                 SET superseded_by = ?1, archived_at = ?2, updated_at = ?2
+                 WHERE memory_id = ?3 AND superseded_by IS NULL AND archived_at IS NULL",
+                rusqlite::params![new.to_string(), now_ts, old.to_string()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        if affected == 0 {
+            // Disambiguate the guard miss: a missing row vs one already
+            // resolved by a concurrent/prior action.
+            let row: Option<(bool, bool)> = match self.conn.query_row(
+                "SELECT archived_at IS NOT NULL, superseded_by IS NOT NULL
+                 FROM memories WHERE memory_id = ?1",
+                rusqlite::params![old.to_string()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            ) {
+                Ok(v) => Some(v),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(Error::Storage(e.to_string())),
+            };
+            return Ok(match row {
+                None => SupersedeGuard::MissingOld,
+                Some((archived, superseded)) => SupersedeGuard::OldResolved {
+                    archived,
+                    superseded,
+                },
+            });
+        }
+        // Vector hygiene (W1.7): the superseded (now archived) memory's
+        // vector leaves the KNN index in the same transaction. Idempotent:
+        // a vectorless row deletes nothing.
+        self.conn
+            .execute(
+                "DELETE FROM memory_vectors WHERE memory_id = ?1",
+                rusqlite::params![old.to_string()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        // One `supersede` oplog row covers the whole compound mutation
+        // (pointer + archive); the replacement id rides in `details`.
+        let details = serde_json::json!({ "new": new.to_string() }).to_string();
+        append_oplog(&self.conn, &self.site_id, "supersede", old, &details)?;
+        Ok(SupersedeGuard::Applied)
     }
 }
 #[cfg(test)]
@@ -4055,18 +4149,134 @@ mod access_tests {
     }
 
     #[test]
-    fn supersede_missing_new_target_fails_fk() {
+    fn supersede_missing_new_target_is_not_found() {
         let store = SqliteStore::open_in_memory(8).unwrap();
         let old = node(&store, "old");
-        // superseded_by REFERENCES memories(memory_id); a missing target must fail
-        // the FK and leave the old note unchanged (transaction rolled back).
-        // foreign_keys=ON is set in SqliteStore::init, so the FK is enforced
-        // immediately on the UPDATE statement (SQLite FKs are not deferred by default).
-        let err = store.supersede(&old.id, &MemoryId::new()).unwrap_err();
-        assert!(matches!(err, Error::Storage(_)));
+        // The current-truth check on `new` loads the row first, so a missing
+        // target fails closed as NotFound (client-safe and precise) BEFORE any
+        // mutation; the FK on superseded_by stays as belt-and-suspenders. The
+        // old note is unchanged (nothing was written).
+        let missing_new = MemoryId::new();
+        let err = store.supersede(&old.id, &missing_new).unwrap_err();
+        assert!(
+            matches!(err, Error::NotFound(ref id) if *id == missing_new),
+            "got {err:?}"
+        );
         let got = store.get_memory(&old.id).unwrap().unwrap();
         assert!(got.superseded_by.is_none(), "rolled back: no superseded_by");
         assert!(got.archived_at.is_none(), "rolled back: not archived");
+    }
+
+    #[test]
+    fn supersede_rejects_self_supersede() {
+        // #501 guard 1: old == new is statically invalid (a self-loop can
+        // never be a "replacement as current truth") and must be refused
+        // before any SQL runs — a distinct validation-class error.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "self target");
+
+        let err = store.supersede(&a.id, &a.id).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "got {err:?}");
+
+        let got = store.get_memory(&a.id).unwrap().unwrap();
+        assert!(got.superseded_by.is_none(), "row untouched: no pointer");
+        assert!(got.archived_at.is_none(), "row untouched: not archived");
+        let oplog: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_oplog WHERE op = 'supersede'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(oplog, 0, "a refused supersede leaves no oplog row");
+    }
+
+    #[test]
+    fn supersede_rejects_already_superseded_old_and_keeps_the_pointer() {
+        // #501 guard 2 (the review-finding regression): the pointer UPDATE is
+        // guarded (`WHERE superseded_by IS NULL AND archived_at IS NULL`), so
+        // a second supersede of the same old row must FAIL with the distinct
+        // stale-plan error instead of silently REWRITING lineage.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let old = node(&store, "old truth");
+        let first = node(&store, "first replacement");
+        let second = node(&store, "second replacement");
+
+        store.supersede(&old.id, &first.id).unwrap();
+        let err = store.supersede(&old.id, &second.id).unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+
+        let got = store.get_memory(&old.id).unwrap().unwrap();
+        assert_eq!(
+            got.superseded_by.as_ref(),
+            Some(&first.id),
+            "the original pointer must never be overwritten"
+        );
+        // Exactly ONE supersede oplog row: the refused attempt wrote nothing.
+        let oplog: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_oplog WHERE op = 'supersede'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(oplog, 1);
+    }
+
+    #[test]
+    fn supersede_rejects_archived_old() {
+        // #501 guard 2b: an archived old row was already retired (explicit
+        // forget or retention) — a supersede plan against it was formed on a
+        // stale view. Previously this silently set the pointer; now it is the
+        // distinct stale-plan error and the row keeps a NULL pointer.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let old = node(&store, "retired row");
+        let new = node(&store, "replacement");
+        store.archive_memory(&old.id).unwrap();
+
+        let err = store.supersede(&old.id, &new.id).unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+
+        let got = store.get_memory(&old.id).unwrap().unwrap();
+        assert!(
+            got.superseded_by.is_none(),
+            "no lineage pointer is invented on a retired row"
+        );
+        assert!(got.archived_at.is_some(), "still archived");
+    }
+
+    #[test]
+    fn supersede_rejects_non_current_new_target() {
+        // #501 guard 3 (the write-side cycle defense): `new` must itself be
+        // current truth (active, not superseded). This is what actually
+        // blocks A->B then B->A — when superseding B, the OLD row B is still
+        // active and unclaimed, so the old-row guard passes; the cycle is
+        // refused because the NEW target A is archived+superseded. Together
+        // with set-once pointers and old != new this makes the pointer graph
+        // acyclic at the write side.
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let a = node(&store, "cycle a");
+        let b = node(&store, "cycle b");
+
+        store.supersede(&a.id, &b.id).unwrap();
+        let err = store.supersede(&b.id, &a.id).unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+
+        // B is fully untouched: still active, still unclaimed.
+        let got_b = store.get_memory(&b.id).unwrap().unwrap();
+        assert!(got_b.superseded_by.is_none(), "no cycle pointer");
+        assert!(got_b.archived_at.is_none(), "B stays active");
+
+        // An archived-but-unsuperseded target is refused the same way.
+        let c = node(&store, "live row");
+        let d = node(&store, "archived target");
+        store.archive_memory(&d.id).unwrap();
+        let err = store.supersede(&c.id, &d.id).unwrap_err();
+        assert!(matches!(err, Error::StalePlan(_)), "got {err:?}");
+        let got_c = store.get_memory(&c.id).unwrap().unwrap();
+        assert!(got_c.superseded_by.is_none() && got_c.archived_at.is_none());
     }
 
     #[test]

--- a/crates/rb-store/src/store/history.rs
+++ b/crates/rb-store/src/store/history.rs
@@ -512,6 +512,24 @@ mod tests {
         id
     }
 
+    /// Plant a supersede pointer with RAW SQL, bypassing the write-side
+    /// guards (#501: `Store::supersede` now rejects self-supersede,
+    /// re-supersede, and non-current targets). Cycle/self-loop fixtures model
+    /// direct DB access, admin scripts, or corruption — exactly the threat
+    /// the read-side cycle defense must survive, which is why these tests
+    /// keep passing as belt-and-suspenders behind the write-side guards.
+    fn force_supersede(store: &SqliteStore, old: &MemoryId, new: &MemoryId) {
+        let now = chrono::Utc::now().timestamp();
+        store
+            .conn
+            .execute(
+                "UPDATE memories SET superseded_by = ?1, archived_at = ?2, updated_at = ?2
+                 WHERE memory_id = ?3",
+                rusqlite::params![new.to_string(), now, old.to_string()],
+            )
+            .unwrap();
+    }
+
     fn link(store: &SqliteStore, from: &MemoryId, to: &MemoryId, lt: LinkType, reason: &str) {
         store
             .add_link(&MemoryLink {
@@ -628,7 +646,7 @@ mod tests {
         let a = seed(&store, &ns, "a");
         let b = seed(&store, &ns, "b");
         store.supersede(&a, &b).unwrap();
-        store.supersede(&b, &a).unwrap(); // closes the cycle A -> B -> A
+        force_supersede(&store, &b, &a); // closes the cycle A -> B -> A (raw SQL: the write path refuses it)
 
         for anchor in [&a, &b] {
             let history = store.memory_history(&ns, anchor, 100, 200, 200).unwrap();
@@ -663,8 +681,8 @@ mod tests {
         let d = seed(&store, &ns, "cycle d");
         store.supersede(&b, &c).unwrap();
         store.supersede(&c, &d).unwrap();
-        store.supersede(&d, &b).unwrap(); // closes the cycle B -> C -> D -> B
-        store.supersede(&a, &c).unwrap(); // the external entry A -> C
+        force_supersede(&store, &d, &b); // closes the cycle B -> C -> D -> B (raw SQL)
+        force_supersede(&store, &a, &c); // the external entry A -> C (raw SQL: C is superseded)
 
         // From D (inside the cycle) and from A (outside, feeding in): every
         // member appears exactly once and nothing is silently dropped.
@@ -726,7 +744,7 @@ mod tests {
         let store = open(&dir.path().join("rb.db"));
         let ns = Namespace::Project("hist-self".to_string());
         let a = seed(&store, &ns, "self-superseded");
-        store.supersede(&a, &a).unwrap();
+        force_supersede(&store, &a, &a); // raw SQL: the write path rejects self-supersede (#501)
 
         let history = store.memory_history(&ns, &a, 100, 200, 200).unwrap();
         assert_eq!(history.chain.len(), 1, "the self-loop adds no members");
@@ -796,7 +814,7 @@ mod tests {
         let c = seed(&store, &ns, "c");
         let d = seed(&store, &ns, "d");
         store.supersede(&c, &d).unwrap();
-        store.supersede(&d, &c).unwrap();
+        force_supersede(&store, &d, &c); // raw SQL: closes the cycle past the write guard
         let history = store.memory_history(&ns, &c, 1, 200, 200).unwrap();
         assert_eq!(history.chain.len(), 2);
         assert!(

--- a/crates/rb-store/src/store/review.rs
+++ b/crates/rb-store/src/store/review.rs
@@ -697,9 +697,14 @@ impl SqliteStore {
 
     /// The supersede transaction body with the pointer GUARD: pointer,
     /// archive, vector prune, and one `supersede` oplog row — but only when
-    /// the pointer is still unclaimed on an active row. MUST run inside an
-    /// open transaction; a guard miss is [`Error::StalePlan`] so the whole
-    /// merge rolls back (never a split chain).
+    /// the pointer is still unclaimed on an active row. Delegates to the
+    /// shared guarded primitive (`SqliteStore::supersede_guarded_in_tx`,
+    /// #501) so there is exactly ONE pointer-take guard in the store; only
+    /// the error mapping is review-specific. MUST run inside an open
+    /// transaction; any guard miss is [`Error::StalePlan`] (the merge's
+    /// members were verified present in step 1, so a miss can only be a
+    /// concurrent claim) and the whole merge rolls back (never a split
+    /// chain).
     fn supersede_unclaimed_in_tx(
         &self,
         old: &MemoryId,
@@ -707,30 +712,13 @@ impl SqliteStore {
         now: chrono::DateTime<chrono::Utc>,
         key: &str,
     ) -> Result<()> {
-        let now_ts = now.timestamp();
-        let affected = self
-            .conn
-            .execute(
-                "UPDATE memories
-                 SET superseded_by = ?1, archived_at = ?2, updated_at = ?2
-                 WHERE memory_id = ?3 AND superseded_by IS NULL AND archived_at IS NULL",
-                rusqlite::params![new.to_string(), now_ts, old.to_string()],
-            )
-            .map_err(storage_err)?;
-        if affected == 0 {
-            return Err(Error::StalePlan(format!(
+        match self.supersede_guarded_in_tx(old, new, now.timestamp())? {
+            super::core::SupersedeGuard::Applied => Ok(()),
+            _ => Err(Error::StalePlan(format!(
                 "{old} was claimed by a concurrent resolution of {key}; re-run review \
                  for a fresh queue"
-            )));
+            ))),
         }
-        self.conn
-            .execute(
-                "DELETE FROM memory_vectors WHERE memory_id = ?1",
-                rusqlite::params![old.to_string()],
-            )
-            .map_err(storage_err)?;
-        let details = serde_json::json!({ "new": new.to_string() }).to_string();
-        super::internal::append_oplog(&self.conn, &self.site_id, "supersede", old, &details)
     }
 
     fn upsert_review_state(

--- a/crates/rb-store/src/store/review.rs
+++ b/crates/rb-store/src/store/review.rs
@@ -699,12 +699,18 @@ impl SqliteStore {
     /// archive, vector prune, and one `supersede` oplog row — but only when
     /// the pointer is still unclaimed on an active row. Delegates to the
     /// shared guarded primitive (`SqliteStore::supersede_guarded_in_tx`,
-    /// #501) so there is exactly ONE pointer-take guard in the store; only
-    /// the error mapping is review-specific. MUST run inside an open
-    /// transaction; any guard miss is [`Error::StalePlan`] (the merge's
-    /// members were verified present in step 1, so a miss can only be a
-    /// concurrent claim) and the whole merge rolls back (never a split
-    /// chain).
+    /// #501) so there is exactly ONE supersede guard in the store; only the
+    /// error mapping is review-specific. MUST run inside an open transaction;
+    /// a guard miss rolls the whole merge back (never a split chain).
+    ///
+    /// Defense-in-depth note: under the current usage every non-`Applied`
+    /// arm is unreachable — the entire merge runs inside ONE single-writer
+    /// transaction whose step 1 verified both members present, active, and
+    /// unresolved, and whose `new` is inserted fresh in the same transaction
+    /// (so the primitive's `new`-side currency check passes by construction).
+    /// The mapping still exists so the merge's all-or-nothing contract holds
+    /// on its own, without depending on caller discipline or the single-tx
+    /// shape staying true forever.
     fn supersede_unclaimed_in_tx(
         &self,
         old: &MemoryId,
@@ -712,9 +718,20 @@ impl SqliteStore {
         now: chrono::DateTime<chrono::Utc>,
         key: &str,
     ) -> Result<()> {
+        use super::core::SupersedeGuard;
         match self.supersede_guarded_in_tx(old, new, now.timestamp())? {
-            super::core::SupersedeGuard::Applied => Ok(()),
-            _ => Err(Error::StalePlan(format!(
+            SupersedeGuard::Applied => Ok(()),
+            // A static caller bug, not a raced plan: review_merge rejects
+            // `a == b` and `note.id == a/b` before the transaction opens.
+            SupersedeGuard::SelfSupersede => Err(Error::InvalidArgument(format!(
+                "a memory cannot supersede itself: {old}"
+            ))),
+            // Exhaustive on purpose (no `_`): a future guard variant must
+            // force this mapping to be reconsidered.
+            SupersedeGuard::MissingOld
+            | SupersedeGuard::OldResolved { .. }
+            | SupersedeGuard::MissingNew
+            | SupersedeGuard::NewNotCurrent { .. } => Err(Error::StalePlan(format!(
                 "{old} was claimed by a concurrent resolution of {key}; re-run review \
                  for a fresh queue"
             ))),

--- a/crates/rb-types/src/error.rs
+++ b/crates/rb-types/src/error.rs
@@ -27,12 +27,16 @@ pub enum Error {
     Enrichment(String),
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
-    /// A review resolution raced a concurrent change (PRD 2026-07-02): the
-    /// item's members were already resolved (archived/superseded) or the
-    /// planned relationship no longer holds at resolve time. Client-safe
-    /// guidance — re-run `review` for a fresh queue. Distinct variant so a
-    /// policy sweep can skip-and-continue past a benign collision while real
-    /// errors still stop the pass.
+    /// A planned mutation raced a concurrent change: the rows it targeted
+    /// were already resolved (archived/superseded) or the planned
+    /// relationship no longer holds at write time. Producers: review
+    /// resolutions (PRD 2026-07-02 — re-run `review` for a fresh queue) and
+    /// the guarded supersede (#501 — the old row was already resolved, or the
+    /// replacement is no longer current truth). Client-safe guidance.
+    /// Distinct variant so tolerant sweeps (review policy, consolidation) can
+    /// skip-and-continue past a benign collision while real errors still stop
+    /// the pass. The Display prefix predates the generalization and is kept
+    /// stable: the `stale_plan` wire kind's message round-trip strips it.
     #[error("stale review plan: {0}")]
     StalePlan(String),
     /// An authenticated peer is not authorized for the requested operation

--- a/crates/rb-types/src/error.rs
+++ b/crates/rb-types/src/error.rs
@@ -35,9 +35,11 @@ pub enum Error {
     /// replacement is no longer current truth). Client-safe guidance.
     /// Distinct variant so tolerant sweeps (review policy, consolidation) can
     /// skip-and-continue past a benign collision while real errors still stop
-    /// the pass. The Display prefix predates the generalization and is kept
-    /// stable: the `stale_plan` wire kind's message round-trip strips it.
-    #[error("stale review plan: {0}")]
+    /// the pass. The Display prefix is subsystem-neutral (it renders in
+    /// daemon logs for non-review paths); the wire KIND string stays
+    /// `stale_plan`, and rb-proto strips this exact prefix on the message
+    /// round-trip — keep the two in lockstep.
+    #[error("stale plan: {0}")]
     StalePlan(String),
     /// An authenticated peer is not authorized for the requested operation
     /// (W2.6: admin ops are gated on the daemon-verified peer identity, not on
@@ -135,6 +137,20 @@ mod tests {
         let id = MemoryId::new();
         let e = Error::NotFound(id.clone());
         assert_eq!(e.to_string(), format!("memory not found: {id}"));
+    }
+
+    #[test]
+    fn stale_plan_display_is_subsystem_neutral() {
+        // #501 review follow-up: StalePlan is produced by review resolutions
+        // AND the guarded supersede (consolidation, remember-fold, near-dup
+        // suppression), so the Display must not claim "review" — operators
+        // grep daemon logs by this rendering. The wire kind stays
+        // `stale_plan`; rb-proto's prefix strip is held in lockstep by its
+        // `stale_plan_round_trips_verbatim` test.
+        assert_eq!(
+            Error::StalePlan("x was already resolved".into()).to_string(),
+            "stale plan: x was already resolved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Vikunja #501 (filed from two independent review findings): the general supersede path was under-guarded — `Store::supersede` accepted `old == new`, and its pointer UPDATE had no guard against overwriting an existing `superseded_by` pointer (only the archive half was idempotent). Direct DB access, admin scripts, or a raced writer could rewrite lineage or seed pointer cycles.

### What changed

- **One shared guarded primitive** (`SqliteStore::supersede_guarded_in_tx`, `crates/rb-store/src/store/core.rs`): pointer + archive + `updated_at` in ONE statement guarded by `WHERE superseded_by IS NULL AND archived_at IS NULL` with a rows-affected check, then vector prune (W1.7) and the `supersede` oplog row. The PR #63 review-merge guard (`supersede_unclaimed_in_tx` in `review.rs`) now **delegates** to it — single source of truth; only the error mapping stays review-specific (its keyed StalePlan message and semantics are unchanged, pinned by the existing `review_merge_is_all_or_nothing_when_a_supersede_pointer_is_taken` test).
- **Guard 1 — self-supersede**: `old == new` refused as `InvalidArgument` (statically invalid; would seed a pointer cycle). Wire kind `invalid_argument` (existing).
- **Guard 2 — set-once pointer**: re-supersede of an already superseded or archived old row refused as `StalePlan` (wire kind `stale_plan`, existing); a 0-rows guard miss is disambiguated from missing-old (`NotFound`, unchanged behavior).
- **Guard 3 — current-truth target**: the `new` target must be present, active, and not itself superseded. This is the write-side cycle defense: with set-once pointers and `old != new`, the last edge of any would-be cycle targets an already-superseded row and is refused (A→B then B→A is blocked HERE — the old-row guard alone does not block it, because B is still active and unclaimed). Missing `new` upgrades from an FK `Storage` error to a precise `NotFound`; the FK stays as belt-and-suspenders.

### Semantics decision: archived-old re-supersede

Previously silently allowed (pointer planted on a retired row). Now a `StalePlan` **error**, not a no-op-with-signal: archived means deliberately retired (explicit forget or retention), so a supersede plan against it was formed on a stale view; planting a lineage pointer would fabricate a decision-evolution step on the W2.2 audit surface (`rusty-brain history` derives the timeline from these pointers), and the store's `Result<()>` cannot carry a signal without a wire shape change. All exposed callers are already tolerant (below).

### Caller-compatibility audit

| Caller | Path | Result |
|---|---|---|
| CLI/MCP `remember --supersedes` | `server.rs` fold | best-effort (warn, new memory kept, lineage preserved) — e2e added |
| SessionEnd fold | `rb-hooks/capture.rs` → fold | chains ids (never re-supersedes); fail-open re-send of a stale id now warns instead of rewriting the pointer |
| Hook near-dup suppression | `suppress_hook_near_duplicates` | best-effort per candidate (warn + continue) |
| Consolidation job | `jobs/consolidation.rs` | **needed the tolerant variant**: `supersede_member` skips-and-continues on `StalePlan` (counted `skipped`) instead of aborting the pass; other errors still fail it — tested |
| Review merge | `review.rs` | delegates to the shared primitive; semantics unchanged |
| Daemon `WriteCommand::Supersede` | `store_handle.rs` | inherits the guards; no event published on refusal — pinned |
| Import/restore, oplog | n/a | no supersede re-application path exists |

### Wire contract

Additive-only: no new ops, no new error kinds (`invalid_argument`, `stale_plan`, `not_found` all pre-exist). `rb-contract-guard check` passes against the unchanged snapshot. The `Error::StalePlan` doc comment is generalized (Display prefix kept stable for the round-trip strip).

### History read-side defense

Cycle/self-loop fixtures in `store/history.rs` now plant corrupt pointers via raw SQL (`force_supersede` helper) since the write path refuses them — proving the CTE cycle defense still holds as belt-and-suspenders against direct-DB corruption.

## Test plan

- RED-first TDD for every guard: `supersede_rejects_self_supersede`, `supersede_rejects_already_superseded_old_and_keeps_the_pointer`, `supersede_rejects_archived_old`, `supersede_rejects_non_current_new_target`, `supersede_missing_new_target_is_not_found` (rb-store); `supersede_member_reports_changed_on_the_happy_path`, `supersede_member_skips_a_concurrently_resolved_member` (consolidation); `store_handle_supersede_rejects_self_and_resolved_rows` (daemon writer); `remember_superseding_an_already_resolved_row_keeps_new_and_lineage` (wire e2e)
- Happy paths unchanged (existing supersede, review-merge, history, consolidation suites all green)
- Gates: `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓, `cargo test --workspace` ✓ (1706 passed), `cargo deny check` ✓, `cargo run -p rb-contract-guard -- check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Supersede operations now prevent self-links, cycles, and changes to already-resolved records.
  - Existing lineage is preserved when a duplicate or outdated supersede request is rejected.
  - Clearer outcomes are provided for missing, stale, or invalid targets.

- **Improvements**
  - Consolidation now skips supersede conflicts caused by concurrent changes and continues processing remaining records.
  - Rejected operations no longer partially modify records or publish change events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->