### PR TITLE
fix(store): fail closed on missing embedding model metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed — Legacy embedding-model metadata recovery
+
+- **Missing `meta.embedding_model` no longer silently adopts the configured
+  provider on a populated database.** Startup now inspects the distinct
+  per-row model stamps before seeding: an empty corpus or a single model that
+  matches the configured provider recovers automatically, while a conflicting
+  or mixed-model corpus fails closed with the existing
+  `--accept-model-change` + `reembed` remediation. The missing-marker recovery
+  runs under a write lock with revalidation; already-seeded opens keep their
+  read-only fast path.
+
 ### Changed — Supersede hardened at the source (#501)
 
 - **`Store::supersede` now guards every half of the mutation** (generalizing

--- a/README.md
+++ b/README.md
@@ -248,7 +248,10 @@ providers — or models, even at the same dimension — against an existing data
 refuses to run rather than silently mix vector spaces. To accept a deliberate model
 swap, restart with `rusty-brain serve --accept-model-change` (or set
 `RB_ACCEPT_MODEL_CHANGE=1` for auto-started daemons) and re-embed the corpus with
-`rusty-brain reembed`.
+`rusty-brain reembed`. For a legacy database whose global model marker is missing,
+startup adopts the configured model only when the corpus is empty or every stored row
+already names that model. A conflicting or mixed-model corpus refuses to start until
+the operator uses the same explicit accept-and-re-embed recovery path.
 
 ### Wire the MCP server into an agent
 

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -445,21 +445,77 @@ fn seed_or_verify_dim(conn: &rusqlite::Connection, embedding_dim: usize) -> Resu
     }
     Ok(())
 }
-/// Seed `meta.embedding_model` on first init (or on the first open of a DB
-/// created before the key existed), or verify it matches on re-open. A
-/// same-dim provider swap would silently mix vector spaces, so this fails
-/// closed with the explicit remediation.
+/// Seed `meta.embedding_model` on first init, or verify it on re-open.
 ///
