### PR TITLE
[codex] Upgrade bundled SQLite to 3.53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,15 +1165,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1199,14 +1190,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1700,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2930,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", default-features = false, features = ["bundled", "cache", "fallible_uint"] }
 sqlite-vec = "0.1"
 include_dir = "0.7"
 sha2 = "0.10"

--- a/crates/rb-store/src/store/core.rs
+++ b/crates/rb-store/src/store/core.rs
@@ -4961,7 +4961,15 @@ mod contradiction_tests {
         let mut expect_outer_loop = false;
         let mut outer_loops = Vec::new();
         for detail in plan {
-            if detail.contains("LEFT-MOST SUBQUERY") || detail.starts_with("UNION ") {
+            // SQLite 3.53 renders compound arms as `LEFT` / `RIGHT` under
+            // `MERGE (UNION)`; older releases used `LEFT-MOST SUBQUERY` and
+            // `UNION ...`. In either format, the next SEARCH/SCAN is the arm's
+            // outer loop.
+            if detail == "LEFT"
+                || detail == "RIGHT"
+                || detail.contains("LEFT-MOST SUBQUERY")
+                || detail.starts_with("UNION ")
+            {
                 expect_outer_loop = true;
                 continue;
             }

--- a/crates/rb-store/src/store/lifecycle.rs
+++ b/crates/rb-store/src/store/lifecycle.rs
@@ -677,6 +677,17 @@ mod open_tests {
     }
 
     #[test]
+    fn bundled_sqlite_is_at_least_3_53() {
+        const MINIMUM_SQLITE_VERSION: i32 = 3_053_000;
+
+        assert!(
+            rusqlite::version_number() >= MINIMUM_SQLITE_VERSION,
+            "bundled SQLite must be at least 3.53.0, found {}",
+            rusqlite::version()
+        );
+    }
+
+    #[test]
     fn open_in_memory_creates_schema_and_seeds_dim() {
         let store = SqliteStore::open_in_memory(1024).unwrap();
         let c = &store.conn;


### PR DESCRIPTION
## Summary

Upgrade the workspace from `rusqlite` 0.32.1 / `libsqlite3-sys` 0.30.1 to `rusqlite` 0.40.1 / `libsqlite3-sys` 0.38.1. With the existing bundled build, this moves the SQLite runtime from 3.46.0 to 3.53.2.

The older bundle deferred SQLite 3.53's planner improvements and upstream fixes for every rusty-brain binary, regardless of the host system SQLite. This change updates the bundled engine while keeping the storage schema and product behavior unchanged.

## Implementation

- preserve the native bundled backend explicitly with `default-features = false` plus `bundled` and `cache`, avoiding rusqlite 0.40's unrelated default WASM backend dependencies
- enable rusqlite 0.40's `fallible_uint` compatibility feature because access-count batching relies on its checked `u64` SQL conversion
- add a regression test requiring bundled SQLite 3.53.0 or newer
- accept both the pre-3.53 and 3.53 `EXPLAIN QUERY PLAN` labels for UNION arms while retaining assertions that `memory_links` drives both halves and the target composite index is used

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo deny check --hide-inclusion-graph`
- `cargo audit` (no vulnerabilities; existing allowed unmaintained `paste` warning only)
- `cargo run -p rb-contract-guard --locked -- check`
- CodeRabbit local review: 0 findings

The rb-store suite exercises sqlite-vec registration and KNN queries, FTS5 creation/search/tokenizer behavior, migrations, WAL concurrency, and the active-contradiction query plan under SQLite 3.53.2. The manual scale benchmark was intentionally not run for this dependency-only follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer SQLite query-plan output, helping compound queries be analyzed correctly.
  * Updated the bundled SQLite integration to support required SQLite capabilities.

* **Tests**
  * Added coverage verifying that the bundled SQLite version is at least 3.53.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->