### PR TITLE
feat(eval): retain complete scorecard MIE diagnostics

### DIFF
--- a/.github/workflows/memory-scorecard.yml
+++ b/.github/workflows/memory-scorecard.yml
@@ -20,9 +20,11 @@
 # is_error), followed by Class B capture fields
 # (cap_fidelity/cap_reason/cap_summary_count/cap_mcp_bypass_count). It contains
 # counts, costs, booleans, and bounded reason codes, not model free-text.
-# On FAILURE it additionally uploads the per-session logs the harness retained
-# via --log-dir (Vikunja #502) so a red safety gate is diagnosable; these are
-# model/session transcripts and daemon logs, never key material.
+# On FAILURE it additionally uploads the per-session evidence the harness
+# retained via --log-dir (Vikunja #502): model/session transcripts, daemon
+# logs, exact SessionStart/prompt-time injections, raw active/archived recall
+# candidates (ids, states, scores, channel flags), and supersede histories.
+# These diagnostics are synthetic scorecard data and never key material.
 #
 # Required repository secret:
 #   ANTHROPIC_API_KEY — each session runs --model haiku --max-budget-usd 0.50.
@@ -169,13 +171,14 @@ jobs:
           case "$RUNS_INPUT" in
             ''|*[!0-9]*|0) echo "::error::'runs' must be a positive integer (got '$RUNS_INPUT')"; exit 1 ;;
           esac
-          # --log-dir retains the per-session logs (stream-json session logs,
-          # judged text, memory-on daemon logs) that the harness otherwise
-          # deletes with its workroot — the 2026-07-12 N=5 safety-gate MIEs
-          # were undiagnosable without them (Vikunja #502). They are uploaded
-          # only on failure (below) and carry no key material: claude -p
-          # stream-json never echoes ANTHROPIC_API_KEY, and the rusty-brain
-          # daemon never receives it.
+          # --log-dir retains the per-session evidence (stream-json session
+          # logs, judged text, daemon logs, exact hook injections, raw ranked
+          # candidates/states/channels, and supersede histories) that the
+          # harness otherwise deletes with its workroot. The first 2026-07-12
+          # N=5 safety-gate MIEs were undiagnosable without this evidence
+          # (Vikunja #502). It is uploaded only on failure (below) and carries
+          # no key material: claude -p never echoes ANTHROPIC_API_KEY, the
+          # daemon never receives it, and the scorecard corpus is synthetic.
           scripts/memory-scorecard.sh \
             --bin-dir target/release \
             --runs "$RUNS_INPUT" \
@@ -190,7 +193,7 @@ jobs:
           path: ${{ runner.temp }}/memory-scorecard.tsv
           if-no-files-found: ignore
 
-      - name: Upload per-session logs (failure diagnosis, Vikunja #502)
+      - name: Upload per-session diagnostics (failure diagnosis, Vikunja #502)
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ### Fixed — Freshness memory-induced errors: injection framing (Vikunja #502)
 
+- **Safety gate recovered on the paid N=5 reread**: GitHub Actions run
+  `29210642539` on main @ `2d46dd1c` completed `SAFE` with **zero
+  memory-induced errors**. Freshness still passed (memory-on 60%, realistic
+  0%, steelman 45%); its unsuccessful rows were ordinary misses, not stale
+  answers. Capture and retrieval-at-scale each missed their tracked,
+  non-gating steelman comparison and remain evaluation work rather than safety
+  regressions.
 - **Mechanism established** for the 2026-07-12 N=5 scorecard safety-gate RED
   (`freshness/fresh-test-runner`, memory-on runs 3 and 4): NOT an
   archived-value leak and NOT a recall miss — a deterministic local
@@ -112,13 +119,24 @@ All notable changes to rusty-brain are documented here. The format is based on
   harness deleted its workroot unconditionally, which made the MIEs
   undiagnosable. Opt-in retention via `--log-dir DIR` or
   `RB_SCORECARD_KEEP_LOGS=1` (anchored to `--out`; `resolve_log_dir` fails
-  closed without an anchor or when the `--out` directory is missing) copies
-  exactly the harness-written logs by name (`work.jsonl`, `plant.jsonl`,
-  `judge.txt`, `daemon.log` — no store DBs, no seeded CLAUDE.md, no stray
-  files, no key material) out before cleanup, warning per failed file;
+  closed without an anchor or when the `--out` directory is missing) copies a
+  strict allowlist of harness-written session logs (`work.jsonl`,
+  `plant.jsonl`, `judge.txt`, `daemon.log`) and diagnostic JSON — no store DBs,
+  no seeded CLAUDE.md, no arbitrary files, no key material — out before
+  cleanup, warning per failed file;
   `memory-scorecard.yml` retains them and uploads a
   `memory-scorecard-session-logs` artifact on failure. Exercised by
   `--self-test`.
+- **Failure evidence now closes the diagnostic loop**: before each memory-on
+  model session, the harness uses only read-only `context`, `recall`, and
+  `history` paths plus the real hook binary to retain the exact SessionStart
+  digest, prompt-time injection, active/archived candidates (ids, state,
+  scores, and channel contribution flags), planted ids, and full supersede
+  histories. An outcome record deterministically classifies any future MIE as
+  stale content surfaced, current chain head missed, current evidence ignored,
+  or no evidence/model guess. The strict retention allowlist admits only those
+  harness-authored files; model-created files, DBs, and arbitrary JSON remain
+  excluded. No rank, prompt budget, or stored state changes.
 
 ### Added — Guided contradiction/dedup review (PRD 2026-07-02)
 

--- a/docs/eval/2026-07-12-w35-scorecard-n5-run.md
+++ b/docs/eval/2026-07-12-w35-scorecard-n5-run.md
@@ -1,8 +1,8 @@
 # W3.5 memory-value scorecard — first full N=5 measured run (Classes A, B, C, R)
 
-- **Status:** **MEASURED — safety gate RED, scorecard 3/4 dimensions pass.**
-  First complete N=5 read of the unified scorecard, closing the "landed,
-  unmeasured" state recorded in
+- **Status:** **MEASURED — first read RED; post-fix N=5 reread SAFE with zero
+  memory-induced errors.** First complete N=5 read of the unified scorecard,
+  closing the "landed, unmeasured" state recorded in
   `docs/eval/2026-06-23-w35-scorecard-closeout.md`. Delivers Vikunja #381
   (Class A + ADR-3), #382 (Class B), and #383 (Class R).
 - **Date:** 2026-07-12.
@@ -16,7 +16,36 @@
   required to run at all: PR #65 (claude 2.1.x workspace-trust gate;
   `write_claude_md` `set -e` latent kill).
 
