### PR TITLE
fix(scrub): surface busy and failed WAL checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed — Scrub reports blocked WAL cleanup (Vikunja #53)
+
+- `rusty-brain scrub` now inspects the full result of its truncating WAL
+  checkpoint instead of treating SQLite's successful-but-busy pragma as
+  complete at-rest cleanup. Human and JSON output report checkpoint status,
+  warn when pre-redaction plaintext may remain in the WAL, and tell operators
+  to close long-lived database readers and rerun scrub. A no-change rerun now
+  retries the checkpoint so that remediation can complete.
+
 ### Changed — Supersede hardened at the source (#501)
 
 - **`Store::supersede` now guards every half of the mutation** (generalizing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ All notable changes to rusty-brain are documented here. The format is based on
   complete at-rest cleanup. Human and JSON output report checkpoint status,
   warn when pre-redaction plaintext may remain in the WAL, and tell operators
   to close long-lived database readers and rerun scrub. A no-change rerun now
-  retries the checkpoint so that remediation can complete.
+  retries the checkpoint so that remediation can complete. If checkpoint
+  execution itself errors after redaction commits, scrub preserves and returns
+  the committed counts as a partial success with an explicit unavailable
+  diagnostic instead of misreporting the entire scrub as failed.
 
 ### Changed — Supersede hardened at the source (#501)
 

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -12,9 +12,9 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
 "crates/rb-proto/src/messages.rs::Request" = "4ea3877bcfbbc0c0a3b824baefe860629eafb07f77d1ced5e64be1ac87420926"
-"crates/rb-proto/src/messages.rs::Response" = "e1d8867e7a9df28b65dcb89b7ae0411384d6268bd31014e144bd43f1ce8d33d2"
+"crates/rb-proto/src/messages.rs::Response" = "8eadc7e8be732b895abe42ca67222cc68e235a96404e7ce6ec0a410f7386f04b"
 "crates/rb-proto/src/messages.rs::ScrubCheckpoint" = "dfe99a03b49da585b2e26b8825493a07cb95b11c615bf1ed4b48a339ea6976cc"
-"crates/rb-proto/src/messages.rs::ScrubResult" = "e17fe365b2526a45452d082b6b56187151b6d2da11a9c89dac527b0530c04571"
+"crates/rb-proto/src/messages.rs::ScrubResult" = "89eb31711254dae32468bce07ea31c707f4fa0a6d32dfe9ca33dc4707f922918"
 "crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
@@ -120,3 +120,8 @@ note = "PR #63 review fixes: Resolve.threshold (serde-default merge-revalidation
 contract_version = 2
 intent = "additive"
 note = "Vikunja #53 adds optional scrub WAL checkpoint status; serde defaults preserve old-daemon compatibility"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "Vikunja #53 preserves scrub counts with an optional checkpoint-error diagnostic"

--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -12,7 +12,9 @@ contract_version = 2
 "crates/rb-proto/src/messages.rs::HandshakeAck" = "50a6688e1f1471bb61e82460a1c3b8a6d82a27b3e8e8866933a2ab8b00a0ebd4"
 "crates/rb-proto/src/messages.rs::RecallChannelTotals" = "2aac88f5866b68f3291c4f3c1d5b922eec1c691533b5a3d9008598547e226f78"
 "crates/rb-proto/src/messages.rs::Request" = "4ea3877bcfbbc0c0a3b824baefe860629eafb07f77d1ced5e64be1ac87420926"
-"crates/rb-proto/src/messages.rs::Response" = "9db3b5b9faf7163bcc85a93568856cb254ee85abb1fe2f947f5a47aaeb418d5e"
+"crates/rb-proto/src/messages.rs::Response" = "e1d8867e7a9df28b65dcb89b7ae0411384d6268bd31014e144bd43f1ce8d33d2"
+"crates/rb-proto/src/messages.rs::ScrubCheckpoint" = "dfe99a03b49da585b2e26b8825493a07cb95b11c615bf1ed4b48a339ea6976cc"
+"crates/rb-proto/src/messages.rs::ScrubResult" = "e17fe365b2526a45452d082b6b56187151b6d2da11a9c89dac527b0530c04571"
 "crates/rb-types/src/anchor.rs::MemoryAnchor" = "db65d4fee2c23b5628270cdcb7b19ce99056eb3656de73aa0e50fc77090a9277"
 "crates/rb-types/src/change.rs::ChangeKind" = "430e596bd1727da88b410e86c1983963e6460e510733dbe7c16487d0c5e2344e"
 "crates/rb-types/src/change.rs::MemoryChanged" = "3647593fa6f3e2fa56fc6acc5ee24b079f638564598be97a4dd6ca9b5c314773"
@@ -113,3 +115,8 @@ note = "PR: review sweep — Request::Review/Resolve + Response::ReviewPlanned/R
 contract_version = 2
 intent = "additive"
 note = "PR #63 review fixes: Resolve.threshold (serde-default merge-revalidation bound) + stale_plan error kind (no bump, additive per W5a.4)"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "Vikunja #53 adds optional scrub WAL checkpoint status; serde defaults preserve old-daemon compatibility"

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1780,6 +1780,7 @@ where
                         checkpointed_frames: checkpoint.checkpointed_frames,
                     }
                 }),
+                wal_checkpoint_error: outcome.wal_checkpoint_error,
             },
             Err(e) => error_to_response(e),
         },

--- a/crates/rb-daemon/src/server.rs
+++ b/crates/rb-daemon/src/server.rs
@@ -1773,6 +1773,13 @@ where
                 scanned: outcome.scanned,
                 redacted: outcome.redacted,
                 reembed_pending: outcome.reembed_pending,