-/// `INSERT OR IGNORE` + re-read, same race-safe idiom as
-/// [`seed_or_verify_dim`] / [`seed_or_get_site_id`].
+/// A legacy DB may have per-row model stamps but no global marker. Recovery is
+/// conservative: an empty corpus adopts the configured model, and a populated
+/// corpus adopts it only when every row already carries that same model. A
+/// disagreement or mixed-model corpus fails closed and requires the explicit
+/// `accept_model_change` + re-embed path.
+///
+/// The common, already-seeded path is read-only. Missing-marker recovery takes
+/// an immediate transaction and re-reads the marker under the write lock, so
+/// concurrent first opens cannot race the row-stamp check and seed.
 fn seed_or_verify_model(conn: &rusqlite::Connection, embedding_model: &str) -> Result<()> {
-    conn.execute(
-        "INSERT OR IGNORE INTO meta (key, value) VALUES ('embedding_model', ?1)",
-        rusqlite::params![embedding_model],
-    )
-    .map_err(storage_err)?;
-    let stored = meta_value(conn, "embedding_model")?
-        .ok_or_else(|| Error::Storage("meta.embedding_model missing after seed".to_string()))?;
+    if let Some(stored) = meta_value(conn, "embedding_model")? {
+        return verify_configured_model(&stored, embedding_model);
+    }
+
+    immediate_tx(conn, || {
+        // Re-check after acquiring the write lock: another opener may have
+        // seeded the marker after the optimistic read above.
+        if let Some(stored) = meta_value(conn, "embedding_model")? {
+            return verify_configured_model(&stored, embedding_model);
+        }
+
+        // At most two values are needed to distinguish empty, uniform, and
+        // mixed corpora; keep recovery bounded even if row stamps are corrupt.
+        let row_models = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT embedding_model
+                     FROM memories
+                     ORDER BY embedding_model
+                     LIMIT 2",
+                )
+                .map_err(storage_err)?;
+            let models = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(storage_err)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(storage_err)?;
+            models
+        };
+
+        match row_models.as_slice() {
+            [] => {}
+            [stored] if stored == embedding_model => {}
+            [stored] => {
+                return Err(Error::Storage(format!(
+                    "embedding model changed (meta.embedding_model is missing, stored rows use: \
+                     {stored}, configured: {embedding_model}); run with --accept-model-change \
+                     to mark the corpus for re-embedding"
+                )))
+            }
+            models => {
+                return Err(Error::Storage(format!(
+                    "meta.embedding_model is missing and stored rows contain mixed embedding \
+                     models {models:?}; run with --accept-model-change to adopt \
+                     {embedding_model} and re-embed the corpus"
+                )))
+            }
+        }
+
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES ('embedding_model', ?1)",
+            rusqlite::params![embedding_model],
+        )
+        .map_err(storage_err)?;
+        Ok(())
+    })
+}
+
+fn verify_configured_model(stored: &str, embedding_model: &str) -> Result<()> {
     if stored != embedding_model {
         return Err(Error::Storage(format!(
             "embedding model changed (stored: {stored}, configured: {embedding_model}); \
@@ -487,6 +543,18 @@ fn seed_or_get_site_id(conn: &rusqlite::Connection) -> Result<String> {
 mod open_tests {
     #![allow(clippy::panic)]
     use super::*;
+    use rb_types::{MemoryNote, MemoryType, Namespace};
+
+    fn insert_memory_with_model(store: &SqliteStore, model: &str, content: &str) {
+        let mut note = MemoryNote::new(
+            Namespace::Project("model-recovery".to_string()),
+            content.to_string(),
+            MemoryType::Insight,
+            5,
+        );
+        note.embedding_model = model.to_string();
+        store.insert_memory(&note, Some(&[0.1f32; 8])).unwrap();
+    }
 
     #[test]
     fn open_in_memory_creates_schema_and_seeds_dim() {
@@ -632,6 +700,95 @@ mod open_tests {
         // ...and a later swap is then refused.
         let err = SqliteStore::open_with_model(&path, 8, "other-model").unwrap_err();
         assert!(err.to_string().contains("embedding model changed"), "{err}");
+    }
+
+    #[test]
+    fn missing_model_marker_with_compatible_rows_is_recovered() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let store = SqliteStore::open(&path, 8).unwrap();
+            insert_memory_with_model(&store, "model-a", "compatible row");
+            assert!(store.meta_value("embedding_model").unwrap().is_none());
+        }
+
+        let recovered = SqliteStore::open_with_model(&path, 8, "model-a").unwrap();
+        assert_eq!(
+            recovered.meta_value("embedding_model").unwrap().as_deref(),
+            Some("model-a")
+        );
+        drop(recovered);
+
+        SqliteStore::open_with_model(&path, 8, "model-a").unwrap();
+    }
+
+    #[test]
+    fn missing_model_marker_with_incompatible_rows_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let store = SqliteStore::open(&path, 8).unwrap();
+            insert_memory_with_model(&store, "model-a", "incompatible row");
+        }
+
+        let err = SqliteStore::open_with_model(&path, 8, "model-b").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("meta.embedding_model is missing"), "{msg}");
+        assert!(
+            msg.contains("stored rows use: model-a") && msg.contains("configured: model-b"),
+            "{msg}"
+        );
+
+        let legacy = SqliteStore::open(&path, 8).unwrap();
+        assert!(legacy.meta_value("embedding_model").unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_model_marker_with_mixed_rows_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let store = SqliteStore::open(&path, 8).unwrap();
+            insert_memory_with_model(&store, "model-a", "first model");
+            insert_memory_with_model(&store, "model-b", "second model");
+        }
+
+        let err = SqliteStore::open_with_model(&path, 8, "model-a").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("mixed embedding models"), "{msg}");
+        assert!(msg.contains("model-a") && msg.contains("model-b"), "{msg}");
+
+        let legacy = SqliteStore::open(&path, 8).unwrap();
+        assert!(legacy.meta_value("embedding_model").unwrap().is_none());
+    }
+
+    #[test]
+    fn explicit_accept_recovers_missing_marker_with_incompatible_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let store = SqliteStore::open(&path, 8).unwrap();
+            insert_memory_with_model(&store, "model-a", "accept this change");
+        }
+        assert!(SqliteStore::open_with_model(&path, 8, "model-b").is_err());
+
+        let legacy = SqliteStore::open(&path, 8).unwrap();
+        assert!(!legacy.accept_model_change("model-b").unwrap());
+        assert_eq!(
+            legacy
+                .memories_for_reembed("model-b", "v2-composite", 10)
+                .unwrap()
+                .len(),
+            1,
+            "the accepted legacy row remains queued for re-embedding"
+        );
+        drop(legacy);
+
+        SqliteStore::open_with_model(&path, 8, "model-b").unwrap();
     }
 
     #[test]

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -679,11 +679,11 @@ mod open_tests {
             "refusal names the invariant: {msg}"
         );
         assert!(
-            msg.contains("stored: deterministic") && msg.contains("configured: voyage-3"),
+            msg.contains("stored: \"deterministic\"") && msg.contains("configured: \"voyage-3\""),
             "refusal names both models: {msg}"
         );
         assert!(
-            msg.contains("--accept-model-change"),
+            msg.contains("--accept-model-change") && msg.contains("rusty-brain reembed"),
             "refusal carries the remediation hint: {msg}"
         );
     }

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -493,15 +493,16 @@ fn seed_or_verify_model(conn: &rusqlite::Connection, embedding_model: &str) -> R
             [stored] => {
                 return Err(Error::Storage(format!(
                     "embedding model changed (meta.embedding_model is missing, stored rows use: \
-                     {stored}, configured: {embedding_model}); run with --accept-model-change \
-                     to mark the corpus for re-embedding"
+                     {stored:?}, configured: {embedding_model:?}); run with \
+                     --accept-model-change to mark the corpus, then run \
+                     `rusty-brain reembed` until changed=0"
                 )))
             }
             models => {
                 return Err(Error::Storage(format!(
                     "meta.embedding_model is missing and stored rows contain mixed embedding \
                      models {models:?}; run with --accept-model-change to adopt \
-                     {embedding_model} and re-embed the corpus"
+                     {embedding_model:?}; then run `rusty-brain reembed` until changed=0"
                 )))
             }
         }