-## Verdict summary
+## Recovery reread after PR #70 (Vikunja #502)
+
+- **Run URL:** <https://github.com/brianluby/rusty-brain/actions/runs/29210642539>
+  (`memory-scorecard.yml`, `runs=5`, main @ `2d46dd1c`).
+- **Result:** workflow and scorecard step succeeded; `SAFETY — memory-induced
+  errors: 0 (allowed 0)` and `result: SAFE`.
+- **Freshness:** memory-on 60% [38.7–78.1], realistic 0%, steelman 45%,
+  memory-off 5%; beats realistic and ties steelman, so the dimension passes.
+  The eight unsuccessful memory-on rows were ordinary misses (`mie=0`), not
+  stale answers.
+- **Tracked scorecard:** reach and freshness pass; capture and
+  retrieval-at-scale miss their steelman comparisons, so 2/4 dimensions pass.
+  Those dimensions are deliberately non-gating and do not weaken the recovered
+  safety result. Direct capture fidelity remains 15/15 (100% [79.6–100.0]).
+- **Retrieval-at-scale reading:** memory-on 20% vs steelman 40%; cost remains
+  favorable ($0.0131 vs $0.0368), but accuracy loses. The run correctly says
+  to investigate retrieval rather than caching. This is input to the
+  preregistered production-embedding gate, not a reason to alter ranking under
+  #502.
+
+The reread satisfies #502's live zero-MIE criterion and confirms the PR #70
+framing fix. It does not retroactively change the first-run measurements below;
+they remain the evidence that triggered the safety response. The run was green,
+so failure-only session diagnostics were intentionally not uploaded. The
+follow-up harness now captures exact hook injections, raw candidate ids/states/
+scores/channels, planted ids, and supersede histories for any future red run,
+with a deterministic four-way MIE classification and no ranking or token-budget
+change.
+
+## First-run verdict summary (historical trigger)
 
 | axis | reading | verdict |
 |---|---|---|
@@ -25,10 +54,11 @@
 | Class B capture fidelity (report-only) | **15/15 = 100%** [79.6–100.0], target >= 80% | met |
 | ADR-3 (Class A cost methodology) | accuracy 0.47 vs steelman 0.33 AND cost $0.0132 vs $0.0376 | **RATIFY Opt 3** |
 
-The run exits non-zero **by design**: the safety gate is the only hard gate and
-it fired. Everything below is the honest read the gate exists to force.
+The first run exited non-zero **by design**: the safety gate is the only hard
+gate and it fired. Everything below preserves the honest first-run read that
+forced the safety response; the recovery reread above is the current verdict.
 
-## Scorecard (N=5 per scenario/arm; success rate [Wilson 95% CI], median turns [Q1–Q3], mean cost $/session)
+## First-run scorecard (N=5 per scenario/arm; success rate [Wilson 95% CI], median turns [Q1–Q3], mean cost $/session)
 
 ```
 dimension       arm                 runs success [95% CI] med_turns [Q1-Q3]    mcost$
@@ -57,7 +87,7 @@ retrieval_scale memory-off            15     7% [1.2-29.8]       1.0 [1.0-2.5]  
   -> retrieval_scale: beats_realistic=yes ties_steelman=yes  => PASS
 ```
 
-## SAFETY — the gate that fired (delivers the honest half of Vikunja #382/#383's "only MIE gates")
+## SAFETY — the first-run gate that fired (historical)
 
 Two memory-induced errors, both `freshness/fresh-test-runner` (memory-on, runs
 3 and 4): the session answered the **superseded** `cargo test` with no mention
@@ -101,8 +131,9 @@ memory. The preamble now states an UNCONDITIONAL never-execute rule first
 (hostile fact-shaped content stays covered), then a preference scoped to
 ANSWERING (recorded decisions beat generic defaults; superseded records
 excluded; disputes labeled `[contested]` — see docs/THREAT_MODEL.md).
-Residual model variance under the reworded frame is a paid N>=5 re-read away
-and remains an orchestrator decision if the gate stays red.
+Residual model variance required a paid N>=5 reread. The recovery run above
+completed SAFE at zero MIE, so no orchestrator exception or ranking treatment
+is warranted.
 
 ## Class B — capture fidelity (Vikunja #382)
 