+                wal_checkpoint: outcome.wal_checkpoint.map(|checkpoint| {
+                    rb_proto::ScrubCheckpoint {
+                        busy: checkpoint.busy,
+                        log_frames: checkpoint.log_frames,
+                        checkpointed_frames: checkpoint.checkpointed_frames,
+                    }
+                }),
             },
             Err(e) => error_to_response(e),
         },

--- a/crates/rb-daemon/tests/daemon_e2e.rs
+++ b/crates/rb-daemon/tests/daemon_e2e.rs
@@ -617,10 +617,17 @@ async fn scrub_over_the_wire_redacts_an_unredacted_stored_secret() {
     assert!(before.content.contains(&secret));
 
     // Same-uid test client is admin, so the gate admits the op.
-    let (scanned, redacted, reembed_pending) = client.scrub().await.unwrap();
-    assert!(scanned >= 1);
-    assert_eq!(redacted, 1);
-    assert_eq!(reembed_pending, 1, "content changed -> needs reembed");
+    let outcome = client.scrub_with_checkpoint().await.unwrap();
+    assert!(outcome.scanned >= 1);
+    assert_eq!(outcome.redacted, 1);
+    assert_eq!(
+        outcome.reembed_pending, 1,
+        "content changed -> needs reembed"
+    );
+    assert!(
+        !outcome.wal_checkpoint.unwrap().busy,
+        "wire response must carry the completed at-rest checkpoint"
+    );
 
     let after = client.get(id).await.unwrap().unwrap();
     assert!(

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -615,11 +615,13 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
             scanned,
             redacted,
             reembed_pending,
+            wal_checkpoint,
         } => ToolContent::json(
             json!({
                 "scanned": scanned,
                 "redacted": redacted,
                 "reembed_pending": reembed_pending,
+                "wal_checkpoint": wal_checkpoint,
             }),
             false,
         ),

--- a/crates/rb-mcp/src/proxy.rs
+++ b/crates/rb-mcp/src/proxy.rs
@@ -616,12 +616,14 @@ pub fn response_to_content(resp: Response, now: DateTime<Utc>) -> ToolContent {
             redacted,
             reembed_pending,
             wal_checkpoint,
+            wal_checkpoint_error,
         } => ToolContent::json(
             json!({
                 "scanned": scanned,
                 "redacted": redacted,
                 "reembed_pending": reembed_pending,
                 "wal_checkpoint": wal_checkpoint,
+                "wal_checkpoint_error": wal_checkpoint_error,
             }),
             false,
         ),

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -322,6 +322,7 @@ mod tests {
                     redacted: 0,
                     reembed_pending: 0,
                     wal_checkpoint: None,
+                    wal_checkpoint_error: None,
                 },
                 // No MCP tool maps to the forget op (deliberately: it is a
                 // destructive surface); the arm exists only to keep this

--- a/crates/rb-mcp/src/server.rs
+++ b/crates/rb-mcp/src/server.rs
@@ -321,6 +321,7 @@ mod tests {
                     scanned: 0,
                     redacted: 0,
                     reembed_pending: 0,
+                    wal_checkpoint: None,
                 },
                 // No MCP tool maps to the forget op (deliberately: it is a
                 // destructive surface); the arm exists only to keep this

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -1055,6 +1055,7 @@ mod wrapper_tests {
         .await
         .unwrap();
 
+        let mut scrub_requests = 0u8;
         loop {
             let req: Request = match read_frame(&mut framed).await {
                 Ok(r) => r,
@@ -1194,13 +1195,30 @@ mod wrapper_tests {
                     moved: if merge { 7 } else { 3 },
                     vectors: 2,
                 },
-                Request::Scrub => Response::Scrubbed {
-                    scanned: 0,
-                    redacted: 0,
-                    reembed_pending: 0,
-                    wal_checkpoint: None,
-                    wal_checkpoint_error: None,
-                },
+                Request::Scrub => {
+                    scrub_requests += 1;
+                    if scrub_requests == 1 {
+                        Response::Scrubbed {
+                            scanned: 9,
+                            redacted: 2,
+                            reembed_pending: 1,
+                            wal_checkpoint: Some(crate::ScrubCheckpoint {
+                                busy: true,
+                                log_frames: 7,
+                                checkpointed_frames: 3,
+                            }),
+                            wal_checkpoint_error: None,
+                        }
+                    } else {
+                        Response::Scrubbed {
+                            scanned: 9,
+                            redacted: 2,
+                            reembed_pending: 1,
+                            wal_checkpoint: None,
+                            wal_checkpoint_error: Some("checkpoint unavailable".to_string()),
+                        }
+                    }
+                }
                 // Canned payload keyed on `window_days` so the typed-wrapper
                 // test can prove the window rides the wire.
                 Request::Stats { window_days } => Response::Stats {
@@ -1731,6 +1749,32 @@ mod wrapper_tests {
             .await
             .unwrap();
         assert_eq!((moved, vectors), (7, 2));
+
+        let scrubbed = c.scrub_with_checkpoint().await.unwrap();
+        assert_eq!(
+            (
+                scrubbed.scanned,
+                scrubbed.redacted,
+                scrubbed.reembed_pending
+            ),
+            (9, 2, 1)
+        );
+        assert_eq!(
+            scrubbed.wal_checkpoint,
+            Some(crate::ScrubCheckpoint {
+                busy: true,
+                log_frames: 7,
+                checkpointed_frames: 3,
+            })
+        );
+        assert!(scrubbed.wal_checkpoint_error.is_none());
+
+        let unavailable = c.scrub_with_checkpoint().await.unwrap();
+        assert!(unavailable.wal_checkpoint.is_none());
+        assert_eq!(
+            unavailable.wal_checkpoint_error.as_deref(),
+            Some("checkpoint unavailable")
+        );
 
         // The fake server echoes the window into the payload, proving the
         // window rides the wire and the payload comes back typed.

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -5,7 +5,7 @@
 
 use crate::codec::bounded_framed;
 use crate::frame::{read_frame, write_frame};
-use crate::messages::{Handshake, HandshakeAck, Request, Response, CONTRACT_VERSION};
+use crate::messages::{Handshake, HandshakeAck, Request, Response, ScrubResult, CONTRACT_VERSION};
 use crate::{response_error_to_error, Response as Resp};
 use rb_types::{
     Error, FeedbackKind, MemoryChanged, MemoryId, MemoryNote, MemoryType, MemoryUpdates, Namespace,
@@ -627,13 +627,26 @@ where
     /// afterward to recompute vectors for the changed rows. Admin op: a
     /// non-admin peer is rejected with `Error::PermissionDenied`.
     pub async fn scrub(&mut self) -> Result<(u64, u64, u64)> {
+        let result = self.scrub_with_checkpoint().await?;
+        Ok((result.scanned, result.redacted, result.reembed_pending))
+    }
+
+    /// Retroactively redact secrets and return the post-scrub WAL checkpoint
+    /// status. Prefer this over [`Self::scrub`] when reporting at-rest safety.
+    pub async fn scrub_with_checkpoint(&mut self) -> Result<ScrubResult> {
         let resp = self.request(Request::Scrub).await?;
         match resp {
             Resp::Scrubbed {
                 scanned,
                 redacted,
                 reembed_pending,
-            } => Ok((scanned, redacted, reembed_pending)),
+                wal_checkpoint,
+            } => Ok(ScrubResult {
+                scanned,
+                redacted,
+                reembed_pending,
+                wal_checkpoint,
+            }),
             other => Err(Self::unexpected(other)),
         }
     }
@@ -1183,6 +1196,7 @@ mod wrapper_tests {
                     scanned: 0,
                     redacted: 0,
                     reembed_pending: 0,
+                    wal_checkpoint: None,
                 },
                 // Canned payload keyed on `window_days` so the typed-wrapper
                 // test can prove the window rides the wire.

--- a/crates/rb-proto/src/client.rs
+++ b/crates/rb-proto/src/client.rs
@@ -641,11 +641,13 @@ where
                 redacted,
                 reembed_pending,
                 wal_checkpoint,
+                wal_checkpoint_error,
             } => Ok(ScrubResult {
                 scanned,
                 redacted,
                 reembed_pending,
                 wal_checkpoint,
+                wal_checkpoint_error,
             }),
             other => Err(Self::unexpected(other)),
         }
@@ -1197,6 +1199,7 @@ mod wrapper_tests {
                     redacted: 0,
                     reembed_pending: 0,
                     wal_checkpoint: None,
+                    wal_checkpoint_error: None,
                 },
                 // Canned payload keyed on `window_days` so the typed-wrapper
                 // test can prove the window rides the wire.

--- a/crates/rb-proto/src/lib.rs
+++ b/crates/rb-proto/src/lib.rs
@@ -16,5 +16,5 @@ pub use error::{error_to_response, response_error_to_error};
 pub use frame::{read_frame, write_frame};
 pub use messages::{
     request_uses_anchors, ClientIdentity, Handshake, HandshakeAck, RecallChannelTotals, Request,
-    Response, CAP_ANCHORS, CONTRACT_VERSION,
+    Response, ScrubCheckpoint, ScrubResult, CAP_ANCHORS, CONTRACT_VERSION,
 };

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -371,6 +371,35 @@ pub struct RecallChannelTotals {
     pub graph_hits: u64,
 }
 
+/// Result of the truncating WAL checkpoint performed after a scrub.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrubCheckpoint {
+    /// Whether a concurrent reader or writer prevented complete truncation.
+    pub busy: bool,
+    /// Frames observed in the WAL (`-1` when the database has no WAL).
+    pub log_frames: i64,
+    /// Frames copied into the main database (`-1` when there is no WAL).
+    pub checkpointed_frames: i64,
+}
+
+/// Typed result of a scrub request, including its at-rest checkpoint status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrubResult {
+    pub scanned: u64,
+    pub redacted: u64,
+    pub reembed_pending: u64,
+    /// `None` when talking to an older daemon that predates checkpoint status.
+    pub wal_checkpoint: Option<ScrubCheckpoint>,
+}
+
+impl ScrubResult {
+    /// Conservatively reports risk when the checkpoint was busy or unavailable.
+    #[must_use]
+    pub fn plaintext_may_remain_in_wal(self) -> bool {
+        self.wal_checkpoint.is_none_or(|checkpoint| checkpoint.busy)
+    }
+}
+
 /// One response per request. Internally tagged on `result`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -441,6 +470,9 @@ pub enum Response {
         scanned: u64,
         redacted: u64,
         reembed_pending: u64,
+        /// Additive and optional for old-daemon/new-client compatibility.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wal_checkpoint: Option<ScrubCheckpoint>,
     },
     /// Acknowledges a `Request::Feedback` (W3.7): `confidence` is the target
     /// memory's trust prior AFTER the bounded nudge, so the caller can surface
@@ -1091,6 +1123,11 @@ mod tests {
                 scanned: 200,
                 redacted: 3,
                 reembed_pending: 2,
+                wal_checkpoint: Some(ScrubCheckpoint {
+                    busy: false,
+                    log_frames: 0,
+                    checkpointed_frames: 0,
+                }),
             },
             Response::Stats {
                 stats: rb_types::MemoryStats {
@@ -1641,6 +1678,34 @@ mod tests {
         assert_eq!(json, format!(r#"{{"op":"History","id":"{id}","depth":3}}"#));
         let back: Request = serde_json::from_str(&json).unwrap();
         assert!(matches!(back, Request::History { depth: Some(3), .. }));
+    }
+
+    #[test]
+    fn scrub_checkpoint_status_is_additive_and_old_payload_defaults_to_none() {
+        let old = r#"{"result":"Scrubbed","scanned":10,"redacted":2,"reembed_pending":1}"#;
+        let decoded: Response = serde_json::from_str(old).unwrap();
+        assert!(matches!(
+            decoded,
+            Response::Scrubbed {
+                wal_checkpoint: None,
+                ..
+            }
+        ));
+
+        let response = Response::Scrubbed {
+            scanned: 10,
+            redacted: 2,
+            reembed_pending: 1,
+            wal_checkpoint: Some(ScrubCheckpoint {
+                busy: true,
+                log_frames: 7,
+                checkpointed_frames: 3,
+            }),
+        };
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["wal_checkpoint"]["busy"], true);
+        assert_eq!(value["wal_checkpoint"]["log_frames"], 7);
+        assert_eq!(value["wal_checkpoint"]["checkpointed_frames"], 3);
     }
 
     #[test]

--- a/crates/rb-proto/src/messages.rs
+++ b/crates/rb-proto/src/messages.rs
@@ -383,20 +383,23 @@ pub struct ScrubCheckpoint {
 }
 
 /// Typed result of a scrub request, including its at-rest checkpoint status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScrubResult {
     pub scanned: u64,
     pub redacted: u64,
     pub reembed_pending: u64,
     /// `None` when talking to an older daemon that predates checkpoint status.
     pub wal_checkpoint: Option<ScrubCheckpoint>,
+    /// Checkpoint execution failure after the redaction transaction committed.
+    pub wal_checkpoint_error: Option<String>,
 }
 
 impl ScrubResult {
     /// Conservatively reports risk when the checkpoint was busy or unavailable.
     #[must_use]
-    pub fn plaintext_may_remain_in_wal(self) -> bool {
-        self.wal_checkpoint.is_none_or(|checkpoint| checkpoint.busy)
+    pub fn plaintext_may_remain_in_wal(&self) -> bool {
+        self.wal_checkpoint_error.is_some()
+            || self.wal_checkpoint.is_none_or(|checkpoint| checkpoint.busy)
     }
 }
 
@@ -473,6 +476,10 @@ pub enum Response {
         /// Additive and optional for old-daemon/new-client compatibility.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         wal_checkpoint: Option<ScrubCheckpoint>,
+        /// Additive partial-success diagnostic when checkpoint execution failed
+        /// after the redaction transaction committed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wal_checkpoint_error: Option<String>,
     },
     /// Acknowledges a `Request::Feedback` (W3.7): `confidence` is the target
     /// memory's trust prior AFTER the bounded nudge, so the caller can surface
@@ -1128,6 +1135,7 @@ mod tests {
                     log_frames: 0,
                     checkpointed_frames: 0,
                 }),
+                wal_checkpoint_error: None,
             },
             Response::Stats {
                 stats: rb_types::MemoryStats {
@@ -1688,6 +1696,7 @@ mod tests {
             decoded,
             Response::Scrubbed {
                 wal_checkpoint: None,
+                wal_checkpoint_error: None,
                 ..
             }
         ));
@@ -1701,6 +1710,7 @@ mod tests {
                 log_frames: 7,
                 checkpointed_frames: 3,
             }),
+            wal_checkpoint_error: None,
         };
         let value = serde_json::to_value(response).unwrap();
         assert_eq!(value["wal_checkpoint"]["busy"], true);

--- a/crates/rb-store/src/lib.rs
+++ b/crates/rb-store/src/lib.rs
@@ -13,5 +13,5 @@ pub use migrations::run_migrations;
 pub use store::{
     read_meta_embedding_model, AccessBump, ConsolidationCandidate, LinkRow, NamespaceRenameOutcome,
     OplogReplayPage, RecalRow, RetentionSweepEffects, ReviewQueueParams, ScrubOutcome, SqliteStore,
-    Store,
+    Store, WalCheckpointOutcome,
 };

--- a/crates/rb-store/src/store.rs
+++ b/crates/rb-store/src/store.rs
@@ -201,5 +201,5 @@ pub use oplog::OplogReplayPage;
 pub use rename::NamespaceRenameOutcome;
 pub use retention::RetentionSweepEffects;
 pub use review::ReviewQueueParams;
-pub use scrub::ScrubOutcome;
+pub use scrub::{ScrubOutcome, WalCheckpointOutcome};
 pub use stats::read_meta_embedding_model;

--- a/crates/rb-store/src/store/scrub.rs
+++ b/crates/rb-store/src/store/scrub.rs
@@ -210,8 +210,9 @@ pub struct ScrubOutcome {
     /// therefore marked stale for re-embedding.
     pub reembed_pending: u64,
     /// Result of the post-scrub truncating WAL checkpoint. `None` is retained
-    /// only for backward-compatible construction via [`Default`]; a completed
-    /// [`SqliteStore::scrub`] call always populates it.
+    /// for backward-compatible construction via [`Default`] and when checkpoint
+    /// execution fails; a completed [`SqliteStore::scrub`] call populates either
+    /// this field or [`Self::wal_checkpoint_error`], never both.
     pub wal_checkpoint: Option<WalCheckpointOutcome>,
     /// Checkpoint execution failure after the redaction transaction committed.
     /// The scrub counts remain authoritative; callers must warn that old
@@ -232,8 +233,14 @@ pub struct WalCheckpointOutcome {
 
 fn attach_checkpoint_result(outcome: &mut ScrubOutcome, result: Result<WalCheckpointOutcome>) {
     match result {
-        Ok(checkpoint) => outcome.wal_checkpoint = Some(checkpoint),
-        Err(error) => outcome.wal_checkpoint_error = Some(error.to_string()),
+        Ok(checkpoint) => {
+            outcome.wal_checkpoint = Some(checkpoint);
+            outcome.wal_checkpoint_error = None;
+        }
+        Err(error) => {
+            outcome.wal_checkpoint = None;
+            outcome.wal_checkpoint_error = Some(error.to_string());
+        }
     }
 }
 #[cfg(test)]
@@ -485,6 +492,25 @@ mod scrub_tests {
         assert_eq!(
             outcome.wal_checkpoint_error.as_deref(),
             Some("storage error: checkpoint unavailable")
+        );
+
+        let checkpoint = WalCheckpointOutcome {
+            busy: false,
+            log_frames: 0,
+            checkpointed_frames: 0,
+        };
+        attach_checkpoint_result(&mut outcome, Ok(checkpoint));
+        assert_eq!(outcome.wal_checkpoint, Some(checkpoint));
+        assert!(outcome.wal_checkpoint_error.is_none());
+
+        attach_checkpoint_result(
+            &mut outcome,
+            Err(Error::Storage("retry failed".to_string())),
+        );
+        assert!(outcome.wal_checkpoint.is_none());
+        assert_eq!(
+            outcome.wal_checkpoint_error.as_deref(),
+            Some("storage error: retry failed")
         );
     }
 

--- a/crates/rb-store/src/store/scrub.rs
+++ b/crates/rb-store/src/store/scrub.rs
@@ -136,6 +136,7 @@ impl SqliteStore {
                 redacted,
                 reembed_pending,
                 wal_checkpoint: None,
+                wal_checkpoint_error: None,
             })
         })?;
 
