### PR TITLE
fix(ci): allow cargo-audit to report push checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
-# CI only reads the repo; no job needs write access to anything.
+# CI reads the repo by default. The cargo-audit job has the sole write
+# exception: rustsec/audit-check creates a GitHub check run on push events.
 permissions:
   contents: read
 
@@ -118,6 +119,12 @@ jobs:
   audit:
     name: cargo-audit
     runs-on: ubuntu-latest
+    # rustsec/audit-check reports its result through the Checks API on push.
+    # Without this job-scoped grant, a clean audit still fails afterward with
+    # "Resource not accessible by integration" while creating the check run.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

- grant `checks: write` only to the `cargo-audit` job while preserving the workflow-wide `contents: read` default
- document why the push event needs the exception
- leave vulnerability failure semantics and the accepted optional-local `paste` advisory treatment unchanged

## Root cause

`rustsec/audit-check` completed the audit successfully on main, then failed while calling the Checks API with `Resource not accessible by integration`. The global read-only token was sufficient for pull-request execution but not for the action's push-event check-run creation.

## Impact

A clean audit can report its result on pushes to main without granting write access to unrelated CI jobs.

## Validation

- `actionlint .github/workflows/ci.yml`
- `cargo audit` — exits 0 with only the documented `RUSTSEC-2024-0436` optional-local warning
- `git diff --check`

The Vikunja #51 acceptance gate remains open until this PR and its post-merge main run are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI workflow permissions and documented the exception for security audit check reporting.
  * Updated the audit job configuration to support publishing check results successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->