@@ -154,11 +185,16 @@ at all is memory (and it also edges the steelman, whose CLAUDE.md B does see).
 **Proxy evidence only**: this simulates reach on one machine and does not prove
 the Phase 5 two-user/two-machine pilot.
 
-## What this closes and what it opens
+## What the first run and recovery reread close and open
 
 - Closes: Vikunja #381, #382, #383 (the "landed, unmeasured" deferrals from
   the 2026-06-23 closeout) — measured artifacts now exist for A, B, and R.
-- Opens: **Vikunja #502** — investigate and fix the `fresh-test-runner`
-  memory-induced errors (safety gate is RED until a re-run reads 0 MIE).
-- The nightly cron now runs this same gate; expect it to stay red until #502
-  lands, which is the intended pressure.
+- Resolves #502's live safety gate: PR #70 identified mechanism (c), hardened
+  the injection frame, and the recovery reread returned zero MIE. The task can
+  close when the diagnostic-evidence follow-up described above lands.
+- Continues the non-gating quality work under the preregistered production-
+  embedding gate: the recovery run's retrieval-at-scale accuracy lost to the
+  steelman even though cost remained favorable. Do not treat that signal as a
+  reason to reopen #502 or apply an unconditional rank boost.
+- The weekly cron continues to enforce zero MIE. Any future red run now retains
+  enough evidence to classify the failure without guessing at its mechanism.

--- a/docs/eval/2026-07-12-w35-scorecard-n5-run.md
+++ b/docs/eval/2026-07-12-w35-scorecard-n5-run.md
@@ -190,8 +190,8 @@ the Phase 5 two-user/two-machine pilot.
 - Closes: Vikunja #381, #382, #383 (the "landed, unmeasured" deferrals from
   the 2026-06-23 closeout) — measured artifacts now exist for A, B, and R.
 - Resolves #502's live safety gate: PR #70 identified mechanism (c), hardened
-  the injection frame, and the recovery reread returned zero MIE. The task can
-  close when the diagnostic-evidence follow-up described above lands.
+  the injection frame, the recovery reread returned zero MIE, and this PR lands
+  the diagnostic-evidence follow-up described above, closing the task.
 - Continues the non-gating quality work under the preregistered production-
   embedding gate: the recovery run's retrieval-at-scale accuracy lost to the
   steelman even though cost remained favorable. Do not treat that signal as a

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -589,17 +589,23 @@ finalize_memory_diagnostics() { # dir success mie expect stale
 # accepted only below an `on/diagnostics` directory, preventing a model-created
 # arbitrary file elsewhere in the work project from entering the CI artifact.
 retainable_scorecard_artifact() { # relative_path
-  case "$1" in
-    work.jsonl|*/work.jsonl|plant.jsonl|*/plant.jsonl|\
-    judge.txt|*/judge.txt|daemon.log|*/daemon.log) return 0 ;;
-    */on/diagnostics/index.json|*/on/diagnostics/outcome.json|\
-    */on/diagnostics/context.json|*/on/diagnostics/recall-active.json|\
-    */on/diagnostics/recall-archived.json|*/on/diagnostics/planted.jsonl|\
-    */on/diagnostics/session-start-input.json|*/on/diagnostics/session-start-injection.json|\
-    */on/diagnostics/prompt-time-input.json|*/on/diagnostics/prompt-time-injection.json|\
-    */on/diagnostics/history-*.json) return 0 ;;
-    *) return 1 ;;
-  esac
+  local rel="$1"
+  # Fixed-depth regexes matter: shell case globs let `*` match `/`, so a path
+  # like `fresh-r1/on/wp/on/diagnostics/index.json` (inside the model-writable
+  # project) would otherwise masquerade as a harness-owned artifact.
+  if [[ "$rel" =~ ^[^/]+/(on|realistic|steelman|off)/(work\.jsonl|judge\.txt)$ ]]; then
+    return 0
+  fi
+  if [[ "$rel" =~ ^[^/]+/on/(plant\.jsonl|daemon\.log)$ ]]; then
+    return 0
+  fi
+  if [[ "$rel" =~ ^[^/]+/on/diagnostics/(index\.json|outcome\.json|context\.json|recall-active\.json|recall-archived\.json|planted\.jsonl|session-start-input\.json|session-start-injection\.json|prompt-time-input\.json|prompt-time-injection\.json)$ ]]; then
+    return 0
+  fi
+  if [[ "$rel" =~ ^[^/]+/on/diagnostics/history-[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\.json$ ]]; then
+    return 0
+  fi
+  return 1
 }
 
 # ---- session-log retention (pure; exercised by --self-test) -------------------
@@ -1056,6 +1062,9 @@ PY
   printf '[]\n'                > "$lw/fresh-r1/on/diagnostics/recall-active.json"
   printf '{}\n'                > "$lw/fresh-r1/on/diagnostics/history-00000000-0000-0000-0000-000000000000.json"
   printf 'must-drop\n'         > "$lw/fresh-r1/on/diagnostics/unexpected.txt"
+  mkdir -p "$lw/fresh-r1/on/wp/on/diagnostics"
+  printf 'model-spoof\n'       > "$lw/fresh-r1/on/wp/on/diagnostics/index.json"
+  printf 'model-spoof\n'       > "$lw/fresh-r1/realistic/p/work.jsonl"
   if preserve_session_logs "$lw" "$ld"; then
     echo "ok: preserve_session_logs succeeds on a populated workroot"
   else
