### PR TITLE
fix(store): make concurrent fresh initialization race-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed — Concurrent vector-schema initialization (Vikunja #506)
+
+- **Fresh dynamic-vector initialization is now single-winner and race-safe**:
+  openers still take the existing read-only `vector_schema_version` fast path,
+  but a missing/outdated marker now enters `BEGIN IMMEDIATE` and revalidates
+  both the marker and `memory_vectors` existence under that lock. A loser that
+  waited for another opener returns against the winner's committed schema
+  instead of acting on a stale “table absent” read and failing with
+  `table memory_vectors already exists`.
+- **Crash and rebuild guarantees are unchanged**: create/rebuild plus the
+  version and cosine-metric markers remain one atomic transaction. A
+  barrier-driven two-opener test forces both connections past the optimistic
+  miss and verifies identical dimension, model, vector schema, metric, and
+  site markers. A checked-in release-mode microbenchmark records why the write
+  lock is slow-path-only; on the task run, unconditional locking cost 1.66x the
+  current-schema marker check (1.52x on the immediate rerun).
+
 ### Changed — Supersede hardened at the source (#501)
 
 - **`Store::supersede` now guards every half of the mutation** (generalizing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,28 @@ All notable changes to rusty-brain are documented here. The format is based on
 
 ## [Unreleased]
 
-### Fixed — Concurrent vector-schema initialization (Vikunja #506)
+### Fixed — Concurrent zero-byte store initialization (Vikunja #506)
 
-- **Fresh dynamic-vector initialization is now single-winner and race-safe**:
-  openers still take the existing read-only `vector_schema_version` fast path,
-  but a missing/outdated marker now enters `BEGIN IMMEDIATE` and revalidates
-  both the marker and `memory_vectors` existence under that lock. A loser that
-  waited for another opener returns against the winner's committed schema
-  instead of acting on a stale “table absent” read and failing with
-  `table memory_vectors already exists`.
+- **Two public opens can now create the same zero-byte database safely**: the
+  busy handler is installed before WAL negotiation, SQLite's occasionally
+  immediate `BUSY`/`LOCKED` journal-mode result gets a bounded retry, and each
+  optimistically-unseen migration takes `BEGIN IMMEDIATE` then rechecks its
+  ledger row. The losing opener validates the winner's checksum instead of
+  replaying already-applied DDL (`duplicate column name`). Already-recorded
+  migrations still take the existing read-only checksum path.
+- **Dynamic-vector initialization is also single-winner**: current schemas keep
+  the existing read-only `vector_schema_version` fast path; a missing/outdated
+  marker takes `BEGIN IMMEDIATE`, then revalidates both the marker and
+  `memory_vectors` existence. A loser returns against the winner's committed
+  schema instead of failing with `table memory_vectors already exists`.
 - **Crash and rebuild guarantees are unchanged**: create/rebuild plus the
-  version and cosine-metric markers remain one atomic transaction. A
-  barrier-driven two-opener test forces both connections past the optimistic
-  miss and verifies identical dimension, model, vector schema, metric, and
-  site markers. A checked-in release-mode microbenchmark records why the write
-  lock is slow-path-only; on the task run, unconditional locking cost 1.66x the
-  current-schema marker check (1.52x on the immediate rerun).
+  version and cosine-metric markers remain one atomic transaction; pending
+  migrations retain one transaction per migration with RAII rollback. A
+  path-scoped barrier drives two real `open_with_model` calls from a nonexistent
+  file and verifies identical dimension, model, vector schema, metric, and site
+  markers. A checked-in release benchmark records why the vector write lock is
+  slow-path-only: unconditional locking cost 1.52–1.66x the current-schema
+  marker check in the task runs.
 
 ### Changed — Supersede hardened at the source (#501)
 

--- a/crates/rb-store/src/migrations.rs
+++ b/crates/rb-store/src/migrations.rs
@@ -115,52 +115,55 @@ fn recorded_checksum(conn: &rusqlite::Connection, version: i64) -> Result<Option
 fn apply_all(conn: &rusqlite::Connection, migs: &[Migration]) -> Result<()> {
     for m in migs {
         match recorded_checksum(conn, m.version)? {
-            Some(existing) => {
-                let current = checksum(&m.sql);
-                if existing != current {
-                    return Err(Error::Migration(format!(
-                        "checksum mismatch for migration {} ({}): \
-                         recorded {existing}, file {current}",
-                        m.version, m.name
-                    )));
-                }
-                // Already applied and unchanged: no-op.
-            }
-            None => {
-                let sum = checksum(&m.sql);
-                conn.execute_batch("BEGIN;").map_err(migration_err)?;
-                let applied = (|| -> Result<()> {
-                    conn.execute_batch(&m.sql).map_err(migration_err)?;
-                    conn.execute(
-                        "INSERT INTO _migrations (version, name, checksum, applied_at) \
-                         VALUES (?1, ?2, ?3, unixepoch())",
-                        rusqlite::params![m.version, m.name, sum],
-                    )
-                    .map_err(migration_err)?;
-                    Ok(())
-                })();
-                match applied {
-                    Ok(()) => {
-                        conn.execute_batch("COMMIT;").map_err(migration_err)?;
-                    }
-                    Err(e) => {
-                        // Best-effort rollback; surface the original error.
-                        let _ = conn.execute_batch("ROLLBACK;");
-                        return Err(e);
-                    }
-                }
-            }
+            Some(existing) => verify_recorded_checksum(m, &existing)?,
+            None => apply_unseen(conn, m)?,
         }
     }
     Ok(())
+}
+
+fn verify_recorded_checksum(migration: &Migration, recorded: &str) -> Result<()> {
+    let current = checksum(&migration.sql);
+    if recorded == current {
+        Ok(())
+    } else {
+        Err(Error::Migration(format!(
+            "checksum mismatch for migration {} ({}): \
+             recorded {recorded}, file {current}",
+            migration.version, migration.name
+        )))
+    }
+}
+
+/// Apply one optimistically-unseen migration under a write lock. Re-read the
+/// ledger after acquiring the lock because another fresh opener may have
+/// applied the migration while this connection waited.
+fn apply_unseen(conn: &rusqlite::Connection, migration: &Migration) -> Result<()> {
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)
+        .map_err(migration_err)?;
+
+    if let Some(existing) = recorded_checksum(conn, migration.version)? {
+        verify_recorded_checksum(migration, &existing)?;
+    } else {
+        let sum = checksum(&migration.sql);
+        conn.execute_batch(&migration.sql).map_err(migration_err)?;
+        conn.execute(
+            "INSERT INTO _migrations (version, name, checksum, applied_at) \
+             VALUES (?1, ?2, ?3, unixepoch())",
+            rusqlite::params![migration.version, migration.name, sum],
+        )
+        .map_err(migration_err)?;
+    }
+
+    tx.commit().map_err(migration_err)
 }
 
 /// Run all pending migrations against `conn`, transactionally and in order.
 ///
 /// - Creates `_migrations` if absent.
 /// - Discovers `NNN_*.sql` files, orders by the numeric prefix.
-/// - Applies each unseen version inside its own transaction, recording the
-///   sha256 checksum.
+/// - Applies each unseen version inside its own immediate transaction,
+///   rechecking the ledger after locking and recording the sha256 checksum.
 /// - Re-applying an already-recorded version is a no-op.
 /// - A checksum change on an already-applied version returns `Error::Migration`.
 pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -36,6 +36,20 @@ impl SqliteStore {
         embedding_dim: usize,
         embedding_model: Option<&str>,
     ) -> Result<Self> {
+        Self::open_inner_with_schema_hook(path, embedding_dim, embedding_model, || {})
+    }
+    /// The real file-open path with a seam that lets concurrency tests pause
+    /// after the optimistic vector-schema check. The production monomorph uses
+    /// a zero-sized no-op closure, so current-schema opens pay no callback cost.
+    fn open_inner_with_schema_hook<F>(
+        path: &Path,
+        embedding_dim: usize,
+        embedding_model: Option<&str>,
+        after_vector_schema_read: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce(),
+    {
         register_vec()?;
         // The DB file holds captured memory text: owner-only (0600), parity with
         // the daemon socket. Pre-create a missing file at 0600 so it is never
@@ -85,7 +99,12 @@ impl SqliteStore {
                 path.display()
             )))
         })?;
