### PR TITLE
docs: reconcile delivered product status and drift guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,6 +3022,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 > (vector + keyword + graph) retrieval over SQLite, exposed via MCP and a CLI.
 >
 > **Status: early development.** The pieces described below are implemented and
-> covered by unit and integration tests, but the project has only had **basic
-> correctness testing**. It has **not** been performance-, scale-, or
-> capability-tested, and retrieval quality has not been measured against real
-> embedding models at any meaningful corpus size. Treat it as a work in progress,
-> not a finished product. Interfaces and on-disk format may change.
+> covered by unit and integration tests. A bounded Claude Code scorecard has
+> provided **N=5 proxy capability evidence**, but this is not production proof:
+> performance, scale, sustained concurrency, resource exhaustion, semantic
+> quality with a production embedding provider, and multi-machine adoption are
+> still unmeasured. Treat it as a work in progress, not a finished product.
+> Interfaces and the on-disk format may change.
 
 ## What it is
 
@@ -102,7 +103,7 @@ degradation, health, security) is declared in
 
 ## What works today
 
-Implemented and test-covered (correctness only — see [Testing](#testing)):
+Implemented and test-covered (correctness is the primary coverage; see [Testing](#testing) for bounded capability evidence and limits):
 
 - **Store and recall** memories scoped by namespace, with enrichment and graph links.
 - **Hybrid retrieval** fusing FTS5 keyword search, `sqlite-vec` vector similarity, and
@@ -113,8 +114,14 @@ Implemented and test-covered (correctness only — see [Testing](#testing)):
   active `contradicts` link (best-effort, never fails recall).
 - **A single-writer daemon** over SQLite WAL with a concurrent read pool, change
   notifications via an in-process broadcast, and auto-start from any client command.
-- **An MCP server** exposing ten tools over stdio.
+- **An MCP server** exposing **12 MCP tools** over stdio (six advertised by
+  default; all 12 remain directly routable).
 - **A CLI** for direct use and scripting.
+- **Activation and operations commands**: bounded project `init`/`import`,
+  read-only `status`/`stats` plus `doctor`, and portable
+  `export`/`backup`/JSON `restore`.
+- **An optional loopback HTTP surface** for non-MCP local clients, off by
+  default and deliberately not an authentication boundary.
 - **Pluggable embeddings** — an offline deterministic provider (default), a Voyage API
   provider, and an optional local ONNX provider behind a feature flag.
 - **Best-effort capture hooks** (`rusty-brain-hooks`) and an installer
@@ -205,7 +212,8 @@ rusty-brain reembed
 rusty-brain init --list-batches
 rusty-brain init --undo <batch-id>
 
-# export memories (post-redaction, sorted by id for git-diffability)
+# export stored memories (sorted by id for git-diffability; run `scrub` first
+# if legacy or manually-entered rows may still contain plaintext secrets)
 rusty-brain export --format markdown
 rusty-brain export --format json --min-importance 5
 rusty-brain export --format csv
@@ -316,9 +324,10 @@ opt-in HTTP listener"): off by default at every layer; the bind must be a
 literal loopback `ip:port` — anything else refuses to start; **admin ops are
 always denied over HTTP** (no kernel-verified peer credential over TCP);
 Host/Origin are checked against loopback (DNS-rebinding/browser defense);
-bodies are capped at 1 MiB; v1 is a same-machine, same-user surface and
-explicitly **not an auth boundary** — on a multi-user machine, any local
-account can reach the non-admin surface while it is enabled.
+bodies are capped at 1 MiB; v1 is a same-machine surface intended for a
+single-user deployment and explicitly **not an auth boundary** — there is no
+same-user enforcement, so on a multi-user machine any local account can reach
+the non-admin surface while it is enabled.
 
 ### Capture hooks (optional)
 
@@ -423,12 +432,15 @@ unpinned overrides are never silently honored.
 
 ## Workspace layout
 
-Thirteen crates, plus a dev-only evaluation harness. Each crate is small and
-single-purpose; dependencies form a compiler-enforced DAG.
+The repository currently contains **18 workspace crates**. Each crate is
+small and single-purpose; dependencies form a compiler-enforced DAG. The
+evaluation and contract-guard crates are development/CI tooling rather than
+shipped runtime components.
 
 | Crate | Responsibility |
 |---|---|
 | `rb-types` | Domain vocabulary: `MemoryId`, `Namespace`, `MemoryNote`, errors, enums. |
+| `rb-config` | Shared configuration, namespace resolution, and path precedence. |
 | `rb-store` | SQLite + `sqlite-vec` engine: schema, migrations, FTS, vector KNN, graph queries. |
 | `rb-proto` | Daemon wire protocol: request/response types, length-delimited JSON framing, socket client. |
 | `rb-embed` | `EmbeddingProvider` trait + deterministic / Voyage / local (feature-gated) providers. |
@@ -436,13 +448,15 @@ single-purpose; dependencies form a compiler-enforced DAG.
 | `rb-engine` | Per-request orchestration: enrich → embed → store → link → recall. |
 | `rb-enrich` | Opt-in LLM enrichment and semantic linking (heuristic offline by default). |
 | `rb-daemon` | Single-writer service: writer thread, read pool, socket listener, change broadcast, namespace isolation. |
-| `rb-mcp` | MCP stdio adapter (the ten tools). |
+| `rb-mcp` | MCP stdio adapter (the 12 tools; six advertised by default). |
 | `rb-redact` | Shared secret-redaction pass (rules + entropy sweep) for capture and `scrub`. |
+| `rb-tokens` | Shared token counting used by prompt and MCP tool-budget guards. |
 | `rusty-brain` | The `rusty-brain` binary: `serve`, `mcp`, and client subcommands. |
 | `rb-agents` | CLI-agnostic agent hook spine: event model and per-CLI adapters. |
 | `rb-hooks` | The `rusty-brain-hooks` capture binary (fail-open). |
 | `rb-install` | The `rusty-brain-install` binary: wire/unwire hooks into agent CLIs. |
 | `rb-eval` *(dev-only)* | Offline deterministic regression harness; excluded from the shipped binary. |
+| `rb-contract-guard` *(CI/dev-only)* | Detects protocol/schema drift and requires an explicit compatibility decision. |
 
 ## Development
 
@@ -476,6 +490,12 @@ The current test suite is about **correctness, not performance or quality**:
   deterministic (non-semantic) vectors. It guards **ranking determinism and
   relative-ordering regressions** — "did this change reorder results?" — and explicitly
   does **not** measure absolute semantic quality.
+- **Bounded N=5 capability scorecard**: the 2026-07-12 Claude Code recovery
+  run was safe with zero memory-induced errors; reach and freshness passed,
+  while capture and retrieval-at-scale missed their steelman comparisons
+  (2/4 tracked dimensions passed). This is small-sample proxy evidence, not a
+  production-embedding quality gate or a user-adoption study. See
+  [`docs/eval/2026-07-12-w35-scorecard-n5-run.md`](docs/eval/2026-07-12-w35-scorecard-n5-run.md).
 - **Nightly real-agent smoke** (`.github/workflows/nightly-claude-smoke.yml`): a
   scheduled macOS job drives a real headless Claude Code session (`claude -p`) against
   freshly built binaries with hooks + MCP installed into an isolated `HOME`, then proves
@@ -487,10 +507,11 @@ The current test suite is about **correctness, not performance or quality**:
   `--model haiku --max-budget-usd 1`). Run it locally with
   `scripts/nightly-claude-smoke.sh --bin-dir target/release`.
 
-**Not yet tested:** performance and latency, behavior at scale (large corpora, many
-concurrent clients), real-world semantic recall quality with a production embedding
-model, and failure modes under resource exhaustion or partial outages. A real-model
-evaluation mode exists but is run manually and is not part of CI.
+**Not yet measured:** performance and latency; large-corpus scale; sustained
+concurrency; resource exhaustion and partial outages; real-world semantic
+quality with a production embedding provider; and multi-user/multi-machine
+activation or adoption. A real-model evaluation mode exists but is manual and
+is not a production semantic-quality gate.
 
 ## Roadmap
 
@@ -498,8 +519,9 @@ Implemented through the retrieval-quality phase (store/recall, the daemon, MCP a
 surfaces, agent capture hooks, composite embeddings, RRF, confidence, and contradiction
 surfacing). Designed but not yet built:
 
-- LLM-assisted memory **evolution** (reconciliation, reflection, importance
-  recalibration) as opt-in background jobs.
+- LLM-assisted memory **evolution** (reconciliation and reflection) beyond the
+  deterministic consolidation, decay, and importance-recalibration jobs that
+  already ship.
 - A **networked / multi-host** surface with real authentication (today it is
   single-machine and per-user).
 - An **ANN vector index** for larger corpora (`sqlite-vec` brute-force KNN is the

--- a/crates/rusty-brain/Cargo.toml
+++ b/crates/rusty-brain/Cargo.toml
@@ -44,6 +44,7 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
 anyhow = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rusty-brain/tests/product_docs.rs
+++ b/crates/rusty-brain/tests/product_docs.rs
@@ -74,7 +74,7 @@ fn readme_mcp_count_matches_tool_definitions() {
 
 fn status_section(document: &str) -> &str {
     let remainder = document
-        .split_once("## Status")
+        .split_once("\n## Status\n")
         .expect("PRD has a Status section")
         .1;
     remainder
@@ -84,7 +84,7 @@ fn status_section(document: &str) -> &str {
 
 fn checklist_section(document: &str) -> &str {
     let remainder = document
-        .split_once("## Implementation Checklist")
+        .split_once("\n## Implementation Checklist\n")
         .expect("delivered PRD has an Implementation Checklist")
         .1;
     remainder
@@ -96,7 +96,7 @@ fn checklist_section(document: &str) -> &str {
 fn delivered_prd_statuses_are_backed_by_cli_surfaces_and_closed_checklists() {
     let command = rusty_brain::cli::Cli::command();
     let index = read("docs/prds/README.md");
-    let claims: [(&str, &[&str]); 3] = [
+    let claims: [(&str, &[&str]); 4] = [
         (
             "docs/prds/2026-07-02-doctor-and-stats-observability.md",
             &["status", "stats", "doctor"],
@@ -108,6 +108,10 @@ fn delivered_prd_statuses_are_backed_by_cli_surfaces_and_closed_checklists() {
         (
             "docs/prds/2026-07-02-portable-export-and-backup.md",
             &["export", "backup", "restore"],
+        ),
+        (
+            "docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md",
+            &["serve"],
         ),
     ];
 
@@ -143,26 +147,6 @@ fn delivered_prd_statuses_are_backed_by_cli_surfaces_and_closed_checklists() {
         }
     }
 
-    let http_prd = "docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md";
-    let document = read(http_prd);
-    assert!(
-        status_section(&document)
-            .trim_start()
-            .starts_with("Delivered "),
-        "{http_prd} must identify its delivered status"
-    );
-    assert!(
-        !checklist_section(&document).contains("- [ ]"),
-        "{http_prd} is marked delivered but still has an unchecked implementation item"
-    );
-    let http_index_row = index
-        .lines()
-        .find(|line| line.contains("2026-07-02-http-surface-and-agent-agnostic-recall.md"))
-        .expect("PRD index includes the delivered HTTP PRD");
-    assert!(
-        http_index_row.contains("Delivered"),
-        "PRD index status drifted from the delivered HTTP PRD: {http_index_row}"
-    );
     let serve = command
         .find_subcommand("serve")
         .expect("delivered HTTP PRD requires serve");

--- a/crates/rusty-brain/tests/product_docs.rs
+++ b/crates/rusty-brain/tests/product_docs.rs
@@ -1,0 +1,174 @@
+//! Guards load-bearing product-documentation claims against the code and
+//! workspace manifests that define them.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use clap::CommandFactory as _;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+fn workspace_members() -> Vec<String> {
+    let manifest: toml::Value = toml::from_str(&read("Cargo.toml")).expect("workspace TOML parses");
+    manifest["workspace"]["members"]
+        .as_array()
+        .expect("workspace.members is an array")
+        .iter()
+        .map(|member| {
+            member
+                .as_str()
+                .expect("workspace member is a string")
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn workspace_inventory_matches_readme_and_architecture() {
+    let members = workspace_members();
+    let readme = read("README.md");
+    let architecture = read("docs/ARCHITECTURE.md");
+    let count_claim = format!("**{} workspace crates**", members.len());
+
+    for (name, document) in [("README", &readme), ("architecture", &architecture)] {
+        assert!(
+            document.contains(&count_claim),
+            "{name} must derive its workspace count from Cargo.toml; expected {count_claim:?}"
+        );
+        for member in &members {
+            let crate_name = Path::new(member)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("workspace member has a final path component");
+            assert!(
+                document.contains(crate_name),
+                "{name} workspace inventory is missing manifest member {crate_name:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn readme_mcp_count_matches_tool_definitions() {
+    let readme = read("README.md");
+    let count = rb_mcp::tool_definitions().len();
+    let claim = format!("**{count} MCP tools**");
+    assert!(
+        readme.contains(&claim),
+        "README must carry the code-derived MCP count marker {claim:?}"
+    );
+    assert!(
+        !readme.contains("ten tools") && !readme.contains("the ten tools"),
+        "README still contains the obsolete ten-tool claim"
+    );
+}
+
+fn status_section(document: &str) -> &str {
+    let remainder = document
+        .split_once("## Status")
+        .expect("PRD has a Status section")
+        .1;
+    remainder
+        .split_once("\n## ")
+        .map_or(remainder, |(status, _)| status)
+}
+
+fn checklist_section(document: &str) -> &str {
+    let remainder = document
+        .split_once("## Implementation Checklist")
+        .expect("delivered PRD has an Implementation Checklist")
+        .1;
+    remainder
+        .split_once("\n## ")
+        .map_or(remainder, |(checklist, _)| checklist)
+}
+
+#[test]
+fn delivered_prd_statuses_are_backed_by_cli_surfaces_and_closed_checklists() {
+    let command = rusty_brain::cli::Cli::command();
+    let index = read("docs/prds/README.md");
+    let claims: [(&str, &[&str]); 3] = [
+        (
+            "docs/prds/2026-07-02-doctor-and-stats-observability.md",
+            &["status", "stats", "doctor"],
+        ),
+        (
+            "docs/prds/2026-07-02-init-and-project-import.md",
+            &["init", "import"],
+        ),
+        (
+            "docs/prds/2026-07-02-portable-export-and-backup.md",
+            &["export", "backup", "restore"],
+        ),
+    ];
+
+    for (prd, commands) in claims {
+        let document = read(prd);
+        assert!(
+            status_section(&document)
+                .trim_start()
+                .starts_with("Delivered "),
+            "{prd} must identify its delivered status"
+        );
+        assert!(
+            !checklist_section(&document).contains("- [ ]"),
+            "{prd} is marked delivered but still has an unchecked implementation item"
+        );
+        let file_name = Path::new(prd)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("PRD path has a file name");
+        let index_row = index
+            .lines()
+            .find(|line| line.contains(file_name))
+            .unwrap_or_else(|| panic!("PRD index is missing {file_name}"));
+        assert!(
+            index_row.contains("Delivered"),
+            "PRD index status drifted from delivered file {file_name}: {index_row}"
+        );
+        for subcommand in commands {
+            assert!(
+                command.find_subcommand(subcommand).is_some(),
+                "{prd} claims delivery but CLI subcommand {subcommand:?} is absent"
+            );
+        }
+    }
+
+    let http_prd = "docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md";
+    let document = read(http_prd);
+    assert!(
+        status_section(&document)
+            .trim_start()
+            .starts_with("Delivered "),
+        "{http_prd} must identify its delivered status"
+    );
+    assert!(
+        !checklist_section(&document).contains("- [ ]"),
+        "{http_prd} is marked delivered but still has an unchecked implementation item"
+    );
+    let http_index_row = index
+        .lines()
+        .find(|line| line.contains("2026-07-02-http-surface-and-agent-agnostic-recall.md"))
+        .expect("PRD index includes the delivered HTTP PRD");
+    assert!(
+        http_index_row.contains("Delivered"),
+        "PRD index status drifted from the delivered HTTP PRD: {http_index_row}"
+    );
+    let serve = command
+        .find_subcommand("serve")
+        .expect("delivered HTTP PRD requires serve");
+    assert!(
+        serve
+            .get_arguments()
+            .any(|argument| argument.get_id().as_str() == "http"),
+        "delivered HTTP PRD requires the public `serve --http` flag"
+    );
+}

--- a/crates/rusty-brain/tests/product_docs.rs
+++ b/crates/rusty-brain/tests/product_docs.rs
@@ -66,8 +66,9 @@ fn readme_mcp_count_matches_tool_definitions() {
         "README must carry the code-derived MCP count marker {claim:?}"
     );
     assert!(
-        !readme.contains("ten tools") && !readme.contains("the ten tools"),
-        "README still contains the obsolete ten-tool claim"
+        !readme.contains("exposing ten tools over stdio")
+            && !readme.contains("It implements ten tools."),
+        "README still contains one of the obsolete ten-tool product claims"
     );
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,11 @@ flowchart TD
   RB --> rbdaemon
   RB --> rbmcp
   RB --> rbconfig
+  RB --> rbembed
+  RB --> rbproto
   RB --> rbredact
+  RB --> rbstore
+  RB --> rbtypes
   HOOKS --> rbagents
   HOOKS --> rbconfig
   HOOKS --> rbproto
@@ -76,7 +80,6 @@ flowchart TD
   rbdaemon --> rbstore
   rbdaemon --> rbproto
   rbmcp --> rbproto
-  rbmcp --> rbtokens
   rbagents --> rbconfig
   rbagents --> rbproto
   rbenrich --> rbengine
@@ -102,6 +105,7 @@ flowchart TD
   EVAL -.-> rbembed
   EVAL -.-> rbsearch
   EVAL -.-> rbstore
+  EVAL -.-> rbtypes
   GUARD -.->|"inspects wire + migrations"| rbproto
   GUARD -.-> rbtypes
   GUARD -.-> rbstore

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,8 +3,11 @@
 This document describes how `rusty-brain` is put together: the crate boundaries,
 the single-writer daemon, the write and recall data flows, the namespace model, and
 the storage layout. It reflects what is **implemented today**. Like the rest of the
-project, it is early-stage and has had basic correctness testing only — no
-performance, scale, or capability testing. For the user-facing overview and
+project, it is early-stage. Its broad automated suite emphasizes correctness;
+there is no performance, scale, sustained-concurrency, resource-exhaustion,
+production-embedding semantic-quality, or multi-machine adoption measurement.
+A bounded N=5 Claude Code scorecard is the only capability evidence; it is
+proxy evidence, not production validation. For the user-facing overview and
 quickstart, see the [README](../README.md).
 
 ## Design background
@@ -20,7 +23,7 @@ left as guidelines.
 
 | Principle | How it shows up |
 |---|---|
-| Focused crates, never a monolith | A workspace of 13 focused crates plus a dev-only harness (14 members), with a compiler-enforced dependency DAG; heavy/optional pieces (ONNX) behind a feature flag; supply-chain policy checked in CI. |
+| Focused crates, never a monolith | **18 workspace crates** with a compiler-enforced dependency DAG; heavy/optional pieces (ONNX) behind a feature flag; evaluation and contract guards stay outside the shipped runtime; supply-chain policy is checked in CI. |
 | One database, one transaction, one truth | Memories, FTS, and vectors in a single SQLite file; all writes serialize through one thread; reads run concurrently over WAL. |
 | Fail-closed boundaries | Namespace isolation and the embedding-dimension contract refuse to run on doubt. |
 | Fail-open capture | Best-effort capture hooks degrade silently and never block an agent session. |
@@ -35,31 +38,73 @@ Dependencies flow downward; no cycles.
 flowchart TD
   subgraph bins["Binaries"]
     RB["rusty-brain<br/>(serve · mcp · client)"]
-    HOOKS["rusty-brain-hooks"]
-    INSTALL["rusty-brain-install"]
+    HOOKS["rusty-brain-hooks<br/>(rb-hooks crate)"]
+    INSTALL["rusty-brain-install<br/>(rb-install crate)"]
   end
 
-  RB --> rbmcp["rb-mcp"]
-  RB --> rbdaemon["rb-daemon"]
-  RB --> rbproto["rb-proto"]
-  HOOKS --> rbagents["rb-agents"]
+  subgraph runtime["Runtime libraries"]
+    rbdaemon["rb-daemon"]
+    rbmcp["rb-mcp"]
+    rbagents["rb-agents"]
+    rbconfig["rb-config"]
+    rbproto["rb-proto"]
+    rbengine["rb-engine"]
+    rbenrich["rb-enrich"]
+    rbembed["rb-embed"]
+    rbsearch["rb-search"]
+    rbstore["rb-store"]
+    rbredact["rb-redact"]
+    rbtokens["rb-tokens"]
+    rbtypes["rb-types"]
+  end
+
+  RB --> rbdaemon
+  RB --> rbmcp
+  RB --> rbconfig
+  RB --> rbredact
+  HOOKS --> rbagents
+  HOOKS --> rbconfig
+  HOOKS --> rbproto
+  HOOKS --> rbredact
+  HOOKS --> rbtokens
   INSTALL --> rbagents
-  rbagents --> rbproto
 
-  rbmcp --> rbproto
-  rbdaemon --> rbengine["rb-engine"]
-  rbdaemon --> rbstore["rb-store"]
+  rbdaemon --> rbconfig
+  rbdaemon --> rbengine
+  rbdaemon --> rbenrich
+  rbdaemon --> rbembed
+  rbdaemon --> rbstore
   rbdaemon --> rbproto
-  rbengine --> rbsearch["rb-search"]
-  rbengine --> rbembed["rb-embed"]
-  rbengine --> rbenrich["rb-enrich"]
-  rbengine --> rbstore
-  rbstore --> rbtypes["rb-types"]
-  rbsearch --> rbtypes
-  rbembed --> rbtypes
-  rbproto --> rbtypes
+  rbmcp --> rbproto
+  rbmcp --> rbtokens
+  rbagents --> rbconfig
+  rbagents --> rbproto
+  rbenrich --> rbengine
+  rbengine --> rbembed
+  rbengine --> rbsearch
+  rbstore --> rbredact
 
-  EVAL["rb-eval (dev-only)"] -.->|"not in shipped binary"| rbengine
+  rbconfig --> rbtypes
+  rbproto --> rbtypes
+  rbagents --> rbtypes
+  rbenrich --> rbtypes
+  rbengine --> rbtypes
+  rbembed --> rbtypes
+  rbsearch --> rbtypes
+  rbstore --> rbtypes
+  rbmcp --> rbtypes
+
+  subgraph dev["Development and CI only"]
+    EVAL["rb-eval"]
+    GUARD["rb-contract-guard"]
+  end
+  EVAL -.->|"offline harness"| rbengine
+  EVAL -.-> rbembed
+  EVAL -.-> rbsearch
+  EVAL -.-> rbstore
+  GUARD -.->|"inspects wire + migrations"| rbproto
+  GUARD -.-> rbtypes
+  GUARD -.-> rbstore
 
   classDef client fill:#e3f2fd,stroke:#4781c4,color:#0d2b4e;
   classDef proc fill:#ede7f6,stroke:#7e57c2,color:#311b54;
@@ -70,18 +115,34 @@ flowchart TD
   classDef base fill:#eceff1,stroke:#90a4ae,color:#263238;
   classDef muted fill:#f5f5f5,stroke:#bdbdbd,color:#616161;
   class RB,HOOKS,INSTALL client;
-  class rbmcp,rbdaemon,rbengine,rbagents,rbproto proc;
+  class rbmcp,rbdaemon,rbengine,rbenrich,rbagents,rbconfig,rbproto,rbtokens proc;
   class rbstore store;
   class rbembed embed;
   class rbsearch decision;
-  class rbenrich accent;
+  class rbredact accent;
   class rbtypes base;
-  class EVAL muted;
+  class EVAL,GUARD muted;
   style bins fill:#f2f7fd,stroke:#9bbbe0,color:#0d2b4e;
+  style runtime fill:#f6f3fb,stroke:#b9a7da,color:#311b54;
+  style dev fill:#f5f5f5,stroke:#bdbdbd,color:#616161;
 ```
 
-`rb-eval` depends on the engine/store/search/embed crates for its offline harness but
-is excluded from the shipped binary's dependency closure (enforced by a CI check).
+All 18 manifest members appear above. `rb-eval` depends on the
+engine/store/search/embed crates for its offline harness but is excluded from
+the shipped binary's dependency closure. `rb-contract-guard` inspects the wire
+types and migrations from source and checks the compatibility snapshot in CI.
+
+## Current product surfaces
+
+- **CLI:** local client and operator commands, including `init`/`import`,
+  `doctor`/`stats`, and portable `export`/`backup`/JSON `restore`.
+- **MCP:** 12 routable tools over stdio; the default `tools/list` advertises a
+  six-tool token-economy subset, with the other six gated by
+  `RB_MCP_FULL_TOOLSET`.
+- **HTTP:** an optional, default-off loopback listener that mirrors the common
+  wire operations for local non-MCP clients. It is not multi-host and is not an
+  authentication boundary; admin and streaming operations remain unavailable
+  over HTTP v1.
 
 ## The single-writer daemon
 
@@ -316,19 +377,25 @@ creates the data directory `0700` when it creates it.
 These are designed-but-not-built seams, called out so they read as boundaries rather
 than gaps:
 
-- **LLM-assisted evolution** — reconciliation, reflection, and importance recalibration
-  as opt-in background jobs.
+- **LLM-assisted evolution** — reconciliation and reflection beyond the
+  deterministic consolidation, decay, and importance-recalibration jobs that
+  already ship.
 - **Networked / multi-host operation** — today the daemon is single-machine and
   per-user; a networked surface with real authentication is a separate future crate.
 - **Approximate vector search (ANN)** — the current brute-force KNN has a documented
   scale ceiling.
-- **A portable export/snapshot format.**
+- **Byte-exact online database backup and replication.** Portable text/JSON/CSV
+  export, JSON restore, and one-command portable snapshots are shipped; raw
+  SQLite disaster recovery and team replication remain separate future work.
 
 ## Honesty note
 
-Everything above is implemented and exercised by unit and integration tests, but the
-system has not been performance-, scale-, or capability-tested, and retrieval quality
-has not been measured with a real embedding model at a meaningful corpus size. The
-offline evaluation harness guards ranking *determinism and regressions*, not absolute
-semantic quality. Read the architecture as a description of intent and current
-structure, not as a benchmarked, production-hardened system.
+Everything above is implemented and exercised by unit and integration tests.
+The bounded N=5 Claude Code scorecard provides small-sample capability evidence:
+its recovery run was safe with zero memory-induced errors, and 2/4 tracked
+dimensions passed. It does not measure performance, large-corpus behavior,
+sustained concurrency, resource exhaustion, semantic quality with a production
+embedding provider, or multi-machine adoption. The offline harness guards
+ranking *determinism and regressions*, not absolute semantic quality. Read the
+architecture as current structure, not as a benchmarked, production-hardened
+system.

--- a/docs/prds/2026-07-02-decision-history-timeline.md
+++ b/docs/prds/2026-07-02-decision-history-timeline.md
@@ -82,8 +82,9 @@ Prints the evolution of the memory identified by `id`:
 
 - The supersede chain in both directions: what this memory supersedes
   (ancestors) and what supersedes it (newer), ordered by time, each with
-  summary, importance, confidence, `created_at`, `origin_*`, and the
-  supersede `reason`.
+  summary, importance, confidence, `created_at`, and `origin_*`. Supersede
+  hops carry no `reason` in v1 because the atomic supersede operation never
+  persisted one; only ordinary link edges expose their stored `reason`.
 - Active `contradicts`/`extends`/`references` edges with the linked memory's
   summary, confidence, and `contested` state.
 - A clear "current truth" pointer (the newest non-archived member of the
@@ -91,9 +92,9 @@ Prints the evolution of the memory identified by `id`:
 
 ### HIST-2. Derivation
 
-Built entirely from existing queries: the supersede link type, the
-`memories.archived_at`/`confidence`/`origin_*` columns, and the existing
-link rows. No new persistence.
+Built entirely from existing queries: the `memories.superseded_by` pointer,
+the `memories.archived_at`/`confidence`/`origin_*` columns, and ordinary link
+rows. No new persistence and no synthetic supersede-link/reason record.
 
 ### HIST-3. Output and limits
 

--- a/docs/prds/2026-07-02-doctor-and-stats-observability.md
+++ b/docs/prds/2026-07-02-doctor-and-stats-observability.md
@@ -2,10 +2,20 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review: the human cannot answer
-"is this helping?", so trust and retention die. The Road-to-Tens `status`
-gate clause (W1.6/W4.3) covers writer health/WAL/corpus for ops, but not the
-user-facing value signal.
+Delivered 2026-07-11 (PR #56, merge `33a2218`, Vikunja #460). `status` and
+`stats` expose the daemon/writer, corpus, feedback, recall, contention,
+retention, WAL, and embedding-model signals in human and JSON forms;
+`doctor` diagnoses the live system without auto-starting or writing and exits
+non-zero on failed checks. Store aggregation lives in
+`crates/rb-store/src/store/stats.rs`, and binary e2e tests cover the value
+signals plus permission/model failures.
+
+Residual scope is explicit: aggregation cost has correctness coverage but no
+large-corpus benchmark; doctor reports the model served by a reachable daemon
+but does not independently probe a remote provider; and it does not yet invoke
+the separately delivered `rusty-brain-install status` hook-wiring report. The
+DB parent directory is intentionally not checked because it may be
+caller-owned; socket directory ownership is checked when present.
 
 ## Owner Area
 
@@ -17,7 +27,7 @@ Touchpoints:
 - `crates/rusty-brain/src/run.rs`
 - `crates/rusty-brain/src/output.rs`
 - `crates/rb-daemon/src/server.rs`
-- `crates/rb-store/src/store.rs`
+- `crates/rb-store/src/store/stats.rs`
 - `crates/rb-proto/src/messages.rs` (additive `Stats` request/response)
 - `crates/rb-types/src/feedback_kind.rs` (feedback aggregates)
 - `crates/rb-daemon/src/change.rs` (oplog-derived activity)

--- a/docs/prds/2026-07-02-doctor-and-stats-observability.md
+++ b/docs/prds/2026-07-02-doctor-and-stats-observability.md
@@ -82,7 +82,8 @@ A health-check + diagnostic that exits non-zero on a problem and prints
 actionable guidance:
 
 - daemon reachable; socket mode correct; DB mode 0600 / dir 0700.
-- embedding provider reachable (or `deterministic` fallback noted loudly).
+- reachable daemon reports the configured embedding model (`deterministic` is
+  noted loudly); doctor does not independently call a remote provider.
 - embedding-model identity matches DB meta (the W0.2 fail-closed contract).
 - WAL checkpoint health; oversized-WAL warning with remediation hint.
 - hooks installed + wiring drift (delegates to installer `status` where

--- a/docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md
+++ b/docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md
@@ -55,7 +55,7 @@ Two coupled gaps:
 ## Goals
 
 - An optional local HTTP/REST listener (`rusty-brain serve --http`) exposing
-  the same operations as the CLI/MCP, for any client.
+  the same non-admin request shapes as the CLI/MCP, for any local client.
 - An agent-agnostic "recall-before-work" abstraction so prompt-time retrieval
   is a capability, not a Claude implementation detail.
 - Default-off, opt-in, loopback-only, with clear security framing; the
@@ -65,8 +65,9 @@ Two coupled gaps:
 
 - Do not replace MCP stdio (it stays the primary agent surface).
 - Do not build team-mode auth (that is Phase 5a/W5a.1); HTTP v1 is loopback
-  + same-user peer-cred, not multi-host.
-- Do not expose admin ops over HTTP without the existing peer-cred gate.
+  only and is not a multi-host surface.
+- Do not expose admin operations over HTTP; TCP callers have no kernel-verified
+  peer credential and are always treated as non-admin.
 - Do not change ranking or the response shape.
 
 ## Functional Requirements
@@ -75,21 +76,20 @@ Two coupled gaps:
 
 - `serve --http [bind]` (default `127.0.0.1:0` or a configured port) starts
   an HTTP listener alongside (or instead of) the UDS listener.
-- REST endpoints mirror CLI/MCP operations: `POST /remember`, `POST
+- REST endpoints mirror non-admin CLI/MCP operations: `POST /remember`, `POST
   /recall`, `GET /memories/:id`, `GET /context`, `POST /feedback`, etc.,
   over JSON. The existing `Response` types serialize directly.
 - Default-off; enabling it is explicit. A config knob (`[http] enable`,
   `bind`) under the same precedence rules as other knobs; secrets stay
   env-only.
 
-### HTTP-2. Security posture (v1: loopback + same-user)
+### HTTP-2. Security posture (v1: loopback-only, non-admin)
 
-- Bind loopback only by default; a non-loopback bind requires an explicit
-  opt-in flag and prints a warning.
-- Peer identity reuses the W2.6 peer-cred machinery where available;
-  admin ops (`RunJob`/`Reembed`/`Scrub`/`NamespaceRename`) stay admin-gated.
+- Refuse every non-loopback bind; v1 has no override or warning-only mode.
+- Treat every HTTP caller as non-admin because TCP supplies no kernel-verified
+  peer credential. Reject `RunJob`, `Reembed`, `Scrub`, and `NamespaceRename`.
 - The threat model is updated: HTTP is a new network surface; v1 is
-  same-machine/same-user and explicitly not an auth boundary.
+  same-machine and explicitly not an auth or same-user boundary.
 
 ### HTTP-3. Transport genericization (pulled forward from W5a.3)
 
@@ -113,8 +113,8 @@ Two coupled gaps:
 
 - `serve --http` responds to `POST /recall` with the same ranked results as
   the CLI, over loopback.
-- A non-loopback bind refuses without an explicit opt-in and warns.
-- Admin ops over HTTP are peer-cred-gated exactly as over UDS.
+- A non-loopback bind is refused with no override.
+- Admin operations are always rejected over HTTP.
 - An agent without `UserPromptSubmit` can still get prompt-time recall via
   its mapped equivalent, or the capability matrix records `unsupported`
   (never silent parity).
@@ -131,13 +131,14 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-Plus an HTTP e2e hitting `/recall` and `/feedback`, and a peer-cred test
+Plus an HTTP e2e hitting `/recall` and `/feedback`, and a non-admin HTTP test
 asserting admin rejection.
 
 ## Risks
 
-- New attack surface. Mitigate: default-off, loopback-only, peer-cred,
-  threat-model update, admin gating; no multi-host auth in v1.
+- New attack surface. Mitigate: default-off, loopback-only binding,
+  unconditionally denied admin operations, and a threat-model update; no
+  multi-host auth in v1.
 - Transport refactor regresses UDS. Mitigate: pull W5a.3's `Client<S>`
   genericization with agreement tests on both transports.
 - Agent recall abstraction too broad. Mitigate: narrow contract (top-k,

--- a/docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md
+++ b/docs/prds/2026-07-02-http-surface-and-agent-agnostic-recall.md
@@ -2,11 +2,23 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review. The roadmap is ~90%
-Claude Code; today everything funnels through stdio MCP or the CLI. A local
-HTTP surface unlocks any tool/script/non-MCP agent and expands TAM beyond
-coding agents, and a generic recall-before-work abstraction is what the
-cross-agent parity PRD is reaching for as a *product* invariant.
+Delivered 2026-07-11 (PR #62, merge `e4ca88e`). The optional listener is
+default-off and loopback-only, reuses the daemon's wire requests/responses,
+and exposes shortcut routes plus generic `POST /ops`. The transport-generic
+`rb_proto::Client<S>` and the shared prompt-time recall contract are shipped;
+the capability matrix records unsupported adapters rather than implying
+parity. HTTP/UDS agreement and HTTP security behavior are covered by
+`crates/rb-daemon/tests/http_e2e.rs`.
+
+The delivered security posture is deliberately stricter than this draft:
+non-loopback binds are refused outright (there is no override), HTTP callers
+are always non-admin because TCP has no kernel peer credential, and streaming
+`subscribe` is rejected. Every route requires an explicit namespace header;
+Host/Origin, JSON media type, body size, deadlines, and connection count are
+bounded. HTTP v1 remains a same-machine convenience surface, not an auth
+boundary or multi-host API. Native prompt-time injection remains Claude-only;
+other adapters are explicitly unsupported or may call `/recall` from their own
+tooling.
 
 ## Owner Area
 
@@ -14,7 +26,8 @@ Primary: transport, server listeners, and the prompt-time injection seam.
 
 Touchpoints:
 
-- `crates/rb-daemon/src/server.rs` (listener; transport seam)
+- `crates/rb-daemon/src/http.rs` (HTTP listener and request hygiene)
+- `crates/rb-daemon/src/server.rs` (shared dispatch; UDS listener)
 - `crates/rb-proto/src/client.rs`, `crates/rb-proto/src/codec.rs`
   (stream-generic framing - the W5a.3 transport-genericization, pulled
   forward)
@@ -132,12 +145,15 @@ asserting admin rejection.
 
 ## Implementation Checklist
 
-- [ ] Generalize codec/client to `Client<S>` (W5a.3 seam).
-- [ ] Add opt-in HTTP listener + REST endpoints.
-- [ ] Loopback default + non-loopback opt-in + peer-cred admin gate.
-- [ ] Promote recall-before-work to an agent capability.
-- [ ] Map per-adapter events to the injection contract; update the matrix.
-- [ ] Update the threat model; add HTTP + UDS agreement tests.
+- [x] Generalize codec/client to `Client<S>` (W5a.3 seam).
+- [x] Add the opt-in HTTP listener, shortcut routes, and generic `/ops`.
+- [x] Enforce loopback-only binding and always deny admin operations over HTTP
+      (stricter than the draft's non-loopback opt-in/peer-cred proposal).
+- [x] Promote recall-before-work to an agent capability and shared contract.
+- [x] Map verified adapter events and record unsupported mappings explicitly in
+      the capability matrix.
+- [x] Update the threat model; add HTTP/UDS agreement and adversarial HTTP
+      security tests.
 
 ## Roadmap Fit
 

--- a/docs/prds/2026-07-02-init-and-project-import.md
+++ b/docs/prds/2026-07-02-init-and-project-import.md
@@ -162,7 +162,7 @@ project tree and asserting recall + DB-bytes redaction + dedup.
 - [x] Wire adapters through redaction and the normal engine remember path.
 - [x] Add `import_batch:<id>` tagging, a private batch ledger, and
       `init --undo` / `--list-batches`.
-- [x] Implement idempotent exact-content dedup through a bounded recall probe
+- [x] Implement idempotent exact redacted-content dedup through a bounded recall probe
       (deliberate deviation from the draft's `near_duplicates()` mechanism).
 - [x] Add fixture-driven e2e coverage for recall, DB-bytes redaction, dedup,
       undo, and dry-run.

--- a/docs/prds/2026-07-02-init-and-project-import.md
+++ b/docs/prds/2026-07-02-init-and-project-import.md
@@ -54,8 +54,8 @@ it is ingested.
   context, so the first recall is non-empty and immediately useful.
 - Reuse existing primitives: batch `remember`, the enricher, namespace
   detection, and the redaction pass. No new storage schema for v1.
-- Make the import safe (redacted, namespaced, reviewable) and reversible
-  (deletable by namespace / source).
+- Make the import safe (redacted, namespaced, reviewable) and reversible through
+  the private per-database batch ledger.
 - Produce a visible "imported N memories" aha-moment at install time.
 
 ## Non-Goals
@@ -81,7 +81,7 @@ A guided first-run command, safe to run idempotently. Behavior:
 - Route every candidate through the existing redaction pass before storing.
 - Store via the engine enrich -> embed -> store path, tagging imported
   memories with `origin_source = "cli"` and a stable `import_batch` tag so
-  they are reviewable and bulk-deletable.
+  they are reviewable; record stored ids in the private batch ledger for undo.
 
 ### INIT-2. `rusty-brain import <path|->`
 
@@ -104,18 +104,19 @@ is logged and skipped.
 ### INIT-4. Provenance and redaction
 
 - Imported memories carry `origin_source = "cli"` and an `import_batch:<id>`
-  tag for reviewability and bulk delete.
+  tag for reviewability; the private sidecar ledger records their ids for undo.
 - Every imported byte passes through `rb-redact` before store; a planted
   secret in a source file must yield zero plaintext in the DB (asserted by a
   test mirroring the W2.4 scrub drill).
 
 ### INIT-5. Idempotency and rollback
 
-- Re-running `init` does not duplicate: near-dup suppression (the existing
-  `near_duplicates()` path) collapses repeats; the importer reports
+- Re-running `init` does not duplicate: a bounded recall probe confirms exact
+  redacted-content equality; the importer reports
   `new`/`skipped-duplicate`/`failed` counts.
-- `rusty-brain delete --tag import_batch:<id>` (or a dedicated `init --undo
-  <batch>`) removes an entire import in one op, cascading to vectors/FTS.
+- `init --undo <batch>` reads the private per-database sidecar ledger and issues
+  idempotent per-id archive calls for exactly the stored set; vector/FTS state
+  follows the normal archive path.
 
 ## Acceptance Criteria
 
@@ -145,7 +146,7 @@ project tree and asserting recall + DB-bytes redaction + dedup.
 ## Risks
 
 - Noisy/low-grade imports pollute recall. Mitigate: default importance cap,
-  import-batch tagging, and the `--undo` escape hatch.
+  import-batch tagging, the private ledger, and the `--undo` escape hatch.
 - Enricher cost/time on large doc sets. Mitigate: bounded defaults,
   `--dry-run`, and reuse of the batched single-connection pattern.
 - Secret leakage from imported files. Mitigate: mandatory redaction pass;

--- a/docs/prds/2026-07-02-init-and-project-import.md
+++ b/docs/prds/2026-07-02-init-and-project-import.md
@@ -2,11 +2,20 @@
 
 ## Status
 
-Draft. Addresses the highest-leverage activation gap surfaced in the
-2026-07-02 senior-PM product review: an empty brain on first run means the
-human sees no value and never builds the capture habit. Not on the existing
-Road-to-Tens roadmap (it is the missing "activation & value-realization"
-dimension).
+Delivered 2026-07-02 (PR #51, merge `f783d1c`). `rusty-brain init` scans the
+bounded project sources below, supports plan/confirmation and batch undo, and
+`rusty-brain import` accepts a bounded file or stdin with dry-run. Both use the
+normal remember path after client-side redaction; fixture-driven e2e coverage
+proves non-empty recall, DB-bytes redaction, rerun idempotency, undo, and
+dry-run no-write behavior.
+
+Two implementation details differ from the draft without reducing the user
+contract: dedup confirms exact redacted-content equality through a bounded
+recall probe rather than calling `near_duplicates()` directly, and undo uses a
+private per-database sidecar ledger of stored ids followed by idempotent
+per-id archive calls rather than a bulk delete-by-tag operation. Import is a
+bounded cold-start tool, not an ongoing sync mechanism; source-quality and
+large-project activation remain unmeasured.
 
 ## Owner Area
 
@@ -147,13 +156,16 @@ project tree and asserting recall + DB-bytes redaction + dedup.
 
 ## Implementation Checklist
 
-- [ ] Add `Init` and `Import` subcommands to `cli.rs`.
-- [ ] Implement source adapters (md/txt/git-log) in a new `import` module.
-- [ ] Wire adapters through the enricher + redaction + engine store path.
-- [ ] Add `import_batch:<id>` provenance/tagging and `init --undo`.
-- [ ] Reuse `near_duplicates()` for import dedup.
-- [ ] Add fixture-driven e2e (recall + DB-bytes redaction + dedup + undo).
-- [ ] Document first-run flow in the README Quickstart.
+- [x] Add `Init` and `Import` subcommands to `cli.rs`.
+- [x] Implement bounded markdown/text/git-log source adapters in `import.rs`.
+- [x] Wire adapters through redaction and the normal engine remember path.
+- [x] Add `import_batch:<id>` tagging, a private batch ledger, and
+      `init --undo` / `--list-batches`.
+- [x] Implement idempotent exact-content dedup through a bounded recall probe
+      (deliberate deviation from the draft's `near_duplicates()` mechanism).
+- [x] Add fixture-driven e2e coverage for recall, DB-bytes redaction, dedup,
+      undo, and dry-run.
+- [x] Document the first-run flow in the README Quickstart.
 
 ## Roadmap Fit
 

--- a/docs/prds/2026-07-02-portable-export-and-backup.md
+++ b/docs/prds/2026-07-02-portable-export-and-backup.md
@@ -2,11 +2,24 @@
 
 ## Status
 
-Draft. From the 2026-07-02 senior-PM product review. The Road-to-Tens plan
-scopes backup/restore (W5b.3) to raw SQLite online-backup, gated behind team
-mode (Phase 5, 6-10 weeks out). Today there is no way to back up, migrate,
-inspect, or version-control memory except grepping a DB - the #1 adoption
-objection ("what if I want to leave / lose it").
+Delivered 2026-07-02 (PR #52, merge `24ac007`). The CLI ships deterministic
+markdown/JSON/CSV export, timestamped portable backup with listing/retention,
+and bounded JSON restore through the redacting, deduplicating normal remember
+path (therefore vectors are recomputed under the current model). Unit and
+binary e2e tests cover deterministic id order, retention pruning,
+export/restore idempotency, recall after restore, and planted-secret absence.
+
+Delivered v1 is narrower than the draft in several reviewable ways: export is
+the current namespace to stdout (no `--all`, output-file flag, `--since`, or
+archived-row mode); filters are type/tags/min-importance; CSV is metadata-only;
+the read is bounded at 100,000 active memories and warns if it may truncate;
+restore accepts JSON only; and no cron/launchd schedule is installed. The e2e
+round trip restores into the same live namespace and proves dedup/continued
+recall, not rank equivalence on a fresh database or semantic parity across two
+production embedding models. Export serializes stored rows; it does not run a
+new redaction pass. The planted-secret test writes through the redacting import
+path, so operators with legacy or manually stored plaintext must run `scrub`
+before exporting. Raw SQLite disaster recovery remains future team-mode work.
 
 ## Owner Area
 
@@ -17,7 +30,7 @@ Touchpoints:
 - `crates/rusty-brain/src/cli.rs` (`Export` / `Backup` / `Restore`)
 - `crates/rusty-brain/src/run.rs`
 - `crates/rusty-brain/src/output.rs`
-- `crates/rb-store/src/store.rs`
+- `crates/rusty-brain/src/export.rs`
 - `crates/rb-proto/src/messages.rs`
 - `crates/rb-eval/` (existing export tooling to productize)
 - `docs/prds/2026-07-02-init-and-project-import.md` (round-trip pair)
@@ -59,7 +72,8 @@ Read-only dump of the current namespace (or `--all`) to stdout or a file:
   created/updated, links, `contested`, provenance.
 - Filters: `--type`, `--tags`, `--min-importance`, `--since <seq>` (oplog),
   `--active` (exclude archived).
-- Content is post-redaction; no secret that was scrubbed is re-emitted.
+- Content reflects the stored post-scrub state; export itself does not mutate
+  or newly redact rows. A secret removed by `scrub` is not re-emitted.
 
 ### EXP-2. `rusty-brain backup`
 
@@ -124,12 +138,15 @@ redaction in the export.
 
 ## Implementation Checklist
 
-- [ ] Add `Export`/`Backup`/`Restore` subcommands.
-- [ ] Productize the `rb-eval` export helpers into the CLI.
-- [ ] Wire restore through the import path + `reembed`.
-- [ ] Add `--retention` pruning for backups.
-- [ ] Add round-trip + redaction e2e tests.
-- [ ] Document the backup/restore + migration story in the README.
+- [x] Add `Export`/`Backup`/`Restore` subcommands.
+- [x] Add dedicated deterministic export formatting in the CLI crate.
+- [x] Wire JSON restore through the import/remember path so vectors are
+      recomputed under the current provider.
+- [x] Add backup listing and `--retention` pruning.
+- [x] Add idempotent export/restore, recall, ordering, and redaction tests
+      (with the fresh-DB/model-swap limitation recorded in Status).
+- [x] Document backup/restore commands and the portable migration story in the
+      README Quickstart.
 
 ## Roadmap Fit
 

--- a/docs/prds/2026-07-02-portable-export-and-backup.md
+++ b/docs/prds/2026-07-02-portable-export-and-backup.md
@@ -46,7 +46,7 @@ swaps.
 ## Goals
 
 - A portable, human-readable, diffable export (memory + metadata + links).
-- A one-command backup with a default schedule, and a restore that round-trips.
+- A one-command backup with retention pruning, and a restore that round-trips.
 - Reuse the export logic the `rb-eval`/scorecard tooling already implements.
 - Restore must be embedding-model-aware (re-embed on import, reusing
   `reembed`) so an export survives a model swap.
@@ -64,14 +64,14 @@ swaps.
 
 ### EXP-1. `rusty-brain export`
 
-Read-only dump of the current namespace (or `--all`) to stdout or a file:
+Read-only dump of the current namespace to stdout:
 
-- Formats: `markdown` (human/diffable), `json` (full-fidelity), `csv`
-  (tabular). Reuse the `rb-eval` export helpers.
+- Formats: `markdown` (human/diffable), `json` (full-fidelity), and
+  metadata-only `csv` (tabular).
 - Fields: id, type, importance, confidence, tags, summary, content, context,
   created/updated, links, `contested`, provenance.
-- Filters: `--type`, `--tags`, `--min-importance`, `--since <seq>` (oplog),
-  `--active` (exclude archived).
+- Filters: `--type`, `--tags`, and `--min-importance`. V1 exports active rows;
+  `--all`, output-file, `--since`, and archived-row modes remain draft-only.
 - Content reflects the stored post-scrub state; export itself does not mutate
   or newly redact rows. A secret removed by `scrub` is not re-emitted.
 
@@ -131,8 +131,8 @@ redaction in the export.
 - Restore under a different model produces different vectors -> different
   ranking. Mitigate: re-embed on restore and document the caveat; the
   fail-closed model-identity contract still governs the live DB.
-- Large-corpus export size. Mitigate: streaming output, format choice, and
-  `--active` default.
+- Large-corpus export size. Mitigate: the bounded active-row snapshot, format
+  choice, and an explicit truncation warning.
 - Leaking secrets via export. Mitigate: export is post-redaction only;
   document residual risk in the threat model.
 

--- a/docs/prds/README.md
+++ b/docs/prds/README.md
@@ -27,18 +27,18 @@ engineering roadmap does not measure.
 
 From the senior-PM product review. Ordered by leverage (Tier 1 = activation/retention loop, Tier 2 = differentiation, Tier 3 = hygiene/scale).
 
-| # | Tier | PRD |
-| --- | --- | --- |
-| 1 | 1 | [First-run cold-start and project import](2026-07-02-init-and-project-import.md) |
-| 2 | 1 | ["Memory is working" observability](2026-07-02-doctor-and-stats-observability.md) |
-| 3 | 1 | [Portable export and one-command backup](2026-07-02-portable-export-and-backup.md) |
-| 4 | 2 | [Typed code anchors](2026-07-02-typed-code-anchors.md) |
-| 5 | 2 | [Decision history and audit timeline](2026-07-02-decision-history-timeline.md) |
-| 6 | 2 | [Guided contradiction/dedup resolution](2026-07-02-contradiction-dedup-review.md) |
-| 7 | 2 | [HTTP/REST surface and agent-agnostic recall](2026-07-02-http-surface-and-agent-agnostic-recall.md) |
-| 8 | 3 | [User-facing retention and forgetting policy](2026-07-02-user-facing-retention-policy.md) |
-| 9 | 3 | [Search and filter parity](2026-07-02-search-filter-parity.md) |
-| 10 | 3 | [Native Windows support](2026-07-02-native-windows-support.md) |
+| # | Tier | PRD | Current status |
+| --- | --- | --- | --- |
+| 1 | 1 | [First-run cold-start and project import](2026-07-02-init-and-project-import.md) | Delivered (PR #51) |
+| 2 | 1 | ["Memory is working" observability](2026-07-02-doctor-and-stats-observability.md) | Delivered (PR #56) |
+| 3 | 1 | [Portable export and one-command backup](2026-07-02-portable-export-and-backup.md) | Delivered (PR #52) |
+| 4 | 2 | [Typed code anchors](2026-07-02-typed-code-anchors.md) | Delivered |
+| 5 | 2 | [Decision history and audit timeline](2026-07-02-decision-history-timeline.md) | Delivered |
+| 6 | 2 | [Guided contradiction/dedup resolution](2026-07-02-contradiction-dedup-review.md) | Delivered |
+| 7 | 2 | [HTTP/REST surface and agent-agnostic recall](2026-07-02-http-surface-and-agent-agnostic-recall.md) | Delivered (PR #62) |
+| 8 | 3 | [User-facing retention and forgetting policy](2026-07-02-user-facing-retention-policy.md) | Delivered |
+| 9 | 3 | [Search and filter parity](2026-07-02-search-filter-parity.md) | Delivered |
+| 10 | 3 | [Native Windows support](2026-07-02-native-windows-support.md) | Deferred; WSL2 remains the documented path |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Vikunja #55 found that the overview documentation had fallen behind the delivered product: workspace and MCP counts were stale, portable export was still described as unbuilt, bounded capability evidence was omitted, delivered PRDs still said Draft, and HIST-1 required a supersede reason that v1 never persisted.

This change reconciles README and architecture reference material with current code: 18 workspace crates, 12 routable MCP tools, delivered init/import, doctor/stats, loopback HTTP, export/backup/restore, and the actual runtime/development dependency DAG. It reports the paid N=5 Claude scorecard as bounded proxy evidence while keeping performance, scale, sustained concurrency, resource exhaustion, production-provider semantic quality, and multi-machine adoption explicitly unmeasured.

The delivered doctor/stats, init/import, HTTP, and portable export/backup PRDs now carry dated delivery evidence, checked implementation lists, and honest residual scope. The PRD index mirrors those statuses. HIST-1 now reflects the actual `superseded_by` lineage: v1 exposes reasons only for ordinary link edges and does not invent a supersede-reason field.

A new product-documentation test derives workspace membership from `Cargo.toml`, the MCP count from tool definitions, and delivered CLI/HTTP claims from the Clap surface, preventing the same drift from recurring.

## Validation

- Full `cargo test -p rusty-brain --locked`
- `cargo test -p rb-mcp exposes_exactly_the_twelve_tools --locked`
- Product documentation drift guard: 3/3 passed
- `cargo clippy -p rusty-brain --all-targets --locked -- -D warnings`
- `cargo fmt --all --check` and `git diff --check`
- Manual dependency-graph verification against direct normal dependencies from every workspace manifest; one graph mismatch was found and fixed

## Merge order

PR #73 should merge first because it overlaps README and architecture model-recovery prose. Rebase this branch afterward and preserve both sets of claims. PRs #74 and #75 do not overlap this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with refreshed status language, expanded MCP tool coverage, clearer testing/roadmap honesty notes, and added safety guidance for exporting/scrubbing legacy secrets.
  * Updated architecture overview and PRD documents to reflect expanded workspace scope and delivered HTTP/REST and agent-agnostic recall behavior, including tightened HTTP security and bounded request handling.
  * Delivered PRDs for init/import, doctor/stats observability, history semantics, and portable export/backup/restore v1 scope and safety limits.
* **Tests**
  * Added automated checks that PRD/README claims match the current workspace crate set, MCP tool count, and available CLI subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->