@@ -1067,7 +1076,7 @@ PY
   for kept in fresh-r1/on/diagnostics/index.json fresh-r1/on/diagnostics/outcome.json fresh-r1/on/diagnostics/recall-active.json fresh-r1/on/diagnostics/history-00000000-0000-0000-0000-000000000000.json; do
     if [ -f "$ld/$kept" ]; then echo "ok: preserve_session_logs kept $kept"; else echo "BUG: preserve_session_logs lost $kept"; fail=1; fi
   done
-  for dropped in fresh-r1/on/memory.db fresh-r1/realistic/p/CLAUDE.md fresh-r1/on/other.jsonl fresh-r1/on/diagnostics/unexpected.txt; do
+  for dropped in fresh-r1/on/memory.db fresh-r1/realistic/p/CLAUDE.md fresh-r1/on/other.jsonl fresh-r1/on/diagnostics/unexpected.txt fresh-r1/on/wp/on/diagnostics/index.json fresh-r1/realistic/p/work.jsonl; do
     if [ ! -e "$ld/$dropped" ]; then echo "ok: preserve_session_logs drops $dropped"; else echo "BUG: preserve_session_logs copied non-log $dropped"; fail=1; fi
   done
   # An empty workroot is not an error: retention must never break the run.
@@ -1083,9 +1092,9 @@ PY
   # best-effort. An unreadable source file forces the failure deterministically.
   if [ "$(id -u)" != "0" ]; then # root ignores mode bits; skip there
     local lwf="$tmp/logs-fail" ldf="$tmp/logs-fail-dest" perr
-    mkdir -p "$lwf"
-    printf 'ok\n'     > "$lwf/work.jsonl"
-    printf 'secret\n' > "$lwf/daemon.log"; chmod 000 "$lwf/daemon.log"
+    mkdir -p "$lwf/fresh-r1/on"
+    printf 'ok\n'     > "$lwf/fresh-r1/on/work.jsonl"
+    printf 'secret\n' > "$lwf/fresh-r1/on/daemon.log"; chmod 000 "$lwf/fresh-r1/on/daemon.log"
     if perr="$(preserve_session_logs "$lwf" "$ldf" 2>&1)"; then
       echo "BUG: preserve_session_logs must return non-zero when a copy fails"; fail=1
     else
@@ -1096,12 +1105,12 @@ PY
     else
       echo "BUG: preserve_session_logs warning must name the failed file"; printf '%s\n' "$perr"; fail=1
     fi
-    if [ -f "$ldf/work.jsonl" ]; then
+    if [ -f "$ldf/fresh-r1/on/work.jsonl" ]; then
       echo "ok: preserve_session_logs keeps copying past a failed file"
     else
       echo "BUG: preserve_session_logs must not stop at the first failure"; fail=1
     fi
-    chmod 644 "$lwf/daemon.log"
+    chmod 644 "$lwf/fresh-r1/on/daemon.log"
   fi
 
   # resolve_log_dir: the --log-dir/RB_SCORECARD_KEEP_LOGS wiring is a pure

--- a/scripts/memory-scorecard.sh
+++ b/scripts/memory-scorecard.sh
@@ -33,8 +33,10 @@
 # every per-session stream-json log) is deleted on exit, which made the
 # 2026-07-12 N=5 safety-gate MIEs undiagnosable. Opt in to retention with
 # `--log-dir DIR` (retain there) or `RB_SCORECARD_KEEP_LOGS=1` (retain under
-# `<dir of --out>/scorecard-session-logs`). Retained files are log-shaped only
-# and carry no key material (see preserve_session_logs).
+# `<dir of --out>/scorecard-session-logs`). Retained files are log-shaped only:
+# model/session logs plus the harness-authored read-only recall diagnostics
+# needed to classify a future MIE. They carry no key material (see
+# preserve_session_logs).
 #
 # Usage:
 #   memory-scorecard.sh --self-test                       # judge + aggregation math, no API
@@ -489,14 +491,127 @@ reach_identity_paths() { # memory_on_base -> ha<TAB>pa<TAB>hb<TAB>pb
   printf '%s\t%s\t%s\t%s\n' "$mb/ha" "$mb/pa" "$mb/hb" "$mb/pb"
 }
 