-        Self::init(conn, embedding_dim, embedding_model)
+        Self::init_with_schema_hook(
+            conn,
+            embedding_dim,
+            embedding_model,
+            after_vector_schema_read,
+        )
     }
     /// Open an ephemeral in-memory store with the given embedding dimension.
     pub fn open_in_memory(embedding_dim: usize) -> Result<Self> {
@@ -100,6 +119,17 @@ impl SqliteStore {
         embedding_dim: usize,
         embedding_model: Option<&str>,
     ) -> Result<Self> {
+        Self::init_with_schema_hook(conn, embedding_dim, embedding_model, || {})
+    }
+    fn init_with_schema_hook<F>(
+        conn: rusqlite::Connection,
+        embedding_dim: usize,
+        embedding_model: Option<&str>,
+        after_vector_schema_read: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce(),
+    {
         // A zero-dimension embedding produces a malformed `float[0]` vec0 column.
         // Reject it up front rather than letting SQLite fail cryptically later.
         if embedding_dim == 0 {
@@ -143,7 +173,7 @@ impl SqliteStore {
         // created at the current vector schema version — or rebuilt in place
         // from a previous version (W1.1 cosine metric + W1.7 namespace
         // partition, one combined rebuild).
-        ensure_vector_schema(&conn, embedding_dim)?;
+        ensure_vector_schema_with_hook(&conn, embedding_dim, after_vector_schema_read)?;
         let site_id = seed_or_get_site_id(&conn)?;
 
         Ok(Self {
@@ -293,22 +323,39 @@ fn upsert_meta(conn: &rusqlite::Connection, key: &str, value: &str) -> Result<()
 /// - table without marker (v1 layout, OR a half-created fresh DB after a
 ///   crash between CREATE and marker): full rebuild — idempotent because the
 ///   stash SELECT reads only columns both layouts expose.
-fn ensure_vector_schema(conn: &rusqlite::Connection, embedding_dim: usize) -> Result<()> {
+fn ensure_vector_schema_with_hook<F>(
+    conn: &rusqlite::Connection,
+    embedding_dim: usize,
+    after_schema_read: F,
+) -> Result<()>
+where
+    F: FnOnce(),
+{
     if meta_value(conn, "vector_schema_version")?.as_deref() == Some(VECTOR_SCHEMA_VERSION) {
         return Ok(());
     }
 
-    let table_exists: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'memory_vectors'",
-            [],
-            |r| r.get(0),
-        )
-        .map_err(storage_err)?;
+    after_schema_read();
 
-    // One transaction for create-or-rebuild + marker: a crash mid-way rolls
-    // everything back and the next open retries from the same state.
+    // Only the slow path takes a write lock. Re-read every decision input
+    // after BEGIN IMMEDIATE: another opener may have completed initialization
+    // while this connection waited for the lock. Keeping the optimistic check
+    // above means a current-schema open remains read-only and lock-free.
+    // Create-or-rebuild + markers stay in one transaction, so a crash mid-way
+    // rolls everything back and the next open retries from the same state.
     immediate_tx(conn, || {
+        if meta_value(conn, "vector_schema_version")?.as_deref() == Some(VECTOR_SCHEMA_VERSION) {
+            return Ok(());
+        }
+
+        let table_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'table' AND name = 'memory_vectors'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(storage_err)?;
         if table_exists > 0 {
             rebuild_vector_table(conn, embedding_dim)?;
         } else {
@@ -1455,6 +1502,130 @@ mod vector_schema_tests {
             .unwrap();
         assert!(ddl.contains("PARTITION KEY"), "ddl: {ddl}");
         assert!(ddl.contains("distance_metric=cosine"), "ddl: {ddl}");
+    }
+
+    #[test]
+    fn concurrent_fresh_vector_schema_opens_agree_on_all_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("concurrent-fresh.db");
+
+        // Leave a genuinely fresh dynamic-vector state: all committed SQL
+        // migrations exist, but dimension/model/site markers and the vec0
+        // table do not. This isolates the vector-schema race from the separate
+        // migration runner while exercising marker seeding in both opens.
+        register_vec().unwrap();
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+            run_migrations(&conn).unwrap();
+        }
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let spawn_open = |path: std::path::PathBuf, barrier: std::sync::Arc<std::sync::Barrier>| {
+            std::thread::spawn(move || -> std::result::Result<[String; 5], String> {
+                let store = SqliteStore::open_inner_with_schema_hook(
+                    &path,
+                    DIM,
+                    Some("deterministic"),
+                    move || {
+                        barrier.wait();
+                    },
+                )
+                .map_err(|error| error.to_string())?;
+                let value = |key| {
+                    store
+                        .meta_value(key)
+                        .map_err(|error| error.to_string())?
+                        .ok_or_else(|| format!("missing meta.{key}"))
+                };
+                Ok([
+                    value("embedding_dim")?,
+                    value("embedding_model")?,
+                    value("vector_schema_version")?,
+                    value("vector_metric")?,
+                    store.site_id().to_string(),
+                ])
+            })
+        };
+
+        let first = spawn_open(path.clone(), std::sync::Arc::clone(&barrier));
+        let second = spawn_open(path, barrier);
+        let first = first.join().unwrap().unwrap();
+        let second = second.join().unwrap().unwrap();
+
+        assert_eq!(first, second, "both opens must observe one committed state");
+        assert_eq!(
+            &first[..4],
+            ["8", "deterministic", VECTOR_SCHEMA_VERSION, "cosine"],
+            "dimension, model, schema version, and metric markers agree"
+        );
+    }
+
+    /// Reproducible task #54 microbenchmark. Run with:
+    /// `cargo test --release -p rb-store vector_schema_current_open_benchmark \
+    /// -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual release-mode microbenchmark"]
+    fn vector_schema_current_open_benchmark() {
+        const ITERATIONS: u32 = 20_000;
+        const SAMPLES: usize = 7;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("current-schema-bench.db");
+        let store = SqliteStore::open_with_model(&path, DIM, "deterministic").unwrap();
+
+        // Warm SQLite's page cache and both statement paths before timing.
+        for _ in 0..1_000 {
+            ensure_vector_schema_with_hook(&store.conn, DIM, || {}).unwrap();
+            immediate_tx(&store.conn, || {
+                std::hint::black_box(meta_value(&store.conn, "vector_schema_version")?);
+                Ok(())
+            })
+            .unwrap();
+        }
+
+        let measure_optimistic = || {
+            let started = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                ensure_vector_schema_with_hook(&store.conn, DIM, || {}).unwrap();
+            }
+            started.elapsed().as_nanos() as f64 / f64::from(ITERATIONS)
+        };
+        let measure_forced_lock = || {
+            let started = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                immediate_tx(&store.conn, || {
+                    std::hint::black_box(meta_value(&store.conn, "vector_schema_version")?);
+                    Ok(())
+                })
+                .unwrap();
+            }
+            started.elapsed().as_nanos() as f64 / f64::from(ITERATIONS)
+        };
+
+        let mut optimistic_samples = Vec::with_capacity(SAMPLES);
+        let mut forced_lock_samples = Vec::with_capacity(SAMPLES);
+        for sample in 0..SAMPLES {
+            // Alternate order to avoid consistently giving either path the
+            // warmer cache or later CPU state.
+            if sample % 2 == 0 {
+                optimistic_samples.push(measure_optimistic());
+                forced_lock_samples.push(measure_forced_lock());
+            } else {
+                forced_lock_samples.push(measure_forced_lock());
+                optimistic_samples.push(measure_optimistic());
+            }
+        }
+        optimistic_samples.sort_by(f64::total_cmp);
+        forced_lock_samples.sort_by(f64::total_cmp);
+        let optimistic_median = optimistic_samples[SAMPLES / 2];
+        let forced_lock_median = forced_lock_samples[SAMPLES / 2];
+        println!(
+            "vector_schema_current_open iterations_per_sample={ITERATIONS} samples={SAMPLES} \
+             optimistic_median_ns_per_op={optimistic_median:.1} \
+             forced_immediate_median_ns_per_op={forced_lock_median:.1} \
+             forced_overhead_ratio={:.2}x",
+            forced_lock_median / optimistic_median
+        );
     }
 
     /// W1.7 acceptance: a namespace whose live rows are <1% of all vectors

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -6,6 +6,9 @@ use crate::error::{io_err, storage_err};
 use crate::migrations::run_migrations;
 use std::path::Path;
 
+const OPEN_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const WAL_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
+
 impl SqliteStore {
     /// Open (or create) a store at `path` with the given embedding dimension.
     ///
@@ -99,6 +102,8 @@ impl SqliteStore {
                 path.display()
             )))
         })?;
+        #[cfg(test)]
+        wait_for_public_open_test_barrier(path);
         Self::init_with_schema_hook(
             conn,
             embedding_dim,
@@ -138,17 +143,17 @@ impl SqliteStore {
             ));
         }
 
-        // WAL gives concurrent readers + one writer with no SQLITE_BUSY storms.
-        // (In-memory DBs ignore WAL and report "memory"; that is fine.)
-        conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(storage_err)?;
-        conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(storage_err)?;
-
         // A busy handler keeps the P1 daemon (multiple connections + WAL
         // checkpoints) from hitting immediate SQLITE_BUSY: a contended write
-        // waits up to 5s for the lock instead of failing right away.
-        conn.busy_timeout(std::time::Duration::from_secs(5))
+        // waits up to 5s for the lock instead of failing right away. Install it
+        // before WAL negotiation: changing a zero-byte DB's journal mode is
+        // itself a write and two first openers can contend there.
+        conn.busy_timeout(OPEN_BUSY_TIMEOUT).map_err(storage_err)?;
+
+        // WAL gives concurrent readers + one writer with no SQLITE_BUSY storms.
+        // (In-memory DBs ignore WAL and report "memory"; that is fine.)
+        enable_wal(&conn)?;
+        conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(storage_err)?;
 
         run_migrations(&conn)?;
@@ -236,6 +241,72 @@ impl SqliteStore {
     pub fn meta_value(&self, key: &str) -> Result<Option<String>> {
         meta_value(&self.conn, key)
     }
+}
+
+/// Enable WAL with a bounded retry for SQLite's journal-mode transition.
+/// SQLite may return BUSY immediately for this pragma even with a busy handler
+/// installed, so two zero-byte first openers need an explicit retry window.
+fn enable_wal(conn: &rusqlite::Connection) -> Result<()> {
+    let deadline = std::time::Instant::now() + OPEN_BUSY_TIMEOUT;
+    loop {
+        match conn.pragma_update(None, "journal_mode", "WAL") {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if matches!(
+                    error.sqlite_error_code(),
+                    Some(rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked)
+                ) && std::time::Instant::now() < deadline =>
+            {
+                std::thread::sleep(WAL_RETRY_INTERVAL);
+            }
+            Err(error) => return Err(Error::Storage(format!("enable WAL journal mode: {error}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+fn public_open_test_barriers() -> &'static std::sync::Mutex<
+    std::collections::HashMap<std::path::PathBuf, std::sync::Arc<std::sync::Barrier>>,
+> {
+    static BARRIERS: std::sync::OnceLock<
+        std::sync::Mutex<
+            std::collections::HashMap<std::path::PathBuf, std::sync::Arc<std::sync::Barrier>>,
+        >,
+    > = std::sync::OnceLock::new();
+    BARRIERS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn wait_for_public_open_test_barrier(path: &Path) {
+    let barrier = public_open_test_barriers()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(path)
+        .cloned();
+    if let Some(barrier) = barrier {
+        barrier.wait();
+    }
+}
+
+#[cfg(test)]
+fn install_public_open_test_barrier(path: &Path, barrier: std::sync::Arc<std::sync::Barrier>) {
+    let previous = public_open_test_barriers()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(path.to_path_buf(), barrier);
+    assert!(
+        previous.is_none(),
+        "test barrier already installed for {path:?}"
+    );
+}
+
+#[cfg(test)]
+fn remove_public_open_test_barrier(path: &Path) {
+    let removed = public_open_test_barriers()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(path);
+    assert!(removed.is_some(), "test barrier missing for {path:?}");
 }
 /// Caches the result of the one-time process-global sqlite-vec registration.
 /// `Ok(())` on success; the error message is cloned on every subsequent call.
@@ -1552,6 +1623,51 @@ mod vector_schema_tests {
         let second = spawn_open(path, barrier);
         let first = first.join().unwrap().unwrap();
         let second = second.join().unwrap().unwrap();
+
+        assert_eq!(first, second, "both opens must observe one committed state");
+        assert_eq!(
+            &first[..4],
+            ["8", "deterministic", VECTOR_SCHEMA_VERSION, "cosine"],
+            "dimension, model, schema version, and metric markers agree"
+        );
+    }
+
+    #[test]
+    fn concurrent_zero_byte_public_opens_agree_on_all_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("zero-byte-concurrent.db");
+        assert!(!path.exists(), "the public opens must create the database");
+
+        // The path-scoped test seam pauses both connections immediately after
+        // Connection::open, so the calls below race the complete public init
+        // path: WAL negotiation, migrations, marker seeding, and vec0 create.
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        install_public_open_test_barrier(&path, barrier);
+        let spawn_open = |path: std::path::PathBuf| {
+            std::thread::spawn(move || -> std::result::Result<[String; 5], String> {
+                let store = SqliteStore::open_with_model(&path, DIM, "deterministic")
+                    .map_err(|error| error.to_string())?;
+                let value = |key| {
+                    store
+                        .meta_value(key)
+                        .map_err(|error| error.to_string())?
+                        .ok_or_else(|| format!("missing meta.{key}"))
+                };
+                Ok([
+                    value("embedding_dim")?,
+                    value("embedding_model")?,
+                    value("vector_schema_version")?,
+                    value("vector_metric")?,
+                    store.site_id().to_string(),
+                ])
+            })
+        };
+
+        let first = spawn_open(path.clone());
+        let second = spawn_open(path.clone());
+        let first = first.join().unwrap().unwrap();
+        let second = second.join().unwrap().unwrap();
+        remove_public_open_test_barrier(&path);
 
         assert_eq!(first, second, "both opens must observe one committed state");
         assert_eq!(

--- a/docs/eval/2026-07-12-vector-schema-init-race.md
+++ b/docs/eval/2026-07-12-vector-schema-init-race.md
@@ -7,24 +7,33 @@ Platform: macOS 26.5.2 arm64, rustc 1.96.0
 
 ## Decision
 
-Keep the existing optimistic `meta.vector_schema_version` read for the common
-current-schema open. Only a missing or outdated marker acquires
-`BEGIN IMMEDIATE`. Once it owns that write lock, the slow path re-reads the
-marker and checks whether `memory_vectors` exists before choosing create or
-rebuild.
+Make each write-bearing stage of a first open single-winner without adding a
+write transaction to current-schema opens:
 
-The revalidation removes the race where two openers both cached “table absent”
-and the loser later attempted a duplicate `CREATE VIRTUAL TABLE`. It also
-preserves the existing crash guarantee: create/rebuild and both schema markers
-commit or roll back together.
+1. Install the existing five-second busy handler before journal-mode setup.
+   Retry only SQLite `BUSY`/`LOCKED` results from the zero-byte WAL transition,
+   bounded by the same deadline.
+2. Keep the migration ledger's optimistic read. Only an unseen migration takes
+   `BEGIN IMMEDIATE`; after acquiring it, re-read the ledger and either validate
+   the concurrent winner's checksum or apply SQL plus its ledger row atomically.
+3. Keep the existing optimistic `meta.vector_schema_version` read. Only a
+   missing or outdated marker takes `BEGIN IMMEDIATE`, then re-read the marker
+   and table state before choosing create or rebuild.
+
+The revalidations remove both stale decisions observed before this fix: replay
+of already-applied migration DDL (`duplicate column name`) and duplicate
+`CREATE VIRTUAL TABLE`. Migration SQL plus its ledger row remains one atomic
+transaction; vector create/rebuild plus both schema markers also still commits
+or rolls back together.
 
 ## Deterministic race coverage
 
-`concurrent_fresh_vector_schema_opens_agree_on_all_markers` starts from a fully
-migrated database with no dynamic vector table or vector-schema marker. A
-barrier in the real file-open path forces both connections past the optimistic
-marker miss before either may take the initialization lock. Both opens must
-succeed and report identical values for:
+`concurrent_zero_byte_public_opens_agree_on_all_markers` starts with no database
+file. A path-scoped test barrier pauses both SQLite connections immediately
+after `Connection::open`; both threads then call the public
+`SqliteStore::open_with_model` path through WAL negotiation, all migrations,
+marker seeding, and vector-table creation. Both opens must succeed and report
+identical values for:
 
 - `embedding_dim`
 - `embedding_model`
@@ -32,9 +41,16 @@ succeed and report identical values for:
 - `vector_metric`
 - `site_id`
 
-The regression test failed before the fix with
-`storage error: table memory_vectors already exists`. It passed ten consecutive
-debug-profile runs after the under-lock revalidation was added.
+Before the complete fix, stress probes failed with `database is locked`,
+`duplicate column name: base_strength`, or
+`table memory_vectors already exists`, depending on which stale first-open
+decision lost the race. The public zero-byte regression passed 100 consecutive
+debug-profile runs after all three initialization stages were hardened.
+
+The narrower
+`concurrent_fresh_vector_schema_opens_agree_on_all_markers` test remains to
+force both connections past the vector marker miss specifically, independent
+of migration scheduling.
 
 ## Current-schema benchmark
 
@@ -51,11 +67,13 @@ Reproduce with:
 cargo test --release -p rb-store vector_schema_current_open_benchmark -- --ignored --nocapture
 ```
 
-Task runs (two invocations of the seven-sample benchmark):
+Task runs (three invocations of the seven-sample benchmark, including the
+post-zero-byte-hardening rerun):
 
 ```text
 run 1: optimistic=1793.7 ns/op, forced-immediate=2984.8 ns/op, ratio=1.66x
 run 2: optimistic=1678.5 ns/op, forced-immediate=2550.6 ns/op, ratio=1.52x
+run 3: optimistic=1597.7 ns/op, forced-immediate=2494.2 ns/op, ratio=1.56x
 ```
 
 This result supports keeping the write lock off the no-op path. Absolute

--- a/docs/eval/2026-07-12-vector-schema-init-race.md
+++ b/docs/eval/2026-07-12-vector-schema-init-race.md
@@ -1,0 +1,63 @@
+# Vector schema initialization race and fast-path benchmark
+
+Date: 2026-07-12  
+Task: Vikunja #506 (rusty-brain project task #54)  
+Base: `9e8312d`  
+Platform: macOS 26.5.2 arm64, rustc 1.96.0
+
+## Decision
+
+Keep the existing optimistic `meta.vector_schema_version` read for the common
+current-schema open. Only a missing or outdated marker acquires
+`BEGIN IMMEDIATE`. Once it owns that write lock, the slow path re-reads the
+marker and checks whether `memory_vectors` exists before choosing create or
+rebuild.
+
+The revalidation removes the race where two openers both cached “table absent”
+and the loser later attempted a duplicate `CREATE VIRTUAL TABLE`. It also
+preserves the existing crash guarantee: create/rebuild and both schema markers
+commit or roll back together.
+
+## Deterministic race coverage
+
+`concurrent_fresh_vector_schema_opens_agree_on_all_markers` starts from a fully
+migrated database with no dynamic vector table or vector-schema marker. A
+barrier in the real file-open path forces both connections past the optimistic
+marker miss before either may take the initialization lock. Both opens must
+succeed and report identical values for:
+
+- `embedding_dim`
+- `embedding_model`
+- `vector_schema_version`
+- `vector_metric`
+- `site_id`
+
+The regression test failed before the fix with
+`storage error: table memory_vectors already exists`. It passed ten consecutive
+debug-profile runs after the under-lock revalidation was added.
+
+## Current-schema benchmark
+
+The ignored `vector_schema_current_open_benchmark` is a release-mode
+microbenchmark of the schema portion of open, not an end-to-end store-open
+benchmark. It compares the shipped optimistic marker check with the alternative
+of taking `BEGIN IMMEDIATE`, reading the same marker, and committing on every
+current-schema open. It warms both paths, alternates their order, and reports
+the median of seven samples with 20,000 iterations per sample.
+
+Reproduce with:
+
+```text
+cargo test --release -p rb-store vector_schema_current_open_benchmark -- --ignored --nocapture
+```
+
+Task runs (two invocations of the seven-sample benchmark):
+
+```text
+run 1: optimistic=1793.7 ns/op, forced-immediate=2984.8 ns/op, ratio=1.66x
+run 2: optimistic=1678.5 ns/op, forced-immediate=2550.6 ns/op, ratio=1.52x
+```
+
+This result supports keeping the write lock off the no-op path. Absolute
+nanosecond values are machine-specific; the checked-in benchmark is the durable
+artifact for rerunning the comparison on release hardware.

--- a/docs/eval/2026-07-12-vector-schema-init-race.md
+++ b/docs/eval/2026-07-12-vector-schema-init-race.md
@@ -1,8 +1,11 @@
 # Vector schema initialization race and fast-path benchmark
 
-Date: 2026-07-12  
-Task: Vikunja #506 (rusty-brain project task #54)  
-Base: `9e8312d`  
+Date: 2026-07-12
+
+Task: Vikunja #506 (rusty-brain project task #54)
+
+Base: `9e8312d`
+
 Platform: macOS 26.5.2 arm64, rustc 1.96.0
 
 ## Decision


### PR DESCRIPTION
## Summary

Vikunja #54 identified that two concurrent first opens could both observe missing vector-schema state and race creation or rebuild. Literal zero-byte testing also exposed earlier contention in WAL negotiation and migration application before vector initialization.

This change makes each write-bearing initialization stage single-winner while preserving optimistic read-only fast paths:

- Install the existing busy handler before WAL negotiation and bounded-retry only SQLite busy/locked journal transitions.
- Read the migration ledger optimistically; for each unseen migration, take `BEGIN IMMEDIATE`, revalidate under the lock, and either validate the concurrent winner or apply SQL plus its ledger row atomically.
- Read the vector schema marker optimistically; on a miss, take `BEGIN IMMEDIATE`, revalidate marker and table state, then atomically create/rebuild plus both markers.

A deterministic path-scoped barrier forces two public `open_with_model` calls through a truly zero-byte database. Both must succeed and agree on dimension, model, vector schema version/metric, and site id. The regression passed 100 consecutive invocations.

The release microbenchmark shows why the fast path stays lock-free: current-schema marker reads measured about 1.60 microseconds per operation versus 2.49 microseconds with a forced immediate transaction, a 1.56x penalty. The checked-in dated report records three runs spanning 1.52x to 1.66x.

## Validation

- Full `rb-store`: 232 passed, 1 ignored benchmark
- Zero-byte concurrent public-open regression: 100 consecutive passes
- `cargo clippy -p rb-store --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- Contract-drift guard passes
- CodeRabbit local review: zero findings

## Merge order

Merge PR #73 first. Both branches touch lifecycle initialization, so this branch should then be rebased and its small conflict resolved before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes open a new or empty database simultaneously.
  * Added retry handling for temporary database locking during initialization.
  * Prevented duplicate migrations and vector-table creation during concurrent setup.
  * Ensured concurrent openings consistently use the committed schema and configuration.

* **Documentation**
  * Added detailed documentation covering vector-schema initialization races, concurrency behavior, and verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->