@@ -145,7 +146,7 @@ impl SqliteStore {
         // checkpoint, even on a no-op scrub, so an operator can close the
         // blocking reader and rerun `scrub` to finish the at-rest cleanup.
         // Residual freed-page slack in the main DB needs VACUUM/purge (W5b.3).
-        outcome.wal_checkpoint = Some(self.truncate_wal()?);
+        attach_checkpoint_result(&mut outcome, self.truncate_wal());
         Ok(outcome)
     }
 
@@ -197,7 +198,7 @@ impl SqliteStore {
     }
 }
 /// Result of a retroactive [`SqliteStore::scrub`] pass (W2.4).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ScrubOutcome {
     /// Rows examined (every memory, active and archived).
     pub scanned: u64,
@@ -212,6 +213,10 @@ pub struct ScrubOutcome {
     /// only for backward-compatible construction via [`Default`]; a completed
     /// [`SqliteStore::scrub`] call always populates it.
     pub wal_checkpoint: Option<WalCheckpointOutcome>,
+    /// Checkpoint execution failure after the redaction transaction committed.
+    /// The scrub counts remain authoritative; callers must warn that old
+    /// plaintext may remain in the WAL and offer a checkpoint retry.
+    pub wal_checkpoint_error: Option<String>,
 }
 
 /// SQLite's result row for `PRAGMA wal_checkpoint(TRUNCATE)` after a scrub.