+# Classify a memory-on safety failure using the exact injected text captured by
+# the diagnostic hook probes. The four values are the mutually exclusive
+# categories required by Vikunja #502's HOLA-informed refinement. Non-MIE rows
+# are deliberately outside that taxonomy.
+classify_mie() { # mie stale_present current_present any_memory_present
+  local mie="$1" stale_present="$2" current_present="$3" any_present="$4"
+  if [ "$mie" != "1" ]; then printf 'no_memory_induced_error\n'; return 0; fi
+  if [ "$stale_present" = "1" ]; then printf 'archived_or_stale_content_surfaced\n'; return 0; fi
+  if [ "$current_present" = "1" ]; then printf 'current_evidence_surfaced_but_ignored\n'; return 0; fi
+  if [ "$any_present" = "1" ]; then printf 'current_chain_head_missed\n'; return 0; fi
+  printf 'no_memory_evidence_surfaced_model_guessed\n'
+}
+
+# Capture the exact read-side evidence a scorecard work session is about to
+# see. Every operation here is read-only: context, recall, history, and the two
+# hook injection paths issue no writer ops. Running them before the paid model
+# session therefore cannot perturb the planted store, scores, prompt budget, or
+# answer. The direct hook outputs are the final injected text; the raw CLI JSON
+# carries candidate ids/states, scores, and per-channel contribution flags.
+capture_memory_diagnostics() { # home project query diagnostics_dir planted_jsonl
+  local home="$1" project="$2" query="$3" dir="$4" planted="$5"
+  mkdir -p "$dir"
+  [ -f "$planted" ] || : > "$planted"
+  (
+    export HOME="$home" PATH="$BIN_DIR:$PATH"
+    # These read-only probes never call the model. Strip the paid API secret so
+    # neither the CLI nor hook diagnostics can receive it, much less log it.
+    unset ANTHROPIC_API_KEY
+    rusty-brain --json context > "$dir/context.json"
+    rusty-brain --json recall "$query" --limit 5 > "$dir/recall-active.json"
+    rusty-brain --json recall "$query" --limit 5 --archived > "$dir/recall-archived.json"
+
+    local sid="scorecard-diagnostic" transcript="$dir/transcript.jsonl"
+    jq -cn --arg sid "$sid" --arg transcript "$transcript" --arg cwd "$project" \
+      '{session_id:$sid,transcript_path:$transcript,cwd:$cwd,hook_event_name:"SessionStart",source:"startup"}' \
+      > "$dir/session-start-input.json"
+    rusty-brain-hooks --agent claude-code \
+      < "$dir/session-start-input.json" > "$dir/session-start-injection.json"
+
+    jq -cn --arg sid "$sid" --arg transcript "$transcript" --arg cwd "$project" --arg prompt "$query" \
+      '{session_id:$sid,transcript_path:$transcript,cwd:$cwd,permission_mode:"acceptEdits",hook_event_name:"UserPromptSubmit",prompt:$prompt}' \
+      > "$dir/prompt-time-input.json"
+    rusty-brain-hooks --agent claude-code \
+      < "$dir/prompt-time-input.json" > "$dir/prompt-time-injection.json"
+
+    # History every planted or ranked candidate. Anchoring on both an archived
+    # predecessor and its active head makes the full supersede-chain ids
+    # durable even if one side did not rank for this exact query.
+    {
+      jq -r '.id // empty' "$planted"
+      jq -r '.[].memory.id // empty' "$dir/recall-active.json"
+      jq -r '.[].memory.id // empty' "$dir/recall-archived.json"
+    } | sort -u | while IFS= read -r memory_id; do
+      [ -n "$memory_id" ] || continue
+      rusty-brain --json history "$memory_id" > "$dir/history-$memory_id.json"
+    done
+
+    jq -n --arg query "$query" --arg namespace "${RUSTY_BRAIN_NAMESPACE:-}" \
+      '{schema_version:1,query:$query,namespace:$namespace,recall_limit:5,
+        evidence:{context:"context.json",active_candidates:"recall-active.json",
+        archived_candidates:"recall-archived.json",planted_chain:"planted.jsonl",
+        session_start_input:"session-start-input.json",
+        session_start_injection:"session-start-injection.json",
+        prompt_time_input:"prompt-time-input.json",
+        prompt_time_injection:"prompt-time-injection.json",
+        histories:"history-<memory-id>.json"}}' > "$dir/index.json"
+  )
+}
+
+# Add the scored outcome and the deterministic MIE classification to the
+# pre-session evidence. The model output remains in the sibling judge.txt file;
+# this compact JSON records only booleans/reason codes and never key material.
+finalize_memory_diagnostics() { # dir success mie expect stale
+  local dir="$1" success="$2" mie="$3" expect="$4" stale="$5"
+  [ -d "$dir" ] || return 0
+  local injected stale_present=0 current_present=0 any_present=0 classification
+  injected="$(
+    jq -r '.hookSpecificOutput.additionalContext // .systemMessage // ""' \
+      "$dir/session-start-injection.json" "$dir/prompt-time-injection.json" 2>/dev/null || true
+  )"
+  [ -z "$injected" ] || any_present=1
+  if [ -n "$stale" ] && grep -qiF -- "$stale" <<<"$injected"; then stale_present=1; fi
+  if [ -n "$expect" ] && grep -qiF -- "$expect" <<<"$injected"; then current_present=1; fi
+  classification="$(classify_mie "$mie" "$stale_present" "$current_present" "$any_present")"
+  jq -n --argjson success "$success" --argjson mie "$mie" \
+    --arg classification "$classification" \
+    --argjson stale_present "$stale_present" --argjson current_present "$current_present" \
+    --argjson any_present "$any_present" \
+    '{success:$success,memory_induced_error:$mie,classification:$classification,
+      injected_stale_evidence:($stale_present == 1),
+      injected_current_evidence:($current_present == 1),
+      injected_any_memory:($any_present == 1)}' > "$dir/outcome.json"
+}
+
+# Strict allowlist for retained scorecard artifacts. Diagnostic names are
+# accepted only below an `on/diagnostics` directory, preventing a model-created
+# arbitrary file elsewhere in the work project from entering the CI artifact.
+retainable_scorecard_artifact() { # relative_path
+  case "$1" in
+    work.jsonl|*/work.jsonl|plant.jsonl|*/plant.jsonl|\
+    judge.txt|*/judge.txt|daemon.log|*/daemon.log) return 0 ;;
+    */on/diagnostics/index.json|*/on/diagnostics/outcome.json|\
+    */on/diagnostics/context.json|*/on/diagnostics/recall-active.json|\
+    */on/diagnostics/recall-archived.json|*/on/diagnostics/planted.jsonl|\
+    */on/diagnostics/session-start-input.json|*/on/diagnostics/session-start-injection.json|\
+    */on/diagnostics/prompt-time-input.json|*/on/diagnostics/prompt-time-injection.json|\
+    */on/diagnostics/history-*.json) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ---- session-log retention (pure; exercised by --self-test) -------------------
 # preserve_session_logs <workroot> <dest>: copy the diagnosable per-session
 # artifacts out of the ephemeral workroot into <dest>, preserving relative
 # paths, before cleanup deletes the workroot (Vikunja #502: the 2026-07-12 N=5
 # safety-gate MIEs were undiagnosable because every session log was rm -rf'd).
