### PR TITLE
[codex] Fix active contradiction recall query plan

### DIFF
--- a/contract-snapshot.toml
+++ b/contract-snapshot.toml
@@ -70,6 +70,7 @@ contract_version = 2
 "008_memory_feedback.sql" = "64901f555624da4b738e437877d6b2b60579dbd5051f55ab476390015a67b70b"
 "009_memory_anchors.sql" = "d65aa99503a1573dfc55e65c60eb4045087e26680e2e6e426fdd6b9be1b3f6eb"
 "010_review_state.sql" = "a174de82d5ebbf75cd68e28369b1ef7ce549daa9874d5d497a5efde067b86d45"
+"011_memory_links_target_index.sql" = "0dc6147340f050df5ae3cac4f3492f6717001e9d02c9bb2a4a98db3fed8c7597"
 
 [[log]]
 contract_version = 2
@@ -125,3 +126,8 @@ note = "Vikunja #53 adds optional scrub WAL checkpoint status; serde defaults pr
 contract_version = 2
 intent = "additive"
 note = "Vikunja #53 preserves scrub counts with an optional checkpoint-error diagnostic"
+
+[[log]]
+contract_version = 2
+intent = "additive"
+note = "active_contradicts links-first query plus migration 011 target-side memory_links index; no wire change"

--- a/crates/rb-store/migrations/011_memory_links_target_index.sql
+++ b/crates/rb-store/migrations/011_memory_links_target_index.sql
@@ -1,0 +1,8 @@
+-- 011_memory_links_target_index.sql
+-- The memory_links primary key starts with source_id, so target-side graph
+-- probes otherwise scan the entire link table. Keep target_id first so every
+-- inbound-edge lookup can seek; link_type then filters contradiction probes
+-- inside the same index search.
+
+CREATE INDEX idx_memory_links_target_type
+  ON memory_links(target_id, link_type);

--- a/crates/rb-store/src/migrations.rs
+++ b/crates/rb-store/src/migrations.rs
@@ -423,4 +423,50 @@ mod tests {
         );
         assert!(bad.is_err(), "CHECK constraint rejects invalid memory_type");
     }