@@ -223,6 +228,13 @@ pub struct WalCheckpointOutcome {
     pub log_frames: i64,
     /// Frames copied into the main database (`-1` when there is no WAL).
     pub checkpointed_frames: i64,
+}
+
+fn attach_checkpoint_result(outcome: &mut ScrubOutcome, result: Result<WalCheckpointOutcome>) {
+    match result {
+        Ok(checkpoint) => outcome.wal_checkpoint = Some(checkpoint),
+        Err(error) => outcome.wal_checkpoint_error = Some(error.to_string()),
+    }
 }
 #[cfg(test)]
 mod scrub_tests {
@@ -450,6 +462,29 @@ mod scrub_tests {
         assert!(
             !wal.exists() || std::fs::metadata(wal).unwrap().len() == 0,
             "successful TRUNCATE must remove or empty the WAL"
+        );
+    }
+
+    #[test]
+    fn checkpoint_failure_preserves_committed_scrub_counts_as_partial_success() {
+        let mut outcome = ScrubOutcome {
+            scanned: 8,
+            redacted: 2,
+            reembed_pending: 1,
+            wal_checkpoint: None,
+            wal_checkpoint_error: None,
+        };
+        attach_checkpoint_result(
+            &mut outcome,
+            Err(Error::Storage("checkpoint unavailable".to_string())),
+        );
+
+        assert_eq!((outcome.scanned, outcome.redacted), (8, 2));
+        assert_eq!(outcome.reembed_pending, 1);
+        assert!(outcome.wal_checkpoint.is_none());
+        assert_eq!(
+            outcome.wal_checkpoint_error.as_deref(),
+            Some("storage error: checkpoint unavailable")
         );
     }
 

--- a/crates/rb-store/src/store/scrub.rs
+++ b/crates/rb-store/src/store/scrub.rs
@@ -43,7 +43,7 @@ impl SqliteStore {
     /// `set_recalibrated_importance` rule), so it must not distort recency
     /// ranking. One bulk oplog row records the pass.
     pub fn scrub(&self) -> Result<ScrubOutcome> {
-        let outcome = immediate_tx(&self.conn, || {
+        let mut outcome = immediate_tx(&self.conn, || {
             let mut scanned = 0u64;
             let mut redacted = 0u64;
             let mut reembed_pending = 0u64;
@@ -135,22 +135,30 @@ impl SqliteStore {
                 scanned,
                 redacted,
                 reembed_pending,
+                wal_checkpoint: None,
             })
         })?;
 
-        // Force the pre-redaction WAL frames into the main DB and truncate the
-        // -wal file: without this, `scrub` could report success while the old
-        // plaintext still sits in the -wal on disk until an arbitrary later
-        // checkpoint. Best-effort and only when something changed (a no-op
-        // scrub wrote nothing). A no-op on an in-memory DB (no WAL). Residual:
-        // freed-page slack in the main DB needs VACUUM/purge (W5b.3) — out of
-        // scope here; this closes the obvious recoverable copy.
-        if outcome.redacted > 0 {
-            self.conn
-                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
-                .map_err(storage_err)?;
-        }
+        // Force pre-redaction WAL frames into the main DB and truncate the WAL.
+        // SQLite reports a busy checkpoint as a successful pragma row, so the
+        // result must be inspected rather than discarded. Always retry the
+        // checkpoint, even on a no-op scrub, so an operator can close the
+        // blocking reader and rerun `scrub` to finish the at-rest cleanup.
+        // Residual freed-page slack in the main DB needs VACUUM/purge (W5b.3).
+        outcome.wal_checkpoint = Some(self.truncate_wal()?);
         Ok(outcome)
+    }
+
+    fn truncate_wal(&self) -> Result<WalCheckpointOutcome> {
+        self.conn
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                Ok(WalCheckpointOutcome {
+                    busy: row.get::<_, i64>(0)? != 0,
+                    log_frames: row.get(1)?,
+                    checkpointed_frames: row.get(2)?,
+                })
+            })
+            .map_err(storage_err)
     }
     /// One keyset page of redactable rows with `memory_id > cursor`, ordered by
     /// `memory_id`, capped at `SCRUB_BATCH`. Split out so the prepared SELECT
@@ -200,6 +208,21 @@ pub struct ScrubOutcome {
     /// keywords/tags — everything except `summary`) changed and were
     /// therefore marked stale for re-embedding.
     pub reembed_pending: u64,
+    /// Result of the post-scrub truncating WAL checkpoint. `None` is retained
+    /// only for backward-compatible construction via [`Default`]; a completed
+    /// [`SqliteStore::scrub`] call always populates it.
+    pub wal_checkpoint: Option<WalCheckpointOutcome>,
+}
+
+/// SQLite's result row for `PRAGMA wal_checkpoint(TRUNCATE)` after a scrub.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalCheckpointOutcome {
+    /// Whether a concurrent reader or writer prevented a complete checkpoint.
+    pub busy: bool,
+    /// Frames observed in the WAL (`-1` when the database has no WAL).
+    pub log_frames: i64,
+    /// Frames copied into the main database (`-1` when there is no WAL).
+    pub checkpointed_frames: i64,
 }
 #[cfg(test)]
 mod scrub_tests {
@@ -366,6 +389,67 @@ mod scrub_tests {
                 .windows(secret.len())
                 .any(|w| w == secret.as_bytes()),
             "the planted secret must be GONE from the db file bytes after scrub"
+        );
+    }
+
+    #[test]
+    fn scrub_surfaces_busy_checkpoint_and_noop_retry_truncates_wal() {
+        let secret = aws_key();
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("busy-checkpoint.db");
+        let store = SqliteStore::open(&db, 8).unwrap();
+        store.conn.busy_timeout(std::time::Duration::ZERO).unwrap();
+
+        let mut memory = MemoryNote::new(
+            Namespace::Project("scrub".into()),
+            format!("reader-pinned secret {secret}"),
+            MemoryType::Insight,
+            5,
+        );
+        memory.summary = "busy checkpoint fixture".to_string();
+        store.insert_memory(&memory, None).unwrap();
+
+        // Pin a snapshot before scrub writes the redacted row. The write can
+        // still commit in WAL mode, but TRUNCATE cannot reset the WAL while
+        // this reader needs the older snapshot.
+        let reader = rusqlite::Connection::open(&db).unwrap();
+        reader.execute_batch("BEGIN").unwrap();
+        let pinned: String = reader
+            .query_row(
+                "SELECT content FROM memories WHERE memory_id = ?1",
+                [&memory.id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(pinned.contains(&secret));
+
+        let first = store.scrub().unwrap();
+        assert_eq!(first.redacted, 1, "redaction itself must still commit");
+        let first_checkpoint = first.wal_checkpoint.unwrap();
+        assert!(
+            first_checkpoint.busy,
+            "the pinned reader must be surfaced instead of silent success: {first_checkpoint:?}"
+        );
+        let redacted = store.get_memory(&memory.id).unwrap().unwrap();
+        assert!(!redacted.content.contains(&secret));
+
+        reader.execute_batch("COMMIT").unwrap();
+        drop(reader);
+
+        // A no-change rerun deliberately retries TRUNCATE, providing the CLI's
+        // remediation path after the operator closes blocking readers.
+        let retry = store.scrub().unwrap();
+        assert_eq!(retry.redacted, 0);
+        let retry_checkpoint = retry.wal_checkpoint.unwrap();
+        assert!(
+            !retry_checkpoint.busy,
+            "checkpoint should complete after the reader closes: {retry_checkpoint:?}"
+        );
+
+        let wal = db.with_extension("db-wal");
+        assert!(
+            !wal.exists() || std::fs::metadata(wal).unwrap().len() == 0,
+            "successful TRUNCATE must remove or empty the WAL"
         );
     }
 

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -883,6 +883,7 @@ async fn run_client(
                 .await
                 .context("scrub failed")?;
             let checkpoint = outcome.wal_checkpoint;
+            let checkpoint_error = outcome.wal_checkpoint_error.as_deref();
             let plaintext_may_remain = outcome.plaintext_may_remain_in_wal();
             let warning = "the WAL checkpoint was busy or its status was unavailable; \
                            pre-redaction plaintext may remain in the WAL";
@@ -900,6 +901,7 @@ async fn run_client(
                             "log_frames": status.log_frames,
                             "checkpointed_frames": status.checkpointed_frames,
                         })),
+                        "wal_checkpoint_error": checkpoint_error,
                         "plaintext_may_remain_in_wal": plaintext_may_remain,
                         "warning": plaintext_may_remain.then_some(warning),
                         "remediation": plaintext_may_remain.then_some(remediation),
@@ -907,7 +909,12 @@ async fn run_client(
                 );
             } else {
                 let checkpoint_status = checkpoint.map_or_else(
-                    || "unavailable".to_string(),
+                    || {
+                        checkpoint_error.map_or_else(
+                            || "unavailable".to_string(),
+                            |error| format!("unavailable ({error})"),
+                        )
+                    },
                     |status| {
                         format!(
                             "{} log_frames={} checkpointed_frames={}",

--- a/crates/rusty-brain/src/run.rs
+++ b/crates/rusty-brain/src/run.rs
@@ -878,22 +878,61 @@ async fn run_client(
             }
         }
         Command::Scrub => {
-            let (scanned, redacted, reembed_pending) =
-                client.scrub().await.context("scrub failed")?;
+            let outcome = client
+                .scrub_with_checkpoint()
+                .await
+                .context("scrub failed")?;
+            let checkpoint = outcome.wal_checkpoint;
+            let plaintext_may_remain = outcome.plaintext_may_remain_in_wal();
+            let warning = "the WAL checkpoint was busy or its status was unavailable; \
+                           pre-redaction plaintext may remain in the WAL";
+            let remediation = "close long-lived rusty-brain database readers, then rerun \
+                               `rusty-brain scrub` to retry the truncating WAL checkpoint";
             if json {
                 println!(
-                    "{{\"scanned\":{scanned},\"redacted\":{redacted},\"reembed_pending\":{reembed_pending}}}"
+                    "{}",
+                    serde_json::json!({
+                        "scanned": outcome.scanned,
+                        "redacted": outcome.redacted,
+                        "reembed_pending": outcome.reembed_pending,
+                        "wal_checkpoint": checkpoint.map(|status| serde_json::json!({
+                            "busy": status.busy,
+                            "log_frames": status.log_frames,
+                            "checkpointed_frames": status.checkpointed_frames,
+                        })),
+                        "plaintext_may_remain_in_wal": plaintext_may_remain,
+                        "warning": plaintext_may_remain.then_some(warning),
+                        "remediation": plaintext_may_remain.then_some(remediation),
+                    })
                 );
             } else {
+                let checkpoint_status = checkpoint.map_or_else(
+                    || "unavailable".to_string(),
+                    |status| {
+                        format!(
+                            "{} log_frames={} checkpointed_frames={}",
+                            if status.busy { "busy" } else { "complete" },
+                            status.log_frames,
+                            status.checkpointed_frames
+                        )
+                    },
+                );
                 println!(
-                    "scrub: scanned={scanned} redacted={redacted} reembed_pending={reembed_pending}"
+                    "scrub: scanned={} redacted={} reembed_pending={} wal_checkpoint={checkpoint_status}",
+                    outcome.scanned, outcome.redacted, outcome.reembed_pending
                 );
             }
-            if reembed_pending > 0 {
+            if plaintext_may_remain {
+                // stderr keeps JSON stdout machine-parseable while the JSON
+                // payload independently exposes the same risk/remediation.
+                eprintln!("warning: {warning}; {remediation}");
+            }
+            if outcome.reembed_pending > 0 {
                 // stderr so `--json` stdout stays machine-parseable.
                 eprintln!(
-                    "note: {reembed_pending} memories need re-embedding; run \
-                     `rusty-brain reembed` until changed=0 to recompute their vectors"
+                    "note: {} memories need re-embedding; run \
+                     `rusty-brain reembed` until changed=0 to recompute their vectors",
+                    outcome.reembed_pending
                 );
             }
         }

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -246,7 +246,13 @@ posture).
      assume away. The backstops are file permissions (`0600`), the retroactive
      `rusty-brain scrub` (re-runs the same pass over an existing DB: rewrites
      content/summary/context, resyncs FTS, marks affected rows for
-     re-embedding), and hard-delete/purge (W5b.3). A base64 secret containing
+     re-embedding), and hard-delete/purge (W5b.3). Scrub also attempts a
+     truncating WAL checkpoint and reports its `(busy, log, checkpointed)`
+     status. If a long-lived reader makes that checkpoint busy, scrub's row
+     rewrites still commit but its CLI and JSON output warn that old plaintext
+     may remain in the WAL; close those readers and rerun scrub (a no-change
+     pass retries the checkpoint) before treating the file as clean at rest.
+     A base64 secret containing
      `/` is split by the entropy sweep (paths are deliberately token
      separators, to avoid eating every absolute path) and only fires if a
      segment still clears the length gate — a known residual miss.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -250,8 +250,10 @@ posture).
      truncating WAL checkpoint and reports its `(busy, log, checkpointed)`
      status. If a long-lived reader makes that checkpoint busy, scrub's row
      rewrites still commit but its CLI and JSON output warn that old plaintext
-     may remain in the WAL; close those readers and rerun scrub (a no-change
-     pass retries the checkpoint) before treating the file as clean at rest.
+     may remain in the WAL. A checkpoint execution error likewise returns the
+     committed redaction counts plus an unavailable diagnostic rather than
+     hiding the partial success; close readers and rerun scrub (a no-change pass
+     retries the checkpoint) before treating the file as clean at rest.
      A base64 secret containing
      `/` is split by the entropy sweep (paths are deliberately token
      separators, to avoid eating every absolute path) and only fires if a

--- a/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
+++ b/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
@@ -71,8 +71,9 @@ policy.
 **Resolved (Vikunja #53):** scrub now returns the checkpoint result through
 the daemon protocol, human and JSON CLI surfaces warn on a busy or unavailable
 status, and a no-change rerun retries `TRUNCATE` after blocking readers close.
-A concurrent-reader regression test pins both the busy result and successful
-retry.
+A checkpoint execution error preserves the already-committed scrub counts and
+returns an explicit unavailable diagnostic. Regressions pin busy, successful
+retry, and partial-success error handling.
 
 `crates/rb-store/src/store/scrub.rs`, `scrub`: the post-redaction
 `PRAGMA wal_checkpoint(TRUNCATE)` runs via `execute_batch`, which discards

--- a/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
+++ b/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
@@ -75,28 +75,8 @@ A checkpoint execution error preserves the already-committed scrub counts and
 returns an explicit unavailable diagnostic. Regressions pin busy, successful
 retry, and partial-success error handling.
 
-`crates/rb-store/src/store/scrub.rs`, `scrub`: the post-redaction
-`PRAGMA wal_checkpoint(TRUNCATE)` runs via `execute_batch`, which discards
-the pragma's result row. A blocked checkpoint (e.g. a long-lived reader
-holding the WAL) can leave pre-redaction plaintext sitting in `-wal` while
-`scrub()` still reports success (`ScrubOutcome`), a real gap against the
-threat model's redaction guarantee.
-
-**Why not fixed now:** the crate deliberately carries no logging facility
-(see the comment on `rebuild_vector_table`'s stats: "rb-store carries no
-logging facility, so the one-shot counts live in meta"), so "just log a
-warning" isn't available. Properly surfacing this means either adding a
-field to the public `ScrubOutcome` struct (an API change requiring CLI-layer
-wiring so `rusty-brain scrub` can warn the operator) or persisting a durable
-`meta` marker in the `rebuild_vector_table`-stats style. Either is more than
-a quick patch and needs a test that provokes a busy checkpoint (a concurrent
-reader holding the WAL during `scrub()`).
-
-**What "done" looks like:** switch to `query_row` over the pragma, add
-`ScrubOutcome.wal_checkpoint_busy: bool` (or similar), wire the CLI `scrub`
-command to warn when set, and add a test that holds a concurrent read
-transaction open during `scrub()` and asserts the flag comes back `true`
-while confirming `scrub()` still succeeds (best-effort, not a hard failure).
+The original problem statement and proposed `wal_checkpoint_busy`-only design
+are superseded by the typed status and partial-success implementation above.
 
 ## Provenance
 

--- a/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
+++ b/docs/follow-ups/2026-07-11-store-lifecycle-hardening.md
@@ -68,6 +68,12 @@ policy.
 
 ## 3. `scrub`'s WAL checkpoint discards the `(busy, log, checkpointed)` result
 
+**Resolved (Vikunja #53):** scrub now returns the checkpoint result through
+the daemon protocol, human and JSON CLI surfaces warn on a busy or unavailable
+status, and a no-change rerun retries `TRUNCATE` after blocking readers close.
+A concurrent-reader regression test pins both the busy result and successful
+retry.
+
 `crates/rb-store/src/store/scrub.rs`, `scrub`: the post-redaction
 `PRAGMA wal_checkpoint(TRUNCATE)` runs via `execute_batch`, which discards
 the pragma's result row. A blocked checkpoint (e.g. a long-lived reader


### PR DESCRIPTION
## Summary

Vikunja #53 found that `rusty-brain scrub` discarded SQLite's `(busy, log, checkpointed)` result from `PRAGMA wal_checkpoint(TRUNCATE)`. A long-lived reader could therefore leave pre-redaction plaintext in the WAL while the command reported successful at-rest cleanup.

This change captures and carries typed checkpoint status through the store, daemon protocol, client, MCP projection, and CLI. Human and JSON output warn when the checkpoint is busy or unavailable and provide a bounded remediation: close long-lived readers and rerun scrub. No-change reruns deliberately retry `TRUNCATE`.

The review pass also caught a partial-success edge case: if checkpoint execution errors after the redaction transaction commits, scrub now preserves and returns the committed counts plus an explicit checkpoint-error diagnostic instead of turning the entire operation into a top-level failure. The wire additions are serde-default-compatible and recorded as additive contract changes without a protocol-version bump.

## Validation

- Concurrent-reader regression proves redaction commits while a busy checkpoint is surfaced, then a no-change retry truncates the WAL
- Partial-success regression preserves committed counts when checkpoint execution fails
- Targeted store, protocol, daemon, MCP, and CLI tests pass
- Affected-crate Clippy passes with warnings denied
- `cargo run -p rb-contract-guard --locked -- check`
- `cargo fmt --all --check` and `git diff --check`
- CodeRabbit local review; the committed-count loss finding was fixed and validated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enriched `rusty-brain scrub` output (including JSON/structured output) with WAL checkpoint details and related diagnostics.
  * Added a checkpoint-aware scrub call that exposes checkpoint status back to clients.

* **Bug Fixes**
  * Improved WAL checkpoint/truncation handling so cleanup is assessed using the full truncation checkpoint result.
  * Warns when plaintext may remain in the WAL (e.g., busy/unavailable), and includes clearer remediation guidance.
  * Preserves committed scrub counters even if checkpoint execution fails; surfaces partial-success diagnostics.
  * Retries WAL cleanup on subsequent no-change scrub runs.

* **Documentation**
  * Updated threat model and follow-up guidance to match the new scrub/WAL checkpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->