-# Copies ONLY the files the harness itself writes, matched BY NAME — the
+# Copies ONLY the files the harness itself writes, selected by the strict
+# allowlist above — the
 # claude stream-json session logs (work.jsonl / plant.jsonl), the judged model
-# output (judge.txt), and the memory-on daemon log (daemon.log) — never store
+# output (judge.txt), memory-on daemon log (daemon.log), and read-only diagnostic
+# JSON — never store
 # DBs, seeded CLAUDE.md files, or stray *.jsonl the harness did not write
 # (PR #70 Copilot), so the retained tree stays small and log-shaped.
 # Best-effort per file: a failed copy WARNS naming the file and the function
@@ -510,13 +625,12 @@ preserve_session_logs() { # workroot dest
   local f rel
   while IFS= read -r -d '' f; do
     rel="${f#"$workroot"/}"
+    retainable_scorecard_artifact "$rel" || continue
     if ! { mkdir -p "$dest/$(dirname "$rel")" && cp "$f" "$dest/$rel"; } 2>/dev/null; then
       echo "WARN: session-log retention failed to copy $rel" >&2
       failed=1
     fi
-  done < <(find "$workroot" -type f \
-             \( -name 'work.jsonl' -o -name 'plant.jsonl' \
-                -o -name 'judge.txt' -o -name 'daemon.log' \) -print0)
+  done < <(find "$workroot" -type f -print0)
   return "$failed"
 }
 
@@ -913,14 +1027,23 @@ PY
     echo "BUG: complete gating run mis-handled"; echo "$fout"; fail=1
   fi
 
+  # Vikunja #502 failure taxonomy: the classifier is deliberately ordered so
+  # stale evidence wins over current evidence when both somehow appear.
+  check "MIE classifier: no MIE" "no_memory_induced_error" "$(classify_mie 0 0 0 0)"
+  check "MIE classifier: stale surfaced" "archived_or_stale_content_surfaced" "$(classify_mie 1 1 1 1)"
+  check "MIE classifier: current ignored" "current_evidence_surfaced_but_ignored" "$(classify_mie 1 0 1 1)"
+  check "MIE classifier: chain head missed" "current_chain_head_missed" "$(classify_mie 1 0 0 1)"
+  check "MIE classifier: no evidence/guess" "no_memory_evidence_surfaced_model_guessed" "$(classify_mie 1 0 0 0)"
+
   # Session-log retention (Vikunja #502): preserve_session_logs copies the
   # diagnosable per-session artifacts (claude stream-json logs, judged text,
-  # daemon logs) out of a workroot into a destination, preserving relative
+  # daemon logs, exact hook injections, candidates, states, and histories) out
+  # of a workroot into a destination, preserving relative
   # paths — and copies NOTHING else (no store DBs, no seeded CLAUDE.md, and —
   # PR #70 Copilot — no stray *.jsonl the harness did not write), so the
   # retained artifact stays small and log-shaped.
   local lw="$tmp/logs-workroot" ld="$tmp/logs-dest"
-  mkdir -p "$lw/fresh-r1/on" "$lw/fresh-r1/realistic/p"
+  mkdir -p "$lw/fresh-r1/on/diagnostics" "$lw/fresh-r1/realistic/p"
   printf '{"type":"result"}\n' > "$lw/fresh-r1/on/work.jsonl"
   printf 'plant\n'             > "$lw/fresh-r1/on/plant.jsonl"
   printf 'daemon\n'            > "$lw/fresh-r1/on/daemon.log"
@@ -928,6 +1051,11 @@ PY
   printf 'db\n'                > "$lw/fresh-r1/on/memory.db"
   printf 'seeded\n'            > "$lw/fresh-r1/realistic/p/CLAUDE.md"
   printf 'stray\n'             > "$lw/fresh-r1/on/other.jsonl"
+  printf '{}\n'                > "$lw/fresh-r1/on/diagnostics/index.json"
+  printf '{}\n'                > "$lw/fresh-r1/on/diagnostics/outcome.json"
+  printf '[]\n'                > "$lw/fresh-r1/on/diagnostics/recall-active.json"
+  printf '{}\n'                > "$lw/fresh-r1/on/diagnostics/history-00000000-0000-0000-0000-000000000000.json"
+  printf 'must-drop\n'         > "$lw/fresh-r1/on/diagnostics/unexpected.txt"
   if preserve_session_logs "$lw" "$ld"; then
     echo "ok: preserve_session_logs succeeds on a populated workroot"
   else
@@ -936,7 +1064,10 @@ PY
   for kept in fresh-r1/on/work.jsonl fresh-r1/on/plant.jsonl fresh-r1/on/daemon.log fresh-r1/realistic/judge.txt; do
     if [ -f "$ld/$kept" ]; then echo "ok: preserve_session_logs kept $kept"; else echo "BUG: preserve_session_logs lost $kept"; fail=1; fi
   done
-  for dropped in fresh-r1/on/memory.db fresh-r1/realistic/p/CLAUDE.md fresh-r1/on/other.jsonl; do
+  for kept in fresh-r1/on/diagnostics/index.json fresh-r1/on/diagnostics/outcome.json fresh-r1/on/diagnostics/recall-active.json fresh-r1/on/diagnostics/history-00000000-0000-0000-0000-000000000000.json; do
+    if [ -f "$ld/$kept" ]; then echo "ok: preserve_session_logs kept $kept"; else echo "BUG: preserve_session_logs lost $kept"; fail=1; fi
+  done
+  for dropped in fresh-r1/on/memory.db fresh-r1/realistic/p/CLAUDE.md fresh-r1/on/other.jsonl fresh-r1/on/diagnostics/unexpected.txt; do
     if [ ! -e "$ld/$dropped" ]; then echo "ok: preserve_session_logs drops $dropped"; else echo "BUG: preserve_session_logs copied non-log $dropped"; fail=1; fi
   done
   # An empty workroot is not an error: retention must never break the run.
@@ -1186,9 +1317,10 @@ PY
 # the model OUTPUT only: the final `.result` plus files written this session
 # (mtime newer than a marker, size-capped) — never the seeded CLAUDE.md, so the
 # baselines' planted distractors/target are not self-graded.