@@ -518,8 +519,9 @@ fn seed_or_verify_model(conn: &rusqlite::Connection, embedding_model: &str) -> R
 fn verify_configured_model(stored: &str, embedding_model: &str) -> Result<()> {
     if stored != embedding_model {
         return Err(Error::Storage(format!(
-            "embedding model changed (stored: {stored}, configured: {embedding_model}); \
-             run with --accept-model-change to mark the corpus for re-embedding"
+            "embedding model changed (stored: {stored:?}, configured: {embedding_model:?}); \
+             run with --accept-model-change to mark the corpus, then run \
+             `rusty-brain reembed` until changed=0"
         )));
     }
     Ok(())
@@ -737,9 +739,10 @@ mod open_tests {
         let msg = err.to_string();
         assert!(msg.contains("meta.embedding_model is missing"), "{msg}");
         assert!(
-            msg.contains("stored rows use: model-a") && msg.contains("configured: model-b"),
+            msg.contains("stored rows use: \"model-a\"") && msg.contains("configured: \"model-b\""),
             "{msg}"
         );
+        assert!(msg.contains("rusty-brain reembed"), "{msg}");
 
         let legacy = SqliteStore::open(&path, 8).unwrap();
         assert!(legacy.meta_value("embedding_model").unwrap().is_none());
@@ -763,6 +766,22 @@ mod open_tests {
 
         let legacy = SqliteStore::open(&path, 8).unwrap();
         assert!(legacy.meta_value("embedding_model").unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_model_marker_with_empty_legacy_row_stamp_names_it_unambiguously() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rb.db");
+
+        {
+            let store = SqliteStore::open(&path, 8).unwrap();
+            insert_memory_with_model(&store, "", "unstamped legacy row");
+        }
+
+        let err = SqliteStore::open_with_model(&path, 8, "model-b").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("stored rows use: \"\""), "{msg}");
+        assert!(msg.contains("rusty-brain reembed"), "{msg}");
     }
 
     #[test]

--- a/crates/rusty-brain/src/doctor.rs
+++ b/crates/rusty-brain/src/doctor.rs
@@ -712,12 +712,13 @@ mod tests {
         // Legacy DB without a stamp: warn, not fail.
         let legacy = check_model_identity(Some("deterministic"), None);
         assert_eq!(legacy.status, CheckStatus::Warn, "{legacy:?}");
+        let hint = legacy
+            .hint
+            .as_deref()
+            .expect("legacy recovery carries explicit remediation");
         assert!(
-            legacy
-                .hint
-                .as_deref()
-                .is_some_and(|hint| hint.contains("--accept-model-change")),
-            "legacy recovery carries explicit remediation: {legacy:?}"
+            hint.contains("--accept-model-change") && hint.contains("rusty-brain reembed"),
+            "legacy recovery names the opt-in and re-embed step: {hint}"
         );
 
         // Provider identity unknown (offline with a remote provider): skip.

--- a/crates/rusty-brain/src/doctor.rs
+++ b/crates/rusty-brain/src/doctor.rs
@@ -220,10 +220,16 @@ pub fn check_model_identity(provider: Option<&str>, meta: Option<&str>) -> Docto
         (Some(_), None) => DoctorCheck {
             name: "embedding-model",
             status: CheckStatus::Warn,
-            detail: "DB has no recorded embedding model (legacy DB; it is \
-                     seeded at the next daemon start)"
+            detail: "DB has no recorded embedding model (legacy DB; startup \
+                     reconciles it against per-row model stamps)"
                 .to_string(),
-            hint: None,
+            hint: Some(
+                "startup adopts the configured model only for an empty corpus \
+                 or when every row already uses it; otherwise restore the \
+                 matching provider or run `rusty-brain serve \
+                 --accept-model-change` followed by `rusty-brain reembed`"
+                    .to_string(),
+            ),
         },
         (None, meta) => DoctorCheck {
             name: "embedding-model",
@@ -706,6 +712,13 @@ mod tests {
         // Legacy DB without a stamp: warn, not fail.
         let legacy = check_model_identity(Some("deterministic"), None);
         assert_eq!(legacy.status, CheckStatus::Warn, "{legacy:?}");
+        assert!(
+            legacy
+                .hint
+                .as_deref()
+                .is_some_and(|hint| hint.contains("--accept-model-change")),
+            "legacy recovery carries explicit remediation: {legacy:?}"
+        );
 
         // Provider identity unknown (offline with a remote provider): skip.
         let skipped = check_model_identity(None, Some("voyage-3"));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -304,7 +304,10 @@ daemon refuse to start rather than write mismatched vectors. The embedding model
 identity (`meta.embedding_model`) is the second: a same-dimension provider swap also
 refuses to start — mixed vector spaces must be impossible — unless explicitly accepted
 via `serve --accept-model-change` (or `RB_ACCEPT_MODEL_CHANGE=1` for auto-started
-daemons) followed by a corpus `reembed`.
+daemons) followed by a corpus `reembed`. A legacy database with no global model marker
+is reconciled from `SELECT DISTINCT memories.embedding_model`: an empty corpus or one
+model matching the configured provider may seed the marker; a conflicting or mixed
+corpus fails closed and requires that explicit accept-and-re-embed flow.
 
 The database file holds captured memory text, so it gets the same posture as the
 daemon socket: the file is created `0600` and tightened fail-closed on every open


### PR DESCRIPTION
## Summary

Vikunja #52 identified a fail-open legacy recovery path: when a populated database lacked `meta.embedding_model`, startup silently seeded the currently configured provider without checking the model recorded on existing memory rows. A provider change could therefore make a mixed vector space look valid.

This change reconciles the missing global marker against distinct per-row model stamps under a write lock. Empty databases and uniformly compatible corpora recover automatically; conflicting or mixed-model corpora fail closed and direct the operator to the explicit `--accept-model-change` plus `rusty-brain reembed` recovery path. Already-seeded databases retain a read-only fast path.

README, architecture, doctor guidance, and the changelog now describe the recovery policy. Tests cover compatible recovery, incompatible and mixed-model refusal, explicit acceptance, fresh initialization, and normal reopen behavior.

## Validation

- `cargo test -p rb-store --locked` — 241 passed
- `cargo test -p rusty-brain doctor --locked` — 11 passed
- `cargo clippy -p rb-store -p rusty-brain --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- CodeRabbit local review; the actionable remediation-assertion suggestion was fixed and revalidated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery for legacy databases missing embedding-model metadata.
  * Databases with empty or consistently matching records can now recover automatically.
  * Databases with conflicting or mixed model records now fail safely instead of silently switching models.
  * Added clearer diagnostics and remediation guidance through the doctor checks.

* **Documentation**
  * Expanded guidance on embedding-model changes, legacy database recovery, and re-embedding workflows.
  * Documented the explicit accept-and-re-embed process for resolving model conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->