+
+    #[test]
+    fn target_link_index_migrates_a_populated_prior_schema() {
+        let c = conn();
+        run_migrations_up_to(&c, 10).unwrap();
+        c.execute_batch(
+            "INSERT INTO memories (
+                 memory_id, namespace, created_at, updated_at, content, summary,
+                 keywords, tags, memory_type, importance, confidence, embedding_model
+             ) VALUES
+                 ('source', 'global', 1, 1, 'source', '', '[]', '[]', 'insight', 5, 1.0, ''),
+                 ('target', 'global', 2, 2, 'target', '', '[]', '[]', 'insight', 5, 1.0, '');
+             INSERT INTO memory_links (
+                 source_id, target_id, link_type, strength, reason, created_at, base_strength
+             ) VALUES ('source', 'target', 'contradicts', 1.0, '', 2, 1.0);",
+        )
+        .unwrap();
+
+        let index_before: i64 = c
+            .query_row(
+                "SELECT count(*) FROM sqlite_master
+                 WHERE type = 'index' AND name = 'idx_memory_links_target_type'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(index_before, 0, "version 10 fixture must lack the index");
+
+        run_migrations(&c).unwrap();
+
+        let index_columns: Vec<String> = c
+            .prepare(
+                "SELECT name FROM pragma_index_info('idx_memory_links_target_type')
+                 ORDER BY seqno",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(index_columns, ["target_id", "link_type"]);
+        let link_count: i64 = c
+            .query_row("SELECT count(*) FROM memory_links", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(link_count, 1, "migration must preserve existing links");
+    }
 }

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -994,6 +994,51 @@ fn build_list_filtered_query(
     Ok((sql, params))
 }
 
+/// Build the exact compound query used to annotate recalled ids whose active,
+/// in-namespace memories participate in an active contradiction.
+#[allow(clippy::vec_box)]
+fn build_active_contradicts_query(
+    ns: &Namespace,
+    ids: &[MemoryId],
+) -> (String, Vec<Box<dyn rusqlite::ToSql>>) {
+    debug_assert!(!ids.is_empty());
+
+    // Both UNION halves share the same ?1..?N (ids) and ?{N+1} (namespace)
+    // positional slots — SQLite parameters are shared across UNION, so binding
+    // N+1 values covers both halves. Do NOT double the params.
+    let placeholders: Vec<String> = (0..ids.len()).map(|i| format!("?{}", i + 1)).collect();
+    let in_list = placeholders.join(", ");
+    let ns_param = format!("?{}", ids.len() + 1);
+    let sql = format!(
+        "SELECT l.source_id AS local FROM memory_links l
+           CROSS JOIN memories far ON far.memory_id = l.target_id
+           CROSS JOIN memories loc ON loc.memory_id = l.source_id
+         WHERE l.link_type = 'contradicts'
+           AND far.archived_at IS NULL
+           AND loc.archived_at IS NULL
+           AND far.namespace = {ns_param}
+           AND loc.namespace = {ns_param}
+           AND l.source_id IN ({in_list})
+         UNION
+         SELECT l.target_id AS local FROM memory_links l
+           CROSS JOIN memories far ON far.memory_id = l.source_id
+           CROSS JOIN memories loc ON loc.memory_id = l.target_id
+         WHERE l.link_type = 'contradicts'
+           AND far.archived_at IS NULL
+           AND loc.archived_at IS NULL
+           AND far.namespace = {ns_param}
+           AND loc.namespace = {ns_param}
+           AND l.target_id IN ({in_list})"
+    );
+
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(ids.len() + 1);
+    for id in ids {
+        params.push(Box::new(id.to_string()));
+    }
+    params.push(Box::new(ns.as_db_string()));
+    (sql, params)
+}
+
 impl Store for SqliteStore {
     fn insert_memory(&self, note: &MemoryNote, embedding: Option<&[f32]>) -> Result<()> {
         // Defense-in-depth validation before touching the DB. The SQL CHECK
@@ -1662,40 +1707,11 @@ impl Store for SqliteStore {
         // out-of-namespace id into the result (`loc` scope). Only ACTIVE,
         // in-namespace contradictions count (spec §9). The SELECT returns the local
         // endpoint id for every matching row; we collect the distinct set.
-        //
-        // Both UNION halves share the same ?1..?N (ids) and ?{N+1} (namespace)
-        // positional slots — SQLite parameters are shared across UNION, so binding
-        // N+1 values covers both halves. Do NOT double the params.
-        let placeholders: Vec<String> = (0..ids.len()).map(|i| format!("?{}", i + 1)).collect();
-        let in_list = placeholders.join(", ");
-        let ns_param = format!("?{}", ids.len() + 1);
-        let sql = format!(
-            "SELECT l.source_id AS local FROM memory_links l
-               JOIN memories far ON far.memory_id = l.target_id
-               JOIN memories loc ON loc.memory_id = l.source_id
-             WHERE l.link_type = 'contradicts'
-               AND far.archived_at IS NULL
-               AND loc.archived_at IS NULL
-               AND far.namespace = {ns_param}
-               AND loc.namespace = {ns_param}
-               AND l.source_id IN ({in_list})
-             UNION
-             SELECT l.target_id AS local FROM memory_links l
-               JOIN memories far ON far.memory_id = l.source_id
-               JOIN memories loc ON loc.memory_id = l.target_id
-             WHERE l.link_type = 'contradicts'
-               AND far.archived_at IS NULL
-               AND loc.archived_at IS NULL
-               AND far.namespace = {ns_param}
-               AND loc.namespace = {ns_param}
-               AND l.target_id IN ({in_list})"
-        );
-
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(ids.len() + 1);
-        for id in ids {
-            params.push(Box::new(id.to_string()));
-        }
-        params.push(Box::new(ns.as_db_string()));
+        // CROSS JOIN is deliberate: SQLite never reorders CROSS JOIN operands, so
+        // memory_links remains the outer loop on old and new planner versions. Plain
+        // JOIN lets SQLite 3.46 drive from idx_mem_ns for ten ids, turning this into
+        // a namespace-by-namespace cross scan even when memory_links is empty.
+        let (sql, params) = build_active_contradicts_query(ns, ids);
         let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
 
         let mut stmt = self
@@ -4928,6 +4944,35 @@ mod contradiction_tests {
             .unwrap();
     }
 
+    fn active_contradicts_query_plan(store: &SqliteStore, ids: &[MemoryId]) -> Vec<String> {
+        let (sql, params) = build_active_contradicts_query(&Namespace::Global, ids);
+        let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|value| value.as_ref()).collect();
+        let mut stmt = store
+            .conn
+            .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+            .unwrap();
+        stmt.query_map(refs.as_slice(), |row| row.get(3))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    }
+
+    fn compound_outer_loops(plan: &[String]) -> Vec<&str> {
+        let mut expect_outer_loop = false;
+        let mut outer_loops = Vec::new();
+        for detail in plan {
+            if detail.contains("LEFT-MOST SUBQUERY") || detail.starts_with("UNION ") {
+                expect_outer_loop = true;
+                continue;
+            }
+            if expect_outer_loop && (detail.starts_with("SEARCH ") || detail.starts_with("SCAN ")) {
+                outer_loops.push(detail.as_str());
+                expect_outer_loop = false;
+            }
+        }
+        outer_loops
+    }
+
     #[test]
     fn empty_input_returns_empty_set() {
         let store = SqliteStore::open_in_memory(8).unwrap();
@@ -4951,6 +4996,94 @@ mod contradiction_tests {
             .unwrap();
         assert!(flagged.contains(&a.id), "source flagged (outbound)");
         assert!(flagged.contains(&b.id), "target flagged (inbound)");
+    }
+
+    #[test]
+    fn flags_target_endpoint_when_only_target_is_queried() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let source = node(&store, "source says x");
+        let target = node(&store, "target says not-x");
+        contradicts(&store, &source, &target);
+
+        let flagged = store
+            .active_contradicts(&Namespace::Global, std::slice::from_ref(&target.id))
+            .unwrap();
+
+        assert_eq!(
+            flagged,
+            [target.id].into_iter().collect(),
+            "the target-side query must flag the requested local endpoint"
+        );
+    }
+
+    #[test]
+    fn active_contradicts_plan_drives_both_halves_from_memory_links() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let ids: Vec<_> = (0..10)
+            .map(|i| node(&store, &format!("memory {i}")).id)
+            .collect();
+
+        let plan = active_contradicts_query_plan(&store, &ids);
+        let outer_loops = compound_outer_loops(&plan);
+
+        assert_eq!(
+            outer_loops.len(),
+            2,
+            "expected one outer loop per UNION half; plan:\n{}",
+            plan.join("\n")
+        );
+        assert!(
+            outer_loops
+                .iter()
+                .all(|detail| detail.split_whitespace().nth(1) == Some("l")),
+            "memory_links must drive both UNION halves; outer loops: {outer_loops:?}; plan:\n{}",
+            plan.join("\n")
+        );
+        assert!(
+            plan.iter().any(|detail| {
+                detail.contains("idx_memory_links_target_type")
+                    && detail.contains("target_id=? AND link_type=?")
+            }),
+            "the target-side half must use both columns of the composite index; plan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    #[cfg(feature = "bench-utils")]
+    #[test]
+    #[ignore = "performance smoke; run explicitly in release mode"]
+    fn active_contradicts_ten_ids_completes_under_one_second_at_ten_thousand_rows() {
+        let store = SqliteStore::open_in_memory(8).unwrap();
+        let rows: Vec<_> = (0..10_000)
+            .map(|i| {
+                (
+                    MemoryNote::new(
+                        Namespace::Global,
+                        format!("benchmark memory {i}"),
+                        MemoryType::Insight,
+                        5,
+                    ),
+                    vec![0.0; 8],
+                )
+            })
+            .collect();
+        store.insert_memory_batch_for_benchmark(&rows).unwrap();
+        let ids: Vec<_> = rows
+            .iter()
+            .take(10)
+            .map(|(note, _)| note.id.clone())
+            .collect();
+
+        let started = std::time::Instant::now();
+        let flagged = store.active_contradicts(&Namespace::Global, &ids).unwrap();
+        let elapsed = started.elapsed();
+
+        eprintln!("active_contradicts elapsed at 10,000 rows: {elapsed:?}");
+        assert!(flagged.is_empty());
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "active_contradicts took {elapsed:?} for 10 ids over 10,000 rows"
+        );
     }
 
     #[test]

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -1009,6 +1009,10 @@ fn build_active_contradicts_query(
     let placeholders: Vec<String> = (0..ids.len()).map(|i| format!("?{}", i + 1)).collect();
     let in_list = placeholders.join(", ");
     let ns_param = format!("?{}", ids.len() + 1);
+    // CROSS JOIN is deliberate: SQLite never reorders CROSS JOIN operands, so
+    // memory_links remains the outer loop on old and new planner versions. Plain
+    // JOIN lets SQLite 3.46 drive from idx_mem_ns for ten ids, turning this into
+    // a namespace-by-namespace cross scan even when memory_links is empty.
     let sql = format!(
         "SELECT l.source_id AS local FROM memory_links l
            CROSS JOIN memories far ON far.memory_id = l.target_id
@@ -1707,10 +1711,6 @@ impl Store for SqliteStore {
         // out-of-namespace id into the result (`loc` scope). Only ACTIVE,
         // in-namespace contradictions count (spec §9). The SELECT returns the local
         // endpoint id for every matching row; we collect the distinct set.
-        // CROSS JOIN is deliberate: SQLite never reorders CROSS JOIN operands, so
-        // memory_links remains the outer loop on old and new planner versions. Plain
-        // JOIN lets SQLite 3.46 drive from idx_mem_ns for ten ids, turning this into
-        // a namespace-by-namespace cross scan even when memory_links is empty.
         let (sql, params) = build_active_contradicts_query(ns, ids);
         let refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|b| b.as_ref()).collect();
 
@@ -5035,14 +5035,15 @@ mod contradiction_tests {
         assert!(
             outer_loops
                 .iter()
-                .all(|detail| detail.split_whitespace().nth(1) == Some("l")),
+                .all(|detail| detail.starts_with("SEARCH l ") || detail.starts_with("SCAN l ")),
             "memory_links must drive both UNION halves; outer loops: {outer_loops:?}; plan:\n{}",
             plan.join("\n")
         );
         assert!(
             plan.iter().any(|detail| {
                 detail.contains("idx_memory_links_target_type")
-                    && detail.contains("target_id=? AND link_type=?")
+                    && detail.contains("target_id=?")
+                    && detail.contains("link_type=?")
             }),
             "the target-side half must use both columns of the composite index; plan:\n{}",
             plan.join("\n")


### PR DESCRIPTION
## Summary

- force both `active_contradicts` UNION halves to drive from `memory_links` with SQLite's non-reorderable `CROSS JOIN` semantics
- add migration 011 with a `(target_id, link_type)` index for the inbound contradiction probe
- pin the plan shape, populated-schema migration, target-only endpoint semantics, and 10k-row performance regression
- record the additive migration in `contract-snapshot.toml`

## User impact and root cause

Every recall annotates up to ten returned ids through `active_contradicts`. With the bundled SQLite 3.46.0 planner, the ten-id `IN` lists caused both compound-query halves to start from `idx_mem_ns`, putting the `memory_links` lookup innermost. That became a namespace-by-namespace cross scan even when `memory_links` was empty, producing multi-second recalls as the corpus grew.

The primary key already made source-side link probes seekable, so another index alone could not prevent the old planner from choosing the bad join order. `CROSS JOIN` now pins `memory_links` as the outer loop on every supported SQLite version. Migration 011 adds the missing target-side access path, and EXPLAIN verifies that both `target_id` and `link_type` participate in that search.

No ranking weights, admission caps, retention behavior, embedding defaults, safety thresholds, or rb-eval harness behavior changed. The optional rusqlite/libsqlite3-sys upgrade is deliberately deferred because this fix stands alone on SQLite 3.46.0.

## EXPLAIN QUERY PLAN

Before, bundled SQLite 3.46.0 with ten ids:

```text
COMPOUND QUERY
LEFT-MOST SUBQUERY
SEARCH far USING INDEX idx_mem_ns (namespace=?)
SEARCH loc USING INDEX idx_mem_ns (namespace=?)
SEARCH l USING COVERING INDEX sqlite_autoindex_memory_links_1 (source_id=? AND target_id=? AND link_type=?)
UNION USING TEMP B-TREE
SEARCH far USING INDEX idx_mem_ns (namespace=?)
SEARCH l USING COVERING INDEX sqlite_autoindex_memory_links_1 (source_id=? AND target_id=? AND link_type=?)
SEARCH loc USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
```

After:

```text
COMPOUND QUERY
LEFT-MOST SUBQUERY
SEARCH l USING COVERING INDEX sqlite_autoindex_memory_links_1 (source_id=?)
SEARCH far USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
SEARCH loc USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
UNION USING TEMP B-TREE
SEARCH l USING INDEX idx_memory_links_target_type (target_id=? AND link_type=?)
SEARCH far USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
SEARCH loc USING INDEX sqlite_autoindex_memories_1 (memory_id=?)
```

## Performance

The release-mode 10,000-row smoke test with ten existing ids and an empty link table measured:

- before: `9.484404834s`
- after: `82.083us`

The after-fix test completed in `0.37s` including fixture construction and process/test overhead; the bound remains a deliberately generous one second for CI variance.

## Test plan

- [x] observed the plan-shape regression test fail before the query change
- [x] observed the 10k-row release smoke fail before the query change at 9.484 seconds
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p rb-contract-guard -- check`
- [x] `cargo deny check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo test --release -p rb-store --features bench-utils active_contradicts_ten_ids_completes_under_one_second_at_ten_thousand_rows -- --ignored --nocapture`
- [x] existing `contested_filter_agrees_with_active_contradicts` drift guard passes unmodified
- [x] CodeRabbit local review: zero findings across all four changed files

## Operator follow-up

`scripts/run-scale-benchmark.sh` was intentionally not run because it is multi-hour. After merge, rerun it to remeasure the Vikunja #57 scale envelope with this query-plan fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contradiction detection when links are evaluated from their target endpoint.
  - Ensured existing linked-memory data remains intact during database upgrades.

- **Performance**
  - Optimized graph lookups for contradiction checks, improving response times for target-side queries.

- **Reliability**
  - Added validation to confirm database upgrades apply correctly and preserve expected query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->