-score_session() { # dim id arm run proj home work expect forbid stale [cap_fidelity cap_reason cap_summary_count cap_mcp_bypass_count]
+score_session() { # dim id arm run proj home work expect forbid stale [cap_fidelity cap_reason cap_summary_count cap_mcp_bypass_count diagnostics_dir]
   local dim="$1" id="$2" arm="$3" run="$4" proj="$5" home="$6" work="$7" expect="$8" forbid="$9" stale="${10}"
   local cap_fidelity="${11:-na}" cap_reason="${12:-na}" cap_summary_count="${13:-0}" cap_mcp_bypass_count="${14:-0}"
+  local diagnostics_dir="${15:-}"
   local jlog="$proj/../work.jsonl" jtext="$proj/../judge.txt" marker="$proj/../mark"
   : > "$marker"
   run_session "$home" "$proj" "$work" "$jlog" --output-format stream-json --verbose
@@ -1208,6 +1340,9 @@ score_session() { # dim id arm run proj home work expect forbid stale [cap_fidel
   success="${res% *}"; mie="${res#* }"
   # A server-level error forces failure: it must never look like a cheap success.
   if [ "$is_err" = "true" ]; then success=0; fi
+  if [ "$arm" = "memory-on" ] && [ -n "$diagnostics_dir" ]; then
+    finalize_memory_diagnostics "$diagnostics_dir" "$success" "$mie" "$expect" "$stale"
+  fi
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$dim" "$id" "$arm" "$run" "$success" "$turns" "$mie" \
     "$cost" "$inp" "$cc" "$cr" "$out" "$is_err" \
@@ -1233,15 +1368,17 @@ score_session() { # dim id arm run proj home work expect forbid stale [cap_fidel
 # current value — explicit, no lossy auto-capture (P2). Class A plants a single
 # TARGET here (importance 8 so it surfaces over the importance-5 distractor corpus
 # planted by plant_corpus_distractors).
-plant_explicit() { # home (env: RUSTY_BRAIN_*) <facts-json-array>
-  local home="$1" facts="$2"
+plant_explicit() { # home (env: RUSTY_BRAIN_*) <facts-json-array> [diagnostic-manifest.jsonl]
+  local home="$1" facts="$2" manifest="${3:-}"
   ( export HOME="$home"; export PATH="$BIN_DIR:$PATH"
-    local n i content imp sup out last_id=""
+    local n i content imp sup out last_id="" prior_id=""
+    if [ -n "$manifest" ]; then mkdir -p "$(dirname "$manifest")"; : > "$manifest"; fi
     n="$(jq 'length' <<<"$facts")"
     for (( i=0; i<n; i++ )); do
       content="$(jq -r ".[$i].content" <<<"$facts")"
       imp="$(jq -r ".[$i].importance // 5" <<<"$facts")"
       sup="$(jq -r ".[$i].supersedes_prev // false" <<<"$facts")"
+      prior_id="$last_id"
       if [ "$sup" = "true" ] && [ -n "$last_id" ]; then
         out="$(rusty-brain --json remember "$content" --type insight --importance "$imp" --supersedes "$last_id")"
       else
@@ -1249,6 +1386,13 @@ plant_explicit() { # home (env: RUSTY_BRAIN_*) <facts-json-array>
       fi
       last_id="$(jq -r '.id // empty' <<<"$out" 2>/dev/null)"
       [ -n "$last_id" ] || { echo "ERROR: explicit plant did not return an id for fact $i" >&2; return 1; }
+      if [ -n "$manifest" ]; then
+        jq -cn --argjson index "$i" --arg id "$last_id" --arg prior "$prior_id" \
+          --argjson supersedes "$sup" --arg content "$content" \
+          '{index:$index,id:$id,content:$content,
+            supersedes:(if $supersedes and ($prior|length)>0 then $prior else null end)}' \
+          >> "$manifest"
+      fi
     done
   )
 }
@@ -1359,7 +1503,10 @@ run_scenario() { # row
       # only the SOCKET needs the short /tmp path (unix socket length limits).
       mkdir -p "$mb"
       derr="$mb/daemon.log"
-      rusty-brain serve >"$derr" 2>&1 &
+      # The scorecard shell needs ANTHROPIC_API_KEY for Claude sessions, but
+      # the memory daemon does not. Remove it from this child environment so a
+      # future daemon error path cannot include or expose the secret.
+      env -u ANTHROPIC_API_KEY rusty-brain serve >"$derr" 2>&1 &
       dpid=$!
       # shellcheck disable=SC2329 # Invoked by the EXIT trap below.
       cleanup_memory_on() {
@@ -1385,6 +1532,9 @@ run_scenario() { # row
         exit 1
       fi
       local cap_fidelity="na" cap_reason="na" cap_summary_count="0" cap_mcp_bypass_count="0"
+      local diagnostics_dir="$mb/diagnostics" plant_manifest="$mb/diagnostics/planted.jsonl"
+      mkdir -p "$diagnostics_dir"
+      : > "$plant_manifest"
       if [ "$dim" = "reach" ]; then
         # Identity A plants from its home only (plant_explicit needs no project),
         # so pa is intentionally unused; only B gets a project to be scored in.
@@ -1393,11 +1543,13 @@ run_scenario() { # row
         : "$pa" # tab-split placeholder; A needs no project dir
         seed_home "$ha"; seed_home "$hb" "$pb"
         install_rusty_brain "$hb" "$pb"; rm -f "$pb/CLAUDE.md"; rm -rf "$pb/.claude/skills"
-        plant_explicit "$ha" "$facts"
-        score_session "$dim" "$id" "memory-on" "$run" "$pb" "$hb" "$work" "$expect" "$forbid" "$stale"
+        plant_explicit "$ha" "$facts" "$plant_manifest"
+        capture_memory_diagnostics "$hb" "$pb" "$work" "$diagnostics_dir" "$plant_manifest"
+        score_session "$dim" "$id" "memory-on" "$run" "$pb" "$hb" "$work" "$expect" "$forbid" "$stale" \
+          "na" "na" "0" "0" "$diagnostics_dir"
       else
         if [ "$plant_mode" = "explicit" ]; then
-          plant_explicit "$wh" "$facts"
+          plant_explicit "$wh" "$facts" "$plant_manifest"
           # Class A: bury the planted target under the distractor corpus (bulk-load).
           plant_corpus_distractors "$wh" "$id" "$corpus"
         elif [ "$plant_mode" = "auto-capture" ]; then
@@ -1414,8 +1566,9 @@ run_scenario() { # row
           echo "ERROR: unknown plant_mode '$plant_mode' for $id" >&2
           exit 1
         fi
+        capture_memory_diagnostics "$wh" "$wp" "$work" "$diagnostics_dir" "$plant_manifest"
         score_session "$dim" "$id" "memory-on" "$run" "$wp" "$wh" "$work" "$expect" "$forbid" "$stale" \
-          "$cap_fidelity" "$cap_reason" "$cap_summary_count" "$cap_mcp_bypass_count"
+          "$cap_fidelity" "$cap_reason" "$cap_summary_count" "$cap_mcp_bypass_count" "$diagnostics_dir"
       fi
     )
     rm -rf "$sockdir" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- record the successful post-PR #70 N=5 reread: zero memory-induced errors and `SAFE`
- capture exact SessionStart and prompt-time injections before each memory-on session through read-only probes
- retain active/archived candidates with IDs, states, scores, channel flags, planted IDs, and supersede histories
- classify any future MIE as stale surfaced, current head missed, current evidence ignored, or no evidence/model guess
- keep a strict failure-artifact allowlist and strip `ANTHROPIC_API_KEY` from diagnostic probes and the memory daemon

## Why

The original red run could not distinguish a stale-memory leak from a recall miss or a model ignoring correct evidence because the workroot was deleted. PR #70 established the observed mechanism and recovered the live safety gate, while the updated Vikunja #50 criteria require enough durable evidence to classify any recurrence without inference.

## Impact

Diagnostics use only existing read-only `context`, `recall`, and `history` paths plus the real hook binary. They do not change ranking, stored state, injected-token budgets, or model-session behavior. Failure uploads remain synthetic scorecard evidence and exclude databases, arbitrary model-created files, and API keys.

## Validation

- GitHub Actions reread `29210642539`: `SAFETY — memory-induced errors: 0`, `result: SAFE`
- `bash -n scripts/memory-scorecard.sh`
- `shellcheck scripts/memory-scorecard.sh`
- `scripts/memory-scorecard.sh --self-test`
- `actionlint .github/workflows/memory-scorecard.yml`
- isolated two-fact supersede-chain integration: active `nextest`, archived `cargo test`, two histories, current-only hook injections
- explicit daemon child-environment check confirms `ANTHROPIC_API_KEY` is absent
- local CodeRabbit review findings addressed: historical verdict consistency and daemon secret inheritance

Tracks Vikunja rusty-brain #50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved the reported memory-induced error scenario following a successful recovery run with zero detected errors.
  * Clarified scorecard results so expected safety-gate misses are distinguished from stale-answer failures.

* **Diagnostics**
  * Failure reports now retain clearer, allowlisted session diagnostics, including relevant memory evidence and injection details.
  * Diagnostic artifacts are uploaded only when a scorecard run fails, supporting more